### PR TITLE
Fixes Bug#1004 : Black background on details and categories screen

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import android.database.sqlite.SQLiteDatabase;
 
 import com.facebook.drawee.backends.pipeline.Fresco;
+import com.facebook.imagepipeline.core.ImagePipelineConfig;
 import com.facebook.stetho.Stetho;
 import com.squareup.leakcanary.LeakCanary;
 import com.squareup.leakcanary.RefWatcher;
@@ -24,7 +25,6 @@ import fr.free.nrw.commons.category.CategoryDao;
 import fr.free.nrw.commons.contributions.ContributionDao;
 import fr.free.nrw.commons.data.DBOpenHelper;
 import fr.free.nrw.commons.di.ApplicationlessInjection;
-import fr.free.nrw.commons.di.CommonsApplicationComponent;
 import fr.free.nrw.commons.modifications.ModifierSequenceDao;
 import fr.free.nrw.commons.utils.FileUtils;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -71,8 +71,11 @@ public class CommonsApplication extends Application {
                 .getInstance(this)
                 .getCommonsApplicationComponent()
                 .inject(this);
-
-        Fresco.initialize(this);
+//        Set DownsampleEnabled to True to downsample the image in case it's heavy
+        ImagePipelineConfig config = ImagePipelineConfig.newBuilder(this)
+                .setDownsampleEnabled(true)
+                .build();
+        Fresco.initialize(this,config);
         if (setupLeakCanary() == RefWatcher.DISABLED) {
             return;
         }


### PR DESCRIPTION
Partially Fixes #1004

In the file CommonsApplication.java, config of fresco initialization was changed to include downsampling

```
//        Set DownsampleEnabled to True to downsample the image in case it's heavy
        ImagePipelineConfig config = ImagePipelineConfig.newBuilder(this)
                .setDownsampleEnabled(true)
                .build();
        Fresco.initialize(this,config);
```

This seems to do the trick in almost all cases on my phone. I haven't included resizing though, as there are chances of NPE and possibility of changing the UI in further updates.