### PR TITLE
Check for location permissions when loading Nearby

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,6 +65,7 @@ android {
         abortOnError false
     }
 
+    //FIXME: Temporary fix for https://github.com/commons-app/apps-android-commons/issues/709
     configurations.all {
         resolutionStrategy.force 'com.android.support:support-annotations:25.2.0'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,9 @@ dependencies {
     compile 'com.android.support:support-v4:25.3.1'
     testCompile 'junit:junit:4.12'
     testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.1'
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
+    androidTestCompile ('com.android.support.test.espresso:espresso-core:2.2.2') {
+        exclude module: 'support-annotations'
+    }
     debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5.1'
     releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.1'
 }
@@ -65,5 +67,9 @@ android {
         disable 'MissingTranslation'
         disable 'ExtraTranslation'
         abortOnError false
+    }
+
+    configurations.all {
+        resolutionStrategy.force 'com.android.support:support-annotations:25.2.0'
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,18 +3,6 @@ apply plugin: 'jacoco-android'
 apply from: 'quality.gradle'
 
 dependencies {
-    compile "com.android.support:support-v4:${project.supportLibVersion}"
-    compile "com.android.support:appcompat-v7:${project.supportLibVersion}"
-    compile "com.android.support:design:${project.supportLibVersion}"
-    compile "com.jakewharton:butterknife:$BUTTERKNIFE_VERSION"
-    annotationProcessor "com.jakewharton:butterknife-compiler:$BUTTERKNIFE_VERSION"
-    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.2@aar') {
-        transitive = true
-    }
-    compile "com.google.guava:guava:${GUAVA_VERSION}"
-
-    androidTestCompile "com.android.support:support-annotations:${project.supportLibVersion}"
-
     compile 'com.github.nicolas-raoul:Quadtree:ac16ea8035bf07'
     compile 'fr.avianey.com.viewpagerindicator:library:2.4.1.1@aar'
     compile 'in.yuvi:http.fluent:1.3'
@@ -22,18 +10,27 @@ dependencies {
     compile 'ch.acra:acra:4.7.0'
     compile 'org.mediawiki:api:1.3'
     compile 'commons-codec:commons-codec:1.10'
+    compile "com.android.support:support-v4:${project.supportLibVersion}"
+    compile "com.android.support:appcompat-v7:${project.supportLibVersion}"
+    compile "com.android.support:design:${project.supportLibVersion}"
     compile 'com.google.code.gson:gson:2.7'
+    compile "com.jakewharton:butterknife:$BUTTERKNIFE_VERSION"
+    annotationProcessor "com.jakewharton:butterknife-compiler:$BUTTERKNIFE_VERSION"
     compile 'com.jakewharton.timber:timber:4.5.1'
+    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.2@aar'){
+        transitive=true
+    }
     compile 'com.facebook.fresco:fresco:1.3.0'
     compile 'com.facebook.stetho:stetho:1.5.0'
-    compile 'com.android.support:support-v4:25.3.1'
+    compile "com.google.guava:guava:${GUAVA_VERSION}"
+
     testCompile 'junit:junit:4.12'
-    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.1'
-    androidTestCompile ('com.android.support.test.espresso:espresso-core:2.2.2') {
-        exclude module: 'support-annotations'
-    }
+    androidTestCompile "com.android.support:support-annotations:${project.supportLibVersion}"
+    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
+
     debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5.1'
     releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.1'
+    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.1'
 }
 
 android {
@@ -54,8 +51,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
-            // See https://stackoverflow.com/questions/40232404/google-play-apk-and-android-studio-apk-usb-debug-behaving-differently - proguard.cfg modification alone insufficient.
+            minifyEnabled false // See https://stackoverflow.com/questions/40232404/google-play-apk-and-android-studio-apk-usb-debug-behaving-differently - proguard.cfg modification alone insufficient.
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
         debug {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,18 @@ apply plugin: 'jacoco-android'
 apply from: 'quality.gradle'
 
 dependencies {
+    compile "com.android.support:support-v4:${project.supportLibVersion}"
+    compile "com.android.support:appcompat-v7:${project.supportLibVersion}"
+    compile "com.android.support:design:${project.supportLibVersion}"
+    compile "com.jakewharton:butterknife:$BUTTERKNIFE_VERSION"
+    annotationProcessor "com.jakewharton:butterknife-compiler:$BUTTERKNIFE_VERSION"
+    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.2@aar') {
+        transitive = true
+    }
+    compile "com.google.guava:guava:${GUAVA_VERSION}"
+
+    androidTestCompile "com.android.support:support-annotations:${project.supportLibVersion}"
+
     compile 'com.github.nicolas-raoul:Quadtree:ac16ea8035bf07'
     compile 'fr.avianey.com.viewpagerindicator:library:2.4.1.1@aar'
     compile 'in.yuvi:http.fluent:1.3'
@@ -10,27 +22,16 @@ dependencies {
     compile 'ch.acra:acra:4.7.0'
     compile 'org.mediawiki:api:1.3'
     compile 'commons-codec:commons-codec:1.10'
-    compile "com.android.support:support-v4:${project.supportLibVersion}"
-    compile "com.android.support:appcompat-v7:${project.supportLibVersion}"
-    compile "com.android.support:design:${project.supportLibVersion}"
     compile 'com.google.code.gson:gson:2.7'
-    compile "com.jakewharton:butterknife:$BUTTERKNIFE_VERSION"
-    annotationProcessor "com.jakewharton:butterknife-compiler:$BUTTERKNIFE_VERSION"
     compile 'com.jakewharton.timber:timber:4.5.1'
-    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.2@aar'){
-        transitive=true
-    }
     compile 'com.facebook.fresco:fresco:1.3.0'
     compile 'com.facebook.stetho:stetho:1.5.0'
-    compile "com.google.guava:guava:${GUAVA_VERSION}"
-
+    compile 'com.android.support:support-v4:25.3.1'
     testCompile 'junit:junit:4.12'
-    androidTestCompile "com.android.support:support-annotations:${project.supportLibVersion}"
+    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.1'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
-
     debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5.1'
     releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.1'
-    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.1'
 }
 
 android {
@@ -51,11 +52,12 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false // See https://stackoverflow.com/questions/40232404/google-play-apk-and-android-studio-apk-usb-debug-behaving-differently - proguard.cfg modification alone insufficient.
+            minifyEnabled false
+            // See https://stackoverflow.com/questions/40232404/google-play-apk-and-android-studio-apk-usb-debug-behaving-differently - proguard.cfg modification alone insufficient.
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
         debug {
-             testCoverageEnabled true
+            testCoverageEnabled true
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -109,7 +109,9 @@ public class NearbyActivity extends NavigationBaseActivity {
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
         switch (requestCode) {
             case LOCATION_REQUEST: {
-                if (grantResults.length > 0 && grantResults[0] != PackageManager.PERMISSION_GRANTED) {
+                if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    refreshView();
+                } else {
                     //If permission not granted, display notification that Nearby Places cannot be displayed
                     int duration = Toast.LENGTH_LONG;
                     Toast toast = Toast.makeText(this, "Nearby places cannot be found without location permissions", duration);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -1,14 +1,18 @@
 package fr.free.nrw.commons.nearby;
 
+import android.Manifest;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.location.LocationManager;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -87,6 +91,17 @@ public class NearbyActivity extends NavigationBaseActivity {
             default:
                 return super.onOptionsItemSelected(item);
         }
+    }
+
+    protected void checkLocationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+                //Carry on
+            } else {
+                //Ask permission
+            }
+        }
+
     }
 
     protected void checkGps() {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -99,12 +99,26 @@ public class NearbyActivity extends NavigationBaseActivity {
     private void checkLocationPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                //Request permission and display notification that Nearby places cannot be shown without permission
                 ActivityCompat.requestPermissions(this,
                         new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, LOCATION_REQUEST);
             }
         }
     }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        switch (requestCode) {
+            case LOCATION_REQUEST: {
+                if (grantResults.length > 0 && grantResults[0] != PackageManager.PERMISSION_GRANTED) {
+                    //If permission not granted, display notification that Nearby Places cannot be displayed
+                    int duration = Toast.LENGTH_LONG;
+                    Toast toast = Toast.makeText(this, "Nearby places cannot be found without location permissions", duration);
+                    toast.show();
+                }
+            }
+        }
+    }
+
 
     protected void checkGps() {
         LocationManager manager = (LocationManager) getSystemService(LOCATION_SERVICE);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -10,6 +10,7 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.content.ContextCompat;
@@ -93,15 +94,14 @@ public class NearbyActivity extends NavigationBaseActivity {
         }
     }
 
-    protected void checkLocationPermission() {
+    private void checkLocationPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
-                //Carry on
-            } else {
-                //Ask permission
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                //Request permission and display notification that Nearby places cannot be shown without permission
+                ActivityCompat.requestPermissions(this,
+                        new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, 1);
             }
         }
-
     }
 
     protected void checkGps() {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -120,13 +120,7 @@ public class NearbyActivity extends NavigationBaseActivity {
                 if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     startLookingForNearby();
                 } else {
-                    //If permission not granted, display notification that Nearby Places cannot be displayed
-/**
-                    int duration = Toast.LENGTH_LONG;
-                    Toast toast = Toast.makeText(this, R.string.no_location_permission, duration);
-                    toast.show();
-*/
-                    //TODO: Open a fragment saying permissions not granted instead
+                    //If permission not granted, go to page that says Nearby Places cannot be displayed
                     if (nearbyAsyncTask != null) {
                         nearbyAsyncTask.cancel(true);
                     }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -99,8 +99,7 @@ public class NearbyActivity extends NavigationBaseActivity {
     private void checkLocationPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                ActivityCompat.requestPermissions(this,
-                        new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, LOCATION_REQUEST);
+                ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, LOCATION_REQUEST);
             }
         }
     }
