### PR TITLE
Use generated version name

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,8 @@ android {
 
     defaultConfig {
         applicationId 'fr.free.nrw.commons'
+        versionCode 66
+        versionName '2.1'
         minSdkVersion project.minSdkVersion
         targetSdkVersion project.targetSdkVersion
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="fr.free.nrw.commons"
-    android:versionCode="66"
-    android:versionName="2.1" >
+    package="fr.free.nrw.commons">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>

--- a/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
@@ -30,7 +30,7 @@ public class AboutActivity extends BaseActivity {
         ButterKnife.bind(this);
 
         uploadsToText.setText(CommonsApplication.EVENTLOG_WIKI);
-        versionText.setText(CommonsApplication.APPLICATION_VERSION);
+        versionText.setText(BuildConfig.VERSION_NAME);
 
         // We can't use formatted strings directly because it breaks with
         // our localization tools. Grab an HTML string and turn it into

--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -5,7 +5,6 @@ import android.accounts.AccountManager;
 import android.accounts.AuthenticatorException;
 import android.accounts.OperationCanceledException;
 import android.app.Application;
-import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.os.Build;
@@ -52,8 +51,6 @@ import fr.free.nrw.commons.caching.CacheController;
 )
 public class CommonsApplication extends Application {
 
-    public static String APPLICATION_VERSION; // Populated in onCreate. Race conditions theoretically possible, but practically not?
-
     private MWApi api;
     private Account currentAccount = null; // Unlike a savings account...
     public static final String API_URL = "https://commons.wikimedia.org/w/api.php";
@@ -84,7 +81,7 @@ public class CommonsApplication extends Application {
         final SSLSocketFactory sslSocketFactory = SSLSocketFactory.getSocketFactory();
         schemeRegistry.register(new Scheme("https", sslSocketFactory, 443));
         ClientConnectionManager cm = new ThreadSafeClientConnManager(params, schemeRegistry);
-        params.setParameter(CoreProtocolPNames.USER_AGENT, "Commons/" + APPLICATION_VERSION + " (https://mediawiki.org/wiki/Apps/Commons) Android/" + Build.VERSION.RELEASE);
+        params.setParameter(CoreProtocolPNames.USER_AGENT, "Commons/" + BuildConfig.VERSION_NAME + " (https://mediawiki.org/wiki/Apps/Commons) Android/" + Build.VERSION.RELEASE);
         return new DefaultHttpClient(cm, params);
     }
 
@@ -104,14 +101,6 @@ public class CommonsApplication extends Application {
                 .discCache(new TotalSizeLimitedDiscCache(StorageUtils.getCacheDirectory(this), 128 * 1024 * 1024))
                 .build();
         ImageLoader.getInstance().init(imageLoaderConfiguration);
-
-        try {
-            PackageInfo pInfo = getPackageManager().getPackageInfo(getPackageName(), 0);
-            APPLICATION_VERSION = pInfo.versionName;
-        } catch (PackageManager.NameNotFoundException e) {
-            // LET US WIN THE AWARD FOR DUMBEST CHECKED EXCEPTION EVER!
-            throw new RuntimeException(e);
-        }
 
         // Initialize EventLogging
         EventLog.setApp(this);

--- a/app/src/main/java/fr/free/nrw/commons/EventLog.java
+++ b/app/src/main/java/fr/free/nrw/commons/EventLog.java
@@ -90,7 +90,7 @@ public class EventLog {
                 fullData.put("wiki", CommonsApplication.EVENTLOG_WIKI);
                 data.put("device", DEVICE);
                 data.put("platform", "Android/" + Build.VERSION.RELEASE);
-                data.put("appversion", "Android/" + CommonsApplication.APPLICATION_VERSION);
+                data.put("appversion", "Android/" + BuildConfig.VERSION_NAME);
                 fullData.put("event", data);
                 return new URL(CommonsApplication.EVENTLOG_URL + "?" + Utils.urlEncode(fullData.toString()) + ";");
             } catch (MalformedURLException e) {

--- a/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
@@ -13,6 +13,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
+import fr.free.nrw.commons.BuildConfig;
 import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.EventLog;
 import fr.free.nrw.commons.Media;
@@ -154,7 +155,7 @@ public class Contribution extends Media {
 
         buffer.append("== {{int:license-header}} ==\n")
                 .append(Utils.licenseTemplateFor(getLicense())).append("\n\n")
-            .append("{{Uploaded from Mobile|platform=Android|version=").append(CommonsApplication.APPLICATION_VERSION).append("}}\n")
+            .append("{{Uploaded from Mobile|platform=Android|version=").append(BuildConfig.VERSION_NAME).append("}}\n")
             .append(getTrackingTemplates());
         return buffer.toString();
     }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -26,6 +26,7 @@ import android.widget.Toast;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import fr.free.nrw.commons.AboutActivity;
+import fr.free.nrw.commons.BuildConfig;
 import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.SettingsActivity;
@@ -136,7 +137,7 @@ public class ContributionsListFragment extends Fragment {
                 Intent feedbackIntent = new Intent(Intent.ACTION_SEND);
                 feedbackIntent.setType("message/rfc822");
                 feedbackIntent.putExtra(Intent.EXTRA_EMAIL, new String[] { CommonsApplication.FEEDBACK_EMAIL });
-                feedbackIntent.putExtra(Intent.EXTRA_SUBJECT, String.format(CommonsApplication.FEEDBACK_EMAIL_SUBJECT, CommonsApplication.APPLICATION_VERSION));
+                feedbackIntent.putExtra(Intent.EXTRA_SUBJECT, String.format(CommonsApplication.FEEDBACK_EMAIL_SUBJECT, BuildConfig.VERSION_NAME));
                 try {
                     startActivity(feedbackIntent);
                 }


### PR DESCRIPTION
The method denoted in this PR is cleaner than the way it is currently implemented, and also any concern of the race condition of `APPLICATION_VERSION` (noted [here](https://github.com/commons-app/apps-android-commons/blob/master/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java#L55)) is removed.

The method used in this PR is described [here](http://stackoverflow.com/a/21119027/3424405) whereas the current implementation is described [here](http://stackoverflow.com/a/6593822/3424405).

Note that defining the `versionCode` and `versionName` in `build.gradle` is logically equivalent to defining it in `AndroidManifest.xml` (as described [here](http://stackoverflow.com/a/32138560/3424405)). It is necessary to define these attributes in `build.gradle` as the `BuildConfig` constants wouldn't be generated otherwise.