### PR TITLE
Use string substitution to avoid translating trademarked text

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
@@ -8,9 +8,11 @@ import android.widget.TextView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import fr.free.nrw.commons.theme.NavigationBaseActivity;
+import fr.free.nrw.commons.ui.widget.HtmlTextView;
 
 public class AboutActivity extends NavigationBaseActivity {
     @BindView(R.id.about_version) TextView versionText;
+    @BindView(R.id.about_license) HtmlTextView aboutLicenseText;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -18,6 +20,9 @@ public class AboutActivity extends NavigationBaseActivity {
         setContentView(R.layout.activity_about);
 
         ButterKnife.bind(this);
+
+        String aboutText = getString(R.string.about_license, getString(R.string.trademarked_name));
+        aboutLicenseText.setHtmlText(aboutText);
 
         versionText.setText(BuildConfig.VERSION_NAME);
         initDrawer();

--- a/app/src/main/java/fr/free/nrw/commons/ui/widget/HtmlTextView.java
+++ b/app/src/main/java/fr/free/nrw/commons/ui/widget/HtmlTextView.java
@@ -20,7 +20,7 @@ public class HtmlTextView extends AppCompatTextView {
         setText(Utils.fromHtml(getText().toString()));
     }
 
-    public void setHtmlText(String newText){
+    public void setHtmlText(String newText) {
         setText(Utils.fromHtml(newText));
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/ui/widget/HtmlTextView.java
+++ b/app/src/main/java/fr/free/nrw/commons/ui/widget/HtmlTextView.java
@@ -19,4 +19,8 @@ public class HtmlTextView extends AppCompatTextView {
         setMovementMethod(LinkMovementMethod.getInstance());
         setText(Utils.fromHtml(getText().toString()));
     }
+
+    public void setHtmlText(String newText){
+        setText(Utils.fromHtml(newText));
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,7 +79,8 @@ Tap this message (or hit back) to skip this step.</string>
   <string name="title_activity_settings">Settings</string>
   <string name="title_activity_signup">Sign Up</string>
   <string name="menu_about">About</string>
-  <string name="about_license">Open Source software released under the &lt;a href=\"https://github.com/commons-app/apps-android-commons/blob/master/COPYING\"&gt;Apache License v2&lt;/a&gt;. Wikimedia Commons and its logo are trademarks of the Wikimedia Foundation and are used with the permission of the Wikimedia Foundation. We are not endorsed by or affiliated with the Wikimedia Foundation.</string>
+  <string name="about_license">Open Source software released under the &lt;a href=\"https://github.com/commons-app/apps-android-commons/blob/master/COPYING\"&gt;Apache License v2&lt;/a&gt;. %1$s and its logo are trademarks of the Wikimedia Foundation and are used with the permission of the Wikimedia Foundation. We are not endorsed by or affiliated with the Wikimedia Foundation.</string>
+  <string name="trademarked_name" translatable="false">Wikimedia Commons</string>
   <string name="about_improve">&lt;a href=\"https://github.com/commons-app/apps-android-commons\"&gt;Source&lt;/a&gt; and &lt;a href=\"https://commons-app.github.io/\"&gt;website&lt;/a&gt; on GitHub. Create a new &lt;a href=\"https://github.com/commons-app/apps-android-commons/issues\"&gt;GitHub issue&lt;/a&gt; for bug reports and suggestions.</string>
   <string name="about_privacy_policy">&lt;a href=\"https://wikimediafoundation.org/wiki/Privacy_policy\"&gt;Privacy policy&lt;/a&gt;</string>
   <string name="about_credits">&lt;a href=\"https://github.com/commons-app/apps-android-commons/blob/master/CREDITS\"&gt;Credits&lt;/a&gt;</string>


### PR DESCRIPTION
Hi, this is my first contribution to an open source app.  Please let me know if I'm doing anything incorrectly!

This is meant to address https://github.com/commons-app/apps-android-commons/issues/397.  In the English `strings.xml` I replaced "Wikimedia Commons" with a placeholder and added a separate string holding the trademarked name.  I added a method to `HtmlTextView.java` so the html string could be updated programmatically (without being set to the raw text).  In `AboutActivity.java` I added code to set the the license text. 


I'm very unclear on how the translation process works.  For example, is marking the trademarked string with `translatable="false` (i.e. `<string name="trademarked_name" translatable="false">Wikimedia Commons</string>`) sufficient?  How do I document the fact that the `about_license` string has changed and needs translation?  

I appreciate any feedback.