### PR TITLE
Description button change

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
@@ -188,8 +188,10 @@ public class SingleUploadFragment extends Fragment {
         String desc = titleDesc.getString("Desc", "");
         Timber.d("Title: %s, Desc: %s", title, desc);
 
-        titleEdit.setText(title);
-        descEdit.setText(desc);
+        if (title.trim().length() > 0 && desc.trim().length() > 0) {
+            titleEdit.setText(title);
+            descEdit.setText(desc);
+        }
     }
 
     private void setLicenseSummary(String license) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
@@ -189,8 +189,8 @@ public class SingleUploadFragment extends Fragment {
         Timber.d("Title: %s, Desc: %s", title, desc);
 
         if (title.trim().length() > 0 && desc.trim().length() > 0) {
-            titleEdit.setText(title);
             descEdit.setText(desc);
+            titleEdit.setText(title);
         }
     }
 


### PR DESCRIPTION
Changed the "Use previous title/description" button so that it does not delete the title and description edit text fields if the user hasn't uploaded yet. #503 