### PR TITLE
Disable LeakCanary for Robolectric tests

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -17,6 +17,7 @@ import android.support.v4.util.LruCache;
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.stetho.Stetho;
 import com.squareup.leakcanary.LeakCanary;
+import com.squareup.leakcanary.RefWatcher;
 
 import org.acra.ACRA;
 import org.acra.ReportingInteractionMode;
@@ -117,12 +118,8 @@ public class CommonsApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        if (LeakCanary.isInAnalyzerProcess(this)) {
-            // This process is dedicated to LeakCanary for heap analysis.
-            // You should not init your app in this process.
-            return;
-        }
-        LeakCanary.install(this);
+
+        setupLeakCanary();
 
         Timber.plant(new Timber.DebugTree());
 
@@ -141,6 +138,13 @@ public class CommonsApplication extends Application {
 
         //For caching area -> categories
         cacheData  = new CacheController();
+    }
+
+    protected RefWatcher setupLeakCanary() {
+        if (LeakCanary.isInAnalyzerProcess(this)) {
+            return RefWatcher.DISABLED;
+        }
+        return LeakCanary.install(this);
     }
 
     /**

--- a/app/src/test/java/fr/free/nrw/commons/TestCommonsApplication.java
+++ b/app/src/test/java/fr/free/nrw/commons/TestCommonsApplication.java
@@ -1,0 +1,11 @@
+package fr.free.nrw.commons;
+
+import com.squareup.leakcanary.RefWatcher;
+
+// This class is automatically discovered by Robolectric
+public class TestCommonsApplication extends CommonsApplication {
+    @Override protected RefWatcher setupLeakCanary() {
+        // No leakcanary in unit tests.
+        return RefWatcher.DISABLED;
+    }
+}


### PR DESCRIPTION
Fixes problems found in #932.

See 'For Robolectric users:' https://github.com/square/leakcanary