### PR TITLE
Use resultCode == RESULT_OK instead of null check

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
@@ -67,12 +67,13 @@ public class ContributionController {
         fragment.startActivityForResult(pickImageIntent, SELECT_FROM_GALLERY);
     }
 
-    public void handleImagePicked(int requestCode, Uri imageData) {
+    public void handleImagePicked(int requestCode, Intent data) {
         Intent shareIntent = new Intent(activity, ShareActivity.class);
         shareIntent.setAction(Intent.ACTION_SEND);
         switch(requestCode) {
             case SELECT_FROM_GALLERY:
                 //FIXME: Handles image picked from gallery (from Google Photos)
+                Uri imageData = data.getData();
                 shareIntent.setType(activity.getContentResolver().getType(imageData));
                 shareIntent.putExtra(Intent.EXTRA_STREAM, imageData);
                 shareIntent.putExtra(UploadService.EXTRA_SOURCE, fr.free.nrw.commons.contributions.Contribution.SOURCE_GALLERY);

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -33,6 +33,8 @@ import fr.free.nrw.commons.SettingsActivity;
 import fr.free.nrw.commons.nearby.NearbyActivity;
 import fr.free.nrw.commons.upload.UploadService;
 
+import static android.app.Activity.RESULT_OK;
+
 public class ContributionsListFragment extends Fragment {
 
     public interface SourceRefresher {
@@ -98,12 +100,11 @@ public class ContributionsListFragment extends Fragment {
         //FIXME: must get the file data for Google Photos when receive the intent answer, in the onActivityResult method
         super.onActivityResult(requestCode, resultCode, data);
 
-        if (data != null) {
-            Log.d("Contributions", "OnActivityResult() parameters: Result code: " + resultCode + " Data: " + data.toString());
-            Uri imageData = data.getData();
-            controller.handleImagePicked(requestCode, imageData);
+        if ( resultCode == RESULT_OK ) {
+            Log.d("Contributions", "OnActivityResult() parameters: Req code: " + requestCode + " Result code: " + resultCode + " Data: " + data);
+            controller.handleImagePicked(requestCode, data);
         } else {
-            Log.e("Contributions", "OnActivityResult() parameters: Result code: " + resultCode + " Data: null");
+            Log.e("Contributions", "OnActivityResult() parameters: Req code: " + requestCode + " Result code: " + resultCode + " Data: " + data);
         }
     }
 


### PR DESCRIPTION
This is to fix "E/Contributions: OnActivityResult() parameters: Result code: -1 Data: null" which I get upon camera capture on emulator.

I couldn't find exactly where the relevant doc is but https://developer.android.com/training/camera/photobasics.html#TaskPhotoView mentions RESULT_OK but not the null check. http://stackoverflow.com/questions/12564112/android-camera-onactivityresult-intent-is-null-if-it-had-extras/12564910#12564910 suggests using RESULTS_OK for camera, too.

@Misaochan: This (kind of) reverts 2f95a79abdbba08be70342f0a89f46e1d523300a and fa5b6c0869071b7d6cb41a3b22b5f3eb964c0d23 so your review will be appreciated.