### PR TITLE
Replace 'removeAll(c)' with 'clear()'

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Media.java
+++ b/app/src/main/java/fr/free/nrw/commons/Media.java
@@ -173,7 +173,7 @@ public class Media implements Parcelable {
     }
 
     public void setCategories(List<String> categories) {
-        this.categories.removeAll(this.categories);
+        this.categories.clear();
         this.categories.addAll(categories);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -235,7 +235,7 @@ public class MediaDetailFragment extends Fragment {
                         coordinates.setText(prettyCoordinates(media));
                         uploadedDate.setText(prettyUploadedDate(media));
 
-                        categoryNames.removeAll(categoryNames);
+                        categoryNames.clear();
                         categoryNames.addAll(media.getCategories());
 
                         categoriesLoaded = true;
@@ -280,7 +280,7 @@ public class MediaDetailFragment extends Fragment {
                     desc.setText(prettyDescription(media));
                     license.setText(prettyLicense(media));
 
-                    categoryNames.removeAll(categoryNames);
+                    categoryNames.clear();
                     categoryNames.addAll(media.getCategories());
 
                     categoriesLoaded = true;


### PR DESCRIPTION
Linked to #612 .

This PR changes 2 files. Currently to remove all elements from a collection we use `removeAll(c)` but `clear()` is more efficient and saves time.
Changed to `clear()`.