### PR TITLE
Updated target sdk version to 25

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,9 +6,8 @@ compileSdkVersion = android-25
 buildToolsVersion = 25.0.1
 
 minSdkVersion = 15
-# Needs to remain at API 23 until https://github.com/commons-app/apps-android-commons/issues/457
-# is fixed
-targetSdkVersion = 23
+
+targetSdkVersion = 25
 android.useDeprecatedNdk=true
 
 # Library dependencies


### PR DESCRIPTION
The camera crash bug does not seem to exist anymore. Another fix probably solved this issue too.