### PR TITLE
Fix readibility of categorization page

### DIFF
--- a/app/src/main/res/layout/fragment_categorization.xml
+++ b/app/src/main/res/layout/fragment_categorization.xml
@@ -10,6 +10,7 @@
     android:paddingRight="16dip"
     android:paddingEnd="16dip"
     android:paddingTop="8dip"
+    android:theme="@style/DarkAppTheme"
     >
 
     <FrameLayout

--- a/app/src/main/res/layout/layout_categories_item.xml
+++ b/app/src/main/res/layout/layout_categories_item.xml
@@ -6,6 +6,7 @@
     android:checkMark="?android:attr/textCheckMark"
     android:checked="false"
     android:gravity="center_vertical"
+    android:theme="@style/DarkAppTheme"
     >
 
 </CheckedTextView>


### PR DESCRIPTION
Force categorization screen always to be on dark menu. Fix number 5 #442 
![selection_012](https://cloud.githubusercontent.com/assets/3127881/24114451/f1713280-0da8-11e7-8f6a-c5a5ce2563c9.png)
