### PR TITLE
Make MediaTest and PageTitleTest use Robolectric

### DIFF
--- a/app/src/test/java/fr/free/nrw/commons/MediaTest.java
+++ b/app/src/test/java/fr/free/nrw/commons/MediaTest.java
@@ -1,15 +1,15 @@
 package fr.free.nrw.commons;
 
-import android.support.test.runner.AndroidJUnit4;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import static org.hamcrest.CoreMatchers.is;
 
-// TODO: use Robolectric and make it runnable without a connected device
-@RunWith(AndroidJUnit4.class)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class MediaTest {
     @Test public void displayTitleShouldStripExtension() {
         Media m = new Media("File:Example.jpg");

--- a/app/src/test/java/fr/free/nrw/commons/PageTitleTest.java
+++ b/app/src/test/java/fr/free/nrw/commons/PageTitleTest.java
@@ -1,17 +1,17 @@
 package fr.free.nrw.commons;
 
-import android.support.test.runner.AndroidJUnit4;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.net.URLEncoder;
 
 import static org.hamcrest.CoreMatchers.is;
 
-// TODO: use Robolectric and make it runnable without a connected device
-@RunWith(AndroidJUnit4.class)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class PageTitleTest {
     @Test public void displayTextShouldNotBeUnderscored() {
         Assert.assertThat(new PageTitle("Ex_1 ").getDisplayText(),


### PR DESCRIPTION
Both `MediaTest.java` and `PageTitleTest.java` files have the following comment:
"TODO: use Robolectric and make it runnable without a connected device".

This request addresses these 2 (minor) TODOs, which was just moving to the test directory and using the robolectric annotations that other tests were already using.