### PR TITLE
Fix improper zooming level on bottom sheet is expanded

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -270,7 +270,7 @@ public class NearbyMapFragment extends DaggerFragment {
                         .target(new LatLng(curLatLng.getLatitude() - CAMERA_TARGET_SHIFT_FACTOR,
                                 curLatLng.getLongitude())) // Sets the new camera target above
                         // current to make it visible when sheet is expanded
-                        .zoom(mapboxMap.getCameraPosition().zoom) // Same zoom level
+                        .zoom(11) // Same zoom level
                         .build();
 
             } else {


### PR DESCRIPTION
## Description

Fixes the issue @misaochan noted here #1241

Current user position marker is visible even when bottom list sheet is expanded. However user is not able to control zooming level when bottom sheet is expanded (zoom level is fixed when list is expanded). 

## Tests performed

ProdDebug, API 19

## Screenshots showing what changed
 

![zoomingissue](https://user-images.githubusercontent.com/3127881/37485093-8fc58090-289b-11e8-9d8a-8cd9e74964ab.gif)
