### PR TITLE
Upgrade build tools (25) and gradle plugin (2.2.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,11 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-23.0.3
+    - build-tools-25.0.0
     - extra-google-m2repository
     - extra-android-m2repository
     - android-23
     - sys-img-x86-android-18
+jdk:
+  # - openjdk8 # not yet available
+  - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Initially started by the Wikimedia Foundation, this app is now maintained by vol
 
 ### Requirements ###
 
-1. [Android SDK][3] (Level 23)
-2. [Gradle][4]
+1. Java SDK 8 (OpenJDK 8 or Oracle Java SE 8)
+2. [Android SDK][3] (Level 23)
+3. [Gradle][4]
 
 ### Build Instructions ###
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,9 +11,9 @@ dependencies {
     compile 'ch.acra:acra:4.7.0'
     compile 'org.mediawiki:api:1.3'
     compile 'commons-codec:commons-codec:1.10'
-    compile 'com.android.support:support-v4:23.4.0'
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:design:23.4.0'
+    compile 'com.android.support:support-v4:25.0.0'
+    compile 'com.android.support:appcompat-v7:25.0.0'
+    compile 'com.android.support:design:25.0.0'
 
     testCompile 'junit:junit:4.12'
 
@@ -23,7 +23,7 @@ dependencies {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "25.0.0"
 
     useLibrary  'org.apache.http.legacy'
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.0'
     }
 }
 


### PR DESCRIPTION
Is it too early?

Our code base seems to be fine with the latest build tools, there might be conflicts if you have other Android projects dependent to the older environment (23.0.3).