### PR TITLE
Get coordinate template when parsing image page

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Media.java
+++ b/app/src/main/java/fr/free/nrw/commons/Media.java
@@ -163,7 +163,7 @@ public class Media implements Parcelable {
     protected int width;
     protected int height;
     protected String license;
-    protected String coordinates;
+    private String coordinates;
     protected String creator;
     protected ArrayList<String> categories; // as loaded at runtime?
     protected Map<String, String> descriptions; // multilingual descriptions as loaded

--- a/app/src/main/java/fr/free/nrw/commons/Media.java
+++ b/app/src/main/java/fr/free/nrw/commons/Media.java
@@ -144,6 +144,14 @@ public class Media implements Parcelable {
         this.license = license;
     }
 
+    public String getCoordinates() {
+        return coordinates;
+    }
+
+    public void setCoordinates(String coordinates) {
+        this.coordinates = coordinates;
+    }
+
     // Primary metadata fields
     protected Uri localUri;
     protected String imageUrl;
@@ -155,6 +163,7 @@ public class Media implements Parcelable {
     protected int width;
     protected int height;
     protected String license;
+    protected String coordinates;
     protected String creator;
     protected ArrayList<String> categories; // as loaded at runtime?
     protected Map<String, String> descriptions; // multilingual descriptions as loaded

--- a/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
@@ -1,5 +1,7 @@
 package fr.free.nrw.commons;
 
+import fr.free.nrw.commons.location.LatLng;
+
 import org.mediawiki.api.ApiResult;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -20,7 +22,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import fr.free.nrw.commons.location.LatLng;
 import timber.log.Timber;
 
 /**

--- a/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
@@ -271,7 +271,7 @@ public class MediaDataExtractor {
      *
      * @param parentNode The node of the coordinates template.
      * @return Pretty formatted coordinates.
-     * @throws IOException
+     * @throws IOException Parsing failed.
      */
     private String getCoordinates(Node parentNode) throws IOException {
         NodeList childNodes = parentNode.getChildNodes();

--- a/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
@@ -20,6 +20,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import fr.free.nrw.commons.location.LatLng;
 import timber.log.Timber;
 
 /**
@@ -252,18 +253,6 @@ public class MediaDataExtractor {
     }
 
     /**
-     * Rounds the float to 4 digits.
-     *
-     * @param coordinate A coordinate value as string.
-     * @return String of the rounded number.
-     */
-    private String formatCoordinate(String coordinate) {
-        Float floatNumber = Float.parseFloat(coordinate);
-        double roundedNumber = Math.round(floatNumber * 10000d) / 10000d;
-        return String.valueOf(roundedNumber);
-    }
-
-    /**
      * Extracts the coordinates from the template and returns them as pretty formatted string.
      * Loops over the children of the coordinate template:
      *      {{Location|47.50111007666667|19.055700301944444}}
@@ -275,9 +264,11 @@ public class MediaDataExtractor {
      */
     private String getCoordinates(Node parentNode) throws IOException {
         NodeList childNodes = parentNode.getChildNodes();
-        String latitudeText = formatCoordinate(childNodes.item(1).getTextContent());
-        String longitudeText = formatCoordinate(childNodes.item(2).getTextContent());
-        return latitudeText + " N," + longitudeText + " E";
+        double latitudeText = Double.parseDouble(childNodes.item(1).getTextContent());
+        double longitudeText = Double.parseDouble(childNodes.item(2).getTextContent());
+        LatLng coordinates = new LatLng(latitudeText, longitudeText);
+
+        return coordinates.getPrettyCoordinateString();
     }
 
     // Extract a dictionary of multilingual texts from a subset of the parse tree.

--- a/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
@@ -42,4 +42,52 @@ public class LatLng {
     public String toString() {
         return "lat/lng: (" + this.latitude + "," + this.longitude + ")";
     }
+
+    /**
+     * Rounds the float to 4 digits.
+     *
+     * @param coordinate A coordinate value as string.
+     * @return String of the rounded number.
+     */
+    private String formatCoordinate(double coordinate) {
+        double roundedNumber = Math.round(coordinate * 10000d) / 10000d;
+        return String.valueOf(roundedNumber);
+    }
+
+    /**
+     * Returns "N" or "S" depending on the latitude.
+     *
+     * @return "N" or "S".
+     */
+    private String getNorthSouth() {
+        if (this.latitude < 0) {
+            return "S";
+        }
+
+        return "N";
+    }
+
+    /**
+     * Returns "E" or "W" depending on the longitude.
+     *
+     * @return "E" or "W".
+     */
+    private String getEastWest() {
+        if (this.longitude < 180) {
+            return "E";
+        }
+
+        return "W";
+    }
+
+    /**
+     * Returns a nicely formatted coordinate string. Used e.g. in
+     * the detail view.
+     *
+     * @return The formatted string.
+     */
+    public String getPrettyCoordinateString() {
+        return formatCoordinate(this.latitude) + " " + this.getNorthSouth() + ", " +
+               formatCoordinate(this.longitude) + " " + this.getEastWest();
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
@@ -87,7 +87,7 @@ public class LatLng {
      * @return The formatted string.
      */
     public String getPrettyCoordinateString() {
-        return formatCoordinate(this.latitude) + " " + this.getNorthSouth() + ", " +
-               formatCoordinate(this.longitude) + " " + this.getEastWest();
+        return formatCoordinate(this.latitude) + " " + this.getNorthSouth() + ", "
+               + formatCoordinate(this.longitude) + " " + this.getEastWest();
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -70,6 +70,7 @@ public class MediaDetailFragment extends Fragment {
     private TextView title;
     private TextView desc;
     private TextView license;
+    private TextView coordinates;
     private LinearLayout categoryContainer;
     private ScrollView scrollView;
     private ArrayList<String> categoryNames;
@@ -123,6 +124,7 @@ public class MediaDetailFragment extends Fragment {
         title = (TextView) view.findViewById(R.id.mediaDetailTitle);
         desc = (TextView) view.findViewById(R.id.mediaDetailDesc);
         license = (TextView) view.findViewById(R.id.mediaDetailLicense);
+        coordinates = (TextView) view.findViewById(R.id.mediaDetailCoordinates);
         categoryContainer = (LinearLayout) view.findViewById(R.id.mediaDetailCategoryContainer);
 
         licenseList = new LicenseList(getActivity());
@@ -226,6 +228,7 @@ public class MediaDetailFragment extends Fragment {
                         // Set text of desc, license, and categories
                         desc.setText(prettyDescription(media));
                         license.setText(prettyLicense(media));
+                        coordinates.setText(prettyCoordinates(media));
 
                         categoryNames.removeAll(categoryNames);
                         categoryNames.addAll(media.getCategories());
@@ -387,5 +390,16 @@ public class MediaDetailFragment extends Fragment {
         } else {
             return licenseObj.getName();
         }
+    }
+
+    /**
+     * Returns the coordinates nicely formatted.
+     *
+     * @return Coordinates as text.
+     */
+    private String prettyCoordinates(Media media) {
+        String coordinates = media.getCoordinates();
+
+        return coordinates;
     }
 }

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -159,6 +159,35 @@
                         />
                 </LinearLayout>
 
+                <LinearLayout
+                    android:orientation="vertical"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/subBackground"
+                    android:padding="16dp"
+                    >
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textColor="@android:color/white"
+                        android:text="Coordinates"
+                        android:textSize="16sp"
+                        android:textStyle="bold"
+                        android:paddingBottom="6dp"
+                        />
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="License link"
+                        android:id="@+id/mediaDetailCoordinates"
+                        android:layout_gravity="left|start"
+                        android:background="?attr/subBackground"
+                        android:textColor="@android:color/white"
+                        android:textSize="14sp"
+                        android:padding="12dp"
+                        />
+                </LinearLayout>
+
                 <fr.free.nrw.commons.media.MediaDetailSpacer
                     android:layout_width="match_parent"
                     android:layout_height="8dp"


### PR DESCRIPTION
Currently the image detail view does not display the
coordinates.
This commit adds the coordinate template to the
parser and displays the results rounded to 4 digits.