### PR TITLE
Fix nearby current location marker

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -55,6 +55,7 @@ import dagger.android.support.DaggerFragment;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.contributions.ContributionController;
 import fr.free.nrw.commons.utils.UriDeserializer;
+import fr.free.nrw.commons.utils.ViewUtil;
 import timber.log.Timber;
 
 import static android.app.Activity.RESULT_OK;
@@ -105,7 +106,8 @@ public class NearbyMapFragment extends DaggerFragment {
     private PolygonOptions currentLocationPolygonOptions;
 
     private boolean isBottomListSheetExpanded;
-    private final double CAMERA_TARGET_SHIFT_FACTOR = 0.06;
+    private final double CAMERA_TARGET_SHIFT_FACTOR_PORTRAIT = 0.06;
+    private final double CAMERA_TARGET_SHIFT_FACTOR_LANDSCAPE = 0.04;
 
     @Inject
     @Named("prefs")
@@ -253,13 +255,24 @@ public class NearbyMapFragment extends DaggerFragment {
             }
 
                 // Make camera to follow user on location change
-                CameraPosition position = new CameraPosition.Builder()
-                        .target(isBottomListSheetExpanded ?
-                                new LatLng(curMapBoxLatLng.getLatitude()- CAMERA_TARGET_SHIFT_FACTOR,
-                                        curMapBoxLatLng.getLongitude())
-                                : curMapBoxLatLng ) // Sets the new camera position
-                        .zoom(mapboxMap.getCameraPosition().zoom) // Same zoom level
-                        .build();
+                CameraPosition position ;
+                if(ViewUtil.isPortrait(getActivity())){
+                    position = new CameraPosition.Builder()
+                            .target(isBottomListSheetExpanded ?
+                                    new LatLng(curMapBoxLatLng.getLatitude()- CAMERA_TARGET_SHIFT_FACTOR_PORTRAIT,
+                                            curMapBoxLatLng.getLongitude())
+                                    : curMapBoxLatLng ) // Sets the new camera position
+                            .zoom(mapboxMap.getCameraPosition().zoom) // Same zoom level
+                            .build();
+                }else {
+                    position = new CameraPosition.Builder()
+                            .target(isBottomListSheetExpanded ?
+                                    new LatLng(curMapBoxLatLng.getLatitude()- CAMERA_TARGET_SHIFT_FACTOR_LANDSCAPE,
+                                            curMapBoxLatLng.getLongitude())
+                                    : curMapBoxLatLng ) // Sets the new camera position
+                            .zoom(mapboxMap.getCameraPosition().zoom) // Same zoom level
+                            .build();
+                }
 
                 mapboxMap.animateCamera(CameraUpdateFactory
                         .newCameraPosition(position), 1000);
@@ -273,12 +286,21 @@ public class NearbyMapFragment extends DaggerFragment {
         if (mapboxMap != null && curLatLng != null) {
             if (isBottomListSheetExpanded) {
                 // Make camera to follow user on location change
-                position = new CameraPosition.Builder()
-                        .target(new LatLng(curLatLng.getLatitude() - CAMERA_TARGET_SHIFT_FACTOR,
-                                curLatLng.getLongitude())) // Sets the new camera target above
-                        // current to make it visible when sheet is expanded
-                        .zoom(11) // Same zoom level
-                        .build();
+                if(ViewUtil.isPortrait(getActivity())) {
+                    position = new CameraPosition.Builder()
+                            .target(new LatLng(curLatLng.getLatitude() - CAMERA_TARGET_SHIFT_FACTOR_PORTRAIT,
+                                    curLatLng.getLongitude())) // Sets the new camera target above
+                            // current to make it visible when sheet is expanded
+                            .zoom(11) // Same zoom level
+                            .build();
+                } else {
+                    position = new CameraPosition.Builder()
+                            .target(new LatLng(curLatLng.getLatitude() - CAMERA_TARGET_SHIFT_FACTOR_LANDSCAPE,
+                                    curLatLng.getLongitude())) // Sets the new camera target above
+                            // current to make it visible when sheet is expanded
+                            .zoom(11) // Same zoom level
+                            .build();
+                }
 
             } else {
                 // Make camera to follow user on location change

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -262,7 +262,9 @@ public class NearbyMapFragment extends DaggerFragment {
                                     new LatLng(curMapBoxLatLng.getLatitude()- CAMERA_TARGET_SHIFT_FACTOR_PORTRAIT,
                                             curMapBoxLatLng.getLongitude())
                                     : curMapBoxLatLng ) // Sets the new camera position
-                            .zoom(mapboxMap.getCameraPosition().zoom) // Same zoom level
+                            .zoom(isBottomListSheetExpanded ?
+                                    11 // zoom level is fixed to 11 when bottom sheet is expanded
+                                    :mapboxMap.getCameraPosition().zoom) // Same zoom level
                             .build();
                 }else {
                     position = new CameraPosition.Builder()
@@ -270,7 +272,9 @@ public class NearbyMapFragment extends DaggerFragment {
                                     new LatLng(curMapBoxLatLng.getLatitude()- CAMERA_TARGET_SHIFT_FACTOR_LANDSCAPE,
                                             curMapBoxLatLng.getLongitude())
                                     : curMapBoxLatLng ) // Sets the new camera position
-                            .zoom(mapboxMap.getCameraPosition().zoom) // Same zoom level
+                            .zoom(isBottomListSheetExpanded ?
+                                    11 // zoom level is fixed to 11 when bottom sheet is expanded
+                                    :mapboxMap.getCameraPosition().zoom) // Same zoom level
                             .build();
                 }
 
@@ -291,14 +295,14 @@ public class NearbyMapFragment extends DaggerFragment {
                             .target(new LatLng(curLatLng.getLatitude() - CAMERA_TARGET_SHIFT_FACTOR_PORTRAIT,
                                     curLatLng.getLongitude())) // Sets the new camera target above
                             // current to make it visible when sheet is expanded
-                            .zoom(11) // Same zoom level
+                            .zoom(11) // Fixed zoom level
                             .build();
                 } else {
                     position = new CameraPosition.Builder()
                             .target(new LatLng(curLatLng.getLatitude() - CAMERA_TARGET_SHIFT_FACTOR_LANDSCAPE,
                                     curLatLng.getLongitude())) // Sets the new camera target above
                             // current to make it visible when sheet is expanded
-                            .zoom(11) // Same zoom level
+                            .zoom(11) // Fixed zoom level
                             .build();
                 }
 
@@ -366,10 +370,29 @@ public class NearbyMapFragment extends DaggerFragment {
         fabRecenter.setOnClickListener(view -> {
             if (curLatLng != null) {
                 mapView.getMapAsync(mapboxMap -> {
-                    CameraPosition position = new CameraPosition.Builder()
-                            .target(new LatLng(curLatLng.getLatitude(), curLatLng.getLongitude())) // Sets the new camera position
-                            .zoom(11) // Sets the zoom
-                            .build(); // Creates a CameraPosition from the builder
+                    CameraPosition position;
+
+                    if(ViewUtil.isPortrait(getActivity())){
+                        position = new CameraPosition.Builder()
+                                .target(isBottomListSheetExpanded ?
+                                        new LatLng(curLatLng.getLatitude()- CAMERA_TARGET_SHIFT_FACTOR_PORTRAIT,
+                                                curLatLng.getLongitude())
+                                        : new LatLng(curLatLng.getLatitude(), curLatLng.getLongitude(), 0)) // Sets the new camera position
+                                .zoom(isBottomListSheetExpanded ?
+                                        11 // zoom level is fixed to 11 when bottom sheet is expanded
+                                        :mapboxMap.getCameraPosition().zoom) // Same zoom level
+                                .build();
+                    }else {
+                        position = new CameraPosition.Builder()
+                                .target(isBottomListSheetExpanded ?
+                                        new LatLng(curLatLng.getLatitude()- CAMERA_TARGET_SHIFT_FACTOR_LANDSCAPE,
+                                                curLatLng.getLongitude())
+                                        : new LatLng(curLatLng.getLatitude(), curLatLng.getLongitude(), 0)) // Sets the new camera position
+                                .zoom(isBottomListSheetExpanded ?
+                                        11 // zoom level is fixed to 11 when bottom sheet is expanded
+                                        :mapboxMap.getCameraPosition().zoom) // Same zoom level
+                                .build();
+                    }
 
                     mapboxMap.animateCamera(CameraUpdateFactory
                             .newCameraPosition(position), 1000);

--- a/app/src/main/java/fr/free/nrw/commons/utils/ViewUtil.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ViewUtil.java
@@ -1,7 +1,9 @@
 package fr.free.nrw.commons.utils;
 
+import android.app.Activity;
 import android.content.Context;
 import android.support.design.widget.Snackbar;
+import android.view.Display;
 import android.view.View;
 import android.widget.Toast;
 
@@ -14,6 +16,15 @@ public class ViewUtil {
     public static void showLongToast(Context context, String text) {
         Toast.makeText(context, text,
                 Toast.LENGTH_LONG).show();
+    }
+
+    public static boolean isPortrait(Context context) {
+        Display orientation = ((Activity)context).getWindowManager().getDefaultDisplay();
+        if(orientation.getWidth() < orientation.getHeight()){
+            return true;
+        } else {
+            return false;
+        }
     }
 
 }


### PR DESCRIPTION
## Description

Fixes #1329 number 8, issue Fix current location point visibility when bottom sheet is expanded, and re-center button is clicked.

Currently recenter button works correctly when bottom sheet is expanded. User can set a zoom level and use map with this zoom level. However, this is not possible when bottom sheet is expanded (zoom level is fixed to 11) , I couldn't find an easy way to do it. Besides, as a user I close bottom sheet while following map, so there is no case when I want to zoom in/out if bottom sheet is expanded.

## Tests performed

Manual test API 19
![Uploading zoom.gif…]()

## Screenshots showing what changed

