### PR TITLE
Disable Refresh While Loading Nearby Places

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -279,7 +279,9 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
             Timber.d("Skipping update of nearby places as location is unavailable");
             return;
         }
-
+        
+        lockNearbyView(true); 
+        // Begin refresh 
         progressBar.setVisibility(View.VISIBLE);
         placesDisposable = Observable.fromCallable(() -> nearbyController
                 .loadAttractionsFromLocation(curLatLang, this))


### PR DESCRIPTION
- simple fix
- set lockNearbyView() to true while Nearby Places loads 
- prevents refreshView() from being called multiple times