### PR TITLE
Fix NPE in nearby fragmnet

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -579,7 +579,9 @@ public class NearbyMapFragment extends DaggerFragment {
                 transparentView.setAlpha(0);
                 closeFabs(isFabOpen);
                 hideFAB();
-                this.getView().requestFocus();
+                if (this.getView() != null) {
+                    this.getView().requestFocus();
+                }
                 break;
         }
     }


### PR DESCRIPTION
## Description

Fixes #1329 number 6, NPE exception when you click one of nearby markers and make information bottom sheet visible, then go to settings and change theme, app will crash when you re-start nearby activity. Editing first entry accordingly.

Added nullcheck, solves the error and all things else goes well.

## Tests performed

Manual tests API 19

