### PR TITLE
Change email address for logs to private mailing list

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -58,7 +58,7 @@ public class CommonsApplication extends MultiDexApplication {
 
     public static final String LOGS_PRIVATE_EMAIL = "commons-app-android-private@googlegroups.com";
 
-    public static final String LOGS_PRIVATE_EMAIL_SUBJECT = "Commons Android App Logs";
+    public static final String LOGS_PRIVATE_EMAIL_SUBJECT = "Commons Android App (%s) Logs";
 
     private RefWatcher refWatcher;
 

--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -54,9 +54,11 @@ public class CommonsApplication extends MultiDexApplication {
 
     public static final String FEEDBACK_EMAIL = "commons-app-android@googlegroups.com";
 
+    public static final String FEEDBACK_EMAIL_SUBJECT = "Commons Android App (%s) Feedback";
+
     public static final String LOGS_PRIVATE_EMAIL = "commons-app-android-private@googlegroups.com";
 
-    public static final String FEEDBACK_EMAIL_SUBJECT = "Commons Android App (%s) Feedback";
+    public static final String LOGS_PRIVATE_EMAIL_SUBJECT = "Commons Android App Logs";
 
     private RefWatcher refWatcher;
 

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -151,8 +151,8 @@ public class SettingsFragment extends PreferenceFragment {
         emailSelectorIntent.setData(Uri.parse("mailto:"));
         //initialize the emailIntent
         final Intent emailIntent = new Intent(Intent.ACTION_SEND);
-        emailIntent.putExtra(Intent.EXTRA_EMAIL, new String[]{CommonsApplication.FEEDBACK_EMAIL});
-        emailIntent.putExtra(Intent.EXTRA_SUBJECT, String.format(CommonsApplication.FEEDBACK_EMAIL_SUBJECT, BuildConfig.VERSION_NAME));
+        emailIntent.putExtra(Intent.EXTRA_EMAIL, new String[]{CommonsApplication.LOGS_PRIVATE_EMAIL});
+        emailIntent.putExtra(Intent.EXTRA_SUBJECT, String.format(CommonsApplication.LOGS_PRIVATE_EMAIL_SUBJECT, BuildConfig.VERSION_NAME));
         emailIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         emailIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
         emailIntent.setSelector( emailSelectorIntent );

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -151,6 +151,7 @@ public class SettingsFragment extends PreferenceFragment {
         emailSelectorIntent.setData(Uri.parse("mailto:"));
         //initialize the emailIntent
         final Intent emailIntent = new Intent(Intent.ACTION_SEND);
+        // Logs must be sent to the PRIVATE email. Please do not modify this without good reason!
         emailIntent.putExtra(Intent.EXTRA_EMAIL, new String[]{CommonsApplication.LOGS_PRIVATE_EMAIL});
         emailIntent.putExtra(Intent.EXTRA_SUBJECT, String.format(CommonsApplication.LOGS_PRIVATE_EMAIL_SUBJECT, BuildConfig.VERSION_NAME));
         emailIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);


### PR DESCRIPTION
As mentioned at #891 , WMF has pretty strict rules about how we maintain user privacy if we are to remain on their Play Store account. When the user taps "send log file" in Settings, they should be sending the file to the private forum (only accessed by devs who have signed the NDA), not the public one.

This is the 3rd time I have needed to make this change, as it keeps being overridden :( (see #974 and #1000). I have modified the variable names and removed header sharing with the feedback option to be even more explicit. Please please be aware of this.