### PR TITLE
Formatted text in Tutorial pageviews

### DIFF
--- a/app/src/main/res/layout-land/welcome_do_upload.xml
+++ b/app/src/main/res/layout-land/welcome_do_upload.xml
@@ -73,16 +73,91 @@
                 android:gravity="center_horizontal"
                 android:textColor="@android:color/white"/>
 
-        <TextView
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
+            android:layout_gravity="center"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bullet"
+                android:paddingRight="4dp"
+                android:textSize="16sp"
+                android:paddingTop="@dimen/standard_gap"
+                android:textColor="@android:color/white"/>
+
+            <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:maxWidth="240dp"
-                android:text="@string/tutorial_2_subtext"
+                android:text="@string/tutorial_2_subtext_1"
                 android:layout_gravity="center"
                 android:textAlignment="textStart"
                 android:paddingTop="@dimen/standard_gap"
                 android:gravity="start"
                 android:textColor="@android:color/white"
-            />
+                />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
+            android:layout_gravity="center"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bullet"
+                android:paddingRight="4dp"
+                android:textSize="16sp"
+                android:textColor="@android:color/white"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:maxWidth="240dp"
+                android:text="@string/tutorial_2_subtext_2"
+                android:layout_gravity="center"
+                android:textAlignment="textStart"
+                android:gravity="start"
+                android:textColor="@android:color/white"
+                />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
+            android:layout_gravity="center"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bullet"
+                android:paddingRight="4dp"
+                android:textSize="16sp"
+                android:textColor="@android:color/white"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:maxWidth="240dp"
+                android:text="@string/tutorial_2_subtext_3"
+                android:layout_gravity="center"
+                android:textAlignment="textStart"
+                android:gravity="start"
+                android:textColor="@android:color/white"
+                />
+
+        </LinearLayout>
+
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout-land/welcome_dont_upload.xml
+++ b/app/src/main/res/layout-land/welcome_dont_upload.xml
@@ -55,16 +55,90 @@
             android:gravity="center_horizontal"
             android:textColor="@android:color/white"/>
 
-        <TextView
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:maxWidth="240dp"
-            android:text="@string/tutorial_3_subtext"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bullet"
+                android:paddingRight="4dp"
+                android:textSize="16sp"
+                android:paddingTop="@dimen/standard_gap"
+                android:textColor="@android:color/white"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:maxWidth="240dp"
+                android:text="@string/tutorial_3_subtext_1"
+                android:layout_gravity="center"
+                android:textAlignment="textStart"
+                android:paddingTop="@dimen/standard_gap"
+                android:gravity="start"
+                android:textColor="@android:color/white"
+                />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
             android:layout_gravity="center"
-            android:textAlignment="textStart"
-            android:paddingTop="@dimen/standard_gap"
-            android:gravity="start"
-            android:textColor="@android:color/white"
-            />
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bullet"
+                android:paddingRight="4dp"
+                android:textSize="16sp"
+                android:textColor="@android:color/white"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:maxWidth="240dp"
+                android:text="@string/tutorial_3_subtext_2"
+                android:layout_gravity="center"
+                android:textAlignment="textStart"
+                android:gravity="start"
+                android:textColor="@android:color/white"
+                />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bullet"
+                android:paddingRight="4dp"
+                android:textSize="16sp"
+                android:textColor="@android:color/white"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:maxWidth="240dp"
+                android:text="@string/tutorial_3_subtext_3"
+                android:layout_gravity="center"
+                android:textAlignment="textStart"
+                android:gravity="start"
+                android:textColor="@android:color/white"
+                />
+
+        </LinearLayout>
+
     </LinearLayout>
+
 </LinearLayout>

--- a/app/src/main/res/layout-land/welcome_image_details.xml
+++ b/app/src/main/res/layout-land/welcome_image_details.xml
@@ -38,16 +38,89 @@
             android:gravity="center_horizontal"
             android:textColor="@android:color/white"/>
 
-        <TextView
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:maxWidth="240dp"
-            android:text="@string/tutorial_4_subtext"
-            android:layout_gravity="center"
-            android:textAlignment="textStart"
-            android:paddingTop="@dimen/standard_gap"
-            android:gravity="start"
-            android:textColor="@android:color/white"
-            />
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bullet"
+                android:paddingRight="4dp"
+                android:textSize="16sp"
+                android:paddingTop="@dimen/standard_gap"
+                android:textColor="@android:color/white"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:maxWidth="240dp"
+                android:text="@string/tutorial_4_subtext_1"
+                android:layout_gravity="center"
+                android:textAlignment="textStart"
+                android:paddingTop="@dimen/standard_gap"
+                android:gravity="start"
+                android:textColor="@android:color/white"
+                />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bullet"
+                android:paddingRight="4dp"
+                android:textSize="16sp"
+                android:textColor="@android:color/white"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:maxWidth="240dp"
+                android:text="@string/tutorial_4_subtext_2"
+                android:layout_gravity="center"
+                android:textAlignment="textStart"
+                android:gravity="start"
+                android:textColor="@android:color/white"
+                />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bullet"
+                android:paddingRight="4dp"
+                android:textSize="16sp"
+                android:textColor="@android:color/white"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:maxWidth="240dp"
+                android:text="@string/tutorial_4_subtext_3"
+                android:layout_gravity="center"
+                android:textAlignment="textStart"
+                android:gravity="start"
+                android:textColor="@android:color/white"
+                />
+
+        </LinearLayout>
+
     </LinearLayout>
