### PR TITLE
Use build tools version 26.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-25.0.1
+    - build-tools-26.0.1
     - extra-google-m2repository
     - extra-android-m2repository
     - ${ANDROID_TARGET}

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ gradleVersion = 2.3.3
 supportLibVersion = 25.3.1
 
 compileSdkVersion = android-25
-buildToolsVersion = 25.0.1
+buildToolsVersion = 26.0.1
 
 minSdkVersion = 15
         


### PR DESCRIPTION
This is an update from Build Tools, Revision 25.0.1 (November 2016) to  Build Tools, Revision 26.0.1 (July 2017). https://developer.android.com/studio/releases/build-tools.html