### PR TITLE
fix for #667 issue https://github.com/commons-app/apps-android-common…

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
@@ -326,14 +326,6 @@ public class CategorizationFragment extends Fragment {
 
     private void startUpdatingCategoryList() {
 
-        if (prefixUpdaterSub != null) {
-            prefixUpdaterSub.cancel(true);
-        }
-
-        if (methodAUpdaterSub != null) {
-            methodAUpdaterSub.cancel(true);
-        }
-
         requestSearchResults();
     }
 
@@ -443,8 +435,6 @@ public class CategorizationFragment extends Fragment {
         });
 
         categoriesFilter.addTextChangedListener(textWatcher);
-
-        startUpdatingCategoryList();
 
         return rootView;
     }
@@ -576,16 +566,22 @@ public class CategorizationFragment extends Fragment {
     private class CategoryTextWatcher implements TextWatcher {
         @Override
         public void beforeTextChanged(CharSequence charSequence, int i, int i2, int i3) {
+            if (prefixUpdaterSub != null) {
+                prefixUpdaterSub.cancel(true);
+            }
+
+            if (methodAUpdaterSub != null) {
+                methodAUpdaterSub.cancel(true);
+            }
         }
 
         @Override
         public void onTextChanged(CharSequence charSequence, int i, int i2, int i3) {
-            startUpdatingCategoryList();
         }
 
         @Override
         public void afterTextChanged(Editable editable) {
-
+            startUpdatingCategoryList();
         }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
@@ -10,6 +10,7 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.os.RemoteException;
 import android.preference.PreferenceManager;
+import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v7.app.AlertDialog;
 import android.text.Editable;
@@ -319,6 +320,12 @@ public class CategorizationFragment extends Fragment {
 
                 latch.countDown();
             }
+
+            @Override
+            protected void onCancelled() {
+                super.onCancelled();
+                latch.countDown();
+            }
         };
         prefixUpdaterSub.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
         methodAUpdaterSub.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
@@ -437,6 +444,13 @@ public class CategorizationFragment extends Fragment {
         categoriesFilter.addTextChangedListener(textWatcher);
 
         return rootView;
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        requestSearchResults();
     }
 
     @Override
@@ -568,10 +582,12 @@ public class CategorizationFragment extends Fragment {
         public void beforeTextChanged(CharSequence charSequence, int i, int i2, int i3) {
             if (prefixUpdaterSub != null) {
                 prefixUpdaterSub.cancel(true);
+                prefixUpdaterSub = null;
             }
 
             if (methodAUpdaterSub != null) {
                 methodAUpdaterSub.cancel(true);
+                methodAUpdaterSub = null;
             }
         }
 


### PR DESCRIPTION
Fix for #667 

This bug can be reproduced on low/bad connections only. Because of asynchronus work of getting new categories

Problem was in async requests, and reaction on cancel was wrong.
First of all to decrease impact on phone internet connection - request should start on after text changed, and cancel on before text changed to deliver proper results.

Also requesting on create view was unnecessary, because results may deliver BEFORE view attached to fragment