### PR TITLE
Moved sign up process redirection urls to build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,6 +86,8 @@ android {
             buildConfigField "String", "MOBILE_HOME_URL", "\"https://commons.m.wikimedia.org/wiki/\""
             buildConfigField "String", "EVENTLOG_URL", "\"https://www.wikimedia.org/beacon/event\""
             buildConfigField "String", "EVENTLOG_WIKI", "\"commonswiki\""
+            buildConfigField "String", "SIGNUP_LANDING_URL", "\"https://commons.m.wikimedia.org/w/index.php?title=Special:CreateAccount&returnto=Main+Page&returntoquery=welcome%3Dyes\""
+            buildConfigField "String", "SIGNUP_SUCCESS_REDIRECTION_URL", "\"https://commons.m.wikimedia.org/w/index.php?title=Main_Page&welcome=yes\""
         }
 
         beta {
@@ -97,6 +99,8 @@ android {
             buildConfigField "String", "MOBILE_HOME_URL", "\"https://commons.m.wikimedia.beta.wmflabs.org/wiki/\""
             buildConfigField "String", "EVENTLOG_URL", "\"https://commons.wikimedia.beta.wmflabs.org/beacon/event\""
             buildConfigField "String", "EVENTLOG_WIKI", "\"commonswiki\""
+            buildConfigField "String", "SIGNUP_LANDING_URL", "\"https://commons.m.wikimedia.beta.wmflabs.org/w/index.php?title=Special:CreateAccount&returnto=Main+Page&returntoquery=welcome%3Dyes\""
+            buildConfigField "String", "SIGNUP_SUCCESS_REDIRECTION_URL", "\"https://commons.m.wikimedia.beta.wmflabs.org/w/index.php?title=Main_Page&welcome=yes\""
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/auth/SignupActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/SignupActivity.java
@@ -6,6 +6,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.Toast;
 
+import fr.free.nrw.commons.BuildConfig;
 import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.theme.BaseActivity;
 import timber.log.Timber;
@@ -27,13 +28,13 @@ public class SignupActivity extends BaseActivity {
         //Needed to refresh Captcha. Might introduce XSS vulnerabilities, but we can trust Wikimedia's site... right?
         webSettings.setJavaScriptEnabled(true);
 
-        webView.loadUrl("https://commons.m.wikimedia.org/w/index.php?title=Special:CreateAccount&returnto=Main+Page&returntoquery=welcome%3Dyes");
+        webView.loadUrl(BuildConfig.SIGNUP_LANDING_URL);
     }
 
     private class MyWebViewClient extends WebViewClient {
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, String url) {
-            if (url.equals("https://commons.m.wikimedia.org/w/index.php?title=Main_Page&welcome=yes")) {
+            if (url.equals(BuildConfig.SIGNUP_SUCCESS_REDIRECTION_URL)) {
                 //Signup success, so clear cookies, notify user, and load LoginActivity again
                 Timber.d("Overriding URL %s", url);
 


### PR DESCRIPTION
Moved sign up process redirection urls to build.gradle as buildConfig fields specific to beta and prod flavors and added necessary usages to SignupActivity. This will ensure that even if somebody is trying to sign up on the beta flavor of the app, they are signed up on the beta server and not on the production server, something which will happen right now. 