### PR TITLE
Fixes #1205

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     compile 'com.facebook.stetho:stetho:1.5.0'
 
     testCompile 'junit:junit:4.12'
-    testCompile 'org.robolectric:robolectric:3.4'
+    testCompile 'org.robolectric:robolectric:3.7.1'
 
     testCompile 'com.squareup.okhttp3:mockwebserver:3.8.1'
     androidTestCompile 'com.squareup.okhttp3:mockwebserver:3.8.1'
@@ -78,7 +78,7 @@ dependencies {
     androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.robolectric:robolectric:3.4'
+    testImplementation 'org.robolectric:robolectric:3.7.1'
     testImplementation 'org.mockito:mockito-all:1.10.19'
 
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.8.1'

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -56,6 +57,8 @@ public class NearbyListFragment extends Fragment {
         View view = inflater.inflate(R.layout.fragment_nearby, container, false);
         recyclerView = (RecyclerView) view.findViewById(R.id.listView);
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        DividerItemDecoration itemDecor = new DividerItemDecoration(recyclerView.getContext(), DividerItemDecoration.VERTICAL);
+        recyclerView.addItemDecoration(itemDecor);
         adapterFactory = new NearbyAdapterFactory(place -> NearbyInfoDialog.showYourself(getActivity(), place));
         return view;
     }


### PR DESCRIPTION
## Description

Fixes #1205

Add DividerItemDecoration to add ItemDivider in RecycleView in NearbyListFragment.


## Screenshots showing what changed
**Before**
![before](https://user-images.githubusercontent.com/20313518/36649869-23b98b72-1ac6-11e8-8153-f745d06ab0b0.jpeg)

**Now**
![after](https://user-images.githubusercontent.com/20313518/36649880-30e05574-1ac6-11e8-9f2e-7d0520f346b0.jpeg)

 
