### PR TITLE
Send log file to private Google group forum instead

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -64,7 +64,7 @@ public class CommonsApplication extends Application implements HasActivityInject
 
     public static final String DEFAULT_EDIT_SUMMARY = "Uploaded using Android Commons app";
 
-    public static final String FEEDBACK_EMAIL = "commons-app-android@googlegroups.com";
+    public static final String FEEDBACK_EMAIL = "commons-app-android-private@googlegroups.com";
     public static final String FEEDBACK_EMAIL_SUBJECT = "Commons Android App (%s) Feedback";
 
     @Inject DispatchingAndroidInjector<Activity> dispatchingActivityInjector;


### PR DESCRIPTION
As mentioned at #891 , WMF has pretty strict rules about how we maintain user privacy if we are to remain on their Play Store account. When the user taps "send log file" in Settings, they should be sending the file to the private forum (only accessed by devs who have signed the NDA), not the public one.