### PR TITLE
Avoid crash when service is disconnected

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
@@ -94,7 +94,7 @@ public  class       ContributionsActivity
         @Override
         public void onServiceDisconnected(ComponentName componentName) {
             // this should never happen
-            throw new RuntimeException("UploadService died but the rest of the process did not!");
+            Timber.e(new RuntimeException("UploadService died but the rest of the process did not!"));
         }
     };
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
@@ -56,7 +56,7 @@ public class UploadController {
         @Override
         public void onServiceDisconnected(ComponentName componentName) {
             // this should never happen
-            throw new RuntimeException("UploadService died but the rest of the process did not!");
+            Timber.e(new RuntimeException("UploadService died but the rest of the process did not!"));
         }
     };
 


### PR DESCRIPTION
Fixes #1036. 

From the android developer docs it doesn't seem that `onServiceDisconnected` is such an event that the app should be crashed by throwing an exception in this scenario. 

https://developer.android.com/reference/android/content/ServiceConnection.html

For now lets avoid the crash by logging the error. As @psh we can move away from dagger injection for this particular service but am not sure if that would eliminate all such crashes.  