### PR TITLE
Set default text when no description found

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyViewHolder.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyViewHolder.java
@@ -25,9 +25,12 @@ public class NearbyViewHolder implements ViewHolder<Place> {
     public void bindModel(Context context, Place place) {
         // Populate the data into the template view using the data object
         tvName.setText(place.name);
-        tvDesc.setText(place.description);
+        String description = place.description;
+        if ( description == null || description.isEmpty() || description.equals("?")) {
+            description = "No Description Found";
+        }
+        tvDesc.setText(description);
         distance.setText(place.distance);
-
         icon.setImageResource(ResourceUtils.getDescriptionIcon(place.description));
     }
 }


### PR DESCRIPTION
When no description is found, currently it is set to "?". This PR will make it to "No Description Found".