### PR TITLE
Replacement of tutorial icon in navigation drawer

### DIFF
--- a/app/src/main/res/drawable/ic_help_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_help_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,19h-2v-2h2v2zM15.07,11.25l-0.9,0.92C13.45,12.9 13,13.5 13,15h-2v-0.5c0,-1.1 0.45,-2.1 1.17,-2.83l1.24,-1.26c0.37,-0.36 0.59,-0.86 0.59,-1.41 0,-1.1 -0.9,-2 -2,-2s-2,0.9 -2,2L8,9c0,-2.21 1.79,-4 4,-4s4,1.79 4,4c0,0.88 -0.36,1.68 -0.93,2.25z"/>
+</vector>

--- a/app/src/main/res/menu/drawer.xml
+++ b/app/src/main/res/menu/drawer.xml
@@ -27,7 +27,7 @@
 
     <item
         android:id="@+id/action_introduction"
-        android:icon="@drawable/ic_info_outline_black_24dp"
+        android:icon="@drawable/ic_help_black_24dp"
         android:title="@string/navigation_item_info"/>
 
     <item


### PR DESCRIPTION
### Description
The PR replaces the tutorial icon in the navigation drawer with a help icon. This enhances the UI of the app.
Fixes #1226 

### Screenshots showing what changed
##### Before:
![whatsapp image 2018-02-28 at 4 06 59 pm 1](https://user-images.githubusercontent.com/20908024/36785903-80616ee0-1caa-11e8-99cb-a8b958a5d9f1.jpeg)
##### After:
![whatsapp image 2018-02-28 at 4 06 55 pm 1](https://user-images.githubusercontent.com/20908024/36785926-94f47fdc-1caa-11e8-8bb1-fd631d8f32e2.jpeg)

Please review :-)
Thanks