### PR TITLE
Links added to TextView about_upload_to in aboutActivity

### DIFF
--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -153,16 +153,6 @@
                 android:gravity="center"
                 />
 
-            <TextView
-                android:id="@+id/about_uploads_to"
-                style="?android:textAppearanceSmall"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/primaryColor"
-                android:layout_marginTop="@dimen/standard_gap"
-                android:text="@string/about_upload_to"
-                android:gravity="center"/>
-
         </LinearLayout>
         </RelativeLayout>
     </ScrollView>

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -158,9 +158,10 @@
                 style="?android:textAppearanceSmall"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/large_gap"
-                android:alpha="0.2"
-                android:gravity="center" />
+                android:textColor="@color/primaryColor"
+                android:layout_marginTop="@dimen/standard_gap"
+                android:text="@string/about_upload_to"
+                android:gravity="center"/>
 
         </LinearLayout>
         </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -252,13 +252,13 @@
   <string name="nearby_wikidata">WIKIDATA</string>
   <string name="nearby_wikipedia">WIKIPEDIA</string>
   <string name="nearby_commons">COMMONS</string>
-
   <string name="about_rate_us"><![CDATA[<u>Rate us</u>]]></string>
   <string name="about_faq"><![CDATA[<u>FAQ</u>]]></string>
   <string name="welcome_skip_button">Skip Tutorial</string>
   
   <string name="no_internet">Internet unavailable</string>
   <string name="internet_established">Internet available</string>
+
   <string name="error_notifications">Error fetching notifications</string>
   <string name="no_notifications">No notifications found</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -255,18 +255,14 @@
   <string name="about_rate_us"><![CDATA[<u>Rate us</u>]]></string>
   <string name="about_faq"><![CDATA[<u>FAQ</u>]]></string>
   <string name="welcome_skip_button">Skip Tutorial</string>
-  
   <string name="no_internet">Internet unavailable</string>
   <string name="internet_established">Internet available</string>
-
   <string name="error_notifications">Error fetching notifications</string>
   <string name="no_notifications">No notifications found</string>
-
   <string name="about_translate"><![CDATA[<u>Translate</u>]]></string>
   <string name="about_translate_title">Languages</string>
   <string name="about_translate_message">Select the language that you would like to submit translations for</string>
   <string name="about_translate_proceed">Proceed</string>
   <string name="about_translate_cancel">Cancel</string>
   <string name="retry">Retry</string>
-
 </resources>


### PR DESCRIPTION
## Description

Fixes #1306 

I have linked the textView about_upload_to to https://commons.wikimedia.org/wiki/Commons:Upload url. 

## Tests performed

Tested on Pixel XL api level 26, with betaRelease.


## Screenshots showing what changed
 
<img width="149" alt="about_upload_to" src="https://user-images.githubusercontent.com/29161745/37559315-b549b3a4-2a49-11e8-8cdd-8fcf59cd9a36.png">


