### PR TITLE
Don't have default values when obtaining item from spinner

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
@@ -101,7 +101,7 @@ public class SingleUploadFragment extends Fragment {
         licenseItems.add(getString(R.string.license_name_cc_by_sa_four));
 
         prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
-        license = prefs.getString(Prefs.DEFAULT_LICENSE, Prefs.Licenses.CC_BY_SA_3);
+        license = prefs.getString(Prefs.DEFAULT_LICENSE, null);
 
         Log.d("Single Upload fragment", license);
 
@@ -152,7 +152,7 @@ public class SingleUploadFragment extends Fragment {
             selectedText.setBackgroundColor(Color.TRANSPARENT);
         }
 
-        String license = Prefs.Licenses.CC_BY_SA_3; // default value
+        String license;
         if(getString(R.string.license_name_cc0).equals(licenseName)) {
             license = Prefs.Licenses.CC0;
         } else if(getString(R.string.license_name_cc_by).equals(licenseName)) {
@@ -163,6 +163,8 @@ public class SingleUploadFragment extends Fragment {
             license = Prefs.Licenses.CC_BY_4;
         } else if(getString(R.string.license_name_cc_by_sa_four).equals(licenseName)) {
             license = Prefs.Licenses.CC_BY_SA_4;
+        } else {
+            throw new IllegalStateException("Unknown licenseName: " + licenseName);
         }
 
         setLicenseSummary(license);

--- a/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
@@ -101,7 +101,7 @@ public class SingleUploadFragment extends Fragment {
         licenseItems.add(getString(R.string.license_name_cc_by_sa_four));
 
         prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
-        license = prefs.getString(Prefs.DEFAULT_LICENSE, null);
+        license = prefs.getString(Prefs.DEFAULT_LICENSE, Prefs.Licenses.CC_BY_SA_3);
 
         Log.d("Single Upload fragment", license);
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
@@ -93,7 +93,7 @@ public class UploadController {
             contribution.setDescription("");
         }
 
-        String license = prefs.getString(Prefs.DEFAULT_LICENSE, null);
+        String license = prefs.getString(Prefs.DEFAULT_LICENSE, Prefs.Licenses.CC_BY_SA_3);
         contribution.setLicense(license);
 
         //FIXME: Add permission request here. Only executeAsyncTask if permission has been granted

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
@@ -93,7 +93,7 @@ public class UploadController {
             contribution.setDescription("");
         }
 
-        String license = prefs.getString(Prefs.DEFAULT_LICENSE, Prefs.Licenses.CC_BY_SA_3);
+        String license = prefs.getString(Prefs.DEFAULT_LICENSE, null);
         contribution.setLicense(license);
 
         //FIXME: Add permission request here. Only executeAsyncTask if permission has been granted


### PR DESCRIPTION
A spinner by definition has only one item selected, so if it is not one of those items an exception should be thrown. That's why this PR removes default values when getting the string from the spinner as this can easily be a source of bugs if a license is ever added to the spinner.