### PR TITLE
Fix crashes where R.id.navigation_view wasn't found

### DIFF
--- a/app/src/main/res/layout/activity_multiple_uploads.xml
+++ b/app/src/main/res/layout/activity_multiple_uploads.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -22,17 +23,12 @@
             android:orientation="vertical"></FrameLayout>
     </RelativeLayout>
 
-    <RelativeLayout
-        android:id="@+id/drawer_pane"
-        android:layout_width="320dp"
-    android:layout_height="match_parent"
+    <android.support.design.widget.NavigationView
+        android:id="@+id/navigation_view"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
         android:layout_gravity="start"
-        android:background="@android:color/white">
-
-        <FrameLayout
-            android:id="@+id/drawer_fragment"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-    </RelativeLayout>
+        app:headerLayout="@layout/drawer_header"
+        app:menu="@menu/drawer" />
 
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_share.xml
+++ b/app/src/main/res/layout/activity_share.xml
@@ -36,17 +36,12 @@
         </FrameLayout>
     </RelativeLayout>
 
-    <RelativeLayout
-        android:id="@+id/drawer_pane"
-        android:layout_width="320dp"
+    <android.support.design.widget.NavigationView
+        android:id="@+id/navigation_view"
+        android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        android:background="@android:color/white">
-
-        <FrameLayout
-            android:id="@+id/drawer_fragment"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-    </RelativeLayout>
+        app:headerLayout="@layout/drawer_header"
+        app:menu="@menu/drawer" />
 
 </android.support.v4.widget.DrawerLayout>


### PR DESCRIPTION
Closes #758.

I had forgotten to migrate all of the old drawer layouts to `NavigationView` in #752. This resolves that and should stop crashes related to `R.id.navigation_view` not being found.