### PR TITLE
Use a Material design for the form fields

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -42,16 +42,25 @@
                 android:layout_height="48dp"
                 />
 
-            <EditText
-                android:id="@+id/loginUsername"
+            <android.support.design.widget.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/username"
-                android:inputType="textNoSuggestions"
-                android:imeOptions="flagNoExtractUi"
                 >
-                <requestFocus />
-            </EditText>
+
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/loginUsername"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/username"
+                    android:imeOptions="flagNoExtractUi"
+                    android:inputType="textNoSuggestions"
+                    >
+
+                    <requestFocus/>
+
+                </android.support.design.widget.TextInputEditText>
+
+            </android.support.design.widget.TextInputLayout>
 
             <EditText
                 android:id="@+id/loginPassword"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,4 +1,5 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     >
@@ -62,14 +63,22 @@
 
             </android.support.design.widget.TextInputLayout>
 
-            <EditText
-                android:id="@+id/loginPassword"
+            <android.support.design.widget.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/password"
-                android:inputType="textPassword"
-                android:imeOptions="flagNoExtractUi"
-                />
+                app:passwordToggleEnabled="false"
+                >
+
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/loginPassword"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/password"
+                    android:imeOptions="flagNoExtractUi"
+                    android:inputType="textPassword"
+                    />
+
+            </android.support.design.widget.TextInputLayout>
 
             <Button
                 android:id="@+id/loginButton"


### PR DESCRIPTION
With the new style, due to the floating label when the user starts typing, there is no confusion as to what information they are inputting. With the old style, when the user starts typing, there is no indication on what the field they are filling in is.

Old design:

![old](https://cloud.githubusercontent.com/assets/6900601/23553776/2f2c0a1a-001a-11e7-9c9a-8f712ea93efd.png)

New design:

![new](https://cloud.githubusercontent.com/assets/6900601/23553799/3d6ab572-001a-11e7-8271-9983fe372190.png)