### PR TITLE
Use different labels for different buttons (toggle vs refresh)

### DIFF
--- a/app/src/main/res/menu/menu_nearby.xml
+++ b/app/src/main/res/menu/menu_nearby.xml
@@ -4,7 +4,7 @@
 
     <item
         android:id="@+id/action_toggle_view"
-        android:title="@string/refresh_button"
+        android:title="@string/toggle_view_button"
         android:icon="@drawable/ic_map_white_24dp"
         android:orderInCategory="1"
         app:showAsAction="ifRoom"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -215,11 +215,12 @@
   <string name="nearby_location_has_not_changed">Location has not changed.</string>
   <string name="nearby_location_not_available">Location not available.</string>
   <string name="location_permission_rationale_nearby">Permission required to display a list of nearby places</string>
-    <string name="get_directions">GET DIRECTIONS</string>
+  <string name="get_directions">GET DIRECTIONS</string>
   <string name="read_article">READ ARTICLE</string>
 
   <string name="notifications_welcome" formatted="false">Welcome to Wikimedia Commons, %1$s! We\'re glad you\'re here.</string>
   <string name="notifications_talk_page_message">%1$s left a message on your talk page</string>
   <string name="notifications_thank_you_edit">Thank you for making an edit</string>
   <string name="notifications_mention">%1$s mentioned you on %2$s.</string>
+  <string name="toggle_view_button">Toggle view</string>
 </resources>


### PR DESCRIPTION
As pointed out at https://github.com/commons-app/apps-android-commons/commit/784b51e29d0a07a3f343dcf1cd374bae25fc5636#r22247055 there doesn't seem to be a good reason to have "Refresh" for the toggle button.