### PR TITLE
Use different package name for debug and release variants

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,6 +94,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
         debug {
+            applicationIdSuffix ".debug"
             testCoverageEnabled true
         }
     }


### PR DESCRIPTION
Fixes #969.

This seems to be happening as the debug and prod versions of the app share the same package name. Ideally they should have separate packages. Different package name would also facilitate testing both versions simultaneously. As seen in the screenshot the package name `fr.free.nrw.commons.debug` package is being displayed for debug build.

<img width="1021" alt="screen shot 2017-11-21 at 11 24 28 am" src="https://user-images.githubusercontent.com/3069373/33057003-991bef2c-ceae-11e7-8be0-1146669c14eb.png">