@@ -110,7 +109,11 @@ public class NearbyActivity extends NavigationBaseActivity {
         switch (requestCode) {
             case LOCATION_REQUEST: {
                 if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    refreshView();
+                    locationManager = new LocationServiceManager(this);
+                    locationManager.registerLocationManager();
+                    curLatLang = locationManager.getLatestLocation();
+                    nearbyAsyncTask = new NearbyAsyncTask(this);
+                    nearbyAsyncTask.execute();
                 } else {
                     //If permission not granted, display notification that Nearby Places cannot be displayed
                     int duration = Toast.LENGTH_LONG;

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -189,7 +189,9 @@ public class NearbyActivity extends NavigationBaseActivity {
     @Override
     protected void onPause() {
         super.onPause();
-        nearbyAsyncTask.cancel(true);
+        if (nearbyAsyncTask != null) {
+            nearbyAsyncTask.cancel(true);
+        }
     }
 
     protected void refreshView() {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -58,6 +58,7 @@ public class NearbyActivity extends NavigationBaseActivity {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
 
+        checkLocationPermission();
         bundle = new Bundle();
         locationManager = new LocationServiceManager(this);
         locationManager.registerLocationManager();

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -121,16 +121,19 @@ public class NearbyActivity extends NavigationBaseActivity {
                     startLookingForNearby();
                 } else {
                     //If permission not granted, display notification that Nearby Places cannot be displayed
-                    /**
+/**
                     int duration = Toast.LENGTH_LONG;
                     Toast toast = Toast.makeText(this, R.string.no_location_permission, duration);
-                    toast.show();*/
-
+                    toast.show();
+*/
                     //TODO: Open a fragment saying permissions not granted instead
+                    if (nearbyAsyncTask != null) {
+                        nearbyAsyncTask.cancel(true);
+                    }
                     FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
-                    Fragment fragment = new NoPermissionsFragment();
-                    fragment.setArguments(bundle);
-                    fragmentTransaction.replace(R.id.container, fragment);
+                    Fragment noPermissionsFragment = new NoPermissionsFragment();
+                    fragmentTransaction.replace(R.id.container, noPermissionsFragment);
+                    fragmentTransaction.addToBackStack(null);
                     fragmentTransaction.commit();
                 }
             }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -136,7 +136,6 @@ public class NearbyActivity extends NavigationBaseActivity {
                     FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
                     Fragment noPermissionsFragment = new NoPermissionsFragment();
                     fragmentTransaction.replace(R.id.container, noPermissionsFragment);
-                    fragmentTransaction.addToBackStack(null);
                     fragmentTransaction.commit();
                 }
             }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -120,13 +120,12 @@ public class NearbyActivity extends NavigationBaseActivity {
                 } else {
                     //If permission not granted, display notification that Nearby Places cannot be displayed
                     int duration = Toast.LENGTH_LONG;
-                    Toast toast = Toast.makeText(this, "Nearby places cannot be found without location permissions", duration);
+                    Toast toast = Toast.makeText(this, R.string.no_location_permission, duration);
                     toast.show();
                 }
             }
         }
     }
-
 
     protected void checkGps() {
         LocationManager manager = (LocationManager) getSystemService(LOCATION_SERVICE);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -43,6 +43,7 @@ public class NearbyActivity extends NavigationBaseActivity {
     @BindView(R.id.progressBar)
     ProgressBar progressBar;
     private boolean isMapViewActive = false;
+    private static final int LOCATION_REQUEST = 1;
 
     private LocationServiceManager locationManager;
     private LatLng curLatLang;
@@ -100,7 +101,7 @@ public class NearbyActivity extends NavigationBaseActivity {
             if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
                 //Request permission and display notification that Nearby places cannot be shown without permission
                 ActivityCompat.requestPermissions(this,
-                        new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, 1);
+                        new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, LOCATION_REQUEST);
             }
         }
     }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -130,6 +130,9 @@ public class NearbyActivity extends NavigationBaseActivity {
                     if (nearbyAsyncTask != null) {
                         nearbyAsyncTask.cancel(true);
                     }
+                    if (progressBar != null) {
+                        progressBar.setVisibility(View.GONE);
+                    }
                     FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
                     Fragment noPermissionsFragment = new NoPermissionsFragment();
                     fragmentTransaction.replace(R.id.container, noPermissionsFragment);
@@ -219,7 +222,9 @@ public class NearbyActivity extends NavigationBaseActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        locationManager.unregisterLocationManager();
+        if (locationManager != null) {
+            locationManager.unregisterLocationManager();
+        }
     }
 
     private class NearbyAsyncTask extends AsyncTask<Void, Integer, List<Place>> {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -10,6 +10,7 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
@@ -113,7 +114,7 @@ public class NearbyActivity extends NavigationBaseActivity {
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         switch (requestCode) {
             case LOCATION_REQUEST: {
                 if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -175,16 +175,18 @@ public class NearbyActivity extends NavigationBaseActivity {
     }
 
     private void showMapView() {
-        if (!isMapViewActive) {
-            isMapViewActive = true;
-            if (nearbyAsyncTask.getStatus() == AsyncTask.Status.FINISHED) {
-                setMapFragment();
-            }
+        if (nearbyAsyncTask != null) {
+            if (!isMapViewActive) {
+                isMapViewActive = true;
+                if (nearbyAsyncTask.getStatus() == AsyncTask.Status.FINISHED) {
+                    setMapFragment();
+                }
 
-        } else {
-            isMapViewActive = false;
-            if (nearbyAsyncTask.getStatus() == AsyncTask.Status.FINISHED) {
-                setListFragment();
+            } else {
+                isMapViewActive = false;
+                if (nearbyAsyncTask.getStatus() == AsyncTask.Status.FINISHED) {
+                    setListFragment();
+                }
             }
         }
     }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -121,9 +121,17 @@ public class NearbyActivity extends NavigationBaseActivity {
                     startLookingForNearby();
                 } else {
                     //If permission not granted, display notification that Nearby Places cannot be displayed
+                    /**
                     int duration = Toast.LENGTH_LONG;
                     Toast toast = Toast.makeText(this, R.string.no_location_permission, duration);
-                    toast.show();
+                    toast.show();*/
+
+                    //TODO: Open a fragment saying permissions not granted instead
+                    FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
+                    Fragment fragment = new NoPermissionsFragment();
+                    fragment.setArguments(bundle);
+                    fragmentTransaction.replace(R.id.container, fragment);
+                    fragmentTransaction.commit();
                 }
             }
         }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -58,7 +58,6 @@ public class NearbyActivity extends NavigationBaseActivity {
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
-
         checkLocationPermission();
         bundle = new Bundle();
         initDrawer();
@@ -101,10 +100,12 @@ public class NearbyActivity extends NavigationBaseActivity {
 
     private void checkLocationPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+            if (ContextCompat.checkSelfPermission(this,
+                    Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
                 startLookingForNearby();
             } else {
-                ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, LOCATION_REQUEST);
+                ActivityCompat.requestPermissions(this,
+                        new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, LOCATION_REQUEST);
             }
         } else {
             startLookingForNearby();

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -61,11 +61,6 @@ public class NearbyActivity extends NavigationBaseActivity {
 
         checkLocationPermission();
         bundle = new Bundle();
-        locationManager = new LocationServiceManager(this);
-        locationManager.registerLocationManager();
-        curLatLang = locationManager.getLatestLocation();
-        nearbyAsyncTask = new NearbyAsyncTask(this);
-        nearbyAsyncTask.execute();
         initDrawer();
     }
 
@@ -96,11 +91,23 @@ public class NearbyActivity extends NavigationBaseActivity {
         }
     }
 
+    private void startLookingForNearby() {
+        locationManager = new LocationServiceManager(this);
+        locationManager.registerLocationManager();
+        curLatLang = locationManager.getLatestLocation();
+        nearbyAsyncTask = new NearbyAsyncTask(this);
+        nearbyAsyncTask.execute();
+    }
+
     private void checkLocationPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+                startLookingForNearby();
+            } else {
                 ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, LOCATION_REQUEST);
             }
+        } else {
+            startLookingForNearby();
         }
     }
 
@@ -109,11 +116,7 @@ public class NearbyActivity extends NavigationBaseActivity {
         switch (requestCode) {
             case LOCATION_REQUEST: {
                 if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    locationManager = new LocationServiceManager(this);
-                    locationManager.registerLocationManager();
-                    curLatLang = locationManager.getLatestLocation();
-                    nearbyAsyncTask = new NearbyAsyncTask(this);
-                    nearbyAsyncTask.execute();
+                    startLookingForNearby();
                 } else {
                     //If permission not granted, display notification that Nearby Places cannot be displayed
                     int duration = Toast.LENGTH_LONG;

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NoPermissionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NoPermissionsFragment.java
@@ -1,0 +1,30 @@
+package fr.free.nrw.commons.nearby;
+
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import fr.free.nrw.commons.R;
+
+/**
+ * A simple {@link Fragment} subclass.
+ */
+public class NoPermissionsFragment extends Fragment {
+
+
+    public NoPermissionsFragment() {
+        // Required empty public constructor
+    }
+
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_no_permissions, container, false);
+    }
+
+}

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NoPermissionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NoPermissionsFragment.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.nearby;
 
-
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -12,24 +11,19 @@ import fr.free.nrw.commons.R;
 import timber.log.Timber;
 
 /**
- * A simple {@link Fragment} subclass.
+ * Tells user that Nearby Places cannot be displayed if location permissions are denied
  */
 public class NoPermissionsFragment extends Fragment {
 
-
     public NoPermissionsFragment() {
-        // Required empty public constructor
     }
-
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        // Inflate the layout for this fragment
         Timber.d("NoPermissionsFragment created");
         View view = inflater.inflate(R.layout.fragment_no_permissions, container, false);
         ButterKnife.bind(this, view);
-
         return view;
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NoPermissionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NoPermissionsFragment.java
@@ -7,7 +7,9 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import butterknife.ButterKnife;
 import fr.free.nrw.commons.R;
+import timber.log.Timber;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -24,7 +26,11 @@ public class NoPermissionsFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_no_permissions, container, false);
+        Timber.d("NoPermissionsFragment created");
+        View view = inflater.inflate(R.layout.fragment_no_permissions, container, false);
+        ButterKnife.bind(this, view);
+
+        return view;
     }
 
 }

