### PR TITLE
Show only the email clients in Feedback Feature (#1203)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -5,6 +5,7 @@ import android.accounts.AccountManager;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.design.widget.NavigationView;
 import android.support.v4.widget.DrawerLayout;
@@ -119,8 +120,9 @@ public abstract class NavigationBaseActivity extends BaseActivity
                 return true;
             case R.id.action_feedback:
                 drawerLayout.closeDrawer(navigationView);
-                Intent feedbackIntent = new Intent(Intent.ACTION_SEND);
+                Intent feedbackIntent = new Intent(Intent.ACTION_SENDTO);
                 feedbackIntent.setType("message/rfc822");
+                feedbackIntent.setData(Uri.parse("mailto:"));
                 feedbackIntent.putExtra(Intent.EXTRA_EMAIL,
                         new String[]{CommonsApplication.FEEDBACK_EMAIL});
                 feedbackIntent.putExtra(Intent.EXTRA_SUBJECT,


### PR DESCRIPTION
## Description

Fixes #1203 

Instead of showing only the email clients, The Feedback feature was showing multiple unsupported clients (WhatsApp, Bluetooth etc). Changes made to display only the email clients.

## Screenshots showing what changed
Before            |  After
:-------------------------:|:-------------------------:
![screenshot_20180226-031109 1](https://user-images.githubusercontent.com/18305466/36647617-6f523fec-1aae-11e8-99c3-9cc7dbde7dda.png)  |  ![screenshot_20180226-032658 1](https://user-images.githubusercontent.com/18305466/36647607-47c2954e-1aae-11e8-82ed-16f9e84a162f.png)