+
 </LinearLayout>

--- a/app/src/main/res/layout/welcome_do_upload.xml
+++ b/app/src/main/res/layout/welcome_do_upload.xml
@@ -67,15 +67,95 @@
         android:textColor="@android:color/white"
         />
 
-    <TextView
-        android:layout_width="295dp"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:maxWidth="240dp"
-        android:text="@string/tutorial_2_subtext"
-        android:layout_gravity="center"
-        android:textAlignment="textStart"
-        android:paddingTop="@dimen/standard_gap"
-        android:gravity="start"
-        android:textColor="@android:color/white"
-        />
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/bullet"
+            android:paddingRight="4dp"
+            android:textSize="16sp"
+            android:paddingTop="@dimen/standard_gap"
+            android:textColor="@android:color/white"/>
+
+        <TextView
+            android:layout_width="295dp"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
+            android:text="@string/tutorial_2_subtext_1"
+            android:layout_gravity="center"
+            android:textAlignment="textStart"
+            android:paddingTop="@dimen/standard_gap"
+            android:gravity="start"
+            android:textColor="@android:color/white"
+            />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/bullet"
+            android:paddingRight="4dp"
+            android:textSize="16sp"
+            android:textColor="@android:color/white"/>
+
+        <TextView
+            android:layout_width="295dp"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
+            android:text="@string/tutorial_2_subtext_2"
+            android:layout_gravity="center"
+            android:textAlignment="textStart"
+            android:gravity="start"
+            android:textColor="@android:color/white"
+            />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bullet"
+                android:paddingRight="4dp"
+                android:textSize="16sp"
+                android:textColor="@android:color/white"/>
+
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="295dp"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
+            android:text="@string/tutorial_2_subtext_3"
+            android:layout_gravity="center"
+            android:textAlignment="textStart"
+            android:gravity="start"
+            android:textColor="@android:color/white"
+            />
+
+    </LinearLayout>
+
+
 </LinearLayout>

--- a/app/src/main/res/layout/welcome_dont_upload.xml
+++ b/app/src/main/res/layout/welcome_dont_upload.xml
@@ -48,15 +48,87 @@
         android:textColor="@android:color/white"
         />
 
-    <TextView
-        android:layout_width="295dp"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:maxWidth="240dp"
-        android:text="@string/tutorial_3_subtext"
-        android:layout_gravity="center"
-        android:textAlignment="textStart"
-        android:paddingTop="@dimen/standard_gap"
-        android:gravity="start"
-        android:textColor="@android:color/white"
-        />
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/bullet"
+            android:paddingRight="4dp"
+            android:textSize="16sp"
+            android:paddingTop="@dimen/standard_gap"
+            android:textColor="@android:color/white"/>
+
+        <TextView
+            android:layout_width="295dp"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
+            android:text="@string/tutorial_3_subtext_1"
+            android:layout_gravity="center"
+            android:textAlignment="textStart"
+            android:paddingTop="@dimen/standard_gap"
+            android:gravity="start"
+            android:textColor="@android:color/white"
+            />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/bullet"
+            android:paddingRight="4dp"
+            android:textSize="16sp"
+            android:textColor="@android:color/white"/>
+
+        <TextView
+            android:layout_width="295dp"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
+            android:text="@string/tutorial_3_subtext_2"
+            android:layout_gravity="center"
+            android:textAlignment="textStart"
+            android:gravity="start"
+            android:textColor="@android:color/white"
+            />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/bullet"
+            android:paddingRight="4dp"
+            android:textSize="16sp"
+            android:textColor="@android:color/white"/>
+
+        <TextView
+            android:layout_width="295dp"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
+            android:text="@string/tutorial_3_subtext_3"
+            android:layout_gravity="center"
+            android:textAlignment="textStart"
+            android:gravity="start"
+            android:textColor="@android:color/white"
+            />
+
+    </LinearLayout>
+
 </LinearLayout>

--- a/app/src/main/res/layout/welcome_image_details.xml
+++ b/app/src/main/res/layout/welcome_image_details.xml
@@ -32,15 +32,101 @@
         android:textColor="@android:color/white"
         />
 
