### PR TITLE
Improvements in Notification Activity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -15,6 +16,7 @@ import android.widget.RelativeLayout;
 
 import com.pedrogomez.renderers.RVRendererAdapter;
 
+import java.lang.ref.WeakReference;
 import java.util.Collections;
 import java.util.List;
 
@@ -25,6 +27,7 @@ import butterknife.ButterKnife;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.theme.NavigationBaseActivity;
+import fr.free.nrw.commons.utils.NetworkUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -62,8 +65,30 @@ public class NotificationActivity extends NavigationBaseActivity {
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         DividerItemDecoration itemDecor = new DividerItemDecoration(recyclerView.getContext(), DividerItemDecoration.VERTICAL);
         recyclerView.addItemDecoration(itemDecor);
-        addNotifications();
+        if (!NetworkUtils.isInternetConnectionEstablished(this)) {
+            progressBar.setVisibility(View.GONE);
+            Snackbar.make(relativeLayout , R.string.no_internet, Snackbar.LENGTH_INDEFINITE)
+                    .setAction(R.string.retry, view -> {
+                        refresh();
+            }).show();
+        }else {
+            addNotifications();
+        }
+
     }
+    private void refresh() {
+        if (!NetworkUtils.isInternetConnectionEstablished(this)) {
+            progressBar.setVisibility(View.GONE);
+            Snackbar.make(relativeLayout , R.string.no_internet, Snackbar.LENGTH_INDEFINITE)
+                    .setAction(R.string.retry, view -> {
+                        refresh();
+                    }).show();
+        }else {
+            progressBar.setVisibility(View.VISIBLE);
+            addNotifications();
+        }
+    }
+
 
     @SuppressLint("CheckResult")
     private void addNotifications() {

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -65,17 +65,9 @@ public class NotificationActivity extends NavigationBaseActivity {
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         DividerItemDecoration itemDecor = new DividerItemDecoration(recyclerView.getContext(), DividerItemDecoration.VERTICAL);
         recyclerView.addItemDecoration(itemDecor);
-        if (!NetworkUtils.isInternetConnectionEstablished(this)) {
-            progressBar.setVisibility(View.GONE);
-            Snackbar.make(relativeLayout , R.string.no_internet, Snackbar.LENGTH_INDEFINITE)
-                    .setAction(R.string.retry, view -> {
-                        refresh();
-            }).show();
-        }else {
-            addNotifications();
-        }
-
+        refresh();
     }
+
     private void refresh() {
         if (!NetworkUtils.isInternetConnectionEstablished(this)) {
             progressBar.setVisibility(View.GONE);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -264,5 +264,6 @@
   <string name="about_translate_message">Select the langauge you want translations for ?</string>
   <string name="about_translate_proceed">Proceed</string>
   <string name="about_translate_cancel">Cancel</string>
+  <string name="retry">Retry</string>
 
 </resources>


### PR DESCRIPTION
## Description

Fixes #1373 

Added no internet check on create of activity if connected then add notification otherwise retry option is available. Retry option to calls retry function.
Retry function checks if Internet is now available if yes then add notification otherwise retry option is available again.

## Tests performed

Manually Tested on {API 25 Moto G5s+} in debug variant.

## Screenshots
![screenshot_20180327-070228](https://user-images.githubusercontent.com/19607555/37941663-f30b7958-318c-11e8-8254-0ea2a71fbb58.png)
