### PR TITLE
Fixes #1268

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,6 +7,7 @@ apply from: 'quality.gradle'
 apply plugin: 'com.getkeepsafe.dexcount'
 
 dependencies {
+    implementation 'com.borjabravo:readmoretextview:2.1.0'
     implementation 'com.github.nicolas-raoul:Quadtree:ac16ea8035bf07'
     implementation 'fr.avianey.com.viewpagerindicator:library:2.4.1.1@aar'
     implementation 'in.yuvi:http.fluent:1.3'
@@ -18,92 +19,76 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.1'
     implementation 'com.jakewharton.timber:timber:4.5.1'
     implementation 'info.debatty:java-string-similarity:0.24'
-    implementation ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.4.1@aar'){
-        transitive=true
+    implementation('com.mapbox.mapboxsdk:mapbox-android-sdk:5.4.1@aar') {
+        transitive = true
     }
-
-
     implementation "com.android.support:support-v4:$SUPPORT_LIB_VERSION"
     implementation "com.android.support:appcompat-v7:$SUPPORT_LIB_VERSION"
     implementation "com.android.support:design:$SUPPORT_LIB_VERSION"
     implementation "com.android.support:customtabs:$SUPPORT_LIB_VERSION"
-
     implementation "com.android.support:cardview-v7:$SUPPORT_LIB_VERSION"
-
     implementation "com.jakewharton:butterknife:$BUTTERKNIFE_VERSION"
     kapt "com.jakewharton:butterknife-compiler:$BUTTERKNIFE_VERSION"
-
     implementation 'com.squareup.okhttp3:okhttp:3.8.1'
     implementation 'com.squareup.okio:okio:1.13.0'
-
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
+
     // Because RxAndroid releases are few and far between, it is recommended you also
+
     // explicitly depend on RxJava's latest version for bug fixes and new features.
     compile 'io.reactivex.rxjava2:rxjava:2.1.2'
     compile 'com.jakewharton.rxbinding2:rxbinding:2.0.0'
     compile 'com.jakewharton.rxbinding2:rxbinding-support-v4:2.0.0'
     compile 'com.jakewharton.rxbinding2:rxbinding-appcompat-v7:2.0.0'
     compile 'com.jakewharton.rxbinding2:rxbinding-design:2.0.0'
-
-    compile 'com.facebook.fresco:fresco:1.3.0'
+    compile 'com.facebook.fresco:fresco:1.5.0'
     compile 'com.facebook.stetho:stetho:1.5.0'
-
+    compile 'com.android.support:multidex:1.0.3'
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.7.1'
-
+    testCompile 'org.robolectric:multidex:3.4.2'
     testCompile 'com.squareup.okhttp3:mockwebserver:3.8.1'
     androidTestCompile 'com.squareup.okhttp3:mockwebserver:3.8.1'
     androidTestCompile "com.android.support:support-annotations:${project.SUPPORT_LIB_VERSION}"
     androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.1'
-
-    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5.1'
-    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.1'
-    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.1'
+    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5.4'
+    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.4'
+    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.4'
     implementation 'io.reactivex.rxjava2:rxjava:2.1.2'
     implementation 'com.jakewharton.rxbinding2:rxbinding:2.0.0'
     implementation 'com.jakewharton.rxbinding2:rxbinding-support-v4:2.0.0'
     implementation 'com.jakewharton.rxbinding2:rxbinding-appcompat-v7:2.0.0'
     implementation 'com.jakewharton.rxbinding2:rxbinding-design:2.0.0'
-
     implementation 'com.facebook.fresco:fresco:1.5.0'
     implementation 'com.facebook.stetho:stetho:1.5.0'
-
     implementation "com.google.dagger:dagger:$DAGGER_VERSION"
     implementation "com.google.dagger:dagger-android-support:$DAGGER_VERSION"
-
     kapt "com.google.dagger:dagger-android-processor:$DAGGER_VERSION"
     kapt "com.google.dagger:dagger-compiler:$DAGGER_VERSION"
-
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
     androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
-
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.7.1'
+    testImplementation 'org.robolectric:multidex:3.4.2'
     testImplementation 'org.mockito:mockito-all:1.10.19'
-
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.8.1'
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.8.1'
     androidTestImplementation "com.android.support:support-annotations:$SUPPORT_LIB_VERSION"
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
-
     debugImplementation "com.squareup.leakcanary:leakcanary-android:$LEAK_CANARY"
     releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$LEAK_CANARY"
     testImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$LEAK_CANARY"
-
     implementation "com.google.dagger:dagger:$DAGGER_VERSION"
     implementation "com.google.dagger:dagger-android-support:$DAGGER_VERSION"
     kapt "com.google.dagger:dagger-compiler:$DAGGER_VERSION"
     kapt "com.google.dagger:dagger-android-processor:$DAGGER_VERSION"
-
-    compile 'com.borjabravo:readmoretextview:2.1.0'
 }
 
 android {
-    compileSdkVersion project.compileSdkVersion
+
+    compileSdkVersion 27
     buildToolsVersion project.buildToolsVersion
-
     useLibrary 'org.apache.http.legacy'
-
     defaultConfig {
         applicationId 'fr.free.nrw.commons'
         versionCode 82
@@ -117,6 +102,19 @@ android {
 
         multiDexEnabled true
     }
+    dexOptions {
+        javaMaxHeapSize "4g"
+    }
+
+    testOptions {
+        unitTests.all {
+            jvmArgs '-noverify'
+        }
+
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 
     sourceSets {
         // use kotlin only in tests (for now)
@@ -126,10 +124,10 @@ android {
         test.assets.srcDirs += 'src/main/assets'
         test.resources.srcDirs += 'src/main/resoures'
     }
-
     buildTypes {
         release {
-            minifyEnabled false // See https://stackoverflow.com/questions/40232404/google-play-apk-and-android-studio-apk-usb-debug-behaving-differently - proguard.cfg modification alone insufficient.
+            minifyEnabled false
+            // See https://stackoverflow.com/questions/40232404/google-play-apk-and-android-studio-apk-usb-debug-behaving-differently - proguard.cfg modification alone insufficient.
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
         debug {
@@ -138,7 +136,6 @@ android {
             versionNameSuffix "-debug-" + getBranchName() + "~" + getBuildVersion()
         }
     }
-
     flavorDimensions 'tier'
     productFlavors {
         prod {
@@ -153,7 +150,6 @@ android {
             buildConfigField "String", "SIGNUP_SUCCESS_REDIRECTION_URL", "\"https://commons.m.wikimedia.org/w/index.php?title=Main_Page&welcome=yes\""
             dimension 'tier'
         }
-
         beta {
             // What values do we need to hit the BETA versions of the site / api ?
             buildConfigField "String", "WIKIMEDIA_API_HOST", "\"https://commons.wikimedia.beta.wmflabs.org/w/api.php\""
@@ -168,18 +164,15 @@ android {
             dimension 'tier'
         }
     }
-
     lintOptions {
         disable 'MissingTranslation'
         disable 'ExtraTranslation'
         abortOnError false
     }
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-
     //FIXME: Temporary fix for https://github.com/commons-app/apps-android-commons/issues/709
     configurations.all {
         resolutionStrategy.force 'com.android.support:support-annotations:25.2.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,14 +14,14 @@
 # org.gradle.parallel=true
 #Thu Mar 01 15:28:48 IST 2018
 systemProp.http.proxyPort=0
-compileSdkVersion=android-26
+compileSdkVersion=android-27
 android.useDeprecatedNdk=true
 BUTTERKNIFE_VERSION=8.6.0
-org.gradle.jvmargs=-Xmx1536M
-buildToolsVersion=26.0.2
-targetSdkVersion=25
+org.gradle.jvmargs=-Xmx4096M
+buildToolsVersion=27.0.0
+targetSdkVersion=27
 android.enableAapt2=false
-SUPPORT_LIB_VERSION=26.0.2
+SUPPORT_LIB_VERSION=27.0.2
 minSdkVersion=15
 systemProp.http.proxyHost=
 LEAK_CANARY=1.5.4


### PR DESCRIPTION
## Description

Fixes #1268 

Below are the libraries then have been updated and all tests in betaDebug and betaRelease are successful.
fresco to 1.5.0
leak-canary to 1.5.4
support library version to 27.1.0
compileSdkVersion to 27
buildToolsVersion to 27
targetSdkVersion to 27
multidex to 1.0.3
