### PR TITLE
Place placeholder strings in separate strings xml file

### DIFF
--- a/app/src/debug/res/values/placeholder_strings.xml
+++ b/app/src/debug/res/values/placeholder_strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="placeholder_place_distance">Overlay</string>
+  <string name="placeholder_place_name">Name</string>
+  <string name="placeholder_place_description">Description</string>
+</resources>

--- a/app/src/main/res/layout/item_place.xml
+++ b/app/src/main/res/layout/item_place.xml
@@ -29,7 +29,7 @@
             style="?android:textAppearanceSmallInverse"
             android:textColor="#ffffff"
             android:background="@color/text_background"
-            tools:text="Overlay"
+            tools:text="@string/placeholder_place_distance"
             />
 
         <TextView
@@ -44,7 +44,7 @@
             android:maxLines="1"
             android:ellipsize="none"
             style="?android:textAppearanceMedium"
-            tools:text="Name"
+            tools:text="@string/placeholder_place_name"
             />
 
         <TextView
@@ -58,7 +58,7 @@
             android:ellipsize="none"
             android:maxLines="4"
             style="?android:textAppearanceSmall"
-            tools:text="Description"
+            tools:text="@string/placeholder_place_description"
             />
 
     </RelativeLayout>


### PR DESCRIPTION
This was mostly inspired by the way the [Google IO App](https://github.com/google/iosched/blob/2016/android/src/debug/res/values/placeholder_strings.xml) handles placeholder strings.

Some benefits that I can think of of this are:

1. Makes strings separate from layout file
2. If you want to see other languages in the layout editor, then adding new languages will be the same as usual (except adding it to `debug/res` instead of `main/res`). This means that the source code of the layout doesn't have to constantly be changed to see the effect of a different language (e.g. English which is written from left to right would look different from Hebrew which is written right to left) but the language settings can be modified from the layout editor instead.

Note that I have strayed slightly from the Google IO App's implementation of this by omitting `translatable=false` from the string resources values in `placeholder_strings.xml` due to point no. 2 listed above.