### PR TITLE
Add credits in about page

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
@@ -1,5 +1,7 @@
 package fr.free.nrw.commons;
 
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
@@ -16,6 +18,7 @@ public class AboutActivity extends BaseActivity {
     @BindView(R.id.about_improve) TextView improveText;
     @BindView(R.id.about_privacy_policy) TextView privacyPolicyText;
     @BindView(R.id.about_uploads_to) TextView uploadsToText;
+    @BindView(R.id.about_credits) TextView creditsText;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -32,10 +35,12 @@ public class AboutActivity extends BaseActivity {
         fixFormatting(licenseText, R.string.about_license);
         fixFormatting(improveText, R.string.about_improve);
         fixFormatting(privacyPolicyText, R.string.about_privacy_policy);
+        fixFormatting(creditsText, R.string.about_credits);
 
         licenseText.setMovementMethod(LinkMovementMethod.getInstance());
         improveText.setMovementMethod(LinkMovementMethod.getInstance());
         privacyPolicyText.setMovementMethod(LinkMovementMethod.getInstance());
+        creditsText.setMovementMethod(LinkMovementMethod.getInstance());
     }
 
     private void fixFormatting(TextView textView, int resource) {

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -58,6 +58,16 @@
         />
 
     <TextView
+        android:id="@+id/about_credits"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        style="?android:textAppearanceSmall"
+        android:gravity="center"
+        android:text="@string/about_credits"
+        />
+
+    <TextView
         android:id="@+id/about_uploads_to"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,6 +77,7 @@ Tap this message (or hit back) to skip this step.</string>
   <string name="about_license">Open Source software released under the &lt;a href=\"https://github.com/wikimedia/apps-android-commons/blob/master/COPYING\"&gt;Apache License v2&lt;/a&gt;. Wikimedia Commons and its logo are trademarks of the Wikimedia Foundation and are used with the permission of the Wikimedia Foundation. We are not endorsed by or affiliated with the Wikimedia Foundation.</string>
   <string name="about_improve">&lt;a href=\"https://github.com/commons-app/apps-android-commons\"&gt;Source&lt;/a&gt; and &lt;a href=\"https://commons-app.github.io/\"&gt;website&lt;/a&gt; on GitHub. Create a new &lt;a href=\"https://github.com/commons-app/apps-android-commons/issues\"&gt;GitHub issue&lt;/a&gt; for bug reports and suggestions.</string>
   <string name="about_privacy_policy">&lt;a href=\"https://wikimediafoundation.org/wiki/Privacy_policy\"&gt;Privacy policy&lt;/a&gt;</string>
+  <string name="about_credits">&lt;a href=\"https://github.com/commons-app/apps-android-commons/blob/master/CREDITS\"&gt;CREDITS&lt;/a&gt;</string>
   <string name="title_activity_about">About</string>
   <string name="menu_feedback">Send Feedback (via Email)</string>
   <string name="no_email_client">No email client installed</string>


### PR DESCRIPTION
Fixes #439. Attached screenshot. 

![credits](https://cloud.githubusercontent.com/assets/3069373/24118790/02f88f18-0dd5-11e7-8a09-ce874bbf4606.png)
