### PR TITLE
Don't pass/store Activity instance in key places.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/MediaWikiImageView.java
+++ b/app/src/main/java/fr/free/nrw/commons/MediaWikiImageView.java
@@ -3,9 +3,11 @@ package fr.free.nrw.commons;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.graphics.drawable.VectorDrawableCompat;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 
+import com.facebook.drawee.generic.GenericDraweeHierarchyBuilder;
 import com.facebook.drawee.view.SimpleDraweeView;
 
 public class MediaWikiImageView extends SimpleDraweeView {
@@ -13,14 +15,17 @@ public class MediaWikiImageView extends SimpleDraweeView {
 
     public MediaWikiImageView(Context context) {
         this(context, null);
+        init();
     }
 
     public MediaWikiImageView(Context context, AttributeSet attrs) {
         this(context, attrs, 0);
+        init();
     }
 
     public MediaWikiImageView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        init();
     }
 
     public void setMedia(Media media) {
@@ -46,6 +51,16 @@ public class MediaWikiImageView extends SimpleDraweeView {
             currentThumbnailTask.cancel(true);
         }
         super.onDetachedFromWindow();
+    }
+
+    private void init() {
+        setHierarchy(GenericDraweeHierarchyBuilder
+                .newInstance(getResources())
+                .setPlaceholderImage(VectorDrawableCompat.create(getResources(),
+                        R.drawable.ic_image_black_24dp, getContext().getTheme()))
+                .setFailureImage(VectorDrawableCompat.create(getResources(),
+                        R.drawable.ic_image_black_24dp, getContext().getTheme()))
+                .build());
     }
 
     private void setImageUrl(@Nullable String url) {

--- a/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.java
@@ -28,8 +28,7 @@ public class WelcomeActivity extends BaseActivity {
     }
 
     private void setUpAdapter() {
-        WelcomePagerAdapter adapter = new WelcomePagerAdapter(this);
-        pager.setAdapter(adapter);
+        pager.setAdapter(new WelcomePagerAdapter());
         indicator.setViewPager(pager);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.java
@@ -13,6 +13,7 @@ public class WelcomeActivity extends BaseActivity {
 
     @BindView(R.id.welcomePager) ViewPager pager;
     @BindView(R.id.welcomePagerIndicator) CirclePageIndicator indicator;
+    private WelcomePagerAdapter adapter = new WelcomePagerAdapter();
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -24,11 +25,19 @@ public class WelcomeActivity extends BaseActivity {
         }
         ButterKnife.bind(this);
 
-        setUpAdapter();
+        pager.setAdapter(adapter);
+        indicator.setViewPager(pager);
+        adapter.setCallback(new WelcomePagerAdapter.Callback() {
+            @Override
+            public void onYesClicked() {
+                finish();
+            }
+        });
     }
 
-    private void setUpAdapter() {
-        pager.setAdapter(new WelcomePagerAdapter());
-        indicator.setViewPager(pager);
+    @Override
+    public void onDestroy() {
+        adapter.setCallback(null);
+        super.onDestroy();
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/WelcomePagerAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/WelcomePagerAdapter.java
@@ -1,6 +1,6 @@
 package fr.free.nrw.commons;
 
-import android.app.Activity;
+import android.support.annotation.Nullable;
 import android.support.v4.view.PagerAdapter;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -11,6 +11,11 @@ import butterknife.OnClick;
 
 public class WelcomePagerAdapter extends PagerAdapter {
     private static final int PAGE_FINAL = 4;
+    private Callback callback;
+
+    public interface Callback {
+        void onYesClicked();
+    }
 
     static final int[] PAGE_LAYOUTS = new int[]{
             R.layout.welcome_wikipedia,
@@ -19,6 +24,10 @@ public class WelcomePagerAdapter extends PagerAdapter {
             R.layout.welcome_image_details,
             R.layout.welcome_final
     };
+
+    public void setCallback(@Nullable Callback callback) {
+        this.callback = callback;
+    }
 
     @Override
     public int getCount() {
@@ -48,14 +57,16 @@ public class WelcomePagerAdapter extends PagerAdapter {
         container.removeView((View) obj);
     }
 
-    public static class ViewHolder {
-        public ViewHolder(View view) {
+    class ViewHolder {
+        ViewHolder(View view) {
             ButterKnife.bind(this, view);
         }
 
         @OnClick(R.id.welcomeYesButton)
-        void onClicked(View view) {
-            ((Activity) view.getContext()).finish();
+        void onClicked() {
+            if (callback != null) {
+                callback.onYesClicked();
+            }
         }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/WelcomePagerAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/WelcomePagerAdapter.java
@@ -1,7 +1,6 @@
 package fr.free.nrw.commons;
 
 import android.app.Activity;
-import android.content.Context;
 import android.support.v4.view.PagerAdapter;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -11,9 +10,6 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 
 public class WelcomePagerAdapter extends PagerAdapter {
-
-    private Context context;
-
     private static final int PAGE_FINAL = 4;
 
     static final int[] PAGE_LAYOUTS = new int[]{
@@ -23,10 +19,6 @@ public class WelcomePagerAdapter extends PagerAdapter {
             R.layout.welcome_image_details,
             R.layout.welcome_final
     };
-
-    public WelcomePagerAdapter(Context context) {
-        this.context = context;
-    }
 
     @Override
     public int getCount() {
@@ -40,11 +32,11 @@ public class WelcomePagerAdapter extends PagerAdapter {
 
     @Override
     public Object instantiateItem(ViewGroup container, int position) {
-        LayoutInflater inflater = LayoutInflater.from(context);
+        LayoutInflater inflater = LayoutInflater.from(container.getContext());
         ViewGroup layout = (ViewGroup) inflater.inflate(PAGE_LAYOUTS[position], container, false);
 
         if (position == PAGE_FINAL) {
-            ViewHolder holder = new ViewHolder(layout, context);
+            ViewHolder holder = new ViewHolder(layout);
             layout.setTag(holder);
         }
         container.addView(layout);
@@ -57,16 +49,13 @@ public class WelcomePagerAdapter extends PagerAdapter {
     }
 
     public static class ViewHolder {
-        private Context context;
-
-        public ViewHolder(View view, Context context) {
+        public ViewHolder(View view) {
             ButterKnife.bind(this, view);
-            this.context = context;
         }
 
         @OnClick(R.id.welcomeYesButton)
-        void onClicked() {
-            ((Activity) context).finish();
+        void onClicked(View view) {
+            ((Activity) view.getContext()).finish();
         }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -43,7 +43,6 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         app = CommonsApplication.getInstance();
 
         setContentView(R.layout.activity_login);
-        final LoginActivity that = this;
 
         loginButton = (Button) findViewById(R.id.loginButton);
         Button signupButton = (Button) findViewById(R.id.signupButton);
@@ -62,12 +61,14 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         loginButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                that.performLogin();
+                performLogin();
             }
         });
         signupButton.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View v) { that.signUp(v); }
+            public void onClick(View v) {
+                signUp(v);
+            }
         });
     }
 
@@ -115,7 +116,7 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     protected void onResume() {
         super.onResume();
         if (prefs.getBoolean("firstrun", true)) {
-            this.startWelcomeIntent();
+            startWelcomeIntent();
             prefs.edit().putBoolean("firstrun", false).apply();
         }
         if (app.getCurrentAccount() != null) {

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
@@ -228,7 +228,8 @@ public  class       ContributionsActivity
     @Override
     public void onLoadFinished(Loader<Cursor> cursorLoader, Cursor cursor) {
         if(contributionsList.getAdapter() == null) {
-            contributionsList.setAdapter(new ContributionsListAdapter(getApplicationContext(), cursor, 0));
+            contributionsList
+                    .setAdapter(new ContributionsListAdapter(getApplicationContext(), cursor, 0));
         } else {
             ((CursorAdapter)contributionsList.getAdapter()).swapCursor(cursor);
         }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
@@ -227,7 +227,7 @@ public  class       ContributionsActivity
     @Override
     public void onLoadFinished(Loader<Cursor> cursorLoader, Cursor cursor) {
         if(contributionsList.getAdapter() == null) {
-            contributionsList.setAdapter(new ContributionsListAdapter(this, cursor, 0));
+            contributionsList.setAdapter(new ContributionsListAdapter(getApplicationContext(), cursor, 0));
         } else {
             ((CursorAdapter)contributionsList.getAdapter()).swapCursor(cursor);
         }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
@@ -81,6 +81,7 @@ public  class       ContributionsActivity
 
     @Override
     protected void onDestroy() {
+        getSupportFragmentManager().removeOnBackStackChangedListener(this);
         super.onDestroy();
         if(isUploadServiceConnected) {
             unbindService(uploadServiceConnection);

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListAdapter.java
@@ -17,7 +17,8 @@ class ContributionsListAdapter extends CursorAdapter {
 
     @Override
     public View newView(Context context, Cursor cursor, ViewGroup viewGroup) {
-        View parent = LayoutInflater.from(context).inflate(R.layout.layout_contribution, viewGroup, false);
+        View parent = LayoutInflater.from(context)
+                .inflate(R.layout.layout_contribution, viewGroup, false);
         parent.setTag(new ContributionViewHolder(parent));
         return parent;
     }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListAdapter.java
@@ -1,25 +1,23 @@
 package fr.free.nrw.commons.contributions;
 
-import android.app.Activity;
 import android.content.Context;
 import android.database.Cursor;
 import android.support.v4.widget.CursorAdapter;
+import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import fr.free.nrw.commons.R;
 
 class ContributionsListAdapter extends CursorAdapter {
-    private Activity activity;
 
-    public ContributionsListAdapter(Activity activity, Cursor c, int flags) {
-        super(activity, c, flags);
-        this.activity = activity;
+    public ContributionsListAdapter(Context context, Cursor c, int flags) {
+        super(context, c, flags);
     }
 
     @Override
     public View newView(Context context, Cursor cursor, ViewGroup viewGroup) {
-        View parent = activity.getLayoutInflater().inflate(R.layout.layout_contribution, viewGroup, false);
+        View parent = LayoutInflater.from(context).inflate(R.layout.layout_contribution, viewGroup, false);
         parent.setTag(new ContributionViewHolder(parent));
         return parent;
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/FileUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileUtils.java
@@ -23,7 +23,7 @@ public class FileUtils {
      */
     // Can be safely suppressed, checks for isKitKat before running isDocumentUri
     @SuppressLint("NewApi")
-    public static String getPath(final Context context, final Uri uri) {
+    public static String getPath(Context context, Uri uri) {
 
         final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
@@ -13,6 +13,7 @@ import android.support.annotation.Nullable;
 
 import java.io.IOException;
 
+import fr.free.nrw.commons.CommonsApplication;
 import timber.log.Timber;
 
 /**
@@ -26,15 +27,13 @@ public class GPSExtractor {
     private double decLatitude, decLongitude;
     private Double currentLatitude = null;
     private Double currentLongitude = null;
-    private Context context;
     public boolean imageCoordsExists;
     private MyLocationListener myLocationListener;
     private LocationManager locationManager;
 
 
-    public GPSExtractor(String filePath, Context context){
+    public GPSExtractor(String filePath){
         this.filePath = filePath;
-        this.context = context;
     }
 
     /**
@@ -42,7 +41,7 @@ public class GPSExtractor {
      * @return true if enabled, false if disabled
      */
     private boolean gpsPreferenceEnabled() {
-        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(CommonsApplication.getInstance());
         boolean gpsPref = sharedPref.getBoolean("allowGps", false);
         Timber.d("Gps pref set to: %b", gpsPref);
         return gpsPref;
@@ -52,7 +51,7 @@ public class GPSExtractor {
      * Registers a LocationManager to listen for current location
      */
     protected void registerLocationManager() {
-        locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+        locationManager = (LocationManager) CommonsApplication.getInstance().getSystemService(Context.LOCATION_SERVICE);
         Criteria criteria = new Criteria();
         String provider = locationManager.getBestProvider(criteria, true);
         myLocationListener = new MyLocationListener();

--- a/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
@@ -32,7 +32,7 @@ public class GPSExtractor {
     private LocationManager locationManager;
 
 
-    public GPSExtractor(String filePath){
+    public GPSExtractor(String filePath) {
         this.filePath = filePath;
     }
 
@@ -41,7 +41,8 @@ public class GPSExtractor {
      * @return true if enabled, false if disabled
      */
     private boolean gpsPreferenceEnabled() {
-        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(CommonsApplication.getInstance());
+        SharedPreferences sharedPref
+                = PreferenceManager.getDefaultSharedPreferences(CommonsApplication.getInstance());
         boolean gpsPref = sharedPref.getBoolean("allowGps", false);
         Timber.d("Gps pref set to: %b", gpsPref);
         return gpsPref;
@@ -51,7 +52,8 @@ public class GPSExtractor {
      * Registers a LocationManager to listen for current location
      */
     protected void registerLocationManager() {
-        locationManager = (LocationManager) CommonsApplication.getInstance().getSystemService(Context.LOCATION_SERVICE);
+        locationManager = (LocationManager) CommonsApplication.getInstance()
+                .getSystemService(Context.LOCATION_SERVICE);
         Criteria criteria = new Criteria();
         String provider = locationManager.getBestProvider(criteria, true);
         myLocationListener = new MyLocationListener();

--- a/app/src/main/java/fr/free/nrw/commons/upload/MultipleShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/MultipleShareActivity.java
@@ -203,7 +203,7 @@ public  class       MultipleShareActivity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        uploadController = new UploadController(this);
+        uploadController = new UploadController();
 
         setContentView(R.layout.activity_multiple_uploads);
         app = CommonsApplication.getInstance();

--- a/app/src/main/java/fr/free/nrw/commons/upload/MultipleShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/MultipleShareActivity.java
@@ -115,7 +115,7 @@ public  class       MultipleShareActivity
 
         Timber.d("Multiple upload begins");
 
-        final ProgressDialog dialog = new ProgressDialog(MultipleShareActivity.this);
+        final ProgressDialog dialog = new ProgressDialog(this);
         dialog.setIndeterminate(false);
         dialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
         dialog.setMax(photosList.size());
@@ -145,12 +145,12 @@ public  class       MultipleShareActivity
 
         uploadsList.setImageOnlyMode(true);
 
-        categorizationFragment = (CategorizationFragment) this.getSupportFragmentManager().findFragmentByTag("categorization");
+        categorizationFragment = (CategorizationFragment) getSupportFragmentManager().findFragmentByTag("categorization");
         if(categorizationFragment == null) {
             categorizationFragment = new CategorizationFragment();
         }
         // FIXME: Stops the keyboard from being shown 'stale' while moving out of this fragment into the next
-        View target = this.getCurrentFocus();
+        View target = getCurrentFocus();
         if (target != null) {
             InputMethodManager imm = (InputMethodManager) target.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
             imm.hideSoftInputFromWindow(target.getWindowToken(), 0);
@@ -221,18 +221,19 @@ public  class       MultipleShareActivity
     @Override
     protected void onDestroy() {
         super.onDestroy();
+        getSupportFragmentManager().removeOnBackStackChangedListener(this);
         uploadController.cleanup();
     }
 
     private void showDetail(int i) {
         if(mediaDetails == null ||!mediaDetails.isVisible()) {
             mediaDetails = new MediaDetailPagerFragment(true);
-            this.getSupportFragmentManager()
+            getSupportFragmentManager()
                     .beginTransaction()
                     .replace(R.id.uploadsFragmentContainer, mediaDetails)
                     .addToBackStack(null)
                     .commit();
-            this.getSupportFragmentManager().executePendingTransactions();
+            getSupportFragmentManager().executePendingTransactions();
         }
         mediaDetails.showImage(i);
     }
@@ -267,7 +268,7 @@ public  class       MultipleShareActivity
             uploadsList = (MultipleUploadListFragment) getSupportFragmentManager().findFragmentByTag("uploadsList");
             if(uploadsList == null) {
                 uploadsList =  new MultipleUploadListFragment();
-                this.getSupportFragmentManager()
+                getSupportFragmentManager()
                         .beginTransaction()
                         .add(R.id.uploadsFragmentContainer, uploadsList, "uploadsList")
                         .commit();

--- a/app/src/main/java/fr/free/nrw/commons/upload/MultipleUploadListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/MultipleUploadListFragment.java
@@ -4,7 +4,9 @@ import android.content.Context;
 import android.graphics.Point;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.graphics.drawable.VectorDrawableCompat;
 import android.support.v4.app.Fragment;
+import android.support.v4.content.ContextCompat;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -24,6 +26,7 @@ import android.widget.GridView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import com.facebook.drawee.generic.GenericDraweeHierarchyBuilder;
 import com.facebook.drawee.view.SimpleDraweeView;
 
 import fr.free.nrw.commons.R;
@@ -82,7 +85,13 @@ public class MultipleUploadListFragment extends Fragment {
                 holder.overlay = (RelativeLayout) view.findViewById(R.id.uploadOverlay);
 
                 holder.image.setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, photoSize.y));
-
+                holder.image.setHierarchy(GenericDraweeHierarchyBuilder
+                        .newInstance(getResources())
+                        .setPlaceholderImage(VectorDrawableCompat.create(getResources(),
+                                R.drawable.ic_image_black_24dp, getContext().getTheme()))
+                        .setFailureImage(VectorDrawableCompat.create(getResources(),
+                                R.drawable.ic_error_outline_black_24dp, getContext().getTheme()))
+                        .build());
                 view.setTag(holder);
             } else {
                 holder = (UploadHolderView)view.getTag();

--- a/app/src/main/java/fr/free/nrw/commons/upload/MwVolleyApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/MwVolleyApi.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.upload;
 
-import android.content.Context;
 import android.net.Uri;
 
 import com.android.volley.Cache;
@@ -21,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import fr.free.nrw.commons.CommonsApplication;
 import timber.log.Timber;
 
 /**
@@ -32,15 +32,13 @@ public class MwVolleyApi {
 
     private static RequestQueue REQUEST_QUEUE;
     private static final Gson GSON = new GsonBuilder().create();
-    private Context context;
 
     protected static Set<String> categorySet;
     private static List<String> categoryList;
 
     private static final String MWURL = "https://commons.wikimedia.org/";
 
-    public MwVolleyApi(Context context) {
-        this.context = context;
+    public MwVolleyApi() {
         categorySet = new HashSet<>();
     }
 
@@ -94,12 +92,8 @@ public class MwVolleyApi {
     }
 
     private synchronized RequestQueue getQueue() {
-        return getQueue(context);
-    }
-
-    private static RequestQueue getQueue(Context context) {
         if (REQUEST_QUEUE == null) {
-            REQUEST_QUEUE = Volley.newRequestQueue(context);
+            REQUEST_QUEUE = Volley.newRequestQueue(CommonsApplication.getInstance());
         }
         return REQUEST_QUEUE;
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -402,7 +402,7 @@ public  class       ShareActivity
                 app.getCacheData().setQtPoint(decLongitude, decLatitude);
             }
 
-            MwVolleyApi apiCall = new MwVolleyApi(this);
+            MwVolleyApi apiCall = new MwVolleyApi();
 
             List<String> displayCatList = app.getCacheData().findCategory();
             boolean catListEmpty = displayCatList.isEmpty();

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -214,7 +214,7 @@ public  class       ShareActivity
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        uploadController = new UploadController(this);
+        uploadController = new UploadController();
         setContentView(R.layout.activity_share);
         ButterKnife.bind(this);
         initBack();

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -60,7 +60,6 @@ public  class       ShareActivity
 
     private UploadController uploadController;
 
-    private CommonsApplication cacheObj;
     private boolean cacheFound;
 
     private GPSExtractor imageObj;
@@ -195,11 +194,11 @@ public  class       ShareActivity
         SingleUploadFragment shareView = (SingleUploadFragment) getSupportFragmentManager().findFragmentByTag("shareView");
         categorizationFragment = (CategorizationFragment) getSupportFragmentManager().findFragmentByTag("categorization");
         if(shareView == null && categorizationFragment == null) {
-                shareView = new SingleUploadFragment();
-                getSupportFragmentManager()
-                        .beginTransaction()
-                        .add(R.id.single_upload_fragment_container, shareView, "shareView")
-                        .commitAllowingStateLoss();
+            shareView = new SingleUploadFragment();
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .add(R.id.single_upload_fragment_container, shareView, "shareView")
+                    .commitAllowingStateLoss();
         }
         uploadController.prepareService();
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -196,7 +196,7 @@ public  class       ShareActivity
         categorizationFragment = (CategorizationFragment) getSupportFragmentManager().findFragmentByTag("categorization");
         if(shareView == null && categorizationFragment == null) {
                 shareView = new SingleUploadFragment();
-                this.getSupportFragmentManager()
+                getSupportFragmentManager()
                         .beginTransaction()
                         .add(R.id.single_upload_fragment_container, shareView, "shareView")
                         .commitAllowingStateLoss();
@@ -373,11 +373,11 @@ public  class       ShareActivity
      * @param gpsEnabled
      */
     public void getFileMetadata(boolean gpsEnabled) {
-        String filePath = FileUtils.getPath(this, mediaUri);
+        String filePath = FileUtils.getPath(getApplicationContext(), mediaUri);
         Timber.d("Filepath: %s", filePath);
         Timber.d("Calling GPSExtractor");
         if(imageObj == null) {
-            imageObj = new GPSExtractor(filePath, this);
+            imageObj = new GPSExtractor(filePath);
         }
 
         if (filePath != null && !filePath.equals("")) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -9,6 +9,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.support.design.widget.Snackbar;
+import android.support.graphics.drawable.VectorDrawableCompat;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.view.MenuItem;
@@ -16,6 +17,7 @@ import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.facebook.drawee.generic.GenericDraweeHierarchyBuilder;
 import com.facebook.drawee.view.SimpleDraweeView;
 
 import java.io.IOException;
@@ -219,6 +221,13 @@ public  class       ShareActivity
         initBack();
         app = CommonsApplication.getInstance();
         backgroundImageView = (SimpleDraweeView)findViewById(R.id.backgroundImage);
+        backgroundImageView.setHierarchy(GenericDraweeHierarchyBuilder
+                .newInstance(getResources())
+                .setPlaceholderImage(VectorDrawableCompat.create(getResources(),
+                        R.drawable.ic_image_black_24dp, getTheme()))
+                .setFailureImage(VectorDrawableCompat.create(getResources(),
+                        R.drawable.ic_error_outline_black_24dp, getTheme()))
+                .build());
 
         //Receive intent from ContributionController.java when user selects picture to upload
         Intent intent = getIntent();

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
@@ -103,10 +103,13 @@ public class UploadController {
                 long length;
                 try {
                     if(contribution.getDataLength() <= 0) {
-                        length = app.getContentResolver().openAssetFileDescriptor(contribution.getLocalUri(), "r").getLength();
+                        length = app.getContentResolver()
+                                .openAssetFileDescriptor(contribution.getLocalUri(), "r")
+                                .getLength();
                         if(length == -1) {
                             // Let us find out the long way!
-                            length = Utils.countBytes(app.getContentResolver().openInputStream(contribution.getLocalUri()));
+                            length = Utils.countBytes(app.getContentResolver()
+                                    .openInputStream(contribution.getLocalUri()));
                         }
                         contribution.setDataLength(length);
                     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.upload;
 
-import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -26,16 +25,13 @@ import timber.log.Timber;
 
 public class UploadController {
     private UploadService uploadService;
-
-    private final Activity activity;
-    final CommonsApplication app;
+    private final CommonsApplication app;
 
     public interface ContributionUploadProgress {
         void onUploadStarted(Contribution contribution);
     }
 
-    public UploadController(Activity activity) {
-        this.activity = activity;
+    public UploadController() {
         app = CommonsApplication.getInstance();
     }
 
@@ -55,15 +51,15 @@ public class UploadController {
     };
 
     public void prepareService() {
-        Intent uploadServiceIntent = new Intent(activity, UploadService.class);
+        Intent uploadServiceIntent = new Intent(app, UploadService.class);
         uploadServiceIntent.setAction(UploadService.ACTION_START_SERVICE);
-        activity.startService(uploadServiceIntent);
-        activity.bindService(uploadServiceIntent, uploadServiceConnection, Context.BIND_AUTO_CREATE);
+        app.startService(uploadServiceIntent);
+        app.bindService(uploadServiceIntent, uploadServiceConnection, Context.BIND_AUTO_CREATE);
     }
 
     public void cleanup() {
         if(isUploadServiceConnected) {
-            activity.unbindService(uploadServiceConnection);
+            app.unbindService(uploadServiceConnection);
         }
     }
 
@@ -82,7 +78,7 @@ public class UploadController {
 
     public void startUpload(final Contribution contribution, final ContributionUploadProgress onComplete) {
 
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activity);
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(app);
 
         //Set creator, desc, and license
         if(TextUtils.isEmpty(contribution.getCreator())) {
@@ -107,10 +103,10 @@ public class UploadController {
                 long length;
                 try {
                     if(contribution.getDataLength() <= 0) {
-                        length = activity.getContentResolver().openAssetFileDescriptor(contribution.getLocalUri(), "r").getLength();
+                        length = app.getContentResolver().openAssetFileDescriptor(contribution.getLocalUri(), "r").getLength();
                         if(length == -1) {
                             // Let us find out the long way!
-                            length = Utils.countBytes(activity.getContentResolver().openInputStream(contribution.getLocalUri()));
+                            length = Utils.countBytes(app.getContentResolver().openInputStream(contribution.getLocalUri()));
                         }
                         contribution.setDataLength(length);
                     }
@@ -126,7 +122,7 @@ public class UploadController {
                 Boolean imagePrefix = false;
 
                 if(mimeType == null || TextUtils.isEmpty(mimeType) || mimeType.endsWith("*")) {
-                    mimeType = activity.getContentResolver().getType(contribution.getLocalUri());
+                    mimeType = app.getContentResolver().getType(contribution.getLocalUri());
                 }
 
                 if(mimeType != null) {
@@ -136,7 +132,7 @@ public class UploadController {
                 }
 
                 if(imagePrefix && contribution.getDateCreated() == null) {
-                    Cursor cursor = activity.getContentResolver().query(contribution.getLocalUri(),
+                    Cursor cursor = app.getContentResolver().query(contribution.getLocalUri(),
                             new String[]{MediaStore.Images.ImageColumns.DATE_TAKEN}, null, null, null);
                     if(cursor != null && cursor.getCount() != 0) {
                         cursor.moveToFirst();

--- a/app/src/main/res/layout/activity_share.xml
+++ b/app/src/main/res/layout/activity_share.xml
@@ -26,9 +26,7 @@
                 android:id="@+id/backgroundImage"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                app:actualImageScaleType="centerCrop"
-                app:placeholderImage="@drawable/ic_image_black_24dp"
-                app:failureImage="@drawable/ic_error_outline_black_24dp" />
+                app:actualImageScaleType="centerCrop" />
 
             <FrameLayout
                 android:id="@+id/single_upload_fragment_container"

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -22,8 +22,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:actualImageScaleType="fitCenter"
-        app:placeholderImage="@drawable/ic_image_black_24dp"
-        app:failureImage="@drawable/ic_image_black_24dp"
         />
 
     <ScrollView

--- a/app/src/main/res/layout/layout_contribution.xml
+++ b/app/src/main/res/layout/layout_contribution.xml
@@ -23,8 +23,6 @@
         android:layout_width="match_parent"
         android:layout_height="240dp"
         app:actualImageScaleType="centerCrop"
-        app:placeholderImage="@drawable/ic_image_black_24dp"
-        app:failureImage="@drawable/ic_image_black_24dp"
         />
 
     <LinearLayout

--- a/app/src/main/res/layout/layout_upload_item.xml
+++ b/app/src/main/res/layout/layout_upload_item.xml
@@ -14,8 +14,6 @@
         android:layout_width="match_parent"
         android:layout_height="192dp"
         app:actualImageScaleType="centerCrop"
-        app:placeholderImage="@drawable/ic_image_black_24dp"
-        app:failureImage="@drawable/ic_error_outline_black_24dp"
         android:scaleType="centerCrop"
         android:contentDescription="@string/upload_image"
         />


### PR DESCRIPTION
This chain of commits goes a long way towards fixing/preventing memory leaks. Also, one of the commits fixes a crash in API <21 where loading of vector drawables is not supported.