### PR TITLE
Removes extra padding in media categories

### DIFF
--- a/app/src/main/res/layout/detail_category_item.xml
+++ b/app/src/main/res/layout/detail_category_item.xml
@@ -21,9 +21,4 @@
         app:drawableStart="@drawable/ic_info_outline_white_24dp"
         />
 
-    <fr.free.nrw.commons.media.MediaDetailSpacer
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/small_gap"
-        />
-
 </LinearLayout>


### PR DESCRIPTION
### Description
The following PR removes the blank inflator view present after the media categories container which made it inconsistent with the rest of the containers.
Fixes #1222 

### Screenshots showing what changed
![old](https://user-images.githubusercontent.com/20908024/36748688-9e39c3d6-1c1e-11e8-9f2a-edc0c4797db7.jpeg)
![new](https://user-images.githubusercontent.com/20908024/36748754-c9fb116e-1c1e-11e8-863b-26d57d6b1fbc.jpeg)

Kindly review :-)
Thanks!