### PR TITLE
Remove unused method implode(…)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -251,20 +251,6 @@ public class Utils {
         throw new RuntimeException("Unrecognized license value");
     }
 
-    public static String implode(String glue, Iterable<String> pieces) {
-        StringBuffer buffer = new StringBuffer();
-        boolean first = true;
-        for (String piece : pieces) {
-            if (first) {
-                first = false;
-            } else {
-                buffer.append(glue);
-            }
-            buffer.append(pieces);
-        }
-        return buffer.toString();
-    }
-
     public static Uri uriForWikiPage(String name) {
         String underscored = name.trim().replace(" ", "_");
         String uriStr = CommonsApplication.HOME_URL + urlEncode(underscored);


### PR DESCRIPTION
I found this kind of funny how long a truly useless piece of code could last for.

This method was added in 4df8ec8fa940c0ff7f7a999379bb29b17064f4a3 but was never used in that commit nor can I find a single usage of the method in the 3.5 years it's been there.

Also I tested it and it doesn't seem to of ever worked correctly anyway. The output of doing `implode(",", Arrays.asList("a", "b", "c"))` is `"[a, b, c],[a, b, c],[a, b, c]"` when it should be `"a,b,c"`. This is due to [this line](https://github.com/commons-app/apps-android-commons/blob/b4231bbfdc967faf5c83eb44104c9f23bfce57e8/app/src/main/java/fr/free/nrw/commons/Utils.java#L204) where the argument should have been `piece` instead of `pieces`. 

The functionality of this method is identical to that of `TextUtils.join(…)` so this is (and always has been) a pointless method.