-    <TextView
-        android:layout_width="278dp"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:maxWidth="240dp"
-        android:text="@string/tutorial_4_subtext"
-        android:layout_gravity="center"
-        android:textAlignment="textStart"
-        android:paddingTop="@dimen/standard_gap"
-        android:gravity="start"
-        android:textColor="@android:color/white"
-        />
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/bullet"
+            android:paddingRight="4dp"
+            android:textSize="16sp"
+            android:paddingTop="@dimen/standard_gap"
+            android:textColor="@android:color/white"/>
+
+        <TextView
+            android:layout_width="295dp"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
+            android:text="@string/tutorial_4_subtext_1"
+            android:layout_gravity="center"
+            android:textAlignment="textStart"
+            android:paddingTop="@dimen/standard_gap"
+            android:gravity="start"
+            android:textColor="@android:color/white"
+            />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bullet"
+                android:paddingRight="4dp"
+                android:textSize="16sp"
+                android:textColor="@android:color/white"/>
+
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="295dp"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
+            android:text="@string/tutorial_4_subtext_2"
+            android:layout_gravity="center"
+            android:textAlignment="textStart"
+            android:gravity="start"
+            android:textColor="@android:color/white"
+            />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bullet"
+                android:paddingRight="4dp"
+                android:textSize="16sp"
+                android:textColor="@android:color/white"/>
+
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="295dp"
+            android:layout_height="wrap_content"
+            android:maxWidth="240dp"
+            android:text="@string/tutorial_4_subtext_3"
+            android:layout_gravity="center"
+            android:textAlignment="textStart"
+            android:gravity="start"
+            android:textColor="@android:color/white"
+            />
+
+    </LinearLayout>
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="app_name">Commons</string>
+  <string name="bullet">&#8226;  </string>
   <string name="menu_settings">Settings</string>
   <string name="username">Username</string>
   <string name="password">Password</string>
@@ -120,11 +121,20 @@
   <string name="tutorial_1_text">Wikimedia Commons hosts most of the images that are used in Wikipedia.</string>
   <string name="tutorial_1_subtext">Your images help educate people around the world!</string>
   <string name="tutorial_2_text">Please upload pictures that are taken or created entirely by yourself:</string>
-  <string name="tutorial_2_subtext">- Natural objects (flowers, animals, mountains)\n- Useful objects (bicycles, train stations)\n- Famous people (your mayor, Olympic athletes you met)</string>
+  <string name="tutorial_2_subtext">Natural objects (flowers, animals, mountains)\n&#8226; Useful objects (bicycles, train stations)\n&#8226; Famous people (your mayor, Olympic athletes you met)</string>
+  <string name="tutorial_2_subtext_1">Natural objects (flowers, animals, mountains)</string>
+  <string name="tutorial_2_subtext_2">Useful objects (bicycles, train stations)</string>
+  <string name="tutorial_2_subtext_3">Famous people (your mayor, Olympic athletes you met)</string>
   <string name="tutorial_3_text">Please do NOT upload:</string>
   <string name="tutorial_3_subtext">- Selfies or pictures of your friends\n- Pictures you downloaded from the Internet\n- Screenshots of proprietary apps</string>
+  <string name="tutorial_3_subtext_1">Selfies or pictures of your friends</string>
+  <string name="tutorial_3_subtext_2">Pictures you downloaded from the Internet</string>
+  <string name="tutorial_3_subtext_3">Screenshots of proprietary apps</string>
   <string name="tutorial_4_text">Example upload:</string>
   <string name="tutorial_4_subtext">- Title: Sydney Opera House\n- Description: Sydney Opera House as viewed from across the bay\n- Categories: Sydney Opera House from the west, Sydney Opera House remote views</string>
+  <string name="tutorial_4_subtext_1">Title: Sydney Opera House</string>
+  <string name="tutorial_4_subtext_2">Description: Sydney Opera House as viewed from across the bay</string>
+  <string name="tutorial_4_subtext_3">Categories: Sydney Opera House from the west, Sydney Opera House remote views</string>
   <string name="welcome_wikipedia_text">Contribute your images. Help Wikipedia articles come to life!</string>
   <string name="welcome_wikipedia_subtext">Images on Wikipedia come from Wikimedia Commons.</string>
   <string name="welcome_copyright_text">Your images help educate people around the world.</string>


### PR DESCRIPTION
## Description
This formats the text properly in all the tutorial layout pages, which enhance the UI of the application.
The PR fixes #1196 

## Changes Made
Instead of a '-', bullet points were used. New line spaces were properly indented after the bullet marks.
The changes were made to the following xml pages:
1) welcome_do_upload.xml(2)
2) welcome_dont_upload.xml(2)
3) welcome_image_details.xml(2)

## Screenshots of sample changes
This is one of the changes
#### Before
![whatsapp_image_2018-02-25_at_12 38 44_pm_ 1 2](https://user-images.githubusercontent.com/20908024/36656160-f8b7a36a-1aec-11e8-8383-aa8131b9d124.jpg)
#### After
![whatsapp_image_2018-02-25_at_12 38 44_pm 2](https://user-images.githubusercontent.com/20908024/36656136-e2437960-1aec-11e8-803d-a5158bbb1a39.jpg)
![whatsapp_image_2018-02-26_at_9 38 18_am](https://user-images.githubusercontent.com/20908024/36656210-36463af2-1aed-11e8-9bbe-fc80d9953ee9.jpg)
![whatsapp_image_2018-02-26_at_9 38 18_am_ 1](https://user-images.githubusercontent.com/20908024/36656217-3f9bc6e4-1aed-11e8-85d7-315d87b2e277.jpg)

## Device and Android Version
Redmi Note 3 and 6.0.1 MB29M
