### PR TITLE
Take out legacy event logging from app.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -50,11 +50,6 @@ public class CommonsApplication extends DaggerApplication {
     @Inject @Named("application_preferences") SharedPreferences applicationPrefs;
     @Inject @Named("prefs") SharedPreferences otherPrefs;
 
-    public static final Object[] EVENT_UPLOAD_ATTEMPT = {"MobileAppUploadAttempts", 5334329L};
-    public static final Object[] EVENT_LOGIN_ATTEMPT = {"MobileAppLoginAttempts", 5257721L};
-    public static final Object[] EVENT_SHARE_ATTEMPT = {"MobileAppShareAttempts", 5346170L};
-    public static final Object[] EVENT_CATEGORIZATION_ATTEMPT = {"MobileAppCategorizationAttempts", 5359208L};
-
     public static final String DEFAULT_EDIT_SUMMARY = "Uploaded using Android Commons app";
 
     public static final String FEEDBACK_EMAIL = "commons-app-android@googlegroups.com";

--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginTask.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginTask.java
@@ -8,9 +8,7 @@ import android.os.Bundle;
 
 import java.io.IOException;
 
-import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.R;
-import fr.free.nrw.commons.mwapi.EventLog;
 import fr.free.nrw.commons.mwapi.MediaWikiApi;
 import timber.log.Timber;
 
@@ -27,7 +25,6 @@ class LoginTask extends AsyncTask<String, String, String> {
     private String twoFactorCode = "";
     private AccountUtil accountUtil;
     private MediaWikiApi mwApi;
-    private SharedPreferences prefs;
 
     public LoginTask(LoginActivity loginActivity, String username, String password,
                      String twoFactorCode, AccountUtil accountUtil,
@@ -38,7 +35,6 @@ class LoginTask extends AsyncTask<String, String, String> {
         this.twoFactorCode = twoFactorCode;
         this.accountUtil = accountUtil;
         this.mwApi = mwApi;
-        this.prefs = prefs;
     }
 
     @Override
@@ -70,11 +66,6 @@ class LoginTask extends AsyncTask<String, String, String> {
     protected void onPostExecute(String result) {
         super.onPostExecute(result);
         Timber.d("Login done!");
-
-        EventLog.schema(CommonsApplication.EVENT_LOGIN_ATTEMPT, mwApi, prefs)
-                .param("username", username)
-                .param("result", result)
-                .log();
 
         if (result.equals("PASS")) {
             handlePassResult();

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -29,20 +29,17 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import dagger.android.support.DaggerFragment;
-import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.auth.SessionManager;
 import fr.free.nrw.commons.contributions.Contribution;
 import fr.free.nrw.commons.contributions.ContributionsActivity;
-import fr.free.nrw.commons.mwapi.EventLog;
 import fr.free.nrw.commons.mwapi.MediaWikiApi;
 
 import static android.Manifest.permission.READ_EXTERNAL_STORAGE;
 import static android.content.Context.DOWNLOAD_SERVICE;
 import static android.content.Intent.ACTION_VIEW;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
-import static fr.free.nrw.commons.CommonsApplication.EVENT_SHARE_ATTEMPT;
 
 public class MediaDetailPagerFragment extends DaggerFragment implements ViewPager.OnPageChangeListener {
 
@@ -110,12 +107,7 @@ public class MediaDetailPagerFragment extends DaggerFragment implements ViewPage
         Media m = provider.getMediaAtPosition(pager.getCurrentItem());
         switch (item.getItemId()) {
             case R.id.menu_share_current_image:
-                // Share - this is just logs it, intent set in onCreateOptionsMenu, around line 252
-                CommonsApplication app = (CommonsApplication) getActivity().getApplication();
-                EventLog.schema(EVENT_SHARE_ATTEMPT, mwApi, prefs)
-                        .param("username", sessionManager.getCurrentAccount().name)
-                        .param("filename", m.getFilename())
-                        .log();
+                // Share - intent set in onCreateOptionsMenu, around line 252
                 return true;
             case R.id.menu_browser_current_image:
                 // View in browser

--- a/app/src/main/java/fr/free/nrw/commons/upload/MultipleShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/MultipleShareActivity.java
@@ -29,7 +29,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import butterknife.ButterKnife;
-import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.auth.AuthenticatedActivity;
@@ -42,7 +41,6 @@ import fr.free.nrw.commons.modifications.CategoryModifier;
 import fr.free.nrw.commons.modifications.ModificationsContentProvider;
 import fr.free.nrw.commons.modifications.ModifierSequence;
 import fr.free.nrw.commons.modifications.TemplateRemoveModifier;
-import fr.free.nrw.commons.mwapi.EventLog;
 import fr.free.nrw.commons.mwapi.MediaWikiApi;
 import timber.log.Timber;
 
@@ -181,13 +179,6 @@ public class MultipleShareActivity extends AuthenticatedActivity
         // FIXME: Make sure that the content provider is up
         // This is the wrong place for it, but bleh - better than not having it turned on by default for people who don't go throughl ogin
         ContentResolver.setSyncAutomatically(sessionManager.getCurrentAccount(), ModificationsContentProvider.AUTHORITY, true); // Enable sync by default!
-        EventLog.schema(CommonsApplication.EVENT_CATEGORIZATION_ATTEMPT, mwApi, prefs)
-                .param("username", sessionManager.getCurrentAccount().name)
-                .param("categories-count", categories.size())
-                .param("files-count", photosList.size())
-                .param("source", Contribution.SOURCE_EXTERNAL)
-                .param("result", "queued")
-                .log();
         finish();
     }
 
@@ -284,27 +275,6 @@ public class MultipleShareActivity extends AuthenticatedActivity
         Toast failureToast = Toast.makeText(this, R.string.authentication_failed, Toast.LENGTH_LONG);
         failureToast.show();
         finish();
-    }
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        if (categorizationFragment != null && categorizationFragment.isVisible()) {
-            EventLog.schema(CommonsApplication.EVENT_CATEGORIZATION_ATTEMPT, mwApi, prefs)
-                    .param("username", sessionManager.getCurrentAccount().name)
-                    .param("categories-count", categorizationFragment.getCurrentSelectedCount())
-                    .param("files-count", photosList.size())
-                    .param("source", Contribution.SOURCE_EXTERNAL)
-                    .param("result", "cancelled")
-                    .log();
-        } else {
-            EventLog.schema(CommonsApplication.EVENT_UPLOAD_ATTEMPT, mwApi, prefs)
-                    .param("username", sessionManager.getCurrentAccount().name)
-                    .param("source", getIntent().getStringExtra(UploadService.EXTRA_SOURCE))
-                    .param("multiple", true)
-                    .param("result", "cancelled")
-                    .log();
-        }
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -10,7 +10,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.ParcelFileDescriptor;
-import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.RequiresApi;
@@ -176,13 +175,6 @@ public  class      ShareActivity
         // This is the wrong place for it, but bleh - better than not having it turned on by default for people who don't go throughl ogin
         ContentResolver.setSyncAutomatically(sessionManager.getCurrentAccount(), ModificationsContentProvider.AUTHORITY, true); // Enable sync by default!
 
-        EventLog.schema(CommonsApplication.EVENT_CATEGORIZATION_ATTEMPT, mwApi, prefs)
-                .param("username", sessionManager.getCurrentAccount().name)
-                .param("categories-count", categories.size())
-                .param("files-count", 1)
-                .param("source", contribution.getSource())
-                .param("result", "queued")
-                .log();
         finish();
     }
 
@@ -191,27 +183,6 @@ public  class      ShareActivity
         super.onSaveInstanceState(outState);
         if (contribution != null) {
             outState.putParcelable("contribution", contribution);
-        }
-    }
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        if (categorizationFragment != null && categorizationFragment.isVisible()) {
-            EventLog.schema(CommonsApplication.EVENT_CATEGORIZATION_ATTEMPT, mwApi, prefs)
-                    .param("username", sessionManager.getCurrentAccount().name)
-                    .param("categories-count", categorizationFragment.getCurrentSelectedCount())
-                    .param("files-count", 1)
-                    .param("source", contribution.getSource())
-                    .param("result", "cancelled")
-                    .log();
-        } else {
-            EventLog.schema(CommonsApplication.EVENT_UPLOAD_ATTEMPT, mwApi, prefs)
-                    .param("username", sessionManager.getCurrentAccount().name)
-                    .param("source", getIntent().getStringExtra(UploadService.EXTRA_SOURCE))
-                    .param("multiple", true)
-                    .param("result", "cancelled")
-                    .log();
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -26,7 +26,6 @@ import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.HandlerService;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
@@ -35,7 +34,6 @@ import fr.free.nrw.commons.contributions.Contribution;
 import fr.free.nrw.commons.contributions.ContributionsActivity;
 import fr.free.nrw.commons.contributions.ContributionsContentProvider;
 import fr.free.nrw.commons.modifications.ModificationsContentProvider;
-import fr.free.nrw.commons.mwapi.EventLog;
 import fr.free.nrw.commons.mwapi.MediaWikiApi;
 import fr.free.nrw.commons.mwapi.UploadResult;
 import timber.log.Timber;
@@ -258,27 +256,12 @@ public class UploadService extends HandlerService<Contribution> {
             String resultStatus = uploadResult.getResultStatus();
             if (!resultStatus.equals("Success")) {
                 showFailedNotification(contribution);
-                EventLog.schema(CommonsApplication.EVENT_UPLOAD_ATTEMPT, mwApi, prefs)
-                        .param("username", sessionManager.getCurrentAccount().name)
-                        .param("source", contribution.getSource())
-                        .param("multiple", contribution.getMultiple())
-                        .param("result", uploadResult.getErrorCode())
-                        .param("filename", contribution.getFilename())
-                        .log();
             } else {
                 contribution.setFilename(uploadResult.getCanonicalFilename());
                 contribution.setImageUrl(uploadResult.getImageUrl());
                 contribution.setState(Contribution.STATE_COMPLETED);
                 contribution.setDateUploaded(uploadResult.getDateUploaded());
                 contribution.save();
-
-                EventLog.schema(CommonsApplication.EVENT_UPLOAD_ATTEMPT, mwApi, prefs)
-                        .param("username", sessionManager.getCurrentAccount().name)
-                        .param("source", contribution.getSource()) //FIXME
-                        .param("filename", contribution.getFilename())
-                        .param("multiple", contribution.getMultiple())
-                        .param("result", "success")
-                        .log();
             }
         } catch (IOException e) {
             Timber.d("I have a network fuckup");


### PR DESCRIPTION
See #995 
These are especially old bits of code, where it seems like WMF folks had set up Eventlogging schemas for some rudimentary analytics of the Commons app. These schemas are no longer queried or monitored, and can be safely removed. When the Commons app has a stronger need for more meaningful analytics, we can revisit reintroducing new and better schemas.