--- a/app/src/main/res/layout/fragment_no_permissions.xml
+++ b/app/src/main/res/layout/fragment_no_permissions.xml
@@ -1,0 +1,13 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="fr.free.nrw.commons.nearby.NoPermissionsFragment">
+
+    <!-- TODO: Update blank fragment layout -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="@string/hello_blank_fragment" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_no_permissions.xml
+++ b/app/src/main/res/layout/fragment_no_permissions.xml
@@ -4,10 +4,16 @@
     android:layout_height="match_parent"
     tools:context="fr.free.nrw.commons.nearby.NoPermissionsFragment">
 
-    <!-- TODO: Update blank fragment layout -->
     <TextView
-        android:layout_width="match_parent"
+        android:id="@+id/textView2"
+        android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+        android:gravity="center"
+        android:paddingLeft="30dp"
+        android:paddingRight="30dp"
+        android:text="@string/nearby_needs_permissions"
+        android:textAlignment="center"
+        android:textSize="18sp" />
+
 
 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,6 +194,7 @@ Tap this message (or hit back) to skip this step.</string>
   <string name="navigation_item_logout">Logout</string>
   <string name="navigation_item_info">Tutorial</string>
 
+  <string name="no_location_permission">Nearby places cannot be found without location permissions</string>
   <string name="no_description_found">no description found</string>
   <string name="nearby_info_menu_commons_article">Commons Article</string>
   <string name="nearby_info_menu_wikidata_article">WikiData Article</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,4 +198,7 @@ Tap this message (or hit back) to skip this step.</string>
   <string name="no_description_found">no description found</string>
   <string name="nearby_info_menu_commons_article">Commons Article</string>
   <string name="nearby_info_menu_wikidata_article">WikiData Article</string>
