### PR TITLE
Remove redundant call to method

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -56,9 +56,6 @@ public class NearbyActivity extends NavigationBaseActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_nearby);
         ButterKnife.bind(this);
-        if (getSupportActionBar() != null) {
-            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-        }
         checkLocationPermission();
         bundle = new Bundle();
         initDrawer();


### PR DESCRIPTION
`setDisplayHomeAsUpEnabled(true)` is called in [`initDrawer`](https://github.com/commons-app/apps-android-commons/compare/master...veyndan:redundant?expand=1#diff-a51e661309ef237491f4f3ad7be735bcL64). It is redundant calling the method twice straight after each other with the same parameter.