### PR TITLE
Fixes #435: Allowing state loss commit for fragment transaction

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -204,7 +204,7 @@ public  class       ShareActivity
                 this.getSupportFragmentManager()
                         .beginTransaction()
                         .add(R.id.single_upload_fragment_container, shareView, "shareView")
-                        .commit();
+                        .commitAllowingStateLoss();
         }
         uploadController.prepareService();
     }


### PR DESCRIPTION
Fixes #435. There could be several approaches for fixing the crash but in our case simply allowing `commitAllowingStateLoss` should be good enough. Feel free to take a look at these links [1](https://medium.com/inloop/demystifying-androids-commitallowingstateloss-cb9011a544cc)[2](http://stackoverflow.com/questions/14860239/checking-if-state-is-saved-before-committing-a-fragmenttransaction) for this fix. 

Also the [article](http://www.androiddesignpatterns.com/2013/08/fragment-transaction-commit-state-loss.html) explaining various use cases is also a good read. 

If the user puts the app in background after selecting a picture(either from gallery or clicking from camera) then ideally we should not commit the `SingleUploadFragment` fragment transaction. Its acceptable for us to allow for state loss rather than crashing the app. 