### PR TITLE
Share file with camera using cache and FileProvider (for API 24)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -126,6 +126,16 @@
         </service>
 
         <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
+
+        <provider
                 android:name=".contributions.ContributionsContentProvider"
                 android:label="@string/provider_contributions"
                 android:syncable="true"

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -197,7 +197,7 @@ public class MediaDetailFragment extends Fragment {
                     extractor.fetch();
                     return Boolean.TRUE;
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    Timber.d(e);
                 }
                 return Boolean.FALSE;
             }

--- a/app/src/main/java/fr/free/nrw/commons/upload/ExistingFileAsync.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ExistingFileAsync.java
@@ -25,17 +25,19 @@ public class ExistingFileAsync extends AsyncTask<Void, Void, Boolean> {
     interface Callback {
         void onResult(Result result);
     }
+
     public enum Result {
         NO_DUPLICATE,
         DUPLICATE_PROCEED,
         DUPLICATE_CANCELLED
     }
-    private final String fileSHA1;
+
+    private final String fileSha1;
     private final Context context;
     private final Callback callback;
 
-    public ExistingFileAsync(String fileSHA1, Context context, Callback callback) {
-        this.fileSHA1 = fileSHA1;
+    public ExistingFileAsync(String fileSha1, Context context, Callback callback) {
+        this.fileSha1 = fileSha1;
         this.context = context;
         this.callback = callback;
     }
@@ -55,7 +57,7 @@ public class ExistingFileAsync extends AsyncTask<Void, Void, Boolean> {
             result = api.action("query")
                     .param("format", "xml")
                     .param("list", "allimages")
-                    .param("aisha1", fileSHA1)
+                    .param("aisha1", fileSha1)
                     .get();
             Timber.d("Searching Commons API for existing file: %s", result);
         } catch (IOException e) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/ExistingFileAsync.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ExistingFileAsync.java
@@ -6,13 +6,13 @@ import android.content.Intent;
 import android.os.AsyncTask;
 import android.support.v7.app.AlertDialog;
 
-import fr.free.nrw.commons.MWApi;
 import org.mediawiki.api.ApiResult;
 
 import java.io.IOException;
 import java.util.ArrayList;
 
 import fr.free.nrw.commons.CommonsApplication;
+import fr.free.nrw.commons.MWApi;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.contributions.ContributionsActivity;
 import timber.log.Timber;
@@ -22,13 +22,22 @@ import timber.log.Timber;
  * Displays a warning to the user if the file already exists on Commons
  */
 public class ExistingFileAsync extends AsyncTask<Void, Void, Boolean> {
+    interface Callback {
+        void onResult(Result result);
+    }
+    public enum Result {
+        NO_DUPLICATE,
+        DUPLICATE_PROCEED,
+        DUPLICATE_CANCELLED
+    }
+    private final String fileSHA1;
+    private final Context context;
+    private final Callback callback;
 
-    private String fileSHA1;
-    private Context context;
-
-    public ExistingFileAsync(String fileSHA1, Context context) {
+    public ExistingFileAsync(String fileSHA1, Context context, Callback callback) {
         this.fileSHA1 = fileSHA1;
         this.context = context;
+        this.callback = callback;
     }
 
     @Override
@@ -79,17 +88,20 @@ public class ExistingFileAsync extends AsyncTask<Void, Void, Boolean> {
                     //Go back to ContributionsActivity
                     Intent intent = new Intent(context, ContributionsActivity.class);
                     context.startActivity(intent);
+                    callback.onResult(Result.DUPLICATE_CANCELLED);
                 }
             });
             builder.setNegativeButton(R.string.yes, new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int id) {
-                    //No need to do anything, user remains on upload screen
+                    callback.onResult(Result.DUPLICATE_PROCEED);
                 }
             });
 
             AlertDialog dialog = builder.create();
             dialog.show();
+        } else {
+            callback.onResult(Result.NO_DUPLICATE);
         }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/upload/FileUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileUtils.java
