### PR TITLE
Image downloading fixed

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -219,9 +219,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
      *
      * @param m Media file to download
      */
-    private void downloadImage(Media m, String filename, Uri uri) {
-
-        String fileName = m.getFilename();
+    private void downloadImage(Media m, String fileName, Uri uri) {
 
         DownloadManager.Request req = new DownloadManager.Request(uri);
         //These are not the image title and description fields, they are download descs for notifications

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -26,6 +26,13 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Toast;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.Iterator;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -36,6 +43,14 @@ import fr.free.nrw.commons.contributions.Contribution;
 import fr.free.nrw.commons.contributions.ContributionsActivity;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.mwapi.MediaWikiApi;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 import static android.Manifest.permission.READ_EXTERNAL_STORAGE;
 import static android.content.Context.DOWNLOAD_SERVICE;
@@ -56,9 +71,15 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
     private ViewPager pager;
     private Boolean editable;
 
+    private String responseStr = "";
+    public static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+    public String downURL;
+
     public MediaDetailPagerFragment() {
         this(false);
     }
+
+    OkHttpClient client;
 
     @SuppressLint("ValidFragment")
     public MediaDetailPagerFragment(Boolean editable) {
@@ -72,7 +93,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
         View view = inflater.inflate(R.layout.fragment_media_detail_pager, container, false);
         pager = (ViewPager) view.findViewById(R.id.mediaDetailsPager);
         pager.addOnPageChangeListener(this);
-
+        client = new OkHttpClient();
         final MediaDetailAdapter adapter = new MediaDetailAdapter(getChildFragmentManager());
 
         if (savedInstanceState != null) {
@@ -121,7 +142,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                 viewIntent.setAction(ACTION_VIEW);
                 viewIntent.setData(m.getFilePageTitle().getMobileUri());
                 //check if web browser available
-                if(viewIntent.resolveActivity(getActivity().getPackageManager()) != null){
+                if (viewIntent.resolveActivity(getActivity().getPackageManager()) != null) {
                     startActivity(viewIntent);
                 } else {
                     Toast toast = Toast.makeText(getContext(), getString(R.string.no_web_browser), LENGTH_SHORT);
@@ -148,26 +169,61 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
         }
     }
 
+    private void downloadMedia(Media m) {
+
+        String filename = m.getFilename().toString();
+        HttpUrl.Builder urlBuilder = HttpUrl.parse("https://commons.wikimedia.beta.wmflabs.org/w/api.php?action=query").newBuilder();
+        urlBuilder.addQueryParameter("format", "json");
+        urlBuilder.addQueryParameter("prop", "imageinfo");
+        urlBuilder.addQueryParameter("iiprop", "url");
+        urlBuilder.addQueryParameter("titles", filename);
+        String url = urlBuilder.build().toString();
+        post(url, "", new Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
+                e.printStackTrace();
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) throws IOException {
+                if (response.isSuccessful()) {
+                    responseStr = response.body().string();
+                    try {
+                        //Extracting the download URL of the image from the json obtained
+                        JSONObject JObject = new JSONObject(responseStr);
+                        JSONObject JObjectQuery = JObject.getJSONObject("query");
+                        JSONObject JObjectPages = JObjectQuery.getJSONObject("pages");
+                        String firstkey = "";
+                        Iterator<?> keys = JObjectPages.keys();
+                        firstkey = (String) keys.next();
+                        JSONObject JObjectFinal = JObjectPages.getJSONObject(firstkey);
+                        JSONArray imageinfo = JObjectFinal.getJSONArray("imageinfo");
+                        JSONObject imageinfo0 = imageinfo.getJSONObject(0);
+                        downURL = imageinfo0.getString("url");
+                        //call to the downloadImage function
+                        downloadImage(m, filename, Uri.parse(downURL));
+
+                    } catch (JSONException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        });
+
+    //return Uri.parse(downURL);
+    }
+
     /**
      * Start the media file downloading to the local SD card/storage.
      * The file can then be opened in Gallery or other apps.
      *
      * @param m Media file to download
      */
-    private void downloadMedia(Media m) {
-        String imageUrl = m.getImageUrl(),
-                fileName = m.getFilename();
+    private void downloadImage(Media m, String filename, Uri uri) {
 
-        if (imageUrl == null || fileName == null) {
-            return;
-        }
+        String fileName = m.getFilename();
 
-        // Strip 'File:' from beginning of filename, we really shouldn't store it
-        fileName = fileName.replaceFirst("^File:", "");
-
-        Uri imageUri = Uri.parse(imageUrl);
-
-        DownloadManager.Request req = new DownloadManager.Request(imageUri);
+        DownloadManager.Request req = new DownloadManager.Request(uri);
         //These are not the image title and description fields, they are download descs for notifications
         req.setDescription(getString(R.string.app_name));
         req.setTitle(m.getDisplayTitle());
@@ -191,6 +247,14 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                 systemService.enqueue(req);
             }
         }
+    }
+
+    private Call post(String url, String json, Callback callback) {
+        RequestBody body = RequestBody.create(JSON, json);
+        Request request = new Request.Builder().url(url).post(body).build();
+        Call call = client.newCall(request);
+        call.enqueue(callback);
+        return call;
     }
 
     @Override


### PR DESCRIPTION
### Description
Clicking the download button now downloads each image uploaded in future without any kind of failure. The first download is however a bit slow, but the subsequent downloads happen in < 1 second.
The PR fixes #1216  

### Testing
The changes have been tested on a real-time device and a few corner cases for image titles have been tried out as well.
Tried out test cases: 
1) ČSD ř. M 260.001 1939-02.17. 24.jpg
2) دمشق جبل قاسيون.jpg
3) A. b. c. d 1.2 . 3
