### PR TITLE
Remove AsyncTask utility methods

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/EventLog.java
+++ b/app/src/main/java/fr/free/nrw/commons/EventLog.java
@@ -109,7 +109,7 @@ public class EventLog {
                 return; // User has disabled tracking
             }
             LogTask logTask = new LogTask();
-            Utils.executeAsyncTask(logTask, this);
+            logTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, this);
         }
 
         public void log() {

--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -1,7 +1,6 @@
 package fr.free.nrw.commons;
 
 import android.net.Uri;
-import android.os.AsyncTask;
 import android.os.Build;
 import android.util.Log;
 
@@ -29,7 +28,6 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
-import java.util.concurrent.Executor;
 import java.util.regex.Pattern;
 
 import javax.xml.transform.Transformer;
@@ -125,27 +123,6 @@ public class Utils {
             e.printStackTrace();
         }
         return outputStream.toString();
-    }
-
-    static public <T> void executeAsyncTask(AsyncTask<T, ?, ?> task,
-                                            T... params) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, params);
-        }
-        else {
-            task.execute(params);
-        }
-    }
-
-    static public <T> void executeAsyncTask(AsyncTask<T, ?, ?> task, Executor executor,
-                                            T... params) {
-        // FIXME: We're simply ignoring the executor on older androids
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            task.executeOnExecutor(executor, params);
-        }
-        else {
-            task.execute(params);
-        }
     }
 
     private static DisplayImageOptions.Builder defaultImageOptionsBuilder;

--- a/app/src/main/java/fr/free/nrw/commons/auth/AuthenticatedActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/AuthenticatedActivity.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 
 import fr.free.nrw.commons.theme.BaseActivity;
 import fr.free.nrw.commons.CommonsApplication;
-import fr.free.nrw.commons.Utils;
 
 public abstract class AuthenticatedActivity extends BaseActivity {
 
@@ -122,7 +121,7 @@ public abstract class AuthenticatedActivity extends BaseActivity {
             // returns, we have a deadlock!
             // Fixed by explicitly asking this to be executed in parallel
             // See: https://groups.google.com/forum/?fromgroups=#!topic/android-developers/8M0RTFfO7-M
-            Utils.executeAsyncTask(addAccountTask);
+            addAccountTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
         } else {
             GetAuthCookieTask task = new GetAuthCookieTask(curAccount, accountManager);
             task.execute();

--- a/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
@@ -43,7 +43,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import fr.free.nrw.commons.R;
-import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.upload.MwVolleyApi;
 
 /**
@@ -145,7 +144,7 @@ public class CategorizationFragment extends Fragment {
             }
         };
 
-        Utils.executeAsyncTask(titleCategoriesSub);
+        titleCategoriesSub.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
         Log.d(TAG, "TitleCatItems in titleCatQuery: " + titleCatItems);
 
         //Only return titleCatItems after API call has finished
@@ -322,8 +321,8 @@ public class CategorizationFragment extends Fragment {
                 latch.countDown();
             }
         };
-        Utils.executeAsyncTask(prefixUpdaterSub);
-        Utils.executeAsyncTask(methodAUpdaterSub);
+        prefixUpdaterSub.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        methodAUpdaterSub.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
     private void startUpdatingCategoryList() {
@@ -400,7 +399,7 @@ public class CategorizationFragment extends Fragment {
     }
 
     private void updateCategoryCount(String name) {
-        Utils.executeAsyncTask(new CategoryCountUpdater(name), executor);
+        new CategoryCountUpdater(name).executeOnExecutor(executor);
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -242,7 +242,7 @@ public class MediaDetailFragment extends Fragment {
                     }
                 }
             };
-            Utils.executeAsyncTask(detailFetchTask);
+            detailFetchTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
         } else {
             //This should not usually happen, image along with associated details should always be loaded from Internet, but keeping this for now for backup.
             //Even if image is loaded from device storage, it will display, albeit with empty desc and cat.

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
@@ -97,7 +97,7 @@ public class UploadController {
         contribution.setLicense(license);
 
         //FIXME: Add permission request here. Only executeAsyncTask if permission has been granted
-        Utils.executeAsyncTask(new AsyncTask<Void, Void, Contribution>() {
+        new AsyncTask<Void, Void, Contribution>() {
 
             // Fills up missing information about Contributions
             // Only does things that involve some form of IO
@@ -162,6 +162,6 @@ public class UploadController {
                 uploadService.queue(UploadService.ACTION_UPLOAD_FILE, contribution);
                 onComplete.onUploadStarted(contribution);
             }
-        });
+        }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 }


### PR DESCRIPTION
As `Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB` is always true [here](https://github.com/commons-app/apps-android-commons/compare/master...veyndan:async-util?expand=1#diff-ead409481556059dfc80428578e29a4bL132) and [here](https://github.com/commons-app/apps-android-commons/compare/master...veyndan:async-util?expand=1#diff-ead409481556059dfc80428578e29a4bL143), these utility methods are no longer needed as it has become an unnecessary abstraction.