### PR TITLE
Introduce dagger

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,12 @@ dependencies {
     implementation 'com.facebook.fresco:fresco:1.3.0'
     implementation 'com.facebook.stetho:stetho:1.5.0'
 
+    implementation "com.google.dagger:dagger:$DAGGER_VERSION"
+    implementation "com.google.dagger:dagger-android-support:$DAGGER_VERSION"
+
+    annotationProcessor "com.google.dagger:dagger-android-processor:$DAGGER_VERSION"
+    annotationProcessor "com.google.dagger:dagger-compiler:$DAGGER_VERSION"
+
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.4'
 

--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -6,6 +6,7 @@ import android.accounts.AccountManagerCallback;
 import android.accounts.AccountManagerFuture;
 import android.accounts.AuthenticatorException;
 import android.accounts.OperationCanceledException;
+import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -26,11 +27,16 @@ import org.acra.annotation.ReportsCrashes;
 import java.io.File;
 import java.io.IOException;
 
+import javax.inject.Inject;
+
+import dagger.android.DispatchingAndroidInjector;
+import dagger.android.HasActivityInjector;
 import fr.free.nrw.commons.auth.AccountUtil;
 import fr.free.nrw.commons.caching.CacheController;
 import fr.free.nrw.commons.contributions.Contribution;
 import fr.free.nrw.commons.data.Category;
 import fr.free.nrw.commons.data.DBOpenHelper;
+import fr.free.nrw.commons.di.DaggerAppComponent;
 import fr.free.nrw.commons.modifications.ModifierSequence;
 import fr.free.nrw.commons.mwapi.ApacheHttpClientMediaWikiApi;
 import fr.free.nrw.commons.mwapi.MediaWikiApi;
@@ -47,7 +53,7 @@ import timber.log.Timber;
         resDialogCommentPrompt = R.string.crash_dialog_comment_prompt,
         resDialogOkToast = R.string.crash_dialog_ok_toast
 )
