### PR TITLE
Update mapbox to 5.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     compile "com.jakewharton:butterknife:$BUTTERKNIFE_VERSION"
     annotationProcessor "com.jakewharton:butterknife-compiler:$BUTTERKNIFE_VERSION"
     compile 'com.jakewharton.timber:timber:4.5.1'
-    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.2@aar'){
+    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.1.0@aar'){
         transitive=true
     }
     compile 'com.facebook.fresco:fresco:1.3.0'


### PR DESCRIPTION
Mapbox just released their new SDK:

https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v5.1.0

I think we can now implement 3D buildings in the map.