### PR TITLE
Issue #171 - Removed warning Unused namespace - removed namespaces fr…

### DIFF
--- a/app/src/main/res/layout/activity_contributions.xml
+++ b/app/src/main/res/layout/activity_contributions.xml
@@ -15,9 +15,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
-        <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:tools="http://schemas.android.com/tools"
-            android:layout_width="match_parent"
+        <FrameLayout android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:id="@+id/contributionsFragmentContainer"
             android:orientation="horizontal"

--- a/app/src/main/res/layout/activity_multiple_uploads.xml
+++ b/app/src/main/res/layout/activity_multiple_uploads.xml
@@ -15,8 +15,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
-        <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            android:id="@+id/uploadsFragmentContainer"
+        <FrameLayout android:id="@+id/uploadsFragmentContainer"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_below="@id/toolbar"


### PR DESCRIPTION
…om within the xml where it is already present at the top of the xml.

Context: The layout xml file already had the namespaces at the root xml node, and thus does not need them within the xml file.