### PR TITLE
Fixed NPE while rapidly switching between list and map on Nearby

### DIFF
--- a/app/src/androidTest/java/fr/free/nrw/commons/upload/FileUtilsTest.java
+++ b/app/src/androidTest/java/fr/free/nrw/commons/upload/FileUtilsTest.java
@@ -7,6 +7,8 @@ import android.support.test.runner.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import fr.free.nrw.commons.BuildConfig;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -14,7 +16,7 @@ import static org.junit.Assert.assertThat;
 public class FileUtilsTest {
     @Test
     public void isSelfOwned() throws Exception {
-        Uri uri = Uri.parse("content://fr.free.nrw.commons.provider/document/1");
+        Uri uri = Uri.parse("content://" + BuildConfig.APPLICATION_ID + ".provider/document/1");
         boolean selfOwned = FileUtils.isSelfOwned(InstrumentationRegistry.getTargetContext(), uri);
         assertThat(selfOwned, is(true));
     }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
@@ -60,7 +60,7 @@ public class NearbyListFragment extends DaggerFragment {
 
         Bundle bundle = this.getArguments();
         if (bundle != null) {
-            String gsonPlaceList = bundle.getString("PlaceList");
+            String gsonPlaceList = bundle.getString("PlaceList", "[]");
             placeList = gson.fromJson(gsonPlaceList, LIST_TYPE);
 
             String gsonLatLng = bundle.getString("CurLatLng");

--- a/app/src/test/java/fr/free/nrw/commons/nearby/NearbyActivityTest.java
+++ b/app/src/test/java/fr/free/nrw/commons/nearby/NearbyActivityTest.java
@@ -1,6 +1,8 @@
 package fr.free.nrw.commons.nearby;
 
 import android.app.Activity;
+import android.location.LocationManager;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -8,8 +10,11 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.Shadows;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadow.api.Shadow;
+import org.robolectric.shadows.ShadowLocationManager;
 
 import fr.free.nrw.commons.BuildConfig;
 import fr.free.nrw.commons.TestCommonsApplication;
@@ -33,6 +38,7 @@ public class NearbyActivityTest {
 
         TestCommonsApplication application = (TestCommonsApplication) RuntimeEnvironment.application;
         when(application.getLocationServiceManager().getLastLocation()).thenReturn(ST_LOUIS_MO_LAT_LNG);
+        when(application.getLocationServiceManager().isProviderEnabled()).thenReturn(true);
 
         activityController = Robolectric.buildActivity(NearbyActivity.class);
         nearbyActivity = activityController.get();


### PR DESCRIPTION
Tiny change that ensures we avoid a `NullPointerException` when we switch between list and map views, during the period of time while data is being loaded (reported in issue #1001)

This PR closes #1007 and also probably closes #998.