### PR TITLE
Further attempts to reduce overwrites

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -25,6 +25,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.concurrent.Executor;
+import java.util.regex.Pattern;
 
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
@@ -242,13 +243,13 @@ public class Utils {
     }
 
     public static String fixExtension(String title, String extension) {
+        Pattern jpegPattern = Pattern.compile("\\.jpeg$", Pattern.CASE_INSENSITIVE);
+
         // People are used to ".jpg" more than ".jpeg" which the system gives us.
         if (extension != null && extension.toLowerCase().equals("jpeg")) {
             extension = "jpg";
         }
-        if (title.toLowerCase().endsWith(".jpeg")) {
-            title = title.replaceFirst("\\.jpeg$", ".jpg");
-        }
+        title = jpegPattern.matcher(title).replaceFirst(".jpg");
         if (extension != null && !title.toLowerCase().endsWith("." + extension.toLowerCase())) {
             title += "." + extension;
         }

--- a/app/src/test/java/fr/free/nrw/commons/UtilsTest.java
+++ b/app/src/test/java/fr/free/nrw/commons/UtilsTest.java
@@ -1,29 +1,49 @@
 package fr.free.nrw.commons;
 import org.junit.Test;
 
-import fr.free.nrw.commons.upload.UploadController;
-
 import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.is;
+
 
 public class UtilsTest {
 
-    @Test public void fixExtensionJpegToJpg() {
-        assertEquals("SampleFile.jpg", Utils.fixExtension("SampleFile.jpeg", "jpeg"));
+    @Test public void fixExtensionJpegToJpeg() {
+        assertThat(Utils.fixExtension("SampleFile.jpeg", "jpeg"), is("SampleFile.jpg"));
+    }
+
+    @Test public void fixExtensionJPEGToJpg() {
+        assertThat(Utils.fixExtension("SampleFile.JPEG", null), is("SampleFile.jpg"));
+    }
+
+    @Test public void fixExtensionNull() {
+        assertThat(Utils.fixExtension("SampleFile.jpeg", "JPEG"), is("SampleFile.jpg"));
+    }
+
+    @Test public void fixExtensionJpgToJpeg() {
+        assertThat(Utils.fixExtension("SampleFile.jpg", "jpeg"), is("SampleFile.jpg"));
     }
 
     @Test public void fixExtensionJpgToJpg() {
-        assertEquals("SampleFile.jpg", Utils.fixExtension("SampleFile.jpg", "jpg"));
+        assertThat(Utils.fixExtension("SampleFile.jpg", "jpg"), is("SampleFile.jpg"));
     }
 
     @Test public void fixExtensionPngToPng() {
-        assertEquals("SampleFile.png", Utils.fixExtension("SampleFile.png", "png"));
+        assertThat(Utils.fixExtension("SampleFile.png", "png"), is("SampleFile.png"));
     }
 
     @Test public void fixExtensionEmptyToJpg() {
-        assertEquals("SampleFile.jpg", Utils.fixExtension("SampleFile", "jpg"));
+        assertThat(Utils.fixExtension("SampleFile", "jpg"), is("SampleFile.jpg"));
+    }
+
+    @Test public void fixExtensionEmptyToJpeg() {
+        assertThat(Utils.fixExtension("SampleFile", "jpeg"), is("SampleFile.jpg"));
     }
 
     @Test public void fixExtensionJpgNotExtension() {
-        assertEquals("SampleFileJpg.jpg", Utils.fixExtension("SampleFileJpg", "jpg"));
+        assertThat(Utils.fixExtension("SAMPLEjpg", "jpg"), is("SAMPLEjpg.jpg"));
+    }
+
+    @Test public void fixExtensionJpegNotExtension() {
+        assertThat(Utils.fixExtension("SAMPLE.jpeg.SAMPLE", "jpg"), is("SAMPLE.jpeg.SAMPLE.jpg"));
     }
 }


### PR DESCRIPTION
- Keep file names of unfinished uploads to avoid overwriting
- Normalize capital-letter file extensions

See Issue #228 