### PR TITLE
Additional fix: Refreshing stopped if no change in location

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -46,7 +46,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
 
     private static final int LOCATION_REQUEST = 1;
     private static final String MAP_LAST_USED_PREFERENCE = "mapLastUsed";
-
+    private boolean LOCATION_CHANGED=false;
     @BindView(R.id.progressBar)
     ProgressBar progressBar;
 
@@ -273,10 +273,15 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
         locationManager.registerLocationManager();
         LatLng lastLocation = locationManager.getLastLocation();
         if (curLatLang != null && curLatLang.equals(lastLocation)) { //refresh view only if location has changed
+            LOCATION_CHANGED=false;
             if (isHardRefresh) {
                 ViewUtil.showLongToast(this, R.string.nearby_location_has_not_changed);
+                swipeLayout.setRefreshing(false);
             }
             return;
+        }
+        else {
+            LOCATION_CHANGED=true;
         }
         curLatLang = lastLocation;
 
@@ -363,6 +368,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
 
     @Override
     public void onLocationChanged(LatLng latLng) {
-        refreshView(false);
+        if(LOCATION_CHANGED)
+            refreshView(false);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -82,8 +82,10 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
 
     private void initViewState() {
         if (sharedPreferences.getBoolean(MAP_LAST_USED_PREFERENCE, false)) {
+            swipeLayout.setEnabled(false);
             viewMode = NearbyActivityMode.MAP;
         } else {
+            swipeLayout.setEnabled(true);
             viewMode = NearbyActivityMode.LIST;
         }
     }
@@ -226,8 +228,10 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
 
     private void toggleView() {
         if (viewMode.isMap()) {
+            swipeLayout.setEnabled(false);
             setMapFragment();
         } else {
+            swipeLayout.setEnabled(true);
             setListFragment();
         }
         sharedPreferences.edit().putBoolean(MAP_LAST_USED_PREFERENCE, viewMode.isMap()).apply();

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -46,7 +46,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
 
     private static final int LOCATION_REQUEST = 1;
     private static final String MAP_LAST_USED_PREFERENCE = "mapLastUsed";
-    private boolean LOCATION_CHANGED=false;
+
     @BindView(R.id.progressBar)
     ProgressBar progressBar;
 
@@ -60,6 +60,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
     private SharedPreferences sharedPreferences;
     private NearbyActivityMode viewMode;
     private Disposable placesDisposable;
+    private boolean locationChanged;
     private boolean lockNearbyView; //Determines if the nearby places needs to be refreshed
     @BindView(R.id.swipe_container) SwipeRefreshLayout swipeLayout;
     @Override
@@ -277,7 +278,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
         locationManager.registerLocationManager();
         LatLng lastLocation = locationManager.getLastLocation();
         if (curLatLang != null && curLatLang.equals(lastLocation)) { //refresh view only if location has changed
-            LOCATION_CHANGED=false;
+            locationChanged=false;
             if (isHardRefresh) {
                 ViewUtil.showLongToast(this, R.string.nearby_location_has_not_changed);
                 swipeLayout.setRefreshing(false);
@@ -285,7 +286,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
             return;
         }
         else {
-            LOCATION_CHANGED=true;
+            locationChanged=true;
         }
         curLatLang = lastLocation;
 
@@ -372,7 +373,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
 
     @Override
     public void onLocationChanged(LatLng latLng) {
-        if(LOCATION_CHANGED)
+        if(locationChanged)
             refreshView(false);
     }
 }


### PR DESCRIPTION
## Description

Additional Fix to #264

- When no change to location occurs the refresh of nearby location doesn't occur now.
- This change has been incorporated for both Pull down gesture refreshing and for the Refresh Button
- I added a flag to ensure that OnLocationChanged() doesn't call refreshView() when location hasn't changed.