### PR TITLE
Send logs only to private Google group forum (round 2)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -58,6 +58,7 @@ public class CommonsApplication extends DaggerApplication {
     public static final String DEFAULT_EDIT_SUMMARY = "Uploaded using Android Commons app";
 
     public static final String FEEDBACK_EMAIL = "commons-app-android@googlegroups.com";
+    public static final String LOGS_PRIVATE_EMAIL = "commons-app-android-private@googlegroups.com";
     public static final String FEEDBACK_EMAIL_SUBJECT = "Commons Android App (%s) Feedback";
 
     private CommonsApplicationComponent component;

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -136,7 +136,7 @@ public class SettingsFragment extends PreferenceFragment {
         Intent feedbackIntent = new Intent(Intent.ACTION_SEND);
         feedbackIntent.setType("message/rfc822");
         feedbackIntent.putExtra(Intent.EXTRA_EMAIL,
-                new String[]{CommonsApplication.FEEDBACK_EMAIL});
+                new String[]{CommonsApplication.LOGS_PRIVATE_EMAIL});
         feedbackIntent.putExtra(Intent.EXTRA_SUBJECT,
                 String.format(CommonsApplication.FEEDBACK_EMAIL_SUBJECT,
                         BuildConfig.VERSION_NAME));


### PR DESCRIPTION
I sent this change through at #974 , but it was overridden.

This time, I made the change more explicit. Logs cannot be sent to the Google group that is publicly viewed - this will likely be viewed as a breach of privacy by WMF.