### PR TITLE
feat: Add checks for title and description in intent extras. (#1273)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
@@ -101,6 +101,14 @@ public class SingleUploadFragment extends CommonsDaggerSupportFragment {
         View rootView = inflater.inflate(R.layout.fragment_single_upload, container, false);
         ButterKnife.bind(this, rootView);
 
+        Intent activityIntent = getActivity().getIntent();
+        if (activityIntent.hasExtra("title")) {
+            titleEdit.setText(activityIntent.getStringExtra("title"));
+        }
+        if (activityIntent.hasExtra("description")) {
+            descEdit.setText(activityIntent.getStringExtra("description"));
+        }
+
         ArrayList<String> licenseItems = new ArrayList<>();
         licenseItems.add(getString(R.string.license_name_cc0));
         licenseItems.add(getString(R.string.license_name_cc_by));


### PR DESCRIPTION
In case other apps want to send a title and description along with the
image, we check if those have been passed as intent extras and set the
EditText values accordingly.

Fixes: #1273
See also: #892