### PR TITLE
Hide Keypad when EditText out of focus

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -116,7 +116,6 @@ public class LoginActivity extends AccountAuthenticatorActivity {
 
 
     public void hideKeyboard(View view) {
-        Log.i("hide", "hideKeyboard: ");
         InputMethodManager inputMethodManager =(InputMethodManager)this.getSystemService(Activity.INPUT_METHOD_SERVICE);
         inputMethodManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
     }

--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -4,6 +4,7 @@ import android.accounts.Account;
 import android.accounts.AccountAuthenticatorActivity;
 import android.accounts.AccountAuthenticatorResponse;
 import android.accounts.AccountManager;
+import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -17,10 +18,12 @@ import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatDelegate;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -91,13 +94,33 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         ButterKnife.bind(this);
 
         usernameEdit.addTextChangedListener(textWatcher);
+        usernameEdit.setOnFocusChangeListener((v, hasFocus) -> {
+            if (!hasFocus) {
+                hideKeyboard(v);
+            }
+        });
+
         passwordEdit.addTextChangedListener(textWatcher);
+        passwordEdit.setOnFocusChangeListener((v, hasFocus) -> {
+            if (!hasFocus) {
+                hideKeyboard(v);
+            }
+        });
+
         twoFactorEdit.addTextChangedListener(textWatcher);
         passwordEdit.setOnEditorActionListener(newLoginInputActionListener());
 
         loginButton.setOnClickListener(view -> performLogin());
         signupButton.setOnClickListener(view -> signUp());
     }
+
+
+    public void hideKeyboard(View view) {
+        Log.i("hide", "hideKeyboard: ");
+        InputMethodManager inputMethodManager =(InputMethodManager)this.getSystemService(Activity.INPUT_METHOD_SERVICE);
+        inputMethodManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
+    }
+
 
     @Override
     protected void onPostCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
@@ -127,7 +127,6 @@ public class CategorizationFragment extends CommonsDaggerSupportFragment {
     }
 
     public void hideKeyboard(View view) {
-        Log.i("hide", "hideKeyboard: ");
         InputMethodManager inputMethodManager =(InputMethodManager)getActivity().getSystemService(Activity.INPUT_METHOD_SERVICE);
         inputMethodManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/MultipleUploadListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/MultipleUploadListFragment.java
@@ -1,5 +1,6 @@
 package fr.free.nrw.commons.upload;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Point;
 import android.net.Uri;
@@ -10,6 +11,7 @@ import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.DisplayMetrics;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -177,7 +179,20 @@ public class MultipleUploadListFragment extends Fragment {
         photosGrid.setColumnWidth(photoSize.x);
 
         baseTitle.addTextChangedListener(textWatcher);
+
+        baseTitle.setOnFocusChangeListener((v, hasFocus) -> {
+            if (!hasFocus) {
+                hideKeyboard(v);
+            }
+        });
+
         return view;
+    }
+
+    public void hideKeyboard(View view) {
+        Log.i("hide", "hideKeyboard: ");
+        InputMethodManager inputMethodManager =(InputMethodManager)getActivity().getSystemService(Activity.INPUT_METHOD_SERVICE);
+        inputMethodManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/upload/MultipleUploadListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/MultipleUploadListFragment.java
@@ -190,7 +190,6 @@ public class MultipleUploadListFragment extends Fragment {
     }
 
     public void hideKeyboard(View view) {
-        Log.i("hide", "hideKeyboard: ");
         InputMethodManager inputMethodManager =(InputMethodManager)getActivity().getSystemService(Activity.INPUT_METHOD_SERVICE);
         inputMethodManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
     }

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -19,6 +19,8 @@
             android:layout_marginRight="@dimen/standard_gap"
             android:layout_marginStart="@dimen/standard_gap"
             android:layout_marginTop="@dimen/large_gap"
+            android:clickable="true"
+            android:focusableInTouchMode="true"
             app:cardCornerRadius="4dp"
             app:cardElevation="4dp">
 
@@ -26,7 +28,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:clickable="true"
+                android:focusableInTouchMode="true">
 
                 <TextView
                     android:id="@+id/title"

--- a/app/src/main/res/layout/fragment_categorization.xml
+++ b/app/src/main/res/layout/fragment_categorization.xml
@@ -11,11 +11,15 @@
     android:paddingEnd="@dimen/standard_gap"
     android:paddingTop="@dimen/small_gap"
     android:theme="@style/DarkAppTheme"
+    android:clickable="true"
+    android:focusableInTouchMode="true"
     >
 
     <FrameLayout
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
+        android:clickable="true"
+        android:focusableInTouchMode="true"
         >
 
         <EditText

--- a/app/src/main/res/layout/fragment_multiple_uploads_list.xml
+++ b/app/src/main/res/layout/fragment_multiple_uploads_list.xml
@@ -3,6 +3,8 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:clickable="true"
+    android:focusableInTouchMode="true"
     >
 
     <EditText


### PR DESCRIPTION
Hey!
To enhance the user experience, the soft keyboard is now being hidden whenever the EditText loses focus. The changes have been made to the following:
  1) acitivity_login
  2) fragment_categorization
  3) fragment_multiple_upload_lists
This PR references the issue #1109 

Please review :-) 
Thanks!