### PR TITLE
Give toast when trying to upload image without giving a Title #1195

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
@@ -25,6 +25,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import java.util.ArrayList;
 
@@ -62,9 +63,6 @@ public class SingleUploadFragment extends CommonsDaggerSupportFragment {
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.activity_share, menu);
-        if (titleEdit != null) {
-            menu.findItem(R.id.menu_upload_single).setEnabled(titleEdit.getText().length() != 0);
-        }
     }
 
     @Override
@@ -72,6 +70,11 @@ public class SingleUploadFragment extends CommonsDaggerSupportFragment {
         switch (item.getItemId()) {
             //What happens when the 'submit' icon is tapped
             case R.id.menu_upload_single:
+
+                if (titleEdit.getText().toString().isEmpty()) {
+                    Toast.makeText(getContext(), R.string.add_title_toast, Toast.LENGTH_LONG).show();
+                    return false;
+                }
 
                 String title = titleEdit.getText().toString();
                 String desc = descEdit.getText().toString();

--- a/app/src/main/res/menu/activity_share.xml
+++ b/app/src/main/res/menu/activity_share.xml
@@ -3,6 +3,6 @@
     <item android:id="@+id/menu_upload_single"
         android:title="@string/menu_upload_single"
         android:icon="@drawable/ic_send_white_24dp"
-        android:enabled="false"
+        android:enabled="true"
         app:showAsAction="always" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
   <string name="menu_share">Share</string>
   <string name="menu_open_in_browser">View in Browser</string>
   <string name="share_title_hint">Title</string>
+  <string name="add_title_toast">Please give a Title to proceed</string>
   <string name="share_description_hint">Description</string>
   <string name="login_failed_network">Unable to login - network failure</string>
   <string name="login_failed_username">Unable to login - please check your username</string>


### PR DESCRIPTION
## Description

Fixes #1195

**Outline of Soultion**
- Made submit button always enabled. Before it was disabled when title was empty and it wasn't intuitive to user as to what is happening on click when title is empty
- Whenever the submit button is clicked with title empty a toast is shown as in screenshot

## Screenshots showing what changed
 
![whatsapp image 2018-02-26 at 2 17 59 pm](https://user-images.githubusercontent.com/12574756/36655860-2eea2648-1b00-11e8-87b5-c62c2a723f3b.jpeg)

