### PR TITLE
Fixing #844 - If a category has exact name entered, show it first

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.1.0@aar'){
         transitive=true
     }
+    compile 'info.debatty:java-string-similarity:0.24'
 
     compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
     // Because RxAndroid releases are few and far between, it is recommended you also

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,20 +12,23 @@ dependencies {
     compile 'ch.acra:acra:4.7.0'
     compile 'org.mediawiki:api:1.3'
     compile 'commons-codec:commons-codec:1.10'
-    compile "com.android.support:support-v4:${project.supportLibVersion}"
-    compile "com.android.support:appcompat-v7:${project.supportLibVersion}"
-    compile "com.android.support:design:${project.supportLibVersion}"
-    compile 'com.google.code.gson:gson:2.8.0'
-    compile "com.jakewharton:butterknife:$BUTTERKNIFE_VERSION"
     compile 'com.github.pedrovgs:renderers:3.3.3'
-    annotationProcessor "com.jakewharton:butterknife-compiler:$BUTTERKNIFE_VERSION"
+    compile 'com.google.code.gson:gson:2.8.0'
     compile 'com.jakewharton.timber:timber:4.5.1'
-    compile 'com.squareup.okhttp3:okhttp:3.8.1'
-    compile 'com.squareup.okio:okio:1.13.0'
+    compile 'info.debatty:java-string-similarity:0.24'
     compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.1.0@aar'){
         transitive=true
     }
-    compile 'info.debatty:java-string-similarity:0.24'
+
+    compile "com.android.support:support-v4:${project.supportLibVersion}"
+    compile "com.android.support:appcompat-v7:${project.supportLibVersion}"
+    compile "com.android.support:design:${project.supportLibVersion}"
+
+    compile "com.jakewharton:butterknife:$BUTTERKNIFE_VERSION"
+    annotationProcessor "com.jakewharton:butterknife-compiler:$BUTTERKNIFE_VERSION"
+
+    compile 'com.squareup.okhttp3:okhttp:3.8.1'
+    compile 'com.squareup.okio:okio:1.13.0'
 
     compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
     // Because RxAndroid releases are few and far between, it is recommended you also

--- a/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
@@ -227,7 +227,8 @@ public class CategorizationFragment extends Fragment {
 
     private Comparator<CategoryItem> sortBySimilarity(final String filter) {
         Comparator<String> stringSimilarityComparator = StringSortingUtils.sortBySimilarity(filter);
-        return (firstItem, secondItem) -> stringSimilarityComparator.compare(firstItem.getName(), secondItem.getName());
+        return (firstItem, secondItem) -> stringSimilarityComparator
+                .compare(firstItem.getName(), secondItem.getName());
     }
 
     private List<String> getStringList(List<CategoryItem> input) {

--- a/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
@@ -25,6 +25,7 @@ import com.pedrogomez.renderers.RVRendererAdapter;
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -36,6 +37,7 @@ import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.data.Category;
 import fr.free.nrw.commons.upload.MwVolleyApi;
+import fr.free.nrw.commons.utils.StringSortingUtils;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
@@ -199,6 +201,7 @@ public class CategorizationFragment extends Fragment {
                 )
                 .filter(categoryItem -> !containsYear(categoryItem.getName()))
                 .distinct()
+                .sorted(sortByMatches(filter))
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         s -> categoriesAdapter.add(s),
@@ -220,6 +223,11 @@ public class CategorizationFragment extends Fragment {
                             }
                         }
                 );
