### PR TITLE
Espresso: match with resource names in settings screen

### DIFF
--- a/app/src/androidTest/java/fr/free/nrw/commons/SettingsActivityTest.java
+++ b/app/src/androidTest/java/fr/free/nrw/commons/SettingsActivityTest.java
@@ -103,8 +103,8 @@ public class SettingsActivityTest {
 
     private static Matcher<View> findPreferenceList() {
         return allOf(
-                ViewMatchers.isDescendantOfA(ViewMatchers.withId(android.R.id.content)),
-                ViewMatchers.withId(android.R.id.list),
+                ViewMatchers.isDescendantOfA(ViewMatchers.withId(R.id.settingsFragment)),
+                ViewMatchers.withResourceName("list"),
                 ViewMatchers.hasFocus()
         );
     }


### PR DESCRIPTION
Apparently this is more robust (especially for SDK version 25)