### PR TITLE
Add beta opt in link in settings page

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,4 +158,6 @@ Tap this message (or hit back) to skip this step.</string>
   <string name="media_detail_media_title">Title of the media</string>
   <string name="media_detail_description">Description</string>
   <string name="media_detail_description_explanation">Description of the media goes here. This can potentially be fairly long, and will need to wrap across multiple lines. We hope it looks nice though.</string>
+  <string name="become_a_tester">Become a Tester</string>
+  <string name="beta_opt_in_link">https://play.google.com/apps/testing/fr.free.nrw.commons</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,6 +158,7 @@ Tap this message (or hit back) to skip this step.</string>
   <string name="media_detail_media_title">Title of the media</string>
   <string name="media_detail_description">Description</string>
   <string name="media_detail_description_explanation">Description of the media goes here. This can potentially be fairly long, and will need to wrap across multiple lines. We hope it looks nice though.</string>
-  <string name="become_a_tester">Become a Tester</string>
+  <string name="become_a_tester_title">Become a Beta Tester</string>
+  <string name="become_a_tester_description">Opt-in to our beta channel on Google Play and get early access to new features and bug fixes</string>
   <string name="beta_opt_in_link">https://play.google.com/apps/testing/fr.free.nrw.commons</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -13,7 +13,8 @@
         android:summary="@string/allow_gps_summary"
         android:key="allowGps" />
 
-    <Preference android:title="@string/become_a_tester" >
+    <Preference android:title="@string/become_a_tester_title"
+        android:summary="@string/become_a_tester_description">
         <intent android:action="android.intent.action.VIEW"
             android:data="@string/beta_opt_in_link" />
     </Preference>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -13,5 +13,10 @@
         android:summary="@string/allow_gps_summary"
         android:key="allowGps" />
 
+    <Preference android:title="@string/become_a_tester" >
+        <intent android:action="android.intent.action.VIEW"
+            android:data="@string/beta_opt_in_link" />
+    </Preference>
+
 
 </PreferenceScreen>


### PR DESCRIPTION
Fixes #431. Added beta link in settings page. 

![beta_opt_in_link](https://cloud.githubusercontent.com/assets/3069373/23832596/9f61b8da-075d-11e7-9022-ce03825d9bef.png)
