### PR TITLE
Fixes #1294 Orientation change cancels the ongoing login process.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -83,6 +83,9 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     private AppCompatDelegate delegate;
     private LoginTextWatcher textWatcher = new LoginTextWatcher();
 
+    private Boolean loginCurrentlyInProgress = false;
+    private static final String LOGING_IN = "logingIn";
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         setTheme(Utils.isDarkTheme(this) ? R.style.DarkAppTheme : R.style.LightAppTheme);
@@ -175,6 +178,7 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     }
 
     private void performLogin() {
+        loginCurrentlyInProgress = true;
         Timber.d("Login to start!");
         final String username = canonicializeUsername(usernameEdit.getText().toString());
         final String password = passwordEdit.getText().toString();
@@ -205,6 +209,7 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         if (result.equals("PASS")) {
             handlePassResult(username, password);
         } else {
+            loginCurrentlyInProgress = false;
             handleOtherResults(result);
         }
     }
@@ -325,6 +330,21 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     @NonNull
     public MenuInflater getMenuInflater() {
         return getDelegate().getMenuInflater();
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putBoolean(LOGING_IN, loginCurrentlyInProgress);
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+        loginCurrentlyInProgress = savedInstanceState.getBoolean(LOGING_IN, false);
+        if(loginCurrentlyInProgress){
+            performLogin();
+        }
     }
 
     public void askUserForTwoFactorAuth() {


### PR DESCRIPTION
## Description

Fixes #1294 

Changes made such that now the ongoing login process is not affected (cancels) by orientation change.

## Tests performed

Tested on API Level 24 & Redmi Note 4 with betaDebug build variant.

## Screenshots showing what changed
 **Before**
![before](https://user-images.githubusercontent.com/20313518/37337375-13f8b120-26da-11e8-9d92-cd5f5d454974.gif)

Now ongoing login process continues even if orientation change occurs.
![after](https://user-images.githubusercontent.com/20313518/37337292-d01e05ea-26d9-11e8-939f-e753b4e6a33e.gif)
