### PR TITLE
Use modified branch names for APK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,4 @@
+apply from: '../gitutils.gradle'
 apply plugin: 'com.android.application'
 apply plugin: 'jacoco-android'
 apply from: 'quality.gradle'
@@ -66,6 +67,7 @@ android {
         applicationId 'fr.free.nrw.commons'
         versionCode 74
         versionName '2.5.0'
+        setProperty("archivesBaseName", "app-commons-v$versionName-" + getBranchName())
         minSdkVersion project.minSdkVersion
         targetSdkVersion project.targetSdkVersion
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -79,6 +81,7 @@ android {
         }
         debug {
             testCoverageEnabled true
+            versionNameSuffix "-debug-" + getBranchName() + "~" + getBuildVersion()
         }
     }
 

--- a/gitutils.gradle
+++ b/gitutils.gradle
@@ -1,0 +1,21 @@
+ext.getBuildVersion = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
+ext.getBranchName = { ->
+    try {
+        def stdOut = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'rev-parse', '--abbrev-ref', 'HEAD'
+            standardOutput = stdOut
+        }
+        return stdOut.toString().trim()
+    } catch (ignored) {
+        return null
+    }
+}


### PR DESCRIPTION
Using branch name and version name in APK to make testing easier. It will have the following advantages:
- Simply looking at the APK name, its version and branch name can be identified. So while working on multiple branches building the APK won't be needed every time. 

<img width="844" alt="screen shot 2017-11-24 at 12 14 19 am" src="https://user-images.githubusercontent.com/3069373/33185987-7302f1b4-d0ac-11e7-840e-8b3a521f2f9c.png">

- The About page will show the current version details ie branch name, latest commit ID for debug builds. This will help in easily verifying that we are on the correct build while testing. The release build will keep showing just the version number as it used to be earlier. 

![version_name](https://user-images.githubusercontent.com/3069373/33186263-372c242e-d0ae-11e7-9d43-7031bc438cce.png)

@neslihanturan This might make your life easier. :)
