### PR TITLE
Removes unsupported clients while sharing log

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -3,10 +3,13 @@ package fr.free.nrw.commons.settings;
 import android.Manifest;
 import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
+import android.content.ComponentName;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -21,6 +24,8 @@ import android.support.v4.content.FileProvider;
 import android.widget.Toast;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -141,19 +146,24 @@ public class SettingsFragment extends PreferenceFragment {
                 appLogsFile
         );
 
-        Intent feedbackIntent = new Intent(Intent.ACTION_SEND);
-        feedbackIntent.setType("message/rfc822");
-        feedbackIntent.putExtra(Intent.EXTRA_EMAIL,
-                new String[]{CommonsApplication.LOGS_PRIVATE_EMAIL});
-        feedbackIntent.putExtra(Intent.EXTRA_SUBJECT,
-                String.format(CommonsApplication.FEEDBACK_EMAIL_SUBJECT,
-                        BuildConfig.VERSION_NAME));
-        feedbackIntent.putExtra(Intent.EXTRA_STREAM,appLogsFilePath);
+        //initialize the emailSelectorIntent
+        Intent emailSelectorIntent = new Intent(Intent.ACTION_SENDTO);
+        emailSelectorIntent.setData(Uri.parse("mailto:"));
+        //initialize the emailIntent
+        final Intent emailIntent = new Intent(Intent.ACTION_SEND);
+        emailIntent.putExtra(Intent.EXTRA_EMAIL, new String[]{CommonsApplication.FEEDBACK_EMAIL});
+        emailIntent.putExtra(Intent.EXTRA_SUBJECT, String.format(CommonsApplication.FEEDBACK_EMAIL_SUBJECT, BuildConfig.VERSION_NAME));
+        emailIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        emailIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        emailIntent.setSelector( emailSelectorIntent );
+        //adding the attachment to the intent
+        emailIntent.putExtra(Intent.EXTRA_STREAM, appLogsFilePath);
 
         try {
-            startActivity(feedbackIntent);
+            startActivity(Intent.createChooser(emailIntent, "Send mail.."));
         } catch (ActivityNotFoundException e) {
             Toast.makeText(getActivity(), R.string.no_email_client, Toast.LENGTH_SHORT).show();
         }
     }
+
 }


### PR DESCRIPTION
### Description
Fixes #1282 
Only the email clients are being shown in the share log intent now. This removes all the unsupported clients shown before.

### Tests performed
Tested on Redmi Note 3

### Screenshots showing what changed
####Before:
![whatsapp image 2018-03-11 at 2 48 14 pm 1](https://user-images.githubusercontent.com/20908024/37485762-6030111c-28b2-11e8-937a-fbed33a21326.jpeg)

####After:
![whatsapp image 2018-03-16 at 12 35 20 am 1](https://user-images.githubusercontent.com/20908024/37485746-56494916-28b2-11e8-8bb5-4334a51dbca4.jpeg)

