### PR TITLE
 Removed No description label

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceRenderer.java
@@ -45,7 +45,7 @@ class PlaceRenderer extends Renderer<Place> {
         tvName.setText(place.name);
         String descriptionText = place.getLongDescription();
         if (descriptionText.equals("?")) {
-            descriptionText = getContext().getString(R.string.no_description_found);
+            descriptionText = "";
         }
         tvDesc.setText(descriptionText);
         distance.setText(place.distance);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceRenderer.java
@@ -44,8 +44,10 @@ class PlaceRenderer extends Renderer<Place> {
         Place place = getContent();
         tvName.setText(place.name);
         String descriptionText = place.getLongDescription();
+        tvDesc.setVisibility(View.VISIBLE);
         if (descriptionText.equals("?")) {
-            descriptionText = "";
+            descriptionText = getContext().getString(R.string.no_description_found);
+            tvDesc.setVisibility(View.INVISIBLE);
         }
         tvDesc.setText(descriptionText);
         distance.setText(place.distance);


### PR DESCRIPTION
## Description

Fixes #1054 

When no description is found the subtitle is empty, rather than writing "no description found" to it.

## Screenshots showing what changed
![nodescription](https://user-images.githubusercontent.com/29161745/37251217-c76c0cac-2531-11e8-80c1-ab60ba20c05a.jpeg)

 

