### PR TITLE
Filter out irrelevant categories #1029

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
@@ -301,7 +301,8 @@ public class CategorizationFragment extends CommonsDaggerSupportFragment {
         //Check if the year in the form of XX(X)0s is relevant, i.e. in the 2000s or 2010s as stated in Issue #1029
         return ((item.matches(".*(19|20)\\d{2}.*") && !item.contains(yearInString) && !item.contains(prevYearInString))
                 || item.matches("(.*)needing(.*)") || item.matches("(.*)taken on(.*)")
-                || (item.matches(".*0s.*") && !item.matches(".*(200|201)0s.*")));
+                || (item.matches(".*0s.*") && !item.matches(".*(200|201)0s.*"))
+                || !item.matches(".*(0|1|2)\\d{1}.{1}\\d{2}.{1}\\d{2}.*"));
     }
 
     private void updateCategoryCount(CategoryItem item) {

--- a/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
@@ -302,7 +302,7 @@ public class CategorizationFragment extends CommonsDaggerSupportFragment {
         return ((item.matches(".*(19|20)\\d{2}.*") && !item.contains(yearInString) && !item.contains(prevYearInString))
                 || item.matches("(.*)needing(.*)") || item.matches("(.*)taken on(.*)")
                 || (item.matches(".*0s.*") && !item.matches(".*(200|201)0s.*"))
-                || !item.matches(".*(0|1|2)\\d{1}.{1}\\d{2}.{1}\\d{2}.*"));
+                || !item.matches(".*(0|1)\\d{1}.{1}\\d{2}.{1}\\d{2}.*"));
     }
 
     private void updateCategoryCount(CategoryItem item) {


### PR DESCRIPTION
Fixes #1029 

Continuing from #1134, I have updated code fragment to format for dates with YY.MM.DD formats to include only 0x or 1x for the year component.