### PR TITLE
Safeguard findUniqueFilename from race conditions

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -284,7 +284,7 @@ public class UploadService extends HandlerService<Contribution> {
         contribution.save();
     }
 
-    private String findUniqueFilename(String fileName) throws IOException {
+    synchronized private String findUniqueFilename(String fileName) throws IOException {
         return findUniqueFilename(fileName, 1);
     }
 


### PR DESCRIPTION
This might partially, but not fully, solve Issue #228 (accidental overwriting).