### PR TITLE
Modify and rename strings

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyViewHolder.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyViewHolder.java
@@ -27,7 +27,7 @@ public class NearbyViewHolder implements ViewHolder<Place> {
         tvName.setText(place.name);
         String description = place.description;
         if ( description == null || description.isEmpty() || description.equals("?")) {
-            description = "No Description Found";
+            description = context.getString(R.string.no_description_found);
         }
         tvDesc.setText(description);
         distance.setText(place.distance);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,7 +192,7 @@ Tap this message (or hit back) to skip this step.</string>
   <string name="navigation_item_settings">Settings</string>
   <string name="navigation_item_feedback">Feedback</string>
   <string name="navigation_item_logout">Logout</string>
-  <string name="navigation_item_info">Introduction</string>
+  <string name="navigation_item_info">Tutorial</string>
 
   <string name="no_description_found">no description found</string>
   <string name="nearby_info_menu_commons_article">Commons Article</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,6 +194,7 @@ Tap this message (or hit back) to skip this step.</string>
   <string name="navigation_item_logout">Logout</string>
   <string name="navigation_item_info">Introduction</string>
 
+  <string name="no_description_found">no description found</string>
   <string name="nearby_info_menu_commons_article">Commons Article</string>
   <string name="nearby_info_menu_wikidata_article">WikiData Article</string>
 </resources>


### PR DESCRIPTION
- Rename "Introduction" to tutorial
- Prevent hardcoded "no description found" string
- Change "no description found" to lowercase to match other description subtitles