### PR TITLE
Hide Keypad on clicking outside the EditText

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
@@ -1,5 +1,6 @@
 package fr.free.nrw.commons.upload;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -11,6 +12,7 @@ import android.support.annotation.NonNull;
 import android.support.v7.app.AlertDialog;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -136,9 +138,27 @@ public class SingleUploadFragment extends CommonsDaggerSupportFragment {
 
         titleEdit.addTextChangedListener(textWatcher);
 
+        titleEdit.setOnFocusChangeListener((v, hasFocus) -> {
+            if (!hasFocus) {
+                hideKeyboard(v);
+            }
+        });
+
+        descEdit.setOnFocusChangeListener((v, hasFocus) -> {
+            if(!hasFocus){
+                hideKeyboard(v);
+            }
+        });
+
         setLicenseSummary(license);
 
         return rootView;
+    }
+
+    public void hideKeyboard(View view) {
+        Log.i("hide", "hideKeyboard: ");
+        InputMethodManager inputMethodManager =(InputMethodManager)getActivity().getSystemService(Activity.INPUT_METHOD_SERVICE);
+        inputMethodManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
     }
 
     @Override

--- a/app/src/main/res/layout/fragment_single_upload.xml
+++ b/app/src/main/res/layout/fragment_single_upload.xml
@@ -12,6 +12,8 @@
     android:paddingEnd="@dimen/standard_gap"
     android:paddingTop="@dimen/small_gap"
     android:theme="@style/DarkAppTheme"
+    android:clickable="true"
+    android:focusableInTouchMode="true"
     >
 
     <EditText


### PR DESCRIPTION
This PR is in response to #1040 
Hide keypad when user clicks outside the editView in Commons Activity