### PR TITLE
Fix: Crash because of no file found error while uploading

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -387,7 +387,12 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
 
     @Override
     @NonNull
-    public UploadResult uploadFile(String filename, InputStream file, long dataLength, String pageContents, String editSummary, final ProgressListener progressListener) throws IOException {
+    public UploadResult uploadFile(String filename,
+                                   @NonNull InputStream file,
+                                   long dataLength,
+                                   String pageContents,
+                                   String editSummary,
+                                   final ProgressListener progressListener) throws IOException {
         ApiResult result = api.upload(filename, file, dataLength, pageContents, editSummary, progressListener::onProgress);
 
         Log.e("WTF", "Result: " + result.toString());

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -182,7 +182,7 @@ public class UploadService extends HandlerService<Contribution> {
     private void uploadContribution(Contribution contribution) {
         MediaWikiApi api = app.getMWApi();
 
-        InputStream file = null;
+        InputStream file;
 
         String notificationTag = contribution.getLocalUri().toString();
 
@@ -193,6 +193,14 @@ public class UploadService extends HandlerService<Contribution> {
             Timber.d("File not found");
             Toast fileNotFound = Toast.makeText(this, R.string.upload_failed, Toast.LENGTH_LONG);
             fileNotFound.show();
+            return;
+        }
+
+        //As the file is null there's no point in continuing the upload process
+        //mwapi.upload accepts a NonNull input stream
+        if(file == null) {
+            Timber.d("File not found");
+            return;
         }
 
         Timber.d("Before execution!");


### PR DESCRIPTION
Fixes #332.

The crash was happening as the `InputStream` passed to the mwApi.upload was `null`. Avoiding crash in this scenario.  