-public class CommonsApplication extends Application {
+public class CommonsApplication extends Application implements HasActivityInjector {
 
     private Account currentAccount = null; // Unlike a savings account...
 
@@ -60,6 +66,9 @@ public class CommonsApplication extends Application {
 
     public static final String FEEDBACK_EMAIL = "commons-app-android@googlegroups.com";
     public static final String FEEDBACK_EMAIL_SUBJECT = "Commons Android App (%s) Feedback";
+
+    @Inject DispatchingAndroidInjector<Activity> dispatchingActivityInjector;
+    @Inject MediaWikiApi mediaWikiApi;
 
     private static CommonsApplication instance = null;
     private MediaWikiApi api = null;
@@ -123,7 +132,11 @@ public class CommonsApplication extends Application {
 
         Timber.plant(new Timber.DebugTree());
 
-
+        DaggerAppComponent
+                .builder()
+                .application(this)
+                .build()
+                .inject(this);
 
         if (!BuildConfig.DEBUG) {
             ACRA.init(this);
@@ -168,11 +181,11 @@ public class CommonsApplication extends Application {
         if (curAccount == null) {
             return false; // This should never happen
         }
-        
-        accountManager.invalidateAuthToken(AccountUtil.accountType(), getMWApi().getAuthCookie());
+
+        accountManager.invalidateAuthToken(AccountUtil.accountType(), mediaWikiApi.getAuthCookie());
         try {
             String authCookie = accountManager.blockingGetAuthToken(curAccount, "", false);
-            getMWApi().setAuthCookie(authCookie);
+            mediaWikiApi.setAuthCookie(authCookie);
             return true;
         } catch (OperationCanceledException | NullPointerException | IOException | AuthenticatorException e) {
             e.printStackTrace();
@@ -247,6 +260,11 @@ public class CommonsApplication extends Application {
         for (Account account : allAccounts) {
             accountManager.removeAccount(account, amCallback, null);
         }
+    }
+
+    @Override
+    public DispatchingAndroidInjector<Activity> activityInjector() {
+        return dispatchingActivityInjector;
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
@@ -23,13 +23,17 @@ import android.widget.AdapterView;
 
 import java.util.ArrayList;
 
+import javax.inject.Inject;
+
 import butterknife.ButterKnife;
+import dagger.android.AndroidInjection;
 import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.HandlerService;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.auth.AuthenticatedActivity;
 import fr.free.nrw.commons.media.MediaDetailPagerFragment;
+import fr.free.nrw.commons.mwapi.MediaWikiApi;
 import fr.free.nrw.commons.settings.Prefs;
 import fr.free.nrw.commons.upload.UploadService;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -56,6 +60,9 @@ public class ContributionsActivity extends AuthenticatedActivity
     private boolean isUploadServiceConnected;
     private ArrayList<DataSetObserver> observersWaitingForLoad = new ArrayList<>();
     private String CONTRIBUTION_SELECTION = "";
+
+    @Inject
+    MediaWikiApi mediaWikiApi;
 
     /*
         This sorts in the following order:
@@ -131,6 +138,7 @@ public class ContributionsActivity extends AuthenticatedActivity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        AndroidInjection.inject(this);
         setContentView(R.layout.activity_contributions);
         ButterKnife.bind(this);
 
@@ -281,7 +289,7 @@ public class ContributionsActivity extends AuthenticatedActivity
     private void setUploadCount() {
         CommonsApplication app = ((CommonsApplication) getApplication());
         compositeDisposable.add(
-                app.getMWApi()
+                mediaWikiApi
                         .getUploadCount(app.getCurrentAccount().name)
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/fr/free/nrw/commons/di/ActivityBuilder.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/ActivityBuilder.java
@@ -1,0 +1,12 @@
+package fr.free.nrw.commons.di;
+
+import dagger.Module;
+import dagger.android.ContributesAndroidInjector;
+import fr.free.nrw.commons.contributions.ContributionsActivity;
+
+@Module
+public abstract class ActivityBuilder {
+
+    @ContributesAndroidInjector()
+    abstract ContributionsActivity bindSplashScreenActivity();
+}

--- a/app/src/main/java/fr/free/nrw/commons/di/AppComponent.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/AppComponent.java
@@ -1,0 +1,29 @@
+package fr.free.nrw.commons.di;
+
+import android.app.Application;
+
+import javax.inject.Singleton;
+
+import dagger.BindsInstance;
+import dagger.Component;
+import dagger.android.support.AndroidSupportInjectionModule;
+import fr.free.nrw.commons.CommonsApplication;
+
+@Singleton
+@Component(modules = {
+        AndroidSupportInjectionModule.class,
+        AppModule.class,
+        ActivityBuilder.class
+})
+public interface AppComponent {
+
+    @Component.Builder
+    interface Builder {
+        @BindsInstance
+        Builder application(Application application);
+
+        AppComponent build();
+    }
+
+    void inject(CommonsApplication application);
+}

--- a/app/src/main/java/fr/free/nrw/commons/di/AppModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/AppModule.java
@@ -1,0 +1,28 @@
+package fr.free.nrw.commons.di;
+
+import android.app.Application;
+import android.content.Context;
+
+import javax.inject.Singleton;
+
+import dagger.Module;
+import dagger.Provides;
+import fr.free.nrw.commons.BuildConfig;
+import fr.free.nrw.commons.mwapi.ApacheHttpClientMediaWikiApi;
+import fr.free.nrw.commons.mwapi.MediaWikiApi;
+
+@Module
+public class AppModule {
+
+    @Provides
+    @Singleton
+    Context provideContext(Application application) {
+        return application;
+    }
+
+    @Provides
+    @Singleton
+    public MediaWikiApi getMWApi() {
+        return new ApacheHttpClientMediaWikiApi(BuildConfig.WIKIMEDIA_API_HOST);
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,7 @@ android.useDeprecatedNdk=true
 
 # Library dependencies
 BUTTERKNIFE_VERSION=8.6.0
+DAGGER_VERSION=2.11
 
 org.gradle.jvmargs=-Xmx1536M
 


### PR DESCRIPTION
Really excited to finally introduce dagger to our app. #890

This PR simply introduces dagger, a lot of `CommonsApplication` usage can be reduced by replacing it with DI. 

Test plan:
Ran the app and checked. Things work as expected.