### PR TITLE
Simplify if statements in Utils and ExistingFileAsync

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -270,10 +270,6 @@ public class Utils {
     }
 
     public static boolean isDarkTheme(Context context) {
-        if (PreferenceManager.getDefaultSharedPreferences(context).getBoolean("theme",true)) {
-            return true;
-        }else {
-            return false;
-        }
+        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean("theme",true);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/upload/ExistingFileAsync.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ExistingFileAsync.java
@@ -57,12 +57,7 @@ public class ExistingFileAsync extends AsyncTask<Void, Void, Boolean> {
         ArrayList<ApiResult> resultNodes = result.getNodes("/api/query/allimages/img");
         Timber.d("Result nodes: %s", resultNodes);
 
-        boolean fileExists;
-        if (!resultNodes.isEmpty()) {
-            fileExists = true;
-        } else {
-            fileExists = false;
-        }
+        boolean fileExists = !resultNodes.isEmpty();
 
         Timber.d("File already exists in Commons: %s", fileExists);
         return fileExists;


### PR DESCRIPTION
This patch simplifies a few if statements by replacing them with returns, which helps improve code readability and simplicity.