### PR TITLE
Remove redundant field in SettingsActivity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsActivity.java
@@ -13,8 +13,6 @@ import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.theme.NavigationBaseActivity;
 
 public class SettingsActivity extends NavigationBaseActivity {
-    private SettingsFragment settingsFragment;
-
     private AppCompatDelegate settingsDelegate;
 
     @Override
@@ -25,8 +23,6 @@ public class SettingsActivity extends NavigationBaseActivity {
         } else {
             setTheme(R.style.LightAppTheme);
         }
-
-        settingsFragment = (SettingsFragment) getFragmentManager().findFragmentById(R.id.settingsFragment);
 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_settings);


### PR DESCRIPTION
There is a field that is set in SettingsActivity that is never used at all. This patch removes that field to improve performance and code tidiness.