### PR TITLE
Fix usage of deprecated function String.fromHtml(String)

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -25,3 +25,6 @@ their contribution to the product.
 * GSON
 * Timber
 * MapBox
+
+3rd party open source apps from which significant code has been reused:
+* Android Wikipedia app https://github.com/wikimedia/apps-android-wikipedia

--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -2,7 +2,10 @@ package fr.free.nrw.commons;
 
 import android.content.Context;
 import android.net.Uri;
+import android.os.Build;
 import android.preference.PreferenceManager;
+import android.text.Html;
+import android.text.Spanned;
 
 import fr.free.nrw.commons.settings.Prefs;
 import timber.log.Timber;
@@ -75,6 +78,19 @@ public class Utils {
             } catch (IOException e) {
                 Timber.e(e, "Exception on closing MD5 input stream");
             }
+        }
+    }
+
+    /** Fix Html.fromHtml is deprecated problem
+     * @param source provided Html string
+     * @return returned Spanned of appropriate method according to version check
+     * */
+    public static Spanned fromHtml(String source) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            return Html.fromHtml(source, Html.FROM_HTML_MODE_LEGACY);
+        } else {
+            //noinspection deprecation
+            return Html.fromHtml(source);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/ui/widget/HtmlTextView.java
+++ b/app/src/main/java/fr/free/nrw/commons/ui/widget/HtmlTextView.java
@@ -2,9 +2,10 @@ package fr.free.nrw.commons.ui.widget;
 
 import android.content.Context;
 import android.support.v7.widget.AppCompatTextView;
-import android.text.Html;
 import android.text.method.LinkMovementMethod;
 import android.util.AttributeSet;
+
+import fr.free.nrw.commons.Utils;
 
 /**
  * An {@link AppCompatTextView} which formats the text to HTML displayable text and makes any
@@ -16,6 +17,6 @@ public class HtmlTextView extends AppCompatTextView {
         super(context, attrs);
 
         setMovementMethod(LinkMovementMethod.getInstance());
-        setText(Html.fromHtml(getText().toString()));
+        setText(Utils.fromHtml(getText().toString()));
     }
 }


### PR DESCRIPTION
String.fromHtml(String) is now deprecated. This patch fixes that by adding a method to Utils that selects the appropriate function based on the user's platform.

Util method lovingly reused from the Android Wikipedia app which is Apache licensed and therefore compatible with this codebase.

https://github.com/wikimedia/apps-android-wikipedia/blob/master/app/src/main/java/org/wikipedia/util/StringUtil.java#L115-L126