### PR TITLE
Add nearby activity Espresso test

### DIFF
--- a/app/src/androidTest/java/fr/free/nrw/commons/NearbyActivityTest.java
+++ b/app/src/androidTest/java/fr/free/nrw/commons/NearbyActivityTest.java
@@ -1,0 +1,29 @@
+package fr.free.nrw.commons;
+
+import android.support.test.espresso.assertion.ViewAssertions;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import fr.free.nrw.commons.nearby.NearbyActivity;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class NearbyActivityTest {
+    @Rule
+    public final ActivityTestRule<NearbyActivity> nearby =
+            new ActivityTestRule<>(NearbyActivity.class);
+
+    @Test
+    public void testActivityLaunch() {
+        onView(withText("Nearby Places")).check(ViewAssertions.matches(isDisplayed()));
+    }
+}

--- a/app/src/androidTest/java/fr/free/nrw/commons/NearbyActivityTest.java
+++ b/app/src/androidTest/java/fr/free/nrw/commons/NearbyActivityTest.java
@@ -1,19 +1,19 @@
 package fr.free.nrw.commons;
 
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
 import android.support.test.espresso.assertion.ViewAssertions;
 import android.support.test.filters.LargeTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
+import fr.free.nrw.commons.nearby.NearbyActivity;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import fr.free.nrw.commons.nearby.NearbyActivity;
-
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)


### PR DESCRIPTION
Currently the nearby activity is not included in the Espresso
tests.
This commit adds one test that checks if the activity loads
and the headline is displayed.