### PR TITLE
Use Wikimedia Maps server instead of Mapbox.

### DIFF
--- a/app/src/main/assets/mapstyle.json
+++ b/app/src/main/assets/mapstyle.json
@@ -1,0 +1,26 @@
+{
+    "version": 8,
+    "sources": {
+        "wikimedia-osm": {
+            "type": "raster",
+            "tiles": [
+                "https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png"
+            ],
+            "tileSize": 128
+        }
+    },
+    "layers": [
+        {
+            "id": "background",
+            "type": "background",
+            "paint": {
+                "background-color": "#606060"
+            }
+        },
+        {
+            "id": "osm",
+            "type": "raster",
+            "source": "wikimedia-osm"
+        }
+    ]
+}

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -3,7 +3,6 @@ package fr.free.nrw.commons.nearby;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -99,11 +98,8 @@ public class NearbyMapFragment extends android.support.v4.app.Fragment {
 
             addCurrentLocationMarker(mapboxMap);
         });
-        if (PreferenceManager.getDefaultSharedPreferences(getActivity()).getBoolean("theme",false)) {
-            mapView.setStyleUrl(getResources().getString(R.string.map_theme_dark));
-        } else {
-            mapView.setStyleUrl(getResources().getString(R.string.map_theme_light));
-        }
+
+        mapView.setStyleUrl("asset://mapstyle.json");
     }
 
     /**


### PR DESCRIPTION
See issue #590
This switches to using the Wikimedia tile server for providing map data. It comes with a couple of drawbacks which are currently unavoidable, but such is the way of open-source...
- The WMF map server does not provide vector tiles, or rather it doesn't provide vectors that are compatible with the Mapbox SDK :(
- It provides only one "theme" of tiles, so you will no longer have a dark vs. light theme.