### PR TITLE
Change position of notifications item in the hamburger menu

### DIFF
--- a/app/src/main/res/menu/drawer.xml
+++ b/app/src/main/res/menu/drawer.xml
@@ -11,6 +11,11 @@
         android:title="@string/navigation_item_nearby"/>
 
     <item
+        android:id="@+id/action_notifications"
+        android:icon="@drawable/ic_notifications_black_24dp"
+        android:title="@string/navigation_item_notification"/>
+
+    <item
         android:id="@+id/action_about"
         android:icon="@drawable/ic_info_outline_black_24dp"
         android:title="@string/navigation_item_about"/>
@@ -34,10 +39,5 @@
         android:id="@+id/action_logout"
         android:icon="@drawable/ic_exit_to_app_black_24dp"
         android:title="@string/navigation_item_logout"/>
-
-    <item
-        android:id="@+id/action_notifications"
-        android:icon="@drawable/ic_notifications_black_24dp"
-        android:title="@string/navigation_item_notification"/>
 
 </menu>


### PR DESCRIPTION
## Description

Part of fixes needed for #7 to go live.

Changed the position of notifications drawer item. 

## Screenshots showing what changed
 
![notifications_drawer_item](https://user-images.githubusercontent.com/3069373/36615946-120fec64-1908-11e8-9a78-e0e1d59de122.png)
