### PR TITLE
Travis-CI: remove stacktrace from gradle output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   - android-wait-for-emulator
 
 script:
-  - ./gradlew clean check connectedCheck jacocoTestReport --stacktrace
+  - ./gradlew clean check connectedCheck jacocoTestReport
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
I have noticed that '--stacktrace' option creates clutters that are often useless, which in part may be responsible for making people to ignore Travis errors.

It will show us stacktraces for gradle code (such as build.gradle) - since we rarely change gradle code, methods lists like the one below are typically meaningless:

```
org.gradle.api.ProjectConfigurationException: A problem occurred configuring project ':app'.
	at org.gradle.configuration.project.LifecycleProjectEvaluator.addConfigurationFailure(LifecycleProjectEvaluator.java:87)
	at org.gradle.configuration.project.LifecycleProjectEvaluator.notifyAfterEvaluate(LifecycleProjectEvaluator.java:82)
	at org.gradle.configuration.project.LifecycleProjectEvaluator.doConfigure(LifecycleProjectEvaluator.java:69)
	at org.gradle.configuration.project.LifecycleProjectEvaluator.access$100(LifecycleProjectEvaluator.java:33)
	at org.gradle.configuration.project.LifecycleProjectEvaluator$ConfigureProject.run(LifecycleProjectEvaluator.java:103)
...
```

I guess this is an option best to be used locally only when needed.

(I think this will cause an error affected by #1068.)