### PR TITLE
Espresso: match with ID

### DIFF
--- a/app/src/androidTest/java/fr/free/nrw/commons/SettingsActivityTest.java
+++ b/app/src/androidTest/java/fr/free/nrw/commons/SettingsActivityTest.java
@@ -103,9 +103,8 @@ public class SettingsActivityTest {
 
     private static Matcher<View> findPreferenceList() {
         return allOf(
-                ViewMatchers.isDescendantOfA(ViewMatchers.withId(R.id.settingsFragment)),
-                ViewMatchers.withResourceName("list"),
-                ViewMatchers.hasFocus()
+                ViewMatchers.withParent(ViewMatchers.withId(R.id.settingsFragment)),
+                ViewMatchers.withId(android.R.id.list)
         );
     }
 }


### PR DESCRIPTION
I'm trying to fix the unstableness of SettingsActivityTest. I meant to have fixed it in #666, but it still sometimes breaks. Because it is not reproduced on my machine, I'm just trying something that might work. A recent example of failures without apparent reason is https://travis-ci.org/commons-app/apps-android-commons/builds/236649183

If this still does not work, it might be a better idea to remove SettingsActivityTest from the automated tests while I work on it.
