### PR TITLE
Added callback when removing accounts on logout 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -223,7 +223,7 @@ public class CommonsApplication extends Application {
 
             @Override
             public void run(AccountManagerFuture<Boolean> accountManagerFuture) {
-                setIndex(index++);
+                setIndex(getIndex() + 1);
 
                 try {
                     if (accountManagerFuture != null) {

--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -151,7 +151,7 @@ public class NavigationBaseActivity extends BaseActivity
         }
     }
 
-    public interface LogoutCompleteListener {
+    public interface LogoutListener {
         void onLogoutComplete();
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -25,6 +25,7 @@ import fr.free.nrw.commons.auth.LoginActivity;
 import fr.free.nrw.commons.contributions.ContributionsActivity;
 import fr.free.nrw.commons.nearby.NearbyActivity;
 import fr.free.nrw.commons.settings.SettingsActivity;
+import timber.log.Timber;
 
 public class NavigationBaseActivity extends BaseActivity
         implements NavigationView.OnNavigationItemSelectedListener {
@@ -132,13 +133,15 @@ public class NavigationBaseActivity extends BaseActivity
                         .setCancelable(false)
                         .setPositiveButton(R.string.yes, (dialog, which) -> {
                             ((CommonsApplication) getApplicationContext())
-                                    .clearApplicationData(NavigationBaseActivity.this);
-                            Intent nearbyIntent = new Intent(
-                                    NavigationBaseActivity.this, LoginActivity.class);
-                            nearbyIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
-                            nearbyIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                            startActivity(nearbyIntent);
-                            finish();
+                                    .clearApplicationData(NavigationBaseActivity.this, () -> {
+                                        Timber.d("Logout complete callback received.");
+                                        Intent nearbyIntent = new Intent(
+                                                NavigationBaseActivity.this, LoginActivity.class);
+                                        nearbyIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                                        nearbyIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                                        startActivity(nearbyIntent);
+                                        finish();
+                                    });
                         })
                         .setNegativeButton(R.string.no, (dialog, which) -> dialog.cancel())
                         .show();
@@ -146,5 +149,9 @@ public class NavigationBaseActivity extends BaseActivity
             default:
                 return false;
         }
+    }
+
+    public interface LogoutCompleteListener {
+        void onLogoutComplete();
     }
 }


### PR DESCRIPTION
This will ensure that the transition to LoginActivity happens only when complete logout process is finished so as to ensure that the race condition mentioned in #848 is avoided. 