### PR TITLE
Remove references to icons when showAsAction is set to never

### DIFF
--- a/app/src/main/res/menu/fragment_contributions_list.xml
+++ b/app/src/main/res/menu/fragment_contributions_list.xml
@@ -15,22 +15,18 @@
     <item android:id="@+id/menu_settings"
           android:title="@string/menu_settings"
           app:showAsAction="never"
-          android:icon="@android:drawable/ic_menu_preferences"
           />
     <item android:id="@+id/menu_about"
           android:title="@string/menu_about"
           app:showAsAction="never"
-          android:icon="@android:drawable/ic_menu_info_details"
           />
     <item android:id="@+id/menu_feedback"
           android:title="@string/menu_feedback"
           app:showAsAction="never"
-          android:icon="@android:drawable/ic_menu_send"
             />
     <item android:id="@+id/menu_nearby"
         android:title="@string/menu_nearby"
         app:showAsAction="never"
-        android:icon="@android:drawable/ic_menu_myplaces"
         />
     <item android:id="@+id/menu_refresh"
           android:title="@string/menu_refresh"

--- a/app/src/main/res/menu/fragment_image_detail.xml
+++ b/app/src/main/res/menu/fragment_image_detail.xml
@@ -9,12 +9,10 @@
         app:showAsAction="ifRoom|withText" />
     <item
         android:id="@+id/menu_browser_current_image"
-        android:icon="@android:drawable/ic_menu_view"
         android:title="@string/menu_open_in_browser"
         app:showAsAction="never" />
     <item
         android:id="@+id/menu_download_current_image"
-        android:icon="@drawable/ic_menu_download"
         android:title="@string/menu_download"
         app:showAsAction="never" />
     <item
@@ -27,7 +25,6 @@
     <item
         android:id="@+id/menu_cancel_current_image"
         android:enabled="false"
-        android:icon="@android:drawable/ic_menu_delete"
         android:title="@string/menu_cancel_upload"
         android:visible="false"
         app:showAsAction="never" />


### PR DESCRIPTION
Even though there isn't currently any noticeable overhead in referencing system icons, when implementing #380 there is no point of including these extra icons in the APK if they are never going to be used (as references to system icons will be replaced with references to local drawables which of course will have to be added to the APK).