### PR TITLE
Use getString(…) with formatArgs

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -202,12 +202,12 @@ public class UploadService extends HandlerService<Contribution> {
                 .setSmallIcon(R.drawable.ic_launcher)
                 .setLargeIcon(BitmapFactory.decodeResource(getResources(), R.drawable.ic_launcher))
                 .setAutoCancel(true)
-                .setContentTitle(String.format(getString(R.string.upload_progress_notification_title_start), contribution.getDisplayTitle()))
+                .setContentTitle(getString(R.string.upload_progress_notification_title_start, contribution.getDisplayTitle()))
                 .setContentText(getResources().getQuantityString(R.plurals.uploads_pending_notification_indicator, toUpload, toUpload))
                 .setOngoing(true)
                 .setProgress(100, 0, true)
                 .setContentIntent(PendingIntent.getActivity(getApplicationContext(), 0, new Intent(this, ContributionsActivity.class), 0))
-                .setTicker(String.format(getString(R.string.upload_progress_notification_title_in_progress), contribution.getDisplayTitle()));
+                .setTicker(getString(R.string.upload_progress_notification_title_in_progress, contribution.getDisplayTitle()));
 
         this.startForeground(NOTIFICATION_UPLOAD_IN_PROGRESS, curProgressNotification.build());
 
@@ -236,8 +236,8 @@ public class UploadService extends HandlerService<Contribution> {
                 }
             }
             NotificationUpdateProgressListener notificationUpdater = new NotificationUpdateProgressListener(notificationTag,
-                    String.format(getString(R.string.upload_progress_notification_title_in_progress), contribution.getDisplayTitle()),
-                    String.format(getString(R.string.upload_progress_notification_title_finishing), contribution.getDisplayTitle()),
+                    getString(R.string.upload_progress_notification_title_in_progress, contribution.getDisplayTitle()),
+                    getString(R.string.upload_progress_notification_title_finishing, contribution.getDisplayTitle()),
                     contribution
             );
             result = api.upload(filename, file, contribution.getDataLength(), contribution.getPageContents(), contribution.getEditSummary(), notificationUpdater);
@@ -298,8 +298,8 @@ public class UploadService extends HandlerService<Contribution> {
                 .setSmallIcon(R.drawable.ic_launcher)
                 .setAutoCancel(true)
                 .setContentIntent(PendingIntent.getActivity(this, 0, new Intent(this, ContributionsActivity.class), 0))
-                .setTicker(String.format(getString(R.string.upload_failed_notification_title), contribution.getDisplayTitle()))
-                .setContentTitle(String.format(getString(R.string.upload_failed_notification_title), contribution.getDisplayTitle()))
+                .setTicker(getString(R.string.upload_failed_notification_title, contribution.getDisplayTitle()))
+                .setContentTitle(getString(R.string.upload_failed_notification_title, contribution.getDisplayTitle()))
                 .setContentText(getString(R.string.upload_failed_notification_subtitle))
                 .build();
         notificationManager.notify(NOTIFICATION_UPLOAD_FAILED, failureNotification);


### PR DESCRIPTION
Doing so allows Android to pass the locale into `String.format(…)` for us, as evident by the source code `Resources#getString(int, Object...)`.