### PR TITLE
Fixes #1275 Set proper with of Navigation drawer in both orientations.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -88,8 +88,11 @@ public abstract class NavigationBaseActivity extends BaseActivity
 
     private void setDrawerPaneWidth() {
         ViewGroup.LayoutParams params = navigationView.getLayoutParams();
-        // set width to lowerBound of 80% of the screen size
-        params.width = (getResources().getDisplayMetrics().widthPixels * 70) / 100;
+        // set width to lowerBound of 70% of the screen size in portrait mode
+        // set width to lowerBound of 50% of the screen size in landscape mode
+        int percentageWidth = getResources().getInteger(R.integer.drawer_width);
+
+        params.width = (getResources().getDisplayMetrics().widthPixels * percentageWidth) / 100;
         navigationView.setLayoutParams(params);
     }
 

--- a/app/src/main/res/values-land/integer.xml
+++ b/app/src/main/res/values-land/integer.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="drawer_width">50</integer>
+</resources>

--- a/app/src/main/res/values/integer.xml
+++ b/app/src/main/res/values/integer.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="drawer_width">70</integer>
+</resources>


### PR DESCRIPTION
## Description

Fixes #1275 

Set proper width to navigation drawer. which is lowerBound of 70% of the screen size in portrait mode and lowerBound of 50% of the screen size in landscape mode.


**Screen-shots:** 

## Changed
**Portrait**
![pa](https://user-images.githubusercontent.com/20313518/37244646-0b56e228-24b2-11e8-8075-fc470fff6315.jpeg)

**Landscape**
![la](https://user-images.githubusercontent.com/20313518/37244648-16f37ea2-24b2-11e8-8548-e6625e41e695.jpeg)
