### PR TITLE
Update Quadtree dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,9 +2,7 @@ apply plugin: 'com.android.application'
 apply from: 'quality.gradle'
 
 dependencies {
-    compile ('com.github.nicolas-raoul:Quadtree:349eb842356bae') {
-        exclude module: 'junit'
-    }
+    compile 'com.github.nicolas-raoul:Quadtree:ac16ea8035bf07'
     compile 'fr.avianey.com.viewpagerindicator:library:2.4.1.1@aar'
     compile 'in.yuvi:http.fluent:1.3'
     compile 'com.android.volley:volley:1.0.0'


### PR DESCRIPTION
Exclusion of transitive dependency no longer required as noted at Quadtree-org/Quadtree#2.