### PR TITLE
Fix for mapbox related crash on Nearby

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.1'
     implementation 'com.jakewharton.timber:timber:4.5.1'
     implementation 'info.debatty:java-string-similarity:0.24'
-    implementation ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.1.0@aar'){
+    implementation ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.2.1@aar'){
         transitive=true
     }
 


### PR DESCRIPTION
Looks like mapbox fixed the issue themselves - https://github.com/mapbox/mapbox-gl-native/issues/4487 - and updating to version *5.2.1* of mapbox solved the crash we were seeing when I repeatedly tapped on the icon to switch between list and map views.

This PR closes #1006 and is related to #998 as it was found during testing for that issue.