### PR TITLE
Fix crash in map view fragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.1'
     implementation 'com.jakewharton.timber:timber:4.5.1'
     implementation 'info.debatty:java-string-similarity:0.24'
-    implementation ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.2.1@aar'){
+    implementation ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.4.1@aar'){
         transitive=true
     }
 


### PR DESCRIPTION
## Fixes crash on orientation change in the map view fragment

Fixes #1181

Updating upstream(map view SDK version) fixes this issue. Apparently they fixed this issue in this diff. https://github.com/mapbox/mapbox-gl-native/pull/10589