### PR TITLE
Fixes #1180

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     compile 'com.facebook.stetho:stetho:1.5.0'
 
     testCompile 'junit:junit:4.12'
-    testCompile 'org.robolectric:robolectric:3.4'
+    testCompile 'org.robolectric:robolectric:3.7.1'
 
     testCompile 'com.squareup.okhttp3:mockwebserver:3.8.1'
     androidTestCompile 'com.squareup.okhttp3:mockwebserver:3.8.1'
@@ -78,7 +78,7 @@ dependencies {
     androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.robolectric:robolectric:3.4'
+    testImplementation 'org.robolectric:robolectric:3.7.1'
     testImplementation 'org.mockito:mockito-all:1.10.19'
 
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.8.1'

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -354,11 +354,25 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
      * Calls fragment for list view.
      */
     private void setListFragment() {
-        FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
-        Fragment fragment = new NearbyListFragment();
-        fragment.setArguments(bundle);
-        fragmentTransaction.replace(R.id.container, fragment, fragment.getClass().getSimpleName());
-        fragmentTransaction.commitAllowingStateLoss();
+        NearbyListFragment nearbyListFragment;
+        final String NEARBY_LIST_FRAGMENT_TAG = "NearByListFragment";
+
+        // Lookup the fragment instance that already exists by tag.
+        nearbyListFragment = (NearbyListFragment) getSupportFragmentManager()
+                .findFragmentByTag(NEARBY_LIST_FRAGMENT_TAG);
+
+        if(nearbyListFragment == null){
+            // Only create fragment if its haven't been instantiated.
+            Timber.d("NearbyListFragment -> Instantiating fragment");
+            FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
+            Fragment fragment = new NearbyListFragment();
+            fragment.setArguments(bundle);
+            fragmentTransaction.replace(R.id.container, fragment, NEARBY_LIST_FRAGMENT_TAG);
+            fragmentTransaction.commitAllowingStateLoss();
+        } else{
+            // fragment is already instantiated, so no need to do it again.
+            Timber.d("NearbyListFragment Fragment already instantiated.");
+        }
     }
 
     @Override

--- a/app/src/test/java/fr/free/nrw/commons/nearby/NearbyActivityTest.java
+++ b/app/src/test/java/fr/free/nrw/commons/nearby/NearbyActivityTest.java
@@ -80,7 +80,7 @@ public class NearbyActivityTest {
         nearbyActivity.onOptionsItemSelected(refresh);
 
         Fragment nearbyListFragment = nearbyActivity.getSupportFragmentManager()
-                .findFragmentByTag(NearbyListFragment.class.getSimpleName());
+                .findFragmentByTag("NearByListFragment");
         assertNotNull(nearbyListFragment);
 
         // one element (AIRPORT) exists in the list


### PR DESCRIPTION
Fixes #1180

## Description
1.Changes in NearybyActivity prevents reinitialising of NearybyFragment if it already exists.
2.Upgraded robolectric from 3.4 to 3.7.1 to solve known issue(AndroidManifest not found).