+
+  <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,7 +195,6 @@ Tap this message (or hit back) to skip this step.</string>
   <string name="navigation_item_info">Tutorial</string>
 
   <string name="nearby_needs_permissions">Nearby places cannot be displayed without location permissions</string>
-  <string name="no_location_permission">Nearby places cannot be found without location permissions</string>
   <string name="no_description_found">no description found</string>
   <string name="nearby_info_menu_commons_article">Commons Article</string>
   <string name="nearby_info_menu_wikidata_article">WikiData Article</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,11 +194,11 @@ Tap this message (or hit back) to skip this step.</string>
   <string name="navigation_item_logout">Logout</string>
   <string name="navigation_item_info">Tutorial</string>
 
+  <string name="nearby_needs_permissions">Nearby places cannot be displayed without location permissions</string>
   <string name="no_location_permission">Nearby places cannot be found without location permissions</string>
   <string name="no_description_found">no description found</string>
   <string name="nearby_info_menu_commons_article">Commons Article</string>
   <string name="nearby_info_menu_wikidata_article">WikiData Article</string>
 
-  <!-- TODO: Remove or change this placeholder text -->
-    <string name="hello_blank_fragment">Hello blank fragment</string>
+
 </resources>


### PR DESCRIPTION
Fix #650 . Adds runtime permissions checking when Nearby is loaded, tells user that Nearby places cannot be found if permissions denied.