### PR TITLE
My proposed solution for #1318.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -294,8 +294,8 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
     }
 
     private void setOnClickListeners(final Media media) {
-        if (licenseLink(media) != null) {
-            license.setOnClickListener(v -> openWebBrowser(licenseLink(media)));
+        if (licenseLink(media) != null && !licenseLink(media).equals("")) {
+            license.setOnClickListener((View v) -> openWebBrowser(licenseLink(media)));
         } else {
             Toast toast = Toast.makeText(getContext(), getString(R.string.null_url), Toast.LENGTH_SHORT);
             toast.show();

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Sat Mar 03 13:58:47 IST 2018
+#Tue Mar 27 19:13:23 BST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Description

Fixes #1318 

{Added an extra condition to if statement, to ensure that licence will not appear as an empty string  in case if an android system fails to read the name of the licence .}

## Tests performed

Tested on {google Pixel 2 created in Android Studio default debug method} with 3 different pictures each one having a different licence selected.
