### PR TITLE
Removed getSupportActionBar command

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/SignupActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/SignupActivity.java
@@ -20,8 +20,6 @@ public class SignupActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
         Timber.d("Signup Activity started");
 
-        getSupportActionBar().hide();
-
         webView = new WebView(this);
         setContentView(webView);
 


### PR DESCRIPTION
The getSupportActionBar method caused a null pointer exception in devices running Android SDK >21 but there is actually no need for it since the theme doesn't have an Action Bar.