### PR TITLE
Fix order of notifications

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -10,6 +10,7 @@ import android.support.v7.widget.RecyclerView;
 
 import com.pedrogomez.renderers.RVRendererAdapter;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -58,6 +59,7 @@ public class NotificationActivity extends NavigationBaseActivity {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(notificationList -> {
+                    Collections.reverse(notificationList);
                     Timber.d("Number of notifications is %d", notificationList.size());
                     setAdapter(notificationList);
                 }, throwable -> Timber.e(throwable, "Error occurred while loading notifications"));


### PR DESCRIPTION
## Description

Part of fixes for #7. Now the newest notification is on the top. 

## Screenshots showing what changed

### Before
 ![notification_order_before](https://user-images.githubusercontent.com/3069373/36616352-7141dd68-1909-11e8-8fc2-5240dc2015e3.png)

### After
 ![notifications_order_after](https://user-images.githubusercontent.com/3069373/36616360-77bd7440-1909-11e8-983b-5b289d90fdf4.png)