+    }
+
+    private Comparator<CategoryItem> sortByMatches(final String filter) {
+        Comparator<String> stringSimilarityComparator = StringSortingUtils.sortBySimilarity(filter);
+        return (firstItem, secondItem) -> stringSimilarityComparator.compare(firstItem.getName(), secondItem.getName());
     }
 
     private List<String> getStringList(List<CategoryItem> input) {

--- a/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
@@ -108,7 +108,7 @@ public class CategorizationFragment extends Fragment {
 
         RxTextView.textChanges(categoriesFilter)
                 .takeUntil(RxView.detaches(categoriesFilter))
-                .debounce(300, TimeUnit.MILLISECONDS)
+                .debounce(500, TimeUnit.MILLISECONDS)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(filter -> updateCategoryList(filter.toString()));
         return rootView;

--- a/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
@@ -201,7 +201,7 @@ public class CategorizationFragment extends Fragment {
                 )
                 .filter(categoryItem -> !containsYear(categoryItem.getName()))
                 .distinct()
-                .sorted(sortByMatches(filter))
+                .sorted(sortBySimilarity(filter))
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         s -> categoriesAdapter.add(s),
@@ -225,7 +225,7 @@ public class CategorizationFragment extends Fragment {
                 );
     }
 
-    private Comparator<CategoryItem> sortByMatches(final String filter) {
+    private Comparator<CategoryItem> sortBySimilarity(final String filter) {
         Comparator<String> stringSimilarityComparator = StringSortingUtils.sortBySimilarity(filter);
         return (firstItem, secondItem) -> stringSimilarityComparator.compare(firstItem.getName(), secondItem.getName());
     }

--- a/app/src/main/java/fr/free/nrw/commons/utils/StringSortingUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/StringSortingUtils.java
@@ -1,0 +1,36 @@
+package fr.free.nrw.commons.utils;
+
+import info.debatty.java.stringsimilarity.Levenshtein;
+import java.util.Comparator;
+
+public class StringSortingUtils {
+
+    private StringSortingUtils() {
+        //no-op
+    }
+
+    public static Comparator<String> sortBySimilarity(final String filter) {
+        return (firstItem, secondItem) -> {
+            double firstItemSimilarity = StringSortingUtils.calculateSimilarity(firstItem, filter);
+            double secondItemSimilarity = StringSortingUtils.calculateSimilarity(secondItem, filter);
+            return (int) Math.signum(secondItemSimilarity - firstItemSimilarity);
+        };
+    }
+
+    private static double calculateSimilarity(String firstString, String secondString) {
+        String longer = firstString.toLowerCase();
+        String shorter = secondString.toLowerCase();
+
+        if (firstString.length() < secondString.length()) {
+            longer = secondString;
+            shorter = firstString;
+        }
+        int longerLength = longer.length();
+        if (longerLength == 0) {
+            return 1.0;
+        }
+
+        double distanceBetweenStrings = new Levenshtein().distance(longer, shorter);
+        return (longerLength - distanceBetweenStrings) / (double) longerLength;
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/utils/StringSortingUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/StringSortingUtils.java
@@ -1,7 +1,7 @@
 package fr.free.nrw.commons.utils;
 
-import info.debatty.java.stringsimilarity.Levenshtein;
 import java.util.Comparator;
+import info.debatty.java.stringsimilarity.Levenshtein;
 
 public class StringSortingUtils {
 

--- a/app/src/main/java/fr/free/nrw/commons/utils/StringSortingUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/StringSortingUtils.java
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.utils;
 
 import java.util.Comparator;
+
 import info.debatty.java.stringsimilarity.Levenshtein;
 
 public class StringSortingUtils {

--- a/app/src/main/java/fr/free/nrw/commons/utils/StringSortingUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/StringSortingUtils.java
@@ -9,10 +9,19 @@ public class StringSortingUtils {
         //no-op
     }
 
+    /**
+     * Returns Comparator for sorting strings by its similarity with Levenshtein
+     * algorithm. By using this Comparator we get results from the highest to
+     * the lowest match.
+     *
+     * @param filter pattern to compare similarity
+     * @return Comparator with string similarity
+     */
+
     public static Comparator<String> sortBySimilarity(final String filter) {
         return (firstItem, secondItem) -> {
-            double firstItemSimilarity = StringSortingUtils.calculateSimilarity(firstItem, filter);
-            double secondItemSimilarity = StringSortingUtils.calculateSimilarity(secondItem, filter);
+            double firstItemSimilarity = calculateSimilarity(firstItem, filter);
+            double secondItemSimilarity = calculateSimilarity(secondItem, filter);
             return (int) Math.signum(secondItemSimilarity - firstItemSimilarity);
         };
     }

--- a/app/src/test/java/fr/free/nrw/commons/utils/StringSortingUtilsTest.java
+++ b/app/src/test/java/fr/free/nrw/commons/utils/StringSortingUtilsTest.java
@@ -1,0 +1,40 @@
+package fr.free.nrw.commons.utils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StringSortingUtilsTest {
+
+    @Test
+    public void testSortingNumbersBySimilarity() throws Exception {
+        List<String> actualList = Arrays.asList("1234567", "4567", "12345", "123", "1234");
+        List<String> expectedList = Arrays.asList("1234", "12345", "123", "1234567", "4567");
+
+        Collections.sort(actualList, StringSortingUtils.sortBySimilarity("tes"));
+        Assert.assertEquals(expectedList, actualList);
+    }
+
+    @Test
+    public void testSortingTextBySimilarity() throws Exception {
+        List<String> actualList = Arrays.asList("The quick brown fox",
+                "quick brown fox",
+                "The",
+                "The quick ",
+                "The fox",
+                "brown fox",
+                "fox");
+        List<String> expectedList = Arrays.asList("The",
+                "The fox",
+                "The quick ",
+                "The quick brown fox",
+                "quick brown fox",
+                "brown fox",
+                "fox");
+
+        Collections.sort(actualList, StringSortingUtils.sortBySimilarity("The"));
+        Assert.assertEquals(expectedList, actualList);
+    }
+}

--- a/app/src/test/java/fr/free/nrw/commons/utils/StringSortingUtilsTest.java
+++ b/app/src/test/java/fr/free/nrw/commons/utils/StringSortingUtilsTest.java
@@ -13,7 +13,7 @@ public class StringSortingUtilsTest {
         List<String> actualList = Arrays.asList("1234567", "4567", "12345", "123", "1234");
         List<String> expectedList = Arrays.asList("1234", "12345", "123", "1234567", "4567");
 
-        Collections.sort(actualList, StringSortingUtils.sortBySimilarity("tes"));
+        Collections.sort(actualList, StringSortingUtils.sortBySimilarity("1234"));
         Assert.assertEquals(expectedList, actualList);
     }
 


### PR DESCRIPTION
(Partially) fixed issue #844 by:

1. incrementing time of debounce for search filter from 0.3s to 0.5s. The smaller time was causing sending multiple requests before user ended typing and when they showed up, they were already out-of-date. Incrementing time by 0.2s is not visible to the user, so it doesn’t impact UX.
2. adding sorting results by string similarity - I used [java-string-similarity](https://github.com/tdebatty/java-string-similarity) library with a Levenshtein algorithm to implement this. There are some tests write for sorting, so you can check how it works.

However, because of a limited number of results from API, this fix is not 100% correct - there can be better results for user inputs that are on the next pages of this request, so this solution only improves search for what we already get from API.