### PR TITLE
Fix lat-long format and add tests

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
@@ -6,6 +6,8 @@ public class LatLng {
     public final double longitude;
 
     /** Accepts latitude and longitude.
+     * North and South values are cut off at 90°
+     *
      * @param latitude double value
      * @param longitude double value
      */
@@ -44,14 +46,15 @@ public class LatLng {
     }
 
     /**
-     * Rounds the float to 4 digits.
+     * Rounds the float to 4 digits and returns absolute value.
      *
      * @param coordinate A coordinate value as string.
      * @return String of the rounded number.
      */
     private String formatCoordinate(double coordinate) {
         double roundedNumber = Math.round(coordinate * 10000d) / 10000d;
-        return String.valueOf(roundedNumber);
+        double absoluteNumber = Math.abs(roundedNumber);
+        return String.valueOf(absoluteNumber);
     }
 
     /**
@@ -73,7 +76,7 @@ public class LatLng {
      * @return "E" or "W".
      */
     private String getEastWest() {
-        if (this.longitude < 180) {
+        if (this.longitude >= 0 && this.longitude < 180) {
             return "E";
         }
 

--- a/app/src/test/java/fr/free/nrw/commons/LatLngTests.java
+++ b/app/src/test/java/fr/free/nrw/commons/LatLngTests.java
@@ -1,0 +1,64 @@
+package fr.free.nrw.commons;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import fr.free.nrw.commons.location.LatLng;
+
+public class LatLngTests {
+    @Test public void testZeroZero() {
+        LatLng place = new LatLng(0, 0);
+        String prettyString = place.getPrettyCoordinateString();
+        Assert.assertThat(prettyString, is("0.0 N, 0.0 E"));
+    }
+
+    @Test public void testAntipode() {
+        LatLng place = new LatLng(0, 180);
+        String prettyString = place.getPrettyCoordinateString();
+        Assert.assertThat(prettyString, is("0.0 N, 180.0 W"));
+    }
+
+    @Test public void testNorthPole() {
+        LatLng place = new LatLng(90, 0);
+        String prettyString = place.getPrettyCoordinateString();
+        Assert.assertThat(prettyString, is("90.0 N, 0.0 E"));
+    }
+
+    @Test public void testSouthPole() {
+        LatLng place = new LatLng(-90, 0);
+        String prettyString = place.getPrettyCoordinateString();
+        Assert.assertThat(prettyString, is("90.0 S, 0.0 E"));
+    }
+
+    @Test public void testLargerNumbers() {
+        LatLng place = new LatLng(120, 380);
+        String prettyString = place.getPrettyCoordinateString();
+        Assert.assertThat(prettyString, is("90.0 N, 20.0 E"));
+    }
+
+    @Test public void testNegativeNumbers() {
+        LatLng place = new LatLng(-120, -30);
+        String prettyString = place.getPrettyCoordinateString();
+        Assert.assertThat(prettyString, is("90.0 S, 30.0 W"));
+    }
+
+    @Test public void testTooBigWestValue() {
+        LatLng place = new LatLng(20, -190);
+        String prettyString = place.getPrettyCoordinateString();
+        Assert.assertThat(prettyString, is("20.0 N, 170.0 E"));
+    }
+
+    @Test public void testRounding() {
+        LatLng place = new LatLng(0.1234567, -0.33333333);
+        String prettyString = place.getPrettyCoordinateString();
+        Assert.assertThat(prettyString, is("0.1235 N, 0.3333 W"));
+    }
+
+    @Test public void testRoundingAgain() {
+        LatLng place = new LatLng(-0.000001, -0.999999);
+        String prettyString = place.getPrettyCoordinateString();
+        Assert.assertThat(prettyString, is("0.0 S, 1.0 W"));
+    }
+}

--- a/app/src/test/java/fr/free/nrw/commons/LatLngTests.java
+++ b/app/src/test/java/fr/free/nrw/commons/LatLngTests.java
@@ -1,11 +1,12 @@
 package fr.free.nrw.commons;
 
+import fr.free.nrw.commons.location.LatLng;
+
 import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.Assert;
 import org.junit.Test;
 
-import fr.free.nrw.commons.location.LatLng;
 
 public class LatLngTests {
     @Test public void testZeroZero() {

--- a/app/src/test/java/fr/free/nrw/commons/LatLngTests.java
+++ b/app/src/test/java/fr/free/nrw/commons/LatLngTests.java
@@ -1,12 +1,11 @@
 package fr.free.nrw.commons;
 
-import fr.free.nrw.commons.location.LatLng;
-
 import static org.hamcrest.CoreMatchers.is;
+
+import fr.free.nrw.commons.location.LatLng;
 
 import org.junit.Assert;
 import org.junit.Test;
-
 
 public class LatLngTests {
     @Test public void testZeroZero() {


### PR DESCRIPTION
Currently the lat-long string in the gallery still contains
negative numbers. Also W values do not work correctly.
This commit fixes the calculations and adds tests for the
LatLng class.