### PR TITLE
Make the theme extend from the material theme instead of holo

### DIFF
--- a/app/src/main/res/values-v14/styles.xml
+++ b/app/src/main/res/values-v14/styles.xml
@@ -1,6 +1,0 @@
-<resources>
-
-    <style name="ProgressBar" parent="android:Widget.Holo.ProgressBar.Horizontal" />
-    <style name="AppTheme" parent="android:Theme.Holo" />
-
-</resources>

--- a/app/src/main/res/values-v9/styles.xml
+++ b/app/src/main/res/values-v9/styles.xml
@@ -1,5 +1,0 @@
-<resources>
-
-    <style name="ProgressBar" parent="android:Widget.ProgressBar.Horizontal" />
-
-</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,4 +19,6 @@
 
     <style name="NotificationProgress" parent="AppTheme" />
 
+    <style name="ProgressBar" parent="Widget.AppCompat.ProgressBar.Horizontal" />
+
 </resources>


### PR DESCRIPTION
The `styles.xml` in `values-v9` is redundant as the `@style/ProgressBar` is always being overridden by the `@style/ProgressBar` defined in `values-v14/styles.xml`. Hence I could safely delete `values-v9/styles.xml` without affecting the behaviour of the app.

Defining a `values-v14/styles.xml` is unnecessary as the `minSdk` is `15` so the styles in that file would always have been used over that of `values/styles.xml`. So I moved those styles to `values/styles.xml` and set the parent to the AppCompat's material theme. As it was already set for `@style/AppTheme`, is was only necessary to modify the `@style/ProgressBar` parent.