### PR TITLE
Remove redundant call to String.format() in CategoryModifier

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/modifications/CategoryModifier.java
+++ b/app/src/main/java/fr/free/nrw/commons/modifications/CategoryModifier.java
@@ -43,6 +43,6 @@ public class CategoryModifier extends PageModifier {
 
     @Override
     public String getEditSumary() {
-        return String.format("Added " + params.optJSONArray(PARAM_CATEGORIES).length() + " categories.");
+        return "Added " + params.optJSONArray(PARAM_CATEGORIES).length() + " categories.";
     }
 }


### PR DESCRIPTION
This patch removes a call to String.format that can be replaced with a literal string which is much clearer and easier to understand.