### PR TITLE
Direct nearby uploads feature branch - Map marker selection and footer visibility now track together.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -24,6 +24,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.annotations.Marker;
 import com.mapbox.mapboxsdk.annotations.MarkerOptions;
 import com.mapbox.mapboxsdk.annotations.PolygonOptions;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
@@ -76,6 +77,7 @@ public class NearbyMapFragment extends android.support.v4.app.Fragment {
     private Animation rotate_forward;
 
     private Place place;
+    private Marker selected;
 
     public NearbyMapFragment() {
     }
@@ -135,6 +137,8 @@ public class NearbyMapFragment extends android.support.v4.app.Fragment {
                 else if (bottomSheetDetailsBehavior.getState() == BottomSheetBehavior
                         .STATE_COLLAPSED) {
                     bottomSheetDetailsBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+                    mapView.getMapAsync(MapboxMap::deselectMarkers);
+                    selected=null;
                     return true;
                 }
             }
@@ -250,8 +254,15 @@ public class NearbyMapFragment extends android.support.v4.app.Fragment {
         mapView.getMapAsync(mapboxMap -> {
             mapboxMap.addMarkers(baseMarkerOptions);
 
+            mapboxMap.setOnInfoWindowCloseListener(marker -> {
+                if (marker == selected){
+                    bottomSheetDetailsBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+                }
+            });
+
             mapboxMap.setOnMarkerClickListener(marker -> {
                 if (marker instanceof NearbyMarker) {
+                    this.selected = marker;
                     NearbyMarker nearbyMarker = (NearbyMarker) marker;
                     Place place = nearbyMarker.getNearbyBaseMarker().getPlace();
                     passInfoToSheet(place);
@@ -325,6 +336,7 @@ public class NearbyMapFragment extends android.support.v4.app.Fragment {
                 this.getView().requestFocus();
                 break;
             case (BottomSheetBehavior.STATE_HIDDEN):
+                mapView.getMapAsync(MapboxMap::deselectMarkers);
                 transparentView.setClickable(false);
                 transparentView.setAlpha(0);
                 closeFabs(isFabOpen);


### PR DESCRIPTION
This PR addresses the bugs 

* Where tapping on the map (away from a marker) dismisses the info window but the footer stays visible
* Dismissing the footer leaves the map marker info window visible

The changes make it so that the map marker info window and our footer always track together.