### PR TITLE
Vertically center nearby list loading icon

### DIFF
--- a/app/src/main/res/layout/activity_nearby.xml
+++ b/app/src/main/res/layout/activity_nearby.xml
@@ -18,6 +18,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="horizontal"
+            android:gravity="center_vertical"
             android:layout_below="@id/toolbar">
 
             <ProgressBar


### PR DESCRIPTION
The loading icon of the nearby places list is currently
at the very top of the view.
This commit vertically centers the loading icon.

![screenshot from 2017-05-25 17-51-19](https://cloud.githubusercontent.com/assets/6953323/26458205/e3b9f782-4172-11e7-9f96-69789bb5021e.png)