### PR TITLE
Make bundle an immutable reference

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -48,7 +48,7 @@ public class NearbyActivity extends NavigationBaseActivity {
 
     private LocationServiceManager locationManager;
     private LatLng curLatLang;
-    private Bundle bundle;
+    private final Bundle bundle = new Bundle();
     private NearbyAsyncTask nearbyAsyncTask;
 
     @Override
@@ -60,7 +60,6 @@ public class NearbyActivity extends NavigationBaseActivity {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
         checkLocationPermission();
-        bundle = new Bundle();
         initDrawer();
     }
 


### PR DESCRIPTION
This means that we don't have to worry about the `bundle` every being `null` (or reassigned to some other value).