### PR TITLE
Fix Underline Tag Bug in About Page

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,8 +85,8 @@
   <string name="about_license">The Wikimedia Commons app is an open-source app created and maintained by grantees and volunteers of the Wikimedia community. The Wikimedia Foundation is not involved in the creation, development, or maintenance of the app. </string>
   <string name="trademarked_name" translatable="false">Wikimedia Commons</string>
   <string name="about_improve">Create a new &lt;a href=\"https://github.com/commons-app/apps-android-commons/issues\"&gt;GitHub issue&lt;/a&gt; for bug reports and suggestions.</string>
-  <string name="about_privacy_policy"><![CDATA[<u>Privacy policy</u>]]></string>
-  <string name="about_credits"><![CDATA[<u>Credits</u>]]></string>
+  <string name="about_privacy_policy"><u>Privacy policy</u></string>
+  <string name="about_credits"><u>Credits</u></string>
   <string name="title_activity_about">About</string>
   <string name="menu_feedback">Send Feedback (via Email)</string>
   <string name="no_email_client">No email client installed</string>


### PR DESCRIPTION
## Description

Fixes #1303 

Fixed Underline Tag in "About Page"

## Screenshots showing what changed
 
![screenshot_20180313-223752](https://user-images.githubusercontent.com/30932899/37357800-55bd83da-270f-11e8-9414-670383fd0d3d.png)

