### PR TITLE
Fix crash of nearby list when the places list is null

### DIFF
--- a/app/src/androidTest/java/fr/free/nrw/commons/NearbyControllerTest.java
+++ b/app/src/androidTest/java/fr/free/nrw/commons/NearbyControllerTest.java
@@ -4,11 +4,6 @@ import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
-import fr.free.nrw.commons.location.LatLng;
-import fr.free.nrw.commons.nearby.NearbyBaseMarker;
-import fr.free.nrw.commons.nearby.NearbyController;
-import fr.free.nrw.commons.nearby.Place;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,6 +11,11 @@ import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import fr.free.nrw.commons.location.LatLng;
+import fr.free.nrw.commons.nearby.NearbyBaseMarker;
+import fr.free.nrw.commons.nearby.NearbyController;
+import fr.free.nrw.commons.nearby.Place;
 
 import static org.hamcrest.CoreMatchers.is;
 

--- a/app/src/androidTest/java/fr/free/nrw/commons/NearbyControllerTest.java
+++ b/app/src/androidTest/java/fr/free/nrw/commons/NearbyControllerTest.java
@@ -1,0 +1,57 @@
+package fr.free.nrw.commons;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import fr.free.nrw.commons.location.LatLng;
+import fr.free.nrw.commons.nearby.NearbyBaseMarker;
+import fr.free.nrw.commons.nearby.NearbyController;
+import fr.free.nrw.commons.nearby.Place;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+
+@RunWith(AndroidJUnit4.class)
+public class NearbyControllerTest {
+    private Context instrumentationContext;
+
+    @Before
+    public void setup() {
+        instrumentationContext = InstrumentationRegistry.getContext();
+    }
+
+    @Test public void testNullAttractions() {
+        LatLng location = new LatLng(0, 0);
+
+        List<NearbyBaseMarker> options =
+            NearbyController.loadAttractionsFromLocationToBaseMarkerOptions(
+                location,
+                null,
+                instrumentationContext
+        );
+
+        Assert.assertThat(options.size(), is(0));
+    }
+
+    @Test public void testEmptyList() {
+        LatLng location = new LatLng(0, 0);
+        List<Place> emptyList = new ArrayList<>();
+
+        List<NearbyBaseMarker> options =
+                NearbyController.loadAttractionsFromLocationToBaseMarkerOptions(
+                        location,
+                        emptyList,
+                        instrumentationContext
+                );
+
+        Assert.assertThat(options.size(), is(0));
+    }
+}

--- a/app/src/androidTest/java/fr/free/nrw/commons/NearbyControllerTest.java
+++ b/app/src/androidTest/java/fr/free/nrw/commons/NearbyControllerTest.java
@@ -32,11 +32,11 @@ public class NearbyControllerTest {
         LatLng location = new LatLng(0, 0);
 
         List<NearbyBaseMarker> options =
-            NearbyController.loadAttractionsFromLocationToBaseMarkerOptions(
-                location,
-                null,
-                instrumentationContext
-        );
+                NearbyController.loadAttractionsFromLocationToBaseMarkerOptions(
+                        location,
+                        null,
+                        instrumentationContext
+                );
 
         Assert.assertThat(options.size(), is(0));
     }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyController.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyController.java
@@ -84,14 +84,20 @@ public class NearbyController {
      *Loads attractions from location for map view, we need to return BaseMarkerOption data type.
      * @param curLatLng users current location
      * @param placeList list of nearby places in Place data type
-     * @return BaseMarkerOprions list that holds nearby places
+     * @return BaseMarkerOptions list that holds nearby places
      */
     public static List<NearbyBaseMarker> loadAttractionsFromLocationToBaseMarkerOptions(
             LatLng curLatLng,
             List<Place> placeList,
             Context context) {
-        List<NearbyBaseMarker> baseMarkerOptionses = new ArrayList<>();
+        List<NearbyBaseMarker> baseMarkerOptions = new ArrayList<>();
+
+        if (placeList == null) {
+            return baseMarkerOptions;
+        }
+
         placeList = placeList.subList(0, Math.min(placeList.size(), MAX_RESULTS));
+
         for (Place place: placeList) {
             String distance = formatDistanceBetween(curLatLng, place.location);
             place.setDistance(distance);
@@ -108,8 +114,8 @@ public class NearbyController {
             nearbyBaseMarker.place(place);
             nearbyBaseMarker.icon(icon);
 
-            baseMarkerOptionses.add(nearbyBaseMarker);
+            baseMarkerOptions.add(nearbyBaseMarker);
         }
-        return baseMarkerOptionses;
+        return baseMarkerOptions;
     }
 }


### PR DESCRIPTION
Currently the NearbyController crashes when it is called with a
places list that is null. This is caused by the NearbyMapFragment
not handling this state correctly.
This commit adds tests for an empty list and null, which reproduce
the problem. An early return in the NearbyController can make
the tests pass, but might not be the best solution for this issue.