### PR TITLE
Fixing Travis build failure on master

### DIFF
--- a/app/src/androidTest/java/fr/free/nrw/commons/SettingsActivityTest.java
+++ b/app/src/androidTest/java/fr/free/nrw/commons/SettingsActivityTest.java
@@ -9,9 +9,8 @@ import android.support.test.espresso.matcher.ViewMatchers;
 import android.support.test.filters.LargeTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
-import android.view.View;
 
-import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,9 +18,6 @@ import org.junit.runner.RunWith;
 import java.util.Map;
 
 import fr.free.nrw.commons.settings.SettingsActivity;
-
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.anything;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
@@ -65,8 +61,8 @@ public class SettingsActivityTest {
     @Test
     public void oneLicenseIsChecked() {
         // click "License" (the first item)
-        Espresso.onData(anything())
-                .inAdapterView(findPreferenceList())
+        Espresso.onData(Matchers.anything())
+                .inAdapterView(ViewMatchers.withId(android.R.id.list))
                 .atPosition(0)
                 .perform(ViewActions.click());
 
@@ -78,8 +74,8 @@ public class SettingsActivityTest {
     @Test
     public void afterClickingCcby4ItWillStay() {
         // click "License" (the first item)
-        Espresso.onData(anything())
-                .inAdapterView(findPreferenceList())
+        Espresso.onData(Matchers.anything())
+                .inAdapterView(ViewMatchers.withId(android.R.id.list))
                 .atPosition(0)
                 .perform(ViewActions.click());
 
@@ -89,8 +85,8 @@ public class SettingsActivityTest {
         ).perform(ViewActions.click());
 
         // click "License" (the first item)
-        Espresso.onData(anything())
-                .inAdapterView(findPreferenceList())
+        Espresso.onData(Matchers.anything())
+                .inAdapterView(ViewMatchers.withId(android.R.id.list))
                 .atPosition(0)
                 .perform(ViewActions.click());
 
@@ -99,13 +95,5 @@ public class SettingsActivityTest {
                 .check(ViewAssertions.matches(
                         ViewMatchers.withText(R.string.license_name_cc_by_four)
                 ));
-    }
-
-    private static Matcher<View> findPreferenceList() {
-        return allOf(
-                ViewMatchers.isDescendantOfA(ViewMatchers.withId(R.id.settingsFragment)),
-                ViewMatchers.withResourceName("list"),
-                ViewMatchers.hasFocus()
-        );
     }
 }

--- a/app/src/test/java/fr/free/nrw/commons/nearby/NearbyAdapterFactoryTest.java
+++ b/app/src/test/java/fr/free/nrw/commons/nearby/NearbyAdapterFactoryTest.java
@@ -22,10 +22,11 @@ import fr.free.nrw.commons.BuildConfig;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.location.LatLng;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class NearbyAdapterFactoryTest {
 
     private static final Place PLACE = new Place("name", Place.Description.AIRPORT,


### PR DESCRIPTION
The error 
```
fr.free.nrw.commons.mwapi.ApacheHttpClientMediaWikiApiTest > initializationError FAILED
    java.lang.NoClassDefFoundError
        Caused by: java.lang.ClassNotFoundException
```
Most likely stems from the deprecated code.  I believe that `SchemeRegistry` has been been removed in the newest API levels and the gradle flag `useLibrary 'org.apache.http.legacy'` gets around the problem for production code, but Robolectric is being strict in its emulation of the API level in the tests.  Although `ApacheHttpClientMediaWikiApiTest` was annotated to pin it to API 21, `NearbyAdapterFactoryTest` was not so I think the highest API level (recently changed to 25 in `gradle.properties`) was winning.  I ran the tests on the command line with gradle and inside Android Studio and they were green with this tweak.  Hopefully it fixes #783 (Travis build error)!