### PR TITLE
Give a more intuitive ordering to the menu items

### DIFF
--- a/app/src/main/res/menu/fragment_contributions_list.xml
+++ b/app/src/main/res/menu/fragment_contributions_list.xml
@@ -2,27 +2,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item android:id="@+id/menu_from_camera"
           android:title="@string/menu_from_camera"
-          android:orderInCategory="100"
           app:showAsAction="ifRoom|withText"
           android:icon="?attr/iconCamera"
             />
     <item android:id="@+id/menu_from_gallery"
         android:title="@string/menu_from_gallery"
-        android:orderInCategory="200"
         app:showAsAction="ifRoom|withText"
         android:icon="?attr/iconPhoto"
-            />
-    <item android:id="@+id/menu_settings"
-          android:title="@string/menu_settings"
-          app:showAsAction="never"
-          />
-    <item android:id="@+id/menu_about"
-          android:title="@string/menu_about"
-          app:showAsAction="never"
-          />
-    <item android:id="@+id/menu_feedback"
-          android:title="@string/menu_feedback"
-          app:showAsAction="never"
             />
     <item android:id="@+id/menu_nearby"
         android:title="@string/menu_nearby"
@@ -32,5 +18,17 @@
           android:title="@string/menu_refresh"
           app:showAsAction="never"
           />
+    <item android:id="@+id/menu_feedback"
+          android:title="@string/menu_feedback"
+          app:showAsAction="never"
+        />
+    <item android:id="@+id/menu_about"
+          android:title="@string/menu_about"
+          app:showAsAction="never"
+        />
+    <item android:id="@+id/menu_settings"
+          android:title="@string/menu_settings"
+          app:showAsAction="never"
+        />
 
 </menu>


### PR DESCRIPTION
Old ordering without icon overflow:
- Camera
- Gallery
- Settings
- About
- Feedback
- Nearby

Old ordering with icon overflow:
- Camera
- Settings
- About
- Feedback
- Nearby
- Gallery

New ordering regardless of icon overflow
- Camera
- Gallery
- Nearby
- Feedback
- About
- Settings