### PR TITLE
Keep obsolete license values to prevent crashe after upgrade

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -214,6 +214,10 @@ public class Utils {
             return "{{self|cc-by-sa-4.0}}";
         } else if (license.equals(Prefs.Licenses.CC0)) {
             return "{{self|cc-zero}}";
+        } else if (license.equals(Prefs.Licenses.CC_BY)) {
+            return "{{self|cc-by-3.0}}";
+        } else if (license.equals(Prefs.Licenses.CC_BY_SA)) {
+            return "{{self|cc-by-sa-3.0}}";
         }
         throw new RuntimeException("Unrecognized license value");
     }
@@ -229,6 +233,10 @@ public class Utils {
             return R.string.license_name_cc_by_sa_four;
         } else if (license.equals(Prefs.Licenses.CC0)) {
             return R.string.license_name_cc0;
+        } else if (license.equals(Prefs.Licenses.CC_BY)) { // for backward compatibility to v2.1
+            return R.string.license_name_cc_by_3_0;
+        } else if (license.equals(Prefs.Licenses.CC_BY_SA)) { // for backward compatibility to v2.1
+            return R.string.license_name_cc_by_sa_3_0;
         }
         throw new RuntimeException("Unrecognized license value");
     }

--- a/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
@@ -12,5 +12,9 @@ public class Prefs {
         public static final String CC_BY_SA_4 = "CC BY-SA 4.0";
         public static final String CC_BY_4 = "CC BY 4.0";
         public static final String CC0 = "CC0";
+
+        // kept for backward compatibility to v2.1
+        @Deprecated public static final String CC_BY = "CC BY";
+        @Deprecated public static final String CC_BY_SA = "CC BY-SA";
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -19,6 +19,22 @@ public class SettingsFragment extends PreferenceFragment {
 
         // Update spinner to show selected value as summary
         ListPreference licensePreference = (ListPreference) findPreference(Prefs.DEFAULT_LICENSE);
+        // WARNING: ORDERING NEEDS TO MATCH FOR THE LICENSE NAMES AND DISPLAY VALUES
+        licensePreference.setEntries(new String[]{
+                getString(R.string.license_name_cc0),
+                getString(R.string.license_name_cc_by_3_0),
+                getString(R.string.license_name_cc_by_4_0),
+                getString(R.string.license_name_cc_by_sa_3_0),
+                getString(R.string.license_name_cc_by_sa_4_0)
+        });
+        licensePreference.setEntryValues(new String[]{
+                Prefs.Licenses.CC0,
+                Prefs.Licenses.CC_BY_3,
+                Prefs.Licenses.CC_BY_4,
+                Prefs.Licenses.CC_BY_SA_3,
+                Prefs.Licenses.CC_BY_SA_4
+        });
+
         licensePreference.setSummary(getString(Utils.licenseNameFor(licensePreference.getValue())));
         licensePreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
             @Override


### PR DESCRIPTION
A follow-up to #478, trying to solve #506.
