### PR TITLE
fixing upload summary

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -49,7 +49,7 @@ public class CommonsApplication extends Application {
     @Inject @Named("application_preferences") SharedPreferences applicationPrefs;
     @Inject @Named("prefs") SharedPreferences otherPrefs;
 
-    public static final String DEFAULT_EDIT_SUMMARY = "Uploaded using Android Commons app";
+    public static final String DEFAULT_EDIT_SUMMARY = "Uploaded using [[COM:MOA|Commons Mobile App]]";
 
     public static final String FEEDBACK_EMAIL = "commons-app-android@googlegroups.com";
 

--- a/app/src/main/java/fr/free/nrw/commons/modifications/ModifierSequence.java
+++ b/app/src/main/java/fr/free/nrw/commons/modifications/ModifierSequence.java
@@ -45,7 +45,7 @@ public class ModifierSequence {
         for (PageModifier modifier: modifiers) {
             editSummary.append(modifier.getEditSumary()).append(" ");
         }
-        editSummary.append("Via Commons Mobile App");
+        editSummary.append("Using [[COM:MOA|Commons Mobile App]]");
         return editSummary.toString();
     }
 


### PR DESCRIPTION
## Description
Adding link to local description page:
(Upload log) !; 15:02 . . Malabarge (talk | contribs | block) uploaded File:Spiegelung 3.jpg ‎(Uploaded using Android Commons app) (Tags: Mobile app edit, Mobile edit)

Using the same edit summary as for edits made using the app, e.g.
(diff | hist) . . ! File:Lul.jpg‎; 14:48 . . (-20)‎ . . ‎Codedoper (talk | contribs | block)‎ (Added 1 categories. Removed template Uncategorized. Via Commons Mobile App) (Tags: Mobile app edit, Mobile edit)

## Screenshots showing what changed
This is status quo, the change will unify the summary and add a link to the local description page:
![unbenannt](https://user-images.githubusercontent.com/6726292/36680594-79790aec-1b16-11e8-8e2a-f184e3f89c46.JPG)
