### PR TITLE
Add missing space between Licence and Coordinates in MediaDetailFragment #1215

### DIFF
--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -149,6 +149,10 @@
                         tools:text="License link" />
                 </LinearLayout>
 
+                <fr.free.nrw.commons.media.MediaDetailSpacer
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/small_gap" />
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
## Description

Fixes #1215 

## Outline of Solution
- Add consistent space between Licence and Coordinates in `MediaDetailFragment`

## Screenshots showing what changed
 
- Attached as comment
