### PR TITLE
Fix extension replacement, add related tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.4.0'
     compile 'com.android.support:design:23.4.0'
 
+    testCompile 'junit:junit:4.12'
 
     //noinspection GradleDependency - old version has required feature
     compile 'com.google.code.gson:gson:1.4'

--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -240,4 +240,18 @@ public class Utils {
             return false;
         }
     }
+
+    public static String fixExtension(String title, String extension) {
+        // People are used to ".jpg" more than ".jpeg" which the system gives us.
+        if (extension != null && extension.toLowerCase().equals("jpeg")) {
+            extension = "jpg";
+        }
+        if (title.toLowerCase().endsWith(".jpeg")) {
+            title = title.replaceFirst("\\.jpeg$", ".jpg");
+        }
+        if (extension != null && !title.toLowerCase().endsWith("." + extension.toLowerCase())) {
+            title += "." + extension;
+        }
+        return title;
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.upload;
 
-import android.Manifest;
 import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
@@ -15,8 +14,6 @@ import android.preference.PreferenceManager;
 import android.provider.MediaStore;
 import android.text.TextUtils;
 import android.util.Log;
-import android.webkit.MimeTypeMap;
-import android.widget.Toast;
 
 import java.io.IOException;
 import java.util.Date;
@@ -24,7 +21,6 @@ import java.util.Date;
 import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.HandlerService;
 import fr.free.nrw.commons.Prefs;
-import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.contributions.Contribution;
 
@@ -69,19 +65,8 @@ public class UploadController {
         }
     }
 
-    public void startUpload(String rawTitle, Uri mediaUri, String description, String mimeType, String source, ContributionUploadProgress onComplete) {
+    public void startUpload(String title, Uri mediaUri, String description, String mimeType, String source, ContributionUploadProgress onComplete) {
         Contribution contribution;
-
-        String title = rawTitle;
-        String extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
-        // People are used to ".jpg" more than ".jpeg" which the system gives us.
-        if (extension != null && extension.toLowerCase().equals("jpeg")) {
-            extension = "jpg";
-        }
-        if(extension != null && !title.toLowerCase().endsWith(extension.toLowerCase())) {
-            title += "." + extension;
-        }
-
 
         contribution = new Contribution(mediaUri, null, title, description, -1, null, null, app.getCurrentAccount().name, CommonsApplication.DEFAULT_EDIT_SUMMARY);
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -17,6 +17,7 @@ import android.app.*;
 import android.content.*;
 import android.support.v4.app.NotificationCompat;
 import android.util.*;
+import android.webkit.MimeTypeMap;
 import android.widget.*;
 
 import fr.free.nrw.commons.contributions.*;
@@ -197,7 +198,11 @@ public class UploadService extends HandlerService<Contribution> {
         this.startForeground(NOTIFICATION_UPLOAD_IN_PROGRESS, curProgressNotification.build());
 
         try {
-            String filename = findUniqueFilename(contribution.getFilename());
+
+            String filename = Utils.fixExtension(
+                    contribution.getFilename(),
+                    MimeTypeMap.getSingleton().getExtensionFromMimeType((String)contribution.getTag("mimeType")));
+            filename = findUniqueFilename(filename);
             if(!api.validateLogin()) {
                 // Need to revalidate!
                 if(app.revalidateAuthToken()) {

--- a/app/src/test/java/fr/free/nrw/commons/UtilsTest.java
+++ b/app/src/test/java/fr/free/nrw/commons/UtilsTest.java
@@ -1,0 +1,29 @@
+package fr.free.nrw.commons;
+import org.junit.Test;
+
+import fr.free.nrw.commons.upload.UploadController;
+
+import static org.junit.Assert.*;
+
+public class UtilsTest {
+
+    @Test public void fixExtensionJpegToJpg() {
+        assertEquals("SampleFile.jpg", Utils.fixExtension("SampleFile.jpeg", "jpeg"));
+    }
+
+    @Test public void fixExtensionJpgToJpg() {
+        assertEquals("SampleFile.jpg", Utils.fixExtension("SampleFile.jpg", "jpg"));
+    }
+
+    @Test public void fixExtensionPngToPng() {
+        assertEquals("SampleFile.png", Utils.fixExtension("SampleFile.png", "png"));
+    }
+
+    @Test public void fixExtensionEmptyToJpg() {
+        assertEquals("SampleFile.jpg", Utils.fixExtension("SampleFile", "jpg"));
+    }
+
+    @Test public void fixExtensionJpgNotExtension() {
+        assertEquals("SampleFileJpg.jpg", Utils.fixExtension("SampleFileJpg", "jpg"));
+    }
+}


### PR DESCRIPTION
Makes sure findUniqueFilename receives filenames with an extension.
More robust extension replacement rules.
 (for #228)