### PR TITLE
Skip CSV header outside of while loop

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
@@ -32,18 +32,13 @@ public class NearbyPlaces {
 
                 BufferedReader in = new BufferedReader(new InputStreamReader(file.openStream()));
 
-                boolean firstLine = true;
+                // Skip CSV header.
+                in.readLine();
+
                 String line;
                 Log.d(TAG, "Reading from CSV file...");
 
                 while ((line = in.readLine()) != null) {
-
-                    // Skip CSV header.
-                    if (firstLine) {
-                        firstLine = false;
-                        continue;
-                    }
-
                     String[] fields = line.split(",");
                     String name = fields[0];
 


### PR DESCRIPTION
Considering we know that the variable `firstLine` is only true on the first pass of the while loop, we are able to take it out of the while loop. As the while loop is very expensive, iterating over hundreds of thousand of times, it seems redundant to do such a comparison (i.e. `if (firstLine)`) that many times when the outcome is deterministic and easy to write.