### PR TITLE
Add 3d extrusions for buildings

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -25,6 +25,15 @@ import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.services.android.telemetry.MapboxTelemetry;
 
+import com.mapbox.mapboxsdk.style.functions.stops.IdentityStops;
+import com.mapbox.mapboxsdk.style.functions.Function;
+import com.mapbox.mapboxsdk.style.layers.FillExtrusionLayer;
+import static com.mapbox.mapboxsdk.style.layers.Filter.eq;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionBase;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionHeight;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionOpacity;
+
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
@@ -106,6 +115,21 @@ public class NearbyMapFragment extends android.support.v4.app.Fragment {
                 });
 
                 addCurrentLocationMarker(mapboxMap);
+
+                // Create fill extrusion layer
+                FillExtrusionLayer fillExtrusionLayer = new FillExtrusionLayer("3d-buildings", "composite");
+                fillExtrusionLayer.setSourceLayer("building");
+                fillExtrusionLayer.setFilter(eq("extrude", "true"));
+                fillExtrusionLayer.setMinZoom(15);
+
+                // Set data-driven styling properties
+                fillExtrusionLayer.setProperties(
+                        fillExtrusionColor(Color.LTGRAY),
+                        fillExtrusionHeight(Function.property("height", new IdentityStops<Float>())),
+                        fillExtrusionBase(Function.property("min_height", new IdentityStops<Float>())),
+                        fillExtrusionOpacity(0.6f)
+                );
+                mapboxMap.addLayer(fillExtrusionLayer);
             }
         });
         if (PreferenceManager.getDefaultSharedPreferences(getActivity()).getBoolean("theme",true)) {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -23,16 +23,10 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
-import com.mapbox.services.android.telemetry.MapboxTelemetry;
-
-import com.mapbox.mapboxsdk.style.functions.stops.IdentityStops;
 import com.mapbox.mapboxsdk.style.functions.Function;
+import com.mapbox.mapboxsdk.style.functions.stops.IdentityStops;
 import com.mapbox.mapboxsdk.style.layers.FillExtrusionLayer;
-import static com.mapbox.mapboxsdk.style.layers.Filter.eq;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionBase;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionColor;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionHeight;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionOpacity;
+import com.mapbox.services.android.telemetry.MapboxTelemetry;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -40,6 +34,12 @@ import java.util.List;
 
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.utils.UriDeserializer;
+
+import static com.mapbox.mapboxsdk.style.layers.Filter.eq;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionBase;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionHeight;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionOpacity;
 
 public class NearbyMapFragment extends android.support.v4.app.Fragment {
     private MapView mapView;


### PR DESCRIPTION
Now that we have the new mapbox SDK we can extrude different map features. I added the extrusion of buildings in this PR. But we probably should discuss if this a good idea. Not sure, but it might transfer more data and take more battery to render the 3d buildings.

![screenshot from 2017-07-15 09-56-11](https://user-images.githubusercontent.com/6953323/28237655-e3aa8280-6944-11e7-9846-d8d830a832d8.png)
