### PR TITLE
Update gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-25.0.0
+    - build-tools-25.0.1
     - extra-google-m2repository
     - extra-android-m2repository
-    - android-23
+    - android-25
     - sys-img-x86-android-18
 jdk:
   # - openjdk8 # not yet available

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,9 +12,9 @@ dependencies {
     compile 'ch.acra:acra:4.7.0'
     compile 'org.mediawiki:api:1.3'
     compile 'commons-codec:commons-codec:1.10'
-    compile 'com.android.support:support-v4:25.0.0'
-    compile 'com.android.support:appcompat-v7:25.0.0'
-    compile 'com.android.support:design:25.0.0'
+    compile 'com.android.support:support-v4:25.2.0'
+    compile 'com.android.support:appcompat-v7:25.2.0'
+    compile 'com.android.support:design:25.2.0'
 
     testCompile 'junit:junit:4.12'
 
@@ -23,7 +23,7 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 25
     buildToolsVersion '25'
 
     useLibrary  'org.apache.http.legacy'
@@ -31,11 +31,7 @@ android {
     defaultConfig {
         applicationId "fr.free.nrw.commons"
         minSdkVersion 15
-        targetSdkVersion 23
-
-        ndk {
-            moduleName "libtranscode"
-        }
+        targetSdkVersion 25
     }
 
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25'
+    buildToolsVersion '25.0.1'
 
     useLibrary  'org.apache.http.legacy'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,31 +12,29 @@ dependencies {
     compile 'ch.acra:acra:4.7.0'
     compile 'org.mediawiki:api:1.3'
     compile 'commons-codec:commons-codec:1.10'
-    compile 'com.android.support:support-v4:25.2.0'
-    compile 'com.android.support:appcompat-v7:25.2.0'
-    compile 'com.android.support:design:25.2.0'
+    compile "com.android.support:support-v4:${project.supportLibVersion}"
+    compile "com.android.support:appcompat-v7:${project.supportLibVersion}"
+    compile "com.android.support:design:${project.supportLibVersion}"
+    compile 'com.google.code.gson:gson:2.7'
 
     testCompile 'junit:junit:4.12'
-
-    //noinspection GradleDependency - old version has required feature
-    compile 'com.google.code.gson:gson:1.4'
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.1'
+    compileSdkVersion project.compileSdkVersion
+    buildToolsVersion project.buildToolsVersion
 
-    useLibrary  'org.apache.http.legacy'
+    useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        applicationId "fr.free.nrw.commons"
-        minSdkVersion 15
-        targetSdkVersion 25
+        applicationId 'fr.free.nrw.commons'
+        minSdkVersion project.minSdkVersion
+        targetSdkVersion project.targetSdkVersion
     }
 
     buildTypes {
         release {
-            minifyEnabled true // See https://stackoverflow.com/questions/40232404/google-play-apk-and-android-studio-apk-usb-debug-behaving-differently and try reverting if the proguard.cfg modification is enough.
+            minifyEnabled false // See https://stackoverflow.com/questions/40232404/google-play-apk-and-android-studio-apk-usb-debug-behaving-differently and try reverting if the proguard.cfg modification is enough.
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath "com.android.tools.build:gradle:${project.gradleVersion}"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-android.useDeprecatedNdk=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,9 @@
+gradleVersion = 2.3.0
+
+supportLibVersion = 25.2.0
+
+compileSdkVersion = android-25
+buildToolsVersion = 25.0.1
+
+minSdkVersion = 15
+targetSdkVersion = 25

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 17 16:02:52 NZST 2016
+#Wed Mar 08 18:04:14 GMT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
Updated gradle build tools to 2.3.0, updated android support libs to v25.2, updated targetSdkVersion to 25. Removed unused ndk libs, code that required it was removed several months ago.

More info in #381 

Also was having a look at some of the other libs and had some questions:
1. On every gradle build I get: 
    ```
    WARNING: Dependency org.apache.httpcomponents:httpclient:4.2.2 is ignored for release as it may be conflicting with the internal version provided by Android.
   ```
   and I'm not sure when it comes from. It seems unrelated to the `org.apache.http.legacy` lib on line 29, as removing that line makes no change. Doesn't seem to be doing anything bad, just might be something that might be adding bulk to the app for no reason.

2. Do we still need to be using the old version of GSON? See #410