### PR TITLE
Simplify string sanitation logic

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyInfoDialog.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyInfoDialog.java
@@ -64,7 +64,7 @@ public class NearbyInfoDialog extends OverlayDialog {
     private void getArticleLink(Bundle bundle) {
         this.sitelinks = bundle.getParcelable(ARG_SITE_LINK);
 
-        if (sitelinks.getWikipediaLink() == null) {
+        if (sitelinks.getWikipediaLink().equals(Uri.EMPTY)) {
             goToButton.setVisibility(View.GONE);
         }
 
@@ -87,16 +87,16 @@ public class NearbyInfoDialog extends OverlayDialog {
         MenuItem wikiDataArticle = popupMenu.getMenu()
                 .findItem(R.id.nearby_info_menu_wikidata_article);
 
-        commonsArticle.setEnabled(sitelinks.getCommonsLink() != null);
-        wikiDataArticle.setEnabled(sitelinks.getWikidataLink() != null);
+        commonsArticle.setEnabled(!sitelinks.getCommonsLink().equals(Uri.EMPTY));
+        wikiDataArticle.setEnabled(!sitelinks.getWikidataLink().equals(Uri.EMPTY));
 
         popupMenu.setOnMenuItemClickListener(menuListener);
         popupMenu.show();
     }
 
     private boolean showMenu() {
-        return sitelinks.getCommonsLink() != null
-                || sitelinks.getWikidataLink() != null;
+        return !sitelinks.getCommonsLink().equals(Uri.EMPTY)
+                || !sitelinks.getWikidataLink().equals(Uri.EMPTY);
     }
 
     private PopupMenu.OnMenuItemClickListener menuListener = new PopupMenu

--- a/app/src/main/java/fr/free/nrw/commons/nearby/Sitelinks.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/Sitelinks.java
@@ -5,8 +5,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
 
-import fr.free.nrw.commons.Utils;
-
 public class Sitelinks implements Parcelable {
     private final String wikipediaLink;
     private final String commonsLink;
@@ -43,31 +41,21 @@ public class Sitelinks implements Parcelable {
         }
     };
 
-    @Nullable
     public Uri getWikipediaLink() {
         return sanitiseString(wikipediaLink);
     }
 
-    @Nullable
     public Uri getCommonsLink() {
         return sanitiseString(commonsLink);
     }
 
-    @Nullable
     public Uri getWikidataLink() {
         return sanitiseString(wikidataLink);
     }
 
-    @Nullable
-    private Uri sanitiseString(String stringUrl) {
-        stringUrl = stringUrl
-                .replaceAll("<", "")
-                .replaceAll(">", "")
-                .replaceAll("[\n\r]", "");
-        if (!Utils.isNullOrWhiteSpace(stringUrl) && stringUrl != null) {
-            return Uri.parse(stringUrl);
-        }
-        return null;
+    private static Uri sanitiseString(String stringUrl) {
+        String sanitisedStringUrl = stringUrl.replaceAll("[<>\n\r]", "").trim();
+        return Uri.parse(sanitisedStringUrl);
     }
 
     public Sitelinks(Sitelinks.Builder builder) {


### PR DESCRIPTION
Simplifies string sanitation logic. An added benefit is that the link URIs never return null but instead `Uri.EMPTY` is returned instead for the case  where there is no link. Through this, the null object pattern has successfully been implemented along with all the benefits of such a pattern.