### PR TITLE
don't start new activity if already in that activity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -77,19 +77,27 @@ public class NavigationBaseActivity extends BaseActivity
         switch (item.getItemId()) {
             case R.id.action_home:
                 drawerLayout.closeDrawer(navigationView);
-                ContributionsActivity.startYourself(this);
+                if (!(this instanceof ContributionsActivity)) {
+                    ContributionsActivity.startYourself(this);
+                }
                 return true;
             case R.id.action_nearby:
                 drawerLayout.closeDrawer(navigationView);
-                NearbyActivity.startYourself(this);
+                if (!(this instanceof NearbyActivity)) {
+                    NearbyActivity.startYourself(this);
+                }
                 return true;
             case R.id.action_about:
                 drawerLayout.closeDrawer(navigationView);
-                AboutActivity.startYourself(this);
+                if (!(this instanceof AboutActivity)) {
+                    AboutActivity.startYourself(this);
+                }
                 return true;
             case R.id.action_settings:
                 drawerLayout.closeDrawer(navigationView);
-                SettingsActivity.startYourself(this);
+                if (!(this instanceof SettingsActivity)) {
+                    SettingsActivity.startYourself(this);
+                }
                 return true;
             case R.id.action_introduction:
                 drawerLayout.closeDrawer(navigationView);


### PR DESCRIPTION
This PR aims to address #665.  

I looked at how some other apps with nav drawers (Gmail, Google Music, Google Play) handle the case where the user taps Activity Z from the drawer while already in Activity Z.  They appear to just close the drawer instead of starting an additional instance of the activity.  

I've implemented this here.  This should prevent the user from tapping the back button and having it seem not to work because the back stack has the same activity multiple times in succession.