### PR TITLE
issue #1130 -(j). bad Token Exception from showDialog() in ExistingFi…

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/ExistingFileAsync.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ExistingFileAsync.java
@@ -1,11 +1,13 @@
 package fr.free.nrw.commons.upload;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
 import android.support.v7.app.AlertDialog;
 
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.contributions.ContributionsActivity;
@@ -28,12 +30,14 @@ public class ExistingFileAsync extends AsyncTask<Void, Void, Boolean> {
         DUPLICATE_CANCELLED
     }
 
+    private final WeakReference<Activity> activity;
     private final MediaWikiApi api;
     private final String fileSha1;
-    private final Context context;
+    private final WeakReference<Context> context;
     private final Callback callback;
 
-    public ExistingFileAsync(String fileSha1, Context context, Callback callback, MediaWikiApi mwApi) {
+    public ExistingFileAsync(WeakReference<Activity> activity, String fileSha1, WeakReference<Context> context, Callback callback, MediaWikiApi mwApi) {
+        this.activity = activity;
         this.fileSha1 = fileSha1;
         this.context = context;
         this.callback = callback;
@@ -69,19 +73,21 @@ public class ExistingFileAsync extends AsyncTask<Void, Void, Boolean> {
         // If file exists, display warning to user.
         // Use soft warning for now (user able to choose to proceed) until have determined that implementation works without bugs
         if (fileExists) {
-            AlertDialog.Builder builder = new AlertDialog.Builder(context);
+            AlertDialog.Builder builder = new AlertDialog.Builder(context.get());
             builder.setMessage(R.string.file_exists)
                     .setTitle(R.string.warning);
             builder.setPositiveButton(R.string.no, (dialog, id) -> {
                 //Go back to ContributionsActivity
-                Intent intent = new Intent(context, ContributionsActivity.class);
-                context.startActivity(intent);
+                Intent intent = new Intent(context.get(), ContributionsActivity.class);
+                context.get().startActivity(intent);
                 callback.onResult(Result.DUPLICATE_CANCELLED);
             });
             builder.setNegativeButton(R.string.yes, (dialog, id) -> callback.onResult(Result.DUPLICATE_PROCEED));
 
             AlertDialog dialog = builder.create();
-            dialog.show();
+            if (!activity.get().isFinishing()) {
+                dialog.show();
+            }
         } else {
             callback.onResult(Result.NO_DUPLICATE);
         }

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -1,7 +1,9 @@
 package fr.free.nrw.commons.upload;
 
 import android.Manifest;
+import android.app.Activity;
 import android.content.ContentResolver;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
@@ -30,6 +32,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.ref.WeakReference;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -366,7 +369,7 @@ public class ShareActivity
                     Timber.d("File SHA1 is: %s", fileSHA1);
 
                     ExistingFileAsync fileAsyncTask =
-                            new ExistingFileAsync(fileSHA1, this, result -> {
+                            new ExistingFileAsync(new WeakReference<Activity>(this), fileSHA1, new WeakReference<Context>(this), result -> {
                                 Timber.d("%s duplicate check: %s", mediaUri.toString(), result);
                                 duplicateCheckPassed = (result == DUPLICATE_PROCEED
                                         || result == NO_DUPLICATE);


### PR DESCRIPTION
For #1130  (j), the exception occurs when app tries to open a dialog from ExistingFileAsync (extends AsyncTaskin) in this case. To fix, we can check if parent activity (the share activity in this case) is still running and show dialog only when it's finished.
To get parent activity into the  ExistingFileAsync class, we can pass it as a parameter. But, this will cause memory leaks when task is complete. 
![weak](https://user-images.githubusercontent.com/25305892/36652870-875fb1ac-1a7f-11e8-9e6a-0f8a0ba0be9c.png)
Solution is to use WeakReference to let the Garbage collector know. I also changed context to be a weakReference. 
Best