### PR TITLE
Making text a link

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
@@ -242,7 +242,10 @@ public class SingleUploadFragment extends DaggerFragment {
     }
 
     private void setLicenseSummary(String license) {
-        licenseSummaryView.setText(getString(R.string.share_license_summary, getString(Utils.licenseNameFor(license))));
+        String udata=getString(R.string.share_license_summary, getString(Utils.licenseNameFor(license)));
+        SpannableString content = new SpannableString(udata);
+        content.setSpan(new UnderlineSpan(), 33, udata.length(), 0);
+        licenseSummaryView.setText(content);
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,7 +87,7 @@
   <string name="no_uploads_yet">You have not yet uploaded any photos.</string>
   <string name="menu_retry_upload">Retry</string>
   <string name="menu_cancel_upload">Cancel</string>
-  <string name="share_license_summary">This image will be licensed under %1$s</string>
+  <string name="share_license_summary">This image will be licensed under <u> %1$s </u></string>
   <string name="media_upload_policy">By submitting this picture, I declare that this is my own work, that it does not contain copyrighted material or selfies, and otherwise adheres to &lt;a href=\"https://commons.wikimedia.org/wiki/Commons:Policies_and_guidelines\"&gt;Wikimedia Commons policies&lt;/a&gt;.</string>
   <string name="menu_download">Download</string>
   <string name="preference_license">License</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,7 +87,7 @@
   <string name="no_uploads_yet">You have not yet uploaded any photos.</string>
   <string name="menu_retry_upload">Retry</string>
   <string name="menu_cancel_upload">Cancel</string>
-  <string name="share_license_summary">This image will be licensed under <u> %1$s </u></string>
+  <string name="share_license_summary">This image will be licensed under %1$s </string>
   <string name="media_upload_policy">By submitting this picture, I declare that this is my own work, that it does not contain copyrighted material or selfies, and otherwise adheres to &lt;a href=\"https://commons.wikimedia.org/wiki/Commons:Policies_and_guidelines\"&gt;Wikimedia Commons policies&lt;/a&gt;.</string>
   <string name="menu_download">Download</string>
   <string name="preference_license">License</string>


### PR DESCRIPTION
Fix for issue #1037
Explicitly show that the license text is a link.