### PR TITLE
Fixes #1250 Removed creation of multiple instances of Notification Activity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -95,6 +95,7 @@ public class NotificationActivity extends NavigationBaseActivity {
 
     public static void startYourself(Context context) {
         Intent intent = new Intent(context, NotificationActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
         context.startActivity(intent);
     }
 }


### PR DESCRIPTION
## Description

Fixes #1250 

Added flag FLAG_ACTIVITY_REORDER_TO_FRONT to prevent the creation of multiple instances of Notification activity.

## Screenshots showing what changed
 
![solved5_2](https://user-images.githubusercontent.com/17095817/36943922-0405c1d2-1fb8-11e8-9974-d1bb9362e229.gif)