@@ -166,10 +166,11 @@ public class FileUtils {
      * @param destination stream copied to
      * @throws IOException thrown when failing to read source or opening destination file
      */
-    public static void copy(@NonNull FileInputStream source, @NonNull FileOutputStream destination) throws IOException {
-        FileChannel source_ = source.getChannel();
-        FileChannel dest_ = destination.getChannel();
-        source_.transferTo(0, source_.size(), dest_);
+    public static void copy(@NonNull FileInputStream source, @NonNull FileOutputStream destination)
+            throws IOException {
+        FileChannel sourceChannel = source.getChannel();
+        FileChannel destinationChannel = destination.getChannel();
+        sourceChannel.transferTo(0, sourceChannel.size(), destinationChannel);
     }
 
     /**
@@ -178,7 +179,8 @@ public class FileUtils {
      * @param destination file path copied to
      * @throws IOException thrown when failing to read source or opening destination file
      */
-    public static void copy(@NonNull FileDescriptor source, @NonNull String destination) throws IOException {
+    public static void copy(@NonNull FileDescriptor source, @NonNull String destination)
+            throws IOException {
         copy(new FileInputStream(source), new FileOutputStream(destination));
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/FileUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileUtils.java
@@ -9,6 +9,16 @@ import android.os.Build;
 import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+import timber.log.Timber;
 
 public class FileUtils {
 
@@ -23,6 +33,7 @@ public class FileUtils {
      */
     // Can be safely suppressed, checks for isKitKat before running isDocumentUri
     @SuppressLint("NewApi")
+    @Nullable
     public static String getPath(Context context, Uri uri) {
 
         final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
@@ -93,6 +104,7 @@ public class FileUtils {
      * @param selectionArgs (Optional) Selection arguments used in the query.
      * @return The value of the _data column, which is typically a file path.
      */
+    @Nullable
     public static String getDataColumn(Context context, Uri uri, String selection,
                                        String[] selectionArgs) {
 
@@ -108,6 +120,8 @@ public class FileUtils {
                 final int column_index = cursor.getColumnIndexOrThrow(column);
                 return cursor.getString(column_index);
             }
+        } catch (IllegalArgumentException e) {
+            Timber.d(e);
         } finally {
             if (cursor != null)
                 cursor.close();
@@ -119,7 +133,7 @@ public class FileUtils {
      * @param uri The Uri to check.
      * @return Whether the Uri authority is ExternalStorageProvider.
      */
-    public static boolean isExternalStorageDocument(Uri uri) {
+    private static boolean isExternalStorageDocument(Uri uri) {
         return "com.android.externalstorage.documents".equals(uri.getAuthority());
     }
 
@@ -127,7 +141,7 @@ public class FileUtils {
      * @param uri The Uri to check.
      * @return Whether the Uri authority is DownloadsProvider.
      */
-    public static boolean isDownloadsDocument(Uri uri) {
+    private static boolean isDownloadsDocument(Uri uri) {
         return "com.android.providers.downloads.documents".equals(uri.getAuthority());
     }
 
@@ -135,7 +149,37 @@ public class FileUtils {
      * @param uri The Uri to check.
      * @return Whether the Uri authority is MediaProvider.
      */
-    public static boolean isMediaDocument(Uri uri) {
+    private static boolean isMediaDocument(Uri uri) {
         return "com.android.providers.media.documents".equals(uri.getAuthority());
     }
+
+    /**
+     * Check if the URI is owned by the current app.
+     */
+    public static boolean isSelfOwned(Context context, Uri uri) {
+        return uri.getAuthority().equals(context.getPackageName() + ".provider");
+    }
+
+    /**
+     * Copy content from source file to destination file.
+     * @param source stream copied from
+     * @param destination stream copied to
+     * @throws IOException thrown when failing to read source or opening destination file
+     */
+    public static void copy(@NonNull FileInputStream source, @NonNull FileOutputStream destination) throws IOException {
+        FileChannel source_ = source.getChannel();
+        FileChannel dest_ = destination.getChannel();
+        source_.transferTo(0, source_.size(), dest_);
+    }
+
+    /**
+     * Copy content from source file to destination file.
+     * @param source file descriptor copied from
+     * @param destination file path copied to
+     * @throws IOException thrown when failing to read source or opening destination file
+     */
+    public static void copy(@NonNull FileDescriptor source, @NonNull String destination) throws IOException {
+        copy(new FileInputStream(source), new FileOutputStream(destination));
+    }
+
 }

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -291,7 +291,9 @@ public  class       ShareActivity
                                 + getResources().getString(R.string.location_permission_rationale);
                 snackbar = requestPermissionUsingSnackBar(
                         permissionRationales,
-                        new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.ACCESS_FINE_LOCATION},
+                        new String[]{
+                                Manifest.permission.READ_EXTERNAL_STORAGE,
+                                Manifest.permission.ACCESS_FINE_LOCATION},
                         REQUEST_PERM_ON_CREATE_STORAGE_AND_LOCATION);
                 View snackbarView = snackbar.getView();
                 TextView textView = (TextView) snackbarView.findViewById(android.support.design.R.id.snackbar_text);
@@ -308,7 +310,7 @@ public  class       ShareActivity
                         REQUEST_PERM_ON_CREATE_LOCATION);
             }
         }
-        preuploadProcessingOfFile();
+        performPreuploadProcessingOfFile();
     }
 
     @Override
@@ -320,7 +322,7 @@ public  class       ShareActivity
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     backgroundImageView.setImageURI(mediaUri);
                     storagePermitted = true;
-                    preuploadProcessingOfFile();
+                    performPreuploadProcessingOfFile();
                 }
                 return;
             }
@@ -328,7 +330,7 @@ public  class       ShareActivity
                 if (grantResults.length >= 1
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     locationPermitted = true;
-                    preuploadProcessingOfFile();
+                    performPreuploadProcessingOfFile();
                 }
                 return;
             }
@@ -337,12 +339,12 @@ public  class       ShareActivity
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     backgroundImageView.setImageURI(mediaUri);
                     storagePermitted = true;
-                    preuploadProcessingOfFile();
+                    performPreuploadProcessingOfFile();
                 }
                 if (grantResults.length >= 2
                         && grantResults[1] == PackageManager.PERMISSION_GRANTED) {
                     locationPermitted = true;
-                    preuploadProcessingOfFile();
+                    performPreuploadProcessingOfFile();
                 }
                 return;
             }
@@ -353,7 +355,7 @@ public  class       ShareActivity
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     //It is OK to call this at both (1) and (4) because if perm had been granted at
                     //snackbar, user should not be prompted at submit button
-                    preuploadProcessingOfFile();
+                    performPreuploadProcessingOfFile();
 
                     //Uploading only begins if storage permission granted from arrow icon
                     uploadBegins();
@@ -364,9 +366,8 @@ public  class       ShareActivity
         }
     }
 
-    private void preuploadProcessingOfFile() {
-        if(!useNewPermissions || storagePermitted) {
-
+    private void performPreuploadProcessingOfFile() {
+        if (!useNewPermissions || storagePermitted) {
             if (!duplicateCheckPassed) {
                 //Test SHA1 of image to see if it matches SHA1 of a file on Commons
                 try {
@@ -375,15 +376,16 @@ public  class       ShareActivity
                     String fileSHA1 = Utils.getSHA1(inputStream);
                     Timber.d("File SHA1 is: %s", fileSHA1);
 
-                    ExistingFileAsync fileAsyncTask = new ExistingFileAsync(fileSHA1, this, new ExistingFileAsync.Callback() {
-                        @Override
-                        public void onResult(ExistingFileAsync.Result result) {
-                            Timber.d("%s duplicate check: %s", mediaUri.toString(), result);
-                            duplicateCheckPassed =
-                                    result == ExistingFileAsync.Result.DUPLICATE_PROCEED
-                                            || result == ExistingFileAsync.Result.NO_DUPLICATE;
-                        }
-                    });
+                    ExistingFileAsync fileAsyncTask =
+                            new ExistingFileAsync(fileSHA1, this, new ExistingFileAsync.Callback() {
+                                @Override
+                                public void onResult(ExistingFileAsync.Result result) {
+                                    Timber.d("%s duplicate check: %s", mediaUri.toString(), result);
+                                    duplicateCheckPassed =
+                                            result == ExistingFileAsync.Result.DUPLICATE_PROCEED
+                                                    || result == ExistingFileAsync.Result.NO_DUPLICATE;
+                                }
+                            });
                     fileAsyncTask.execute();
                 } catch (IOException e) {
                     Timber.d(e, "IO Exception: ");
@@ -392,12 +394,13 @@ public  class       ShareActivity
 
             getFileMetadata(locationPermitted);
         } else {
-            Timber.w("not ready for preprocess: useNewPermissions=%s storage=%s location=%s",
+            Timber.w("not ready for preprocessing: useNewPermissions=%s storage=%s location=%s",
                     useNewPermissions, storagePermitted, locationPermitted);
         }
     }
 
-    private Snackbar requestPermissionUsingSnackBar(String rationale, final String[] perms, final int code) {
+    private Snackbar requestPermissionUsingSnackBar(
+            String rationale, final String[] perms, final int code) {
         Snackbar snackbar = Snackbar.make(findViewById(android.R.id.content), rationale,
                 Snackbar.LENGTH_INDEFINITE)
                 .setAction(R.string.ok, new View.OnClickListener() {

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
@@ -113,35 +113,36 @@ public class UploadController {
                         }
                         contribution.setDataLength(length);
                     }
-                } catch(IOException e) {
+                } catch (IOException e) {
                     Timber.e(e, "IO Exception: ");
-                } catch(NullPointerException e) {
+                } catch (NullPointerException e) {
                     Timber.e(e, "Null Pointer Exception: ");
-                } catch(SecurityException e) {
+                } catch (SecurityException e) {
                     Timber.e(e, "Security Exception: ");
                 }
 
                 String mimeType = (String)contribution.getTag("mimeType");
                 Boolean imagePrefix = false;
 
-                if(mimeType == null || TextUtils.isEmpty(mimeType) || mimeType.endsWith("*")) {
+                if (mimeType == null || TextUtils.isEmpty(mimeType) || mimeType.endsWith("*")) {
                     mimeType = app.getContentResolver().getType(contribution.getLocalUri());
                 }
 
-                if(mimeType != null) {
+                if (mimeType != null) {
                     contribution.setTag("mimeType", mimeType);
                     imagePrefix = mimeType.startsWith("image/");
                     Timber.d("MimeType is: %s", mimeType);
                 }
 
-                if(imagePrefix && contribution.getDateCreated() == null) {
+                if (imagePrefix && contribution.getDateCreated() == null) {
+                    Timber.d("local uri   " + contribution.getLocalUri());
                     Cursor cursor = app.getContentResolver().query(contribution.getLocalUri(),
                             new String[]{MediaStore.Images.ImageColumns.DATE_TAKEN}, null, null, null);
-                    if(cursor != null && cursor.getCount() != 0) {
+                    if (cursor != null && cursor.getCount() != 0 && cursor.getColumnCount() != 0) {
                         cursor.moveToFirst();
                         Date dateCreated = new Date(cursor.getLong(0));
                         Date epochStart = new Date(0);
-                        if(dateCreated.equals(epochStart) || dateCreated.before(epochStart)) {
+                        if (dateCreated.equals(epochStart) || dateCreated.before(epochStart)) {
                             // If date is incorrect (1st second of unix time) then set it to the current date
                             dateCreated = new Date();
                         }

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="images" path="images/" />
+</paths>

--- a/app/src/test/java/fr/free/nrw/commons/FileUtilsTest.java
+++ b/app/src/test/java/fr/free/nrw/commons/FileUtilsTest.java
@@ -1,0 +1,40 @@
+package fr.free.nrw.commons;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import fr.free.nrw.commons.upload.FileUtils;
+
+import static org.hamcrest.CoreMatchers.is;
+
+public class FileUtilsTest {
+    @Test public void copiedFileIsIdenticalToSource() throws IOException {
+        File source = File.createTempFile("temp", "");
+        File dest = File.createTempFile("temp", "");
+        writeToFile(source, "Hello, World");
+        FileUtils.copy(new FileInputStream(source), new FileOutputStream(dest));
+        Assert.assertThat(getString(dest), is(getString(source)));
+    }
+
+    private static void writeToFile(File file, String s) throws IOException {
+        BufferedOutputStream buf = new BufferedOutputStream(new FileOutputStream(file));
+        buf.write(s.getBytes());
+        buf.close();
+    }
+
+    private static String getString(File file) throws IOException {
+        int size = (int) file.length();
+        byte[] bytes = new byte[size];
+        BufferedInputStream buf = new BufferedInputStream(new FileInputStream(file));
+        buf.read(bytes, 0, bytes.length);
+        buf.close();
+        return new String(bytes);
+    }
+}


### PR DESCRIPTION
Attempted fix for #457.

EDIT: since this PR became rather long, here is a quick summary.
* What this is about: it changes the way files shared between the camera and the app, and the timings of when storage permission is requested.
* What needs to be done: testing photo-capturing and sharing from the gallery on (ideally, physical) devices with across different versions of Android, and code review of the rather large changes of [ShareActivity.java](https://github.com/commons-app/apps-android-commons/pull/727/files#diff-a83ce591f5495a6097b96f65d03c9a4c) and other files.

API 22 (emulator), API 23 (real device) and API 25 (emulator) have been covered my (manual) tests - taking and sharing a photo, sharing from gallery and EXIF extraction.

Anyone willing to do it for API 24 and API 26 preferably on physical devices?
