### PR TITLE
Fixes #1262 Show correct image upload count in beta build variants.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import butterknife.ButterKnife;
+import fr.free.nrw.commons.BuildConfig;
 import fr.free.nrw.commons.HandlerService;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
@@ -139,6 +140,12 @@ public  class       ContributionsActivity
         requestAuthToken();
         initDrawer();
         setTitle(getString(R.string.title_activity_contributions));
+
+        if(!BuildConfig.FLAVOR.equalsIgnoreCase("beta")){
+            Timber.d("setUploadCount()");
+            setUploadCount();
+        }
+
     }
 
     @Override
@@ -265,10 +272,25 @@ public  class       ContributionsActivity
     }
 
     @SuppressWarnings("ConstantConditions")
-    public void setUploadCount(int uploadCount) {
-        getSupportActionBar().setSubtitle(getResources()
-                .getQuantityString(R.plurals.contributions_subtitle, uploadCount, uploadCount));
+    private void setUploadCount() {
+        compositeDisposable.add(mediaWikiApi
+                .getUploadCount(sessionManager.getCurrentAccount().name)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        uploadCount -> getSupportActionBar().setSubtitle(getResources()
+                                .getQuantityString(R.plurals.contributions_subtitle,
+                                        uploadCount, uploadCount)),
+                        t -> Timber.e(t, "Fetching upload count failed")
+                ));
     }
+
+    public void betaSetUploadCount(int betaUploadCount){
+        Timber.d("" + betaUploadCount);
+        getSupportActionBar().setSubtitle(getResources()
+                .getQuantityString(R.plurals.contributions_subtitle, betaUploadCount, betaUploadCount));
+    }
+
 
     @Override
     public void notifyDatasetChanged() {

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
@@ -139,7 +139,6 @@ public  class       ContributionsActivity
         requestAuthToken();
         initDrawer();
         setTitle(getString(R.string.title_activity_contributions));
-        setUploadCount();
     }
 
     @Override
@@ -266,17 +265,9 @@ public  class       ContributionsActivity
     }
 
     @SuppressWarnings("ConstantConditions")
-    private void setUploadCount() {
-        compositeDisposable.add(mediaWikiApi
-                .getUploadCount(sessionManager.getCurrentAccount().name)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(
-                        uploadCount -> getSupportActionBar().setSubtitle(getResources()
-                                .getQuantityString(R.plurals.contributions_subtitle,
-                                        uploadCount, uploadCount)),
-                        t -> Timber.e(t, "Fetching upload count failed")
-                ));
+    public void setUploadCount(int uploadCount) {
+        getSupportActionBar().setSubtitle(getResources()
+                .getQuantityString(R.plurals.contributions_subtitle, uploadCount, uploadCount));
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
@@ -142,7 +142,6 @@ public  class       ContributionsActivity
         setTitle(getString(R.string.title_activity_contributions));
 
         if(!BuildConfig.FLAVOR.equalsIgnoreCase("beta")){
-            Timber.d("setUploadCount()");
             setUploadCount();
         }
 
@@ -286,7 +285,6 @@ public  class       ContributionsActivity
     }
 
     public void betaSetUploadCount(int betaUploadCount){
-        Timber.d("" + betaUploadCount);
         getSupportActionBar().setSubtitle(getResources()
                 .getQuantityString(R.plurals.contributions_subtitle, betaUploadCount, betaUploadCount));
     }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -27,6 +27,7 @@ import javax.inject.Named;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import fr.free.nrw.commons.BuildConfig;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.nearby.NearbyActivity;
@@ -88,8 +89,12 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
 
     public void setAdapter(ListAdapter adapter) {
         this.contributionsList.setAdapter(adapter);
-        Timber.d("ContributionsListFragment -> " + adapter.getCount());
-        ((ContributionsActivity) getActivity()).setUploadCount(adapter.getCount());
+        Timber.d("" + adapter.getCount());
+
+        if(BuildConfig.FLAVOR.equalsIgnoreCase("beta")){
+            Timber.d("betaBuild : adapter count -> " + adapter.getCount());
+            ((ContributionsActivity) getActivity()).betaSetUploadCount(adapter.getCount());
+        }
     }
 
     public void changeProgressBarVisibility(boolean isVisible) {

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -56,6 +56,7 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
 
     private ContributionController controller;
 
+
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_contributions, container, false);
@@ -87,6 +88,8 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
 
     public void setAdapter(ListAdapter adapter) {
         this.contributionsList.setAdapter(adapter);
+        Timber.d("ContributionsListFragment -> " + adapter.getCount());
+        ((ContributionsActivity) getActivity()).setUploadCount(adapter.getCount());
     }
 
     public void changeProgressBarVisibility(boolean isVisible) {

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -89,10 +89,8 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
 
     public void setAdapter(ListAdapter adapter) {
         this.contributionsList.setAdapter(adapter);
-        Timber.d("" + adapter.getCount());
 
         if(BuildConfig.FLAVOR.equalsIgnoreCase("beta")){
-            Timber.d("betaBuild : adapter count -> " + adapter.getCount());
             ((ContributionsActivity) getActivity()).betaSetUploadCount(adapter.getCount());
         }
     }


### PR DESCRIPTION
## Description

Fixes #1262 
Fixed upload count to show correct number of pictures upload by user in beta version of app.
Instead of fetching it from sever, it is now set to number of items in ContributionListFragment's adapter.getCount(), since it equals number of pictures upload by the user.

## Screenshots showing what changed
## Before:
![whatsapp image 2018-03-06 at 8 52 40 am](https://user-images.githubusercontent.com/20313518/37048422-de8ebbba-2193-11e8-9abd-cdd15be4f18f.jpeg)

## After:
![whatsapp image 2018-03-06 at 11 12 07 pm](https://user-images.githubusercontent.com/20313518/37048440-ed000370-2193-11e8-9f11-625b35742937.jpeg)
