### PR TITLE
remove signup activity from activity's backstack.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/SignupActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/SignupActivity.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.auth;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -44,9 +43,8 @@ public class SignupActivity extends BaseActivity {
                         Toast.LENGTH_LONG
                 );
                 toast.show();
-
-                Intent intent = new Intent(CommonsApplication.getInstance(), LoginActivity.class);
-                startActivity(intent);
+                // terminate on task completion.
+                finish();
                 return true;
             } else {
                 //If user clicks any other links in the webview


### PR DESCRIPTION
Currently, SignupActivity remains in back stack even after a successful signup and I think there is no need to keep it in back stack. So a call to Activity.finish() method can do the work.