### PR TITLE
Fix NPEs in ModificationsSyncAdapter

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
@@ -95,6 +95,7 @@ public class ModificationsSyncAdapter extends AbstractThreadedSyncAdapter {
                 Cursor contributionCursor;
 
                 if (contributionsClient == null) {
+                    Timber.e("ContributionsClient is null. This should not happen!");
                     return;
                 }
 

--- a/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
@@ -128,6 +128,7 @@ public class ModificationsSyncAdapter extends AbstractThreadedSyncAdapter {
 
                     Timber.d("Response is %s", editResult);
 
+                    if (!"Success".equals(editResult)) {
                         // FIXME: Log this somewhere else
                         Timber.d("Non success result! %s", editResult);
                     } else {

--- a/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
@@ -99,9 +99,13 @@ public class ModificationsSyncAdapter extends AbstractThreadedSyncAdapter {
                 } catch (RemoteException e) {
                     throw new RuntimeException(e);
                 }
-                contributionCursor.moveToFirst();
-                contrib = contributionDao.fromCursor(contributionCursor);
 
+                if (contributionCursor != null) {
+                    contributionCursor.moveToFirst();
+                }
+
+                contrib = contributionDao.fromCursor(contributionCursor);
+                
                 if (contrib.getState() == Contribution.STATE_COMPLETED) {
                     String pageContent;
                     try {

--- a/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
@@ -105,8 +105,8 @@ public class ModificationsSyncAdapter extends AbstractThreadedSyncAdapter {
                 }
 
                 contrib = contributionDao.fromCursor(contributionCursor);
-                
-                if (contrib.getState() == Contribution.STATE_COMPLETED) {
+
+                if (contrib != null && contrib.getState() == Contribution.STATE_COMPLETED) {
                     String pageContent;
                     try {
                         pageContent = mwApi.revisionsByFilename(contrib.getFilename());

--- a/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
@@ -95,6 +95,7 @@ public class ModificationsSyncAdapter extends AbstractThreadedSyncAdapter {
 
                 Cursor contributionCursor;
                 try {
+                    //TODO: How do we prevent this NPE?
                     contributionCursor = contributionsClient.query(sequence.getMediaUri(), null, null, null, null);
                 } catch (RemoteException e) {
                     throw new RuntimeException(e);

--- a/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
@@ -128,7 +128,6 @@ public class ModificationsSyncAdapter extends AbstractThreadedSyncAdapter {
 
                     Timber.d("Response is %s", editResult);
 
-                    if (!editResult.equals("Success")) {
                         // FIXME: Log this somewhere else
                         Timber.d("Non success result! %s", editResult);
                     } else {

--- a/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
@@ -111,7 +111,7 @@ public class ModificationsSyncAdapter extends AbstractThreadedSyncAdapter {
                     try {
                         pageContent = mwApi.revisionsByFilename(contrib.getFilename());
                     } catch (IOException e) {
-                        Timber.d("Network fuckup on modifications sync!");
+                        Timber.d("Network messed up on modifications sync!");
                         continue;
                     }
 
@@ -122,7 +122,7 @@ public class ModificationsSyncAdapter extends AbstractThreadedSyncAdapter {
                     try {
                         editResult = mwApi.edit(editToken, processedPageContent, contrib.getFilename(), sequence.getEditSummary());
                     } catch (IOException e) {
-                        Timber.d("Network fuckup on modifications sync!");
+                        Timber.d("Network messed up on modifications sync!");
                         continue;
                     }
 

--- a/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/modifications/ModificationsSyncAdapter.java
@@ -92,10 +92,13 @@ public class ModificationsSyncAdapter extends AbstractThreadedSyncAdapter {
             while (!allModifications.isAfterLast()) {
                 ModifierSequence sequence = modifierSequenceDao.fromCursor(allModifications);
                 Contribution contrib;
-
                 Cursor contributionCursor;
+
+                if (contributionsClient == null) {
+                    return;
+                }
+
                 try {
-                    //TODO: How do we prevent this NPE?
                     contributionCursor = contributionsClient.query(sequence.getMediaUri(), null, null, null, null);
                 } catch (RemoteException e) {
                     throw new RuntimeException(e);


### PR DESCRIPTION
For #1087 . Adds null check at crash location based on @psh 's recommendation. Also adds a few other null checks to areas where Android Studio flagged potential NPEs. Please let me know if I handled the null checks appropriately.

A TODO that help would be appreciated with - best way to prevent NPE for a cursor query?

Also, we probably need to reexamine why the cursor is empty to begin with, in addition to these fixes.