### PR TITLE
Refactored NearbyActivity to extract out reusable code outside of the activity 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/ViewHolder.java
+++ b/app/src/main/java/fr/free/nrw/commons/ViewHolder.java
@@ -1,0 +1,7 @@
+package fr.free.nrw.commons;
+
+import android.content.Context;
+
+public interface ViewHolder<T> {
+    void bindModel(Context context, T model);
+}

--- a/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
@@ -5,10 +5,9 @@ public class LatLng {
     public final double latitude;
     public final double longitude;
 
-    /**
-     * Accepts latitude and longitude
-     * @param latitude
-     * @param longitude
+    /** Accepts latitude and longitude.
+     * @param latitude double value
+     * @param longitude double value
      */
     public LatLng(double latitude, double longitude) {
         if(-180.0D <= longitude && longitude < 180.0D) {

--- a/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
@@ -5,6 +5,11 @@ public class LatLng {
     public final double latitude;
     public final double longitude;
 
+    /**
+     * Accepts latitude and longitude
+     * @param latitude
+     * @param longitude
+     */
     public LatLng(double latitude, double longitude) {
         if(-180.0D <= longitude && longitude < 180.0D) {
             this.longitude = longitude;

--- a/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
@@ -1,11 +1,11 @@
-package fr.free.nrw.commons.nearby;
+package fr.free.nrw.commons.location;
 
 public class LatLng {
 
     public final double latitude;
     public final double longitude;
 
-    LatLng(double latitude, double longitude) {
+    public LatLng(double latitude, double longitude) {
         if(-180.0D <= longitude && longitude < 180.0D) {
             this.longitude = longitude;
         } else {

--- a/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
@@ -12,7 +12,7 @@ public class LocationServiceManager implements LocationListener {
     public static final String TAG = "LocationServiceManager";
     private String provider;
     private LocationManager locationManager;
-    private LatLng mLatestLocation;
+    private LatLng latestLocation;
 
     public LocationServiceManager(Context context) {
         this.locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
@@ -20,17 +20,17 @@ public class LocationServiceManager implements LocationListener {
     }
 
     public LatLng getLatestLocation() {
-        return mLatestLocation;
+        return latestLocation;
     }
 
-    /**
-     * Registers a LocationManager to listen for current location
+    /** Registers a LocationManager to listen for current location
      */
     public void registerLocationManager() {
         try {
             locationManager.requestLocationUpdates(provider, 400, 1, this);
             Location location = locationManager.getLastKnownLocation(provider);
-            //Location works, just need to 'send' GPS coords via emulator extended controls if testing on emulator
+            //Location works, just need to 'send' GPS coords
+            // via emulator extended controls if testing on emulator
             Log.d(TAG, "Checking for location...");
             if (location != null) {
                 this.onLocationChanged(location);
@@ -42,6 +42,8 @@ public class LocationServiceManager implements LocationListener {
         }
     }
 
+    /** Unregisters location manager
+     */
     public void unregisterLocationManager() {
         try {
             locationManager.removeUpdates(this);
@@ -54,9 +56,10 @@ public class LocationServiceManager implements LocationListener {
     public void onLocationChanged(Location location) {
         double currentLatitude = location.getLatitude();
         double currentLongitude = location.getLongitude();
-        Log.d(TAG, "Latitude: " + String.valueOf(currentLatitude) + " Longitude: " + String.valueOf(currentLongitude));
+        Log.d(TAG, "Latitude: " + String.valueOf(currentLatitude)
+                + " Longitude: " + String.valueOf(currentLongitude));
 
-        mLatestLocation = new LatLng(currentLatitude, currentLongitude);
+        latestLocation = new LatLng(currentLatitude, currentLongitude);
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
@@ -23,7 +23,7 @@ public class LocationServiceManager implements LocationListener {
         return latestLocation;
     }
 
-    /** Registers a LocationManager to listen for current location
+    /** Registers a LocationManager to listen for current location.
      */
     public void registerLocationManager() {
         try {
@@ -42,7 +42,7 @@ public class LocationServiceManager implements LocationListener {
         }
     }
 
-    /** Unregisters location manager
+    /** Unregisters location manager.
      */
     public void unregisterLocationManager() {
         try {

--- a/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
@@ -1,0 +1,76 @@
+package fr.free.nrw.commons.location;
+
+import android.content.Context;
+import android.location.Criteria;
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
+import android.os.Bundle;
+import android.util.Log;
+
+public class LocationServiceManager implements LocationListener {
+    public static final String TAG = "LocationServiceManager";
+    private String provider;
+    private LocationManager locationManager;
+    private LatLng mLatestLocation;
+
+    public LocationServiceManager(Context context) {
+        this.locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+        provider = locationManager.getBestProvider(new Criteria(), true);
+    }
+
+    public LatLng getLatestLocation() {
+        return mLatestLocation;
+    }
+
+    /**
+     * Registers a LocationManager to listen for current location
+     */
+    public void registerLocationManager() {
+        try {
+            locationManager.requestLocationUpdates(provider, 400, 1, this);
+            Location location = locationManager.getLastKnownLocation(provider);
+            //Location works, just need to 'send' GPS coords via emulator extended controls if testing on emulator
+            Log.d(TAG, "Checking for location...");
+            if (location != null) {
+                this.onLocationChanged(location);
+            }
+        } catch (IllegalArgumentException e) {
+            Log.e(TAG, "Illegal argument exception", e);
+        } catch (SecurityException e) {
+            Log.e(TAG, "Security exception", e);
+        }
+    }
+
+    public void unregisterLocationManager() {
+        try {
+            locationManager.removeUpdates(this);
+        } catch (SecurityException e) {
+            Log.e(TAG, "Security exception", e);
+        }
+    }
+
+    @Override
+    public void onLocationChanged(Location location) {
+        double currentLatitude = location.getLatitude();
+        double currentLongitude = location.getLongitude();
+        Log.d(TAG, "Latitude: " + String.valueOf(currentLatitude) + " Longitude: " + String.valueOf(currentLongitude));
+
+        mLatestLocation = new LatLng(currentLatitude, currentLongitude);
+    }
+
+    @Override
+    public void onStatusChanged(String provider, int status, Bundle extras) {
+        Log.d(TAG, provider + "'s status changed to " + status);
+    }
+
+    @Override
+    public void onProviderEnabled(String provider) {
+        Log.d(TAG, "Provider " + provider + " enabled");
+    }
+
+    @Override
+    public void onProviderDisabled(String provider) {
+        Log.d(TAG, "Provider " + provider + " disabled");
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -1,30 +1,18 @@
 package fr.free.nrw.commons.nearby;
 
-import android.content.Context;
-import android.location.Criteria;
-import android.location.Location;
-import android.location.LocationListener;
-import android.location.LocationManager;
 import android.os.Bundle;
 import android.support.v4.app.FragmentTransaction;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 
-import fr.free.nrw.commons.theme.BaseActivity;
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.location.LocationServiceManager;
+import fr.free.nrw.commons.theme.BaseActivity;
 
 public class NearbyActivity extends BaseActivity {
 
-    private MyLocationListener myLocationListener;
-    private LocationManager locationManager;
-    private String provider;
-    private Criteria criteria;
-    private LatLng mLatestLocation;
-
-    private double currentLatitude, currentLongitude;
-    //private String gpsCoords;
+    private LocationServiceManager locationManager;
 
     private static final String TAG = NearbyActivity.class.getName();
 
@@ -35,7 +23,8 @@ public class NearbyActivity extends BaseActivity {
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
-        registerLocationManager();
+        locationManager = new LocationServiceManager(this);
+        locationManager.registerLocationManager();
 
         // Begin the transaction
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
@@ -70,75 +59,10 @@ public class NearbyActivity extends BaseActivity {
         getSupportFragmentManager().beginTransaction()
                 .replace(R.id.container, new NearbyListFragment()).commit();
     }
-    protected LatLng getmLatestLocation() {
-        return mLatestLocation;
-    }
-    /**
-     * Registers a LocationManager to listen for current location
-     */
-    protected void registerLocationManager() {
-        locationManager = (LocationManager) this.getSystemService(Context.LOCATION_SERVICE);
-        criteria = new Criteria();
-        provider = locationManager.getBestProvider(criteria, true);
-        myLocationListener = new MyLocationListener();
-
-        try {
-            locationManager.requestLocationUpdates(provider, 400, 1, myLocationListener);
-            Location location = locationManager.getLastKnownLocation(provider);
-            //Location works, just need to 'send' GPS coords via emulator extended controls if testing on emulator
-            Log.d(TAG, "Checking for location...");
-            if (location != null) {
-                myLocationListener.onLocationChanged(location);
-            }
-        } catch (IllegalArgumentException e) {
-            Log.e(TAG, "Illegal argument exception", e);
-        } catch (SecurityException e) {
-            Log.e(TAG, "Security exception", e);
-        }
-    }
-
-    protected void unregisterLocationManager() {
-        try {
-            locationManager.removeUpdates(myLocationListener);
-        } catch (SecurityException e) {
-            Log.e(TAG, "Security exception", e);
-        }
-    }
-
-    /**
-     * Listen for user's location when it changes
-     */
-    private class MyLocationListener implements LocationListener {
-
-        @Override
-        public void onLocationChanged(Location location) {
-            currentLatitude = location.getLatitude();
-            currentLongitude = location.getLongitude();
-            Log.d(TAG, "Latitude: " + String.valueOf(currentLatitude) + " Longitude: " + String.valueOf(currentLongitude));
-
-            mLatestLocation = new LatLng(currentLatitude, currentLongitude);
-        }
-
-        @Override
-        public void onStatusChanged(String provider, int status, Bundle extras) {
-            Log.d(TAG, provider + "'s status changed to " + status);
-        }
-
-        @Override
-        public void onProviderEnabled(String provider) {
-            Log.d(TAG, "Provider " + provider + " enabled");
-        }
-
-        @Override
-        public void onProviderDisabled(String provider) {
-            Log.d(TAG, "Provider " + provider + " disabled");
-        }
-    }
 
     @Override
     protected void onDestroy(){
         super.onDestroy();
-
-        unregisterLocationManager();
+        locationManager.unregisterLocationManager();
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyAdapter.java
@@ -1,0 +1,45 @@
+package fr.free.nrw.commons.nearby;
+
+import android.content.Context;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+
+import java.util.List;
+
+import fr.free.nrw.commons.R;
+
+public class NearbyAdapter extends ArrayAdapter<Place> {
+    public List<Place> placesList;
+    private Context mContext;
+
+    public NearbyAdapter(Context context, List<Place> places) {
+        super(context, R.layout.item_place, places);
+        this.mContext = context;
+        placesList = places;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        // Get the data item for this position
+        Place place = getItem(position);
+        Log.d("NearbyAdapter", "Place " + place.name);
+
+        // Check if an existing view is being reused, otherwise inflate the view
+        if (convertView == null) {
+            convertView = LayoutInflater.from(getContext()).inflate(R.layout.item_place, parent, false);
+        }
+
+        NearbyViewHolder viewHolder = new NearbyViewHolder(convertView);
+        viewHolder.bindModel(mContext, place);
+        // Return the completed view to render on screen
+        return convertView;
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyAdapter.java
@@ -7,9 +7,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 
-import java.util.List;
-
 import fr.free.nrw.commons.R;
+
+import java.util.List;
 
 public class NearbyAdapter extends ArrayAdapter<Place> {
     private List<Place> placesList;
@@ -19,9 +19,9 @@ public class NearbyAdapter extends ArrayAdapter<Place> {
         return placesList;
     }
 
-    /** Accepts activity context and list of places
-     * @param context
-     * @param places
+    /** Accepts activity context and list of places.
+     * @param context activity context
+     * @param places list of places
      */
     public NearbyAdapter(Context context, List<Place> places) {
         super(context, R.layout.item_place, places);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyAdapter.java
@@ -12,12 +12,20 @@ import java.util.List;
 import fr.free.nrw.commons.R;
 
 public class NearbyAdapter extends ArrayAdapter<Place> {
-    public List<Place> placesList;
-    private Context mContext;
+    private List<Place> placesList;
+    private Context context;
 
+    public List<Place> getPlacesList() {
+        return placesList;
+    }
+
+    /** Accepts activity context and list of places
+     * @param context
+     * @param places
+     */
     public NearbyAdapter(Context context, List<Place> places) {
         super(context, R.layout.item_place, places);
-        this.mContext = context;
+        this.context = context;
         placesList = places;
     }
 
@@ -29,11 +37,12 @@ public class NearbyAdapter extends ArrayAdapter<Place> {
 
         // Check if an existing view is being reused, otherwise inflate the view
         if (convertView == null) {
-            convertView = LayoutInflater.from(getContext()).inflate(R.layout.item_place, parent, false);
+            convertView = LayoutInflater.from(getContext())
+                    .inflate(R.layout.item_place, parent, false);
         }
 
         NearbyViewHolder viewHolder = new NearbyViewHolder(convertView);
-        viewHolder.bindModel(mContext, place);
+        viewHolder.bindModel(context, place);
         // Return the completed view to render on screen
         return convertView;
     }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
@@ -12,10 +12,6 @@ import android.view.ViewGroup;
 import android.widget.ListView;
 import android.widget.ProgressBar;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnItemClick;
@@ -25,6 +21,10 @@ import fr.free.nrw.commons.location.LocationServiceManager;
 
 import static fr.free.nrw.commons.utils.LengthUtils.computeDistanceBetween;
 import static fr.free.nrw.commons.utils.LengthUtils.formatDistanceBetween;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
 public class NearbyListFragment extends ListFragment implements TaskListener {
 
@@ -166,14 +166,18 @@ public class NearbyListFragment extends ListFragment implements TaskListener {
         }
     }
 
-    @OnItemClick(R.id.listview) void onItemClicked(int position) {
+    @OnItemClick(R.id.listview)
+    void onItemClicked(int position) {
         Place place = places.get(position);
         LatLng placeLatLng = place.location;
 
         double latitude = placeLatLng.latitude;
         double longitude = placeLatLng.longitude;
 
-        Log.d(TAG, "Item at position " + position + " has coords: Lat: " + latitude + " Long: " + longitude);
+        Log.d(TAG, "Item at position "
+                + position + " has coords: Lat: "
+                + latitude + " Long: "
+                + longitude);
 
         //Open map app at given position
         Uri gmmIntentUri = Uri.parse("geo:0,0?q=" + latitude + "," + longitude);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.OnItemClick;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.utils.ResourceUtils;
 
@@ -164,29 +165,26 @@ public class NearbyListFragment extends ListFragment implements TaskListener {
 
             listview.setAdapter(mAdapter);
 
-            listview.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-                @Override
-                public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-
-                    Place place = places.get(position);
-                    LatLng placeLatLng = place.location;
-
-                    double latitude = placeLatLng.latitude;
-                    double longitude = placeLatLng.longitude;
-
-                    Log.d(TAG, "Item at position " + position + " has coords: Lat: " + latitude + " Long: " + longitude);
-
-                    //Open map app at given position
-                    Uri gmmIntentUri = Uri.parse("geo:0,0?q=" + latitude + "," + longitude);
-                    Intent mapIntent = new Intent(Intent.ACTION_VIEW, gmmIntentUri);
-
-                    if (mapIntent.resolveActivity(getActivity().getPackageManager()) != null) {
-                        startActivity(mapIntent);
-                    }
-                }
-            });
             listener.onTaskFinished(result);
             mAdapter.notifyDataSetChanged();
+        }
+    }
+
+    @OnItemClick(R.id.listview) void onItemClicked(int position) {
+        Place place = places.get(position);
+        LatLng placeLatLng = place.location;
+
+        double latitude = placeLatLng.latitude;
+        double longitude = placeLatLng.longitude;
+
+        Log.d(TAG, "Item at position " + position + " has coords: Lat: " + latitude + " Long: " + longitude);
+
+        //Open map app at given position
+        Uri gmmIntentUri = Uri.parse("geo:0,0?q=" + latitude + "," + longitude);
+        Intent mapIntent = new Intent(Intent.ACTION_VIEW, gmmIntentUri);
+
+        if (mapIntent.resolveActivity(getActivity().getPackageManager()) != null) {
+            startActivity(mapIntent);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.nearby;
 
-import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -10,12 +9,8 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
-import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.ProgressBar;
-import android.widget.TextView;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -25,7 +20,8 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnItemClick;
 import fr.free.nrw.commons.R;
-import fr.free.nrw.commons.utils.ResourceUtils;
+import fr.free.nrw.commons.location.LatLng;
+import fr.free.nrw.commons.location.LocationServiceManager;
 
 import static fr.free.nrw.commons.utils.LengthUtils.computeDistanceBetween;
 import static fr.free.nrw.commons.utils.LengthUtils.formatDistanceBetween;
@@ -69,7 +65,7 @@ public class NearbyListFragment extends ListFragment implements TaskListener {
 
         //Check that this is the first time view is created, to avoid double list when screen orientation changed
         if(savedInstanceState == null) {
-            mLatestLocation = ((NearbyActivity) getActivity()).getmLatestLocation();
+            mLatestLocation = new LocationServiceManager(getActivity()).getLatestLocation();
             nearbyAsyncTask = new NearbyAsyncTask(this);
             nearbyAsyncTask.execute();
             progressBar.setVisibility(View.VISIBLE);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
@@ -19,12 +19,12 @@ import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.location.LatLng;
 import fr.free.nrw.commons.location.LocationServiceManager;
 
-import static fr.free.nrw.commons.utils.LengthUtils.computeDistanceBetween;
-import static fr.free.nrw.commons.utils.LengthUtils.formatDistanceBetween;
-
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+
+import static fr.free.nrw.commons.utils.LengthUtils.computeDistanceBetween;
+import static fr.free.nrw.commons.utils.LengthUtils.formatDistanceBetween;
 
 public class NearbyListFragment extends ListFragment implements TaskListener {
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
@@ -190,53 +190,6 @@ public class NearbyListFragment extends ListFragment implements TaskListener {
         }
     }
 
-    private class NearbyAdapter extends ArrayAdapter<Place> {
-
-        public List<Place> placesList;
-        private Context mContext;
-
-        public NearbyAdapter(Context context, List<Place> places) {
-            super(context, R.layout.item_place, places);
-            mContext = context;
-            placesList = places;
-        }
-
-        @Override
-        public View getView(int position, View convertView, ViewGroup parent) {
-            // Get the data item for this position
-            Place place = getItem(position);
-            Log.d(TAG, "Place " + place.name);
-
-            // Check if an existing view is being reused, otherwise inflate the view
-            if (convertView == null) {
-                convertView = LayoutInflater.from(getContext()).inflate(R.layout.item_place, parent, false);
-            }
-
-            // Lookup view for data population
-            TextView tvName = (TextView) convertView.findViewById(R.id.tvName);
-            TextView tvDesc = (TextView) convertView.findViewById(R.id.tvDesc);
-            TextView distance = (TextView) convertView.findViewById(R.id.distance);
-            ImageView icon = (ImageView) convertView.findViewById(R.id.icon);
-
-            String quotelessName = place.name.replaceAll("^\"|\"$", "");
-
-            // Populate the data into the template view using the data object
-            tvName.setText(quotelessName);
-            tvDesc.setText(place.description);
-            distance.setText(place.distance);
-
-            icon.setImageResource(ResourceUtils.getDescriptionIcon(place.description));
-
-            // Return the completed view to render on screen
-            return convertView;
-        }
-
-        @Override
-        public long getItemId(int position) {
-            return position;
-        }
-    }
-
     private List<Place> loadAttractionsFromLocation(final LatLng curLatLng) {
 
         List<Place> places = NearbyPlaces.get();

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
@@ -1,5 +1,8 @@
 package fr.free.nrw.commons.nearby;
 
+import static fr.free.nrw.commons.utils.LengthUtils.computeDistanceBetween;
+import static fr.free.nrw.commons.utils.LengthUtils.formatDistanceBetween;
+
 import android.content.Intent;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -22,9 +25,6 @@ import fr.free.nrw.commons.location.LocationServiceManager;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-
-import static fr.free.nrw.commons.utils.LengthUtils.computeDistanceBetween;
-import static fr.free.nrw.commons.utils.LengthUtils.formatDistanceBetween;
 
 public class NearbyListFragment extends ListFragment implements TaskListener {
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
@@ -3,6 +3,8 @@ package fr.free.nrw.commons.nearby;
 import android.os.StrictMode;
 import android.util.Log;
 
+import fr.free.nrw.commons.location.LatLng;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -10,7 +12,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import fr.free.nrw.commons.location.LatLng;
 
 public class NearbyPlaces {
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
@@ -10,6 +10,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import fr.free.nrw.commons.location.LatLng;
+
 public class NearbyPlaces {
 
     private static final String TAG = NearbyPlaces.class.getName();

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyViewHolder.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyViewHolder.java
@@ -1,0 +1,35 @@
+package fr.free.nrw.commons.nearby;
+
+import android.content.Context;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.ViewHolder;
+import fr.free.nrw.commons.utils.ResourceUtils;
+
+public class NearbyViewHolder implements ViewHolder<Place> {
+    @BindView(R.id.tvName) TextView tvName;
+    @BindView(R.id.tvDesc) TextView tvDesc;
+    @BindView(R.id.distance) TextView distance;
+    @BindView(R.id.icon) ImageView icon;
+
+    public NearbyViewHolder(View view) {
+        ButterKnife.bind(this, view);
+    }
+
+    @Override
+    public void bindModel(Context context, Place place) {
+        String quotelessName = place.name.replaceAll("^\"|\"$", "");
+
+        // Populate the data into the template view using the data object
+        tvName.setText(quotelessName);
+        tvDesc.setText(place.description);
+        distance.setText(place.distance);
+
+        icon.setImageResource(ResourceUtils.getDescriptionIcon(place.description));
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
@@ -3,6 +3,8 @@ package fr.free.nrw.commons.nearby;
 import android.graphics.Bitmap;
 import android.net.Uri;
 
+import fr.free.nrw.commons.location.LatLng;
+
 public class Place {
 
     public String name;

--- a/app/src/main/java/fr/free/nrw/commons/utils/LengthUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/LengthUtils.java
@@ -5,10 +5,10 @@ import fr.free.nrw.commons.location.LatLng;
 import java.text.NumberFormat;
 
 public class LengthUtils {
-    /** Returns a formatted distance string between two points
-     * @param point1
-     * @param point2
-     * @return
+    /** Returns a formatted distance string between two points.
+     * @param point1 LatLng type point1
+     * @param point2 LatLng type point2
+     * @return string distance
      */
     public static String formatDistanceBetween(LatLng point1, LatLng point2) {
         if (point1 == null || point2 == null) {

--- a/app/src/main/java/fr/free/nrw/commons/utils/LengthUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/LengthUtils.java
@@ -1,0 +1,49 @@
+package fr.free.nrw.commons.utils;
+
+import java.text.NumberFormat;
+
+import fr.free.nrw.commons.nearby.LatLng;
+
+public class LengthUtils {
+    public static String formatDistanceBetween(LatLng point1, LatLng point2) {
+        if (point1 == null || point2 == null) {
+            return null;
+        }
+
+        NumberFormat numberFormat = NumberFormat.getNumberInstance();
+        double distance = Math.round(computeDistanceBetween(point1, point2));
+
+        // Adjust to KM if M goes over 1000 (see javadoc of method for note
+        // on only supporting metric)
+        if (distance >= 1000) {
+            numberFormat.setMaximumFractionDigits(1);
+            return numberFormat.format(distance / 1000) + "km";
+        }
+        return numberFormat.format(distance) + "m";
+    }
+
+    public static double computeDistanceBetween(LatLng from, LatLng to) {
+        return computeAngleBetween(from, to) * 6371009.0D;
+    }
+
+    private static double computeAngleBetween(LatLng from, LatLng to) {
+        return distanceRadians(Math.toRadians(from.latitude), Math.toRadians(from.longitude), Math.toRadians(to.latitude), Math.toRadians(to.longitude));
+    }
+
+    private static double distanceRadians(double lat1, double lng1, double lat2, double lng2) {
+        return arcHav(havDistance(lat1, lat2, lng1 - lng2));
+    }
+
+    private static double arcHav(double x) {
+        return 2.0D * Math.asin(Math.sqrt(x));
+    }
+
+    private static double havDistance(double lat1, double lat2, double dLng) {
+        return hav(lat1 - lat2) + hav(dLng) * Math.cos(lat1) * Math.cos(lat2);
+    }
+
+    private static double hav(double x) {
+        double sinHalf = Math.sin(x * 0.5D);
+        return sinHalf * sinHalf;
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/utils/LengthUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/LengthUtils.java
@@ -2,7 +2,7 @@ package fr.free.nrw.commons.utils;
 
 import java.text.NumberFormat;
 
-import fr.free.nrw.commons.nearby.LatLng;
+import fr.free.nrw.commons.location.LatLng;
 
 public class LengthUtils {
     public static String formatDistanceBetween(LatLng point1, LatLng point2) {

--- a/app/src/main/java/fr/free/nrw/commons/utils/LengthUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/LengthUtils.java
@@ -1,10 +1,15 @@
 package fr.free.nrw.commons.utils;
 
-import java.text.NumberFormat;
-
 import fr.free.nrw.commons.location.LatLng;
 
+import java.text.NumberFormat;
+
 public class LengthUtils {
+    /** Returns a formatted distance string between two points
+     * @param point1
+     * @param point2
+     * @return
+     */
     public static String formatDistanceBetween(LatLng point1, LatLng point2) {
         if (point1 == null || point2 == null) {
             return null;
@@ -27,7 +32,10 @@ public class LengthUtils {
     }
 
     private static double computeAngleBetween(LatLng from, LatLng to) {
-        return distanceRadians(Math.toRadians(from.latitude), Math.toRadians(from.longitude), Math.toRadians(to.latitude), Math.toRadians(to.longitude));
+        return distanceRadians(Math.toRadians(from.latitude),
+                Math.toRadians(from.longitude),
+                Math.toRadians(to.latitude),
+                Math.toRadians(to.longitude));
     }
 
     private static double distanceRadians(double lat1, double lng1, double lat2, double lng2) {
@@ -38,8 +46,8 @@ public class LengthUtils {
         return 2.0D * Math.asin(Math.sqrt(x));
     }
 
-    private static double havDistance(double lat1, double lat2, double dLng) {
-        return hav(lat1 - lat2) + hav(dLng) * Math.cos(lat1) * Math.cos(lat2);
+    private static double havDistance(double lat1, double lat2, double longitude) {
+        return hav(lat1 - lat2) + hav(longitude) * Math.cos(lat1) * Math.cos(lat2);
     }
 
     private static double hav(double x) {

--- a/app/src/main/java/fr/free/nrw/commons/utils/ResourceUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ResourceUtils.java
@@ -8,15 +8,16 @@ public class ResourceUtils {
 
     /**
      * See https://github.com/commons-app/apps-android-commons/issues/250
-     * Most common types of desc: building, house, cottage, farmhouse, village, civil parish, church, railway station,
+     * Most common types of desc: building, house, cottage, farmhouse,
+     * village, civil parish, church, railway station,
      * gatehouse, milestone, inn, secondary school, hotel
      * @param description Place description
-     * @return
+     * @return icon res id
      */
     @DrawableRes
     public static int getDescriptionIcon(String description) {
         int resourceId;
-        switch(description) {
+        switch (description) {
             case "building":
                 resourceId = R.drawable.round_icon_generic_building;
                 break;

--- a/app/src/main/java/fr/free/nrw/commons/utils/ResourceUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ResourceUtils.java
@@ -1,0 +1,88 @@
+package fr.free.nrw.commons.utils;
+
+import android.support.annotation.DrawableRes;
+
+import fr.free.nrw.commons.R;
+
+public class ResourceUtils {
+
+    /**
+     * See https://github.com/commons-app/apps-android-commons/issues/250
+     * Most common types of desc: building, house, cottage, farmhouse, village, civil parish, church, railway station,
+     * gatehouse, milestone, inn, secondary school, hotel
+     * @param description Place description
+     * @return
+     */
+    @DrawableRes
+    public static int getDescriptionIcon(String description) {
+        int resourceId;
+        switch(description) {
+            case "building":
+                resourceId = R.drawable.round_icon_generic_building;
+                break;
+            case "house":
+                resourceId = R.drawable.round_icon_house;
+                break;
+            case "cottage":
+                resourceId = R.drawable.round_icon_house;
+                break;
+            case "farmhouse":
+                resourceId = R.drawable.round_icon_house;
+                break;
+            case "church":
+                resourceId = R.drawable.round_icon_church;
+                break;
+            case "railway station":
+                resourceId = R.drawable.round_icon_railway_station;
+                break;
+            case "gatehouse":
+                resourceId = R.drawable.round_icon_gatehouse;
+                break;
+            case "milestone":
+                resourceId = R.drawable.round_icon_milestone;
+                break;
+            case "inn":
+                resourceId = R.drawable.round_icon_house;
+                break;
+            case "city":
+                resourceId = R.drawable.round_icon_city;
+                break;
+            case "secondary school":
+                resourceId = R.drawable.round_icon_school;
+                break;
+            case "edu":
+                resourceId = R.drawable.round_icon_school;
+                break;
+            case "isle":
+                resourceId = R.drawable.round_icon_island;
+                break;
+            case "mountain":
+                resourceId = R.drawable.round_icon_mountain;
+                break;
+            case "airport":
+                resourceId = R.drawable.round_icon_airport;
+                break;
+            case "bridge":
+                resourceId = R.drawable.round_icon_bridge;
+                break;
+            case "road":
+                resourceId = R.drawable.round_icon_road;
+                break;
+            case "forest":
+                resourceId = R.drawable.round_icon_forest;
+                break;
+            case "park":
+                resourceId = R.drawable.round_icon_park;
+                break;
+            case "river":
+                resourceId = R.drawable.round_icon_river;
+                break;
+            case "waterfall":
+                resourceId = R.drawable.round_icon_waterfall;
+                break;
+            default:
+                resourceId = R.drawable.round_icon_unknown;
+        }
+        return resourceId;
+    }
+}


### PR DESCRIPTION
Have refactored the `NearbyActivity` and `NearbyListFragment` to make it a lot cleaner. 

- Moved out length/distance calculation utils methods to `LengthUtils`
- Create `ResourceUtils` for getting appropriate icon resource based on `Place` description 
- Created `NearbyAdapter` and `NearbyViewHolder` outside of the activity class. This way it can be used in other activities too in the future. 
- Started [using Butterknife](https://github.com/commons-app/apps-android-commons/wiki/Code-Style) for the view bindings.
- Created `LocationServiceManager` to fetch location. This would enable its usage in other places as well. 

Have tested that the Nearby Places page works as expected. 