### PR TITLE
Call setupPlaceList() onResume in NearbyActivity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -262,6 +262,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
         super.onResume();
         lockNearbyView = false;
         checkGps();
+        setupPlaceList(this);
     }
 
     private void refreshView(boolean isHardRefresh) {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -262,7 +262,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
         super.onResume();
         lockNearbyView = false;
         checkGps();
-        setupPlaceList(this);
+        refreshView(false);
     }
 
     private void refreshView(boolean isHardRefresh) {


### PR DESCRIPTION
In our current master, there is an issue with Nearby Places not loading at all - the progress bar runs forever. After digging around a bit, I figured the reason is that `setupPlaceList(this)` is only being called in refreshView and not when the activity is loaded.

This fixes that problem in my tests, but there is a small issue where the very first time Nearby loads (on a newly started application), it says "No Nearby Places found", probably because the GPS hasn't had time to get a fix yet. The second time onwards, this works fine. 

But would be great if anyone could build on this to fix that, perhaps by delaying the first load until a location is found?