### PR TITLE
Fix whole page map issue

### DIFF
--- a/app/src/main/res/layout/activity_nearby.xml
+++ b/app/src/main/res/layout/activity_nearby.xml
@@ -21,9 +21,10 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:layout_below="@id/toolbar"
                 android:gravity="center_vertical"
                 android:orientation="horizontal">
 
@@ -37,7 +38,7 @@
                     android:id="@+id/container"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" />
-        </LinearLayout>
+            </LinearLayout>
             <android.support.design.widget.FloatingActionButton
                 android:id="@+id/fab_list"
                 android:layout_width="wrap_content"
@@ -88,7 +89,7 @@
 
 
         </RelativeLayout>
-        
+
         <include layout="@layout/bottom_sheet_nearby" />
 
         <include


### PR DESCRIPTION
## Description

Fixes #1354

add `android:layout_below` to the Layout that contains the `container `view
like that the toolbar will be always visible
## Tests performed

Tested on {API 19 : Emulator ,API 21 : galaxy note 3 }


## Screenshots showing what changed

 
![29243113_2109729295722012_520617527_o](https://user-images.githubusercontent.com/17969012/37835213-ef68849c-2eaf-11e8-8479-0fb9854548d8.png)
