### PR TITLE
Remove lint results from Travis reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ after_success:
 after_failure:
   - echo '*** Connected Test Rsults ***'
   - w3m -dump ${TRAVIS_BUILD_DIR}/app/build/reports/androidTests/connected/*Test.html
-  - echo '*** Lint Results ***'
-  - cat ${TRAVIS_BUILD_DIR}/app/build/reports/lint-results.xml
 jdk:
   # - openjdk8 # not yet available
   - oraclejdk8


### PR DESCRIPTION
It appears that the presence of lint results is more confusing than useful. At least as long as they are non-voting ("abortOnError false"). Lint results are long and can make it harder to find the cause of build/test failures.