### PR TITLE
Fix issues around location in nearby activity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,4 @@
-//apply from: '../gitutils.gradle'
+apply from: '../gitutils.gradle'
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
@@ -99,7 +99,7 @@ android {
         }
         debug {
             testCoverageEnabled true
-            //versionNameSuffix "-debug-" + getBranchName() + "~" + getBuildVersion()
+            versionNameSuffix "-debug-" + getBranchName() + "~" + getBuildVersion()
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,4 @@
-apply from: '../gitutils.gradle'
+//apply from: '../gitutils.gradle'
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
@@ -78,10 +78,9 @@ android {
 
     defaultConfig {
         applicationId 'fr.free.nrw.commons'
-
         versionCode 76
         versionName '2.6.1'
-        setProperty("archivesBaseName", "app-commons-v$versionName-" + getBranchName())
+        //setProperty("archivesBaseName", "app-commons-v$versionName-" + getBranchName())
 
         minSdkVersion project.minSdkVersion
         targetSdkVersion project.targetSdkVersion
@@ -100,7 +99,7 @@ android {
         }
         debug {
             testCoverageEnabled true
-            versionNameSuffix "-debug-" + getBranchName() + "~" + getBuildVersion()
+            //versionNameSuffix "-debug-" + getBranchName() + "~" + getBuildVersion()
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,7 +80,7 @@ android {
         applicationId 'fr.free.nrw.commons'
         versionCode 76
         versionName '2.6.1'
-        //setProperty("archivesBaseName", "app-commons-v$versionName-" + getBranchName())
+        setProperty("archivesBaseName", "app-commons-v$versionName-" + getBranchName())
 
         minSdkVersion project.minSdkVersion
         targetSdkVersion project.targetSdkVersion

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
     <uses-permission android:name="com.google.android.apps.photos.permission.GOOGLE_PHOTOS"/>
     <uses-permission android:name="android.permission.READ_LOGS"/>
 
+    <!-- Needed only if your app targets Android 5.0 (API level 21) or higher. -->
+    <uses-feature android:name="android.hardware.location.gps" />
+
     <application
         android:name=".CommonsApplication"
         android:icon="@drawable/ic_launcher"

--- a/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
@@ -1,5 +1,8 @@
 package fr.free.nrw.commons.location;
 
+import android.location.Location;
+import android.support.annotation.NonNull;
+
 public class LatLng {
 
     private final double latitude;
@@ -20,6 +23,10 @@ public class LatLng {
         }
         this.latitude = Math.max(-90.0D, Math.min(90.0D, latitude));
         this.accuracy = accuracy;
+    }
+
+    public static LatLng from(@NonNull Location location) {
+        return new LatLng(location.getLatitude(), location.getLongitude(), location.getAccuracy());
     }
 
     public int hashCode() {

--- a/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
@@ -1,11 +1,15 @@
 package fr.free.nrw.commons.location;
 
+import android.Manifest;
+import android.app.Activity;
 import android.content.Context;
-import android.location.Criteria;
+import android.content.pm.PackageManager;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 import android.os.Bundle;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -17,59 +21,136 @@ import timber.log.Timber;
 
 @Singleton
 public class LocationServiceManager implements LocationListener {
+    public static final int LOCATION_REQUEST = 1;
 
-    private String provider;
+    private static final long MIN_LOCATION_UPDATE_REQUEST_TIME_IN_MILLIS = 2 * 60 * 1000;
+    private static final long MIN_LOCATION_UPDATE_REQUEST_DISTANCE_IN_METERS = 10;
+
+    private Context context;
     private LocationManager locationManager;
-    private LatLng lastLocation;
-    private Float latestLocationAccuracy;
+    private Location lastLocation;
     private final List<LocationUpdateListener> locationListeners = new CopyOnWriteArrayList<>();
+    private boolean isLocationManagerRegistered = false;
 
     @Inject
     public LocationServiceManager(Context context) {
+        this.context = context;
         this.locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
-        provider = locationManager.getBestProvider(new Criteria(), true);
     }
 
     public boolean isProviderEnabled() {
         return locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
     }
 
-    public LatLng getLastLocation() {
-        return lastLocation;
+    public boolean isLocationPermissionGranted() {
+        return ContextCompat.checkSelfPermission(context,
+                Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED;
     }
 
-    /**
-     * Returns the accuracy of the location. The measurement is
-     * given as a radius in meter of 68 % confidence.
-     *
-     * @return Float
-     */
-    public Float getLatestLocationAccuracy() {
-        return latestLocationAccuracy;
+    public void requestPermissions(Activity activity) {
+        if (activity.isFinishing()) {
+            return;
+        }
+        ActivityCompat.requestPermissions(activity,
+                new String[]{Manifest.permission.ACCESS_FINE_LOCATION},
+                LOCATION_REQUEST);
+    }
+
+    public boolean isPermissionExplanationRequired(Activity activity) {
+        if (activity.isFinishing()) {
+            return false;
+        }
+        return ActivityCompat.shouldShowRequestPermissionRationale(activity,
+                Manifest.permission.ACCESS_FINE_LOCATION);
+    }
+
+    public LatLng getLastLocation() {
+        if (lastLocation == null) {
+            return null;
+        }
+        return LatLng.from(lastLocation);
     }
 
     /** Registers a LocationManager to listen for current location.
      */
     public void registerLocationManager() {
+        if (!isLocationManagerRegistered)
+            isLocationManagerRegistered = requestLocationUpdatesFromProvider(LocationManager.NETWORK_PROVIDER)
+                    && requestLocationUpdatesFromProvider(LocationManager.GPS_PROVIDER);
+    }
+
+    private boolean requestLocationUpdatesFromProvider(String locationProvider) {
         try {
-            locationManager.requestLocationUpdates(provider, 400, 1, this);
-            Location location = locationManager.getLastKnownLocation(provider);
-            //Location works, just need to 'send' GPS coords
-            // via emulator extended controls if testing on emulator
-            Timber.d("Checking for location...");
-            if (location != null) {
-                this.onLocationChanged(location);
-            }
+            locationManager.requestLocationUpdates(locationProvider,
+                    MIN_LOCATION_UPDATE_REQUEST_TIME_IN_MILLIS,
+                    MIN_LOCATION_UPDATE_REQUEST_DISTANCE_IN_METERS,
+                    this);
+            return true;
         } catch (IllegalArgumentException e) {
             Timber.e(e, "Illegal argument exception");
+            return false;
         } catch (SecurityException e) {
             Timber.e(e, "Security exception");
+            return false;
         }
+    }
+
+    protected boolean isBetterLocation(Location location, Location currentBestLocation) {
+        if (currentBestLocation == null) {
+            // A new location is always better than no location
+            return true;
+        }
+
+        // Check whether the new location fix is newer or older
+        long timeDelta = location.getTime() - currentBestLocation.getTime();
+        boolean isSignificantlyNewer = timeDelta > MIN_LOCATION_UPDATE_REQUEST_TIME_IN_MILLIS;
+        boolean isSignificantlyOlder = timeDelta < -MIN_LOCATION_UPDATE_REQUEST_TIME_IN_MILLIS;
+        boolean isNewer = timeDelta > 0;
+
+        // If it's been more than two minutes since the current location, use the new location
+        // because the user has likely moved
+        if (isSignificantlyNewer) {
+            return true;
+            // If the new location is more than two minutes older, it must be worse
+        } else if (isSignificantlyOlder) {
+            return false;
+        }
+
+        // Check whether the new location fix is more or less accurate
+        int accuracyDelta = (int) (location.getAccuracy() - currentBestLocation.getAccuracy());
+        boolean isLessAccurate = accuracyDelta > 0;
+        boolean isMoreAccurate = accuracyDelta < 0;
+        boolean isSignificantlyLessAccurate = accuracyDelta > 200;
+
+        // Check if the old and new location are from the same provider
+        boolean isFromSameProvider = isSameProvider(location.getProvider(),
+                currentBestLocation.getProvider());
+
+        // Determine location quality using a combination of timeliness and accuracy
+        if (isMoreAccurate) {
+            return true;
+        } else if (isNewer && !isLessAccurate) {
+            return true;
+        } else if (isNewer && !isSignificantlyLessAccurate && isFromSameProvider) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether two providers are the same
+     */
+    private boolean isSameProvider(String provider1, String provider2) {
+        if (provider1 == null) {
+            return provider2 == null;
+        }
+        return provider1.equals(provider2);
     }
 
     /** Unregisters location manager.
      */
     public void unregisterLocationManager() {
+        isLocationManagerRegistered = false;
         try {
             locationManager.removeUpdates(this);
         } catch (SecurityException e) {
@@ -89,15 +170,11 @@ public class LocationServiceManager implements LocationListener {
 
     @Override
     public void onLocationChanged(Location location) {
-        double currentLatitude = location.getLatitude();
-        double currentLongitude = location.getLongitude();
-        latestLocationAccuracy = location.getAccuracy();
-        Timber.d("Latitude: %f Longitude: %f Accuracy %f",
-                currentLatitude, currentLongitude, latestLocationAccuracy);
-        lastLocation = new LatLng(currentLatitude, currentLongitude, latestLocationAccuracy);
-
-        for (LocationUpdateListener listener : locationListeners) {
-            listener.onLocationChanged(lastLocation);
+        if (isBetterLocation(location, lastLocation)) {
+            lastLocation = location;
+            for (LocationUpdateListener listener : locationListeners) {
+                listener.onLocationChanged(LatLng.from(lastLocation));
+            }
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -163,7 +163,10 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
                                 Timber.d("Loaded settings page");
                                 startActivityForResult(callGPSSettingIntent, 1);
                             })
-                    .setNegativeButton(R.string.menu_cancel_upload, (dialog, id) -> dialog.cancel())
+                    .setNegativeButton(R.string.menu_cancel_upload, (dialog, id) -> {
+                        showLocationPermissionDeniedErrorDialog();
+                        dialog.cancel();
+                    })
                     .create()
                     .show();
         } else {
@@ -188,7 +191,10 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
                                 requestLocationPermissions();
                                 dialog.dismiss();
                             })
-                            .setNegativeButton("Cancel", null)
+                            .setNegativeButton("Cancel", (dialog, id) -> {
+                                showLocationPermissionDeniedErrorDialog();
+                                dialog.cancel();
+                            })
                             .create()
                             .show();
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -213,4 +213,5 @@ Tap this message (or hit back) to skip this step.</string>
 
   <string name="nearby_location_has_not_changed">Location has not changed.</string>
   <string name="nearby_location_not_available">Location not available.</string>
+  <string name="location_permission_rationale_nearby">Permission required to display a list of nearby places</string>
 </resources>

--- a/app/src/test/java/fr/free/nrw/commons/nearby/NearbyActivityTest.java
+++ b/app/src/test/java/fr/free/nrw/commons/nearby/NearbyActivityTest.java
@@ -1,7 +1,6 @@
 package fr.free.nrw.commons.nearby;
 
 import android.app.Activity;
-import android.support.v4.app.Fragment;
 
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
- Fixes the issue where nearby list was not loaded in the first attempt. 

How to reproduce?
- Initially phone's GPS is off or the Commons app doesn't have location permissions.
- Either of these things are provided at run time.
- The nearby list just keeps loading. 
- It loads after killing the app. 

The above issue is now fixed. 

- App was continuously listening for location updates and draining a lot of battery

How do you know?
- The location Setting page in the your phone tags Commons app as high battery usage application. 

The above should be hopefully fixed. 
- The app now stops listening for location updates as soon as the nearby list is populated. 
- It again registers the location manager when the refresh button is clicked. 

- App now uses multiple providers to fetch the location. 

Why?

`GPS_PROVIDER` is usually slower. Now the app would be using both `NETWORK_PROVIDER` for coarse location and `GPS_PROVIDER` for finer location. Upon receiving a location update, it will determine if the newer location is better than the last location. If it is, the newer location would be used. 

Also fixes #982.