### PR TITLE
Fixed bug #1399 Overlapping problem

### DIFF
--- a/app/src/main/res/layout/bottom_sheet_details.xml
+++ b/app/src/main/res/layout/bottom_sheet_details.xml
@@ -1,42 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/mainBackground"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
-    android:visibility="gone"
-    app:behavior_hideable="true"
+    android:background="?attr/mainBackground"
+    app:layout_behavior="@string/bottom_sheet_behavior"
     app:behavior_peekHeight="72dp"
-    app:layout_behavior="@string/bottom_sheet_behavior">
+    app:behavior_hideable="true"
+    android:visibility="visible"
+
+    >
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="72dp"
         android:layout_marginVertical="8dp"
         android:gravity="center_vertical"
-        android:layout_marginTop="12dp"
-        android:layout_marginBottom="8dp"
         >
 
         <ImageView
             android:id="@+id/icon"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:layout_marginLeft="16dp"/>
+            android:layout_marginLeft="16dp">
+        </ImageView>
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:orientation="vertical"
             android:layout_marginLeft="16dp"
-            android:layout_marginRight="16dp"
-            android:orientation="vertical">
+            android:layout_marginRight="16dp">
 
             <TextView
                 android:id="@+id/title"
-                android:layout_width="230dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textSize="16sp" />
+                android:textSize="16sp"
+                android:layout_marginRight="50dp"
+                android:maxLines="2"
+                android:ellipsize="end"
+                />
             <TextView
                 android:id="@+id/category"
                 android:layout_width="wrap_content"
@@ -44,73 +49,71 @@
                 android:textSize="14sp" />
         </LinearLayout>
     </LinearLayout>
-
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginBottom="8dp"
         android:layout_marginTop="7dp"
-        android:background="@android:color/darker_gray" />
-
+        android:layout_marginBottom="8dp"
+        android:background="@android:color/darker_gray"/>
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        >
 
         <LinearLayout
             android:id="@+id/directionsButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:background="@drawable/button_background_selector"
+            android:padding="16dp"
             android:clickable="true"
+            android:background="@drawable/button_background_selector"
             android:orientation="vertical"
-            android:padding="16dp">
-
+            >
             <ImageView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
                 android:duplicateParentState="true"
                 app:srcCompat="@drawable/ic_directions_black_24dp" />
-
             <TextView
-                android:id="@+id/directionsButtonText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:duplicateParentState="true"
+                android:id="@+id/directionsButtonText"
                 android:paddingTop="8dp"
+                android:duplicateParentState="true"
+                android:textColor="@color/text_color_selector"
+                android:layout_gravity="center_horizontal"
                 android:text="@string/nearby_directions"
-                android:textColor="@color/text_color_selector" />
+                />
         </LinearLayout>
-
         <LinearLayout
             android:id="@+id/wikidataButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:background="@drawable/button_background_selector"
+            android:padding="16dp"
             android:clickable="true"
+            android:background="@drawable/button_background_selector"
             android:orientation="vertical"
-            android:padding="16dp">
-
+            >
             <ImageView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
                 android:duplicateParentState="true"
                 app:srcCompat="@drawable/ic_wikidata_logo_24dp" />
-
             <TextView
-                android:id="@+id/wikidataButtonText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:duplicateParentState="true"
+                android:id="@+id/wikidataButtonText"
                 android:paddingTop="8dp"
+                android:duplicateParentState="true"
+                android:textColor="@color/text_color_selector"
+                android:layout_gravity="center_horizontal"
                 android:text="@string/nearby_wikidata"
-                android:textColor="@color/text_color_selector" />
+                />
         </LinearLayout>
 
         <LinearLayout
@@ -118,27 +121,29 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:background="@drawable/button_background_selector"
+            android:padding="16dp"
             android:clickable="true"
+            android:background="@drawable/button_background_selector"
             android:orientation="vertical"
-            android:padding="16dp">
-
+            >
             <ImageView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
                 android:duplicateParentState="true"
-                app:srcCompat="@drawable/ic_wikipedia_logo_24dp" />
-
+                app:srcCompat="@drawable/ic_wikipedia_logo_24dp"
+                />
             <TextView
-                android:id="@+id/wikipediaButtonText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:duplicateParentState="true"
+                android:id="@+id/wikipediaButtonText"
                 android:paddingTop="8dp"
+                android:duplicateParentState="true"
+                android:textColor="@color/text_color_selector"
+                android:layout_gravity="center_horizontal"
                 android:text="@string/nearby_wikipedia"
-                android:textColor="@color/text_color_selector" />
+
+                />
         </LinearLayout>
 
         <LinearLayout
@@ -146,44 +151,44 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:background="@drawable/button_background_selector"
+            android:padding="16dp"
             android:clickable="true"
+            android:background="@drawable/button_background_selector"
             android:orientation="vertical"
-            android:padding="16dp">
-
+            >
             <ImageView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
                 android:duplicateParentState="true"
-                app:srcCompat="@drawable/ic_commons_icon_vector" />
-
+                app:srcCompat="@drawable/ic_commons_icon_vector"
+                />
             <TextView
-                android:id="@+id/commonsButtonText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:duplicateParentState="true"
+                android:id="@+id/commonsButtonText"
                 android:paddingTop="8dp"
+                android:duplicateParentState="true"
+                android:textColor="@color/text_color_selector"
+                android:layout_gravity="center_horizontal"
                 android:text="@string/nearby_commons"
-                android:textColor="@color/text_color_selector" />
+
+                />
         </LinearLayout>
     </LinearLayout>
-
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginBottom="8dp"
         android:layout_marginTop="7dp"
-        android:background="@android:color/darker_gray" />
-
+        android:layout_marginBottom="8dp"
+        android:background="@android:color/darker_gray"/>
     <TextView
         android:id="@+id/description"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
         android:layout_marginLeft="72dp"
         android:layout_marginRight="16dp"
+        android:layout_marginBottom="16dp"
         android:textSize="16sp" />
 
 

--- a/app/src/main/res/layout/bottom_sheet_details.xml
+++ b/app/src/main/res/layout/bottom_sheet_details.xml
@@ -1,44 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical"
     android:background="?attr/mainBackground"
-    app:layout_behavior="@string/bottom_sheet_behavior"
-    app:behavior_peekHeight="72dp"
+    android:orientation="vertical"
+    android:visibility="visible"
     app:behavior_hideable="true"
-    android:visibility="gone"
-
-    >
+    app:behavior_peekHeight="72dp"
+    app:layout_behavior="@string/bottom_sheet_behavior">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="72dp"
+        android:layout_height="wrap_content"
         android:layout_marginVertical="8dp"
         android:gravity="center_vertical"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="8dp"
         >
 
         <ImageView
             android:id="@+id/icon"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:layout_marginLeft="16dp">
-        </ImageView>
+            android:layout_marginLeft="16dp"/>
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
             android:layout_marginLeft="16dp"
-            android:layout_marginRight="16dp">
+            android:layout_marginRight="16dp"
+            android:orientation="vertical">
 
             <TextView
                 android:id="@+id/title"
-                android:layout_width="wrap_content"
+                android:layout_width="230dp"
                 android:layout_height="wrap_content"
                 android:textSize="16sp" />
-
             <TextView
                 android:id="@+id/category"
                 android:layout_width="wrap_content"
@@ -46,71 +44,73 @@
                 android:textSize="14sp" />
         </LinearLayout>
     </LinearLayout>
+
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginTop="7dp"
         android:layout_marginBottom="8dp"
-        android:background="@android:color/darker_gray"/>
+        android:layout_marginTop="7dp"
+        android:background="@android:color/darker_gray" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        >
+        android:orientation="horizontal">
 
         <LinearLayout
             android:id="@+id/directionsButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:padding="16dp"
-            android:clickable="true"
             android:background="@drawable/button_background_selector"
+            android:clickable="true"
             android:orientation="vertical"
-            >
+            android:padding="16dp">
+
             <ImageView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
                 android:duplicateParentState="true"
                 app:srcCompat="@drawable/ic_directions_black_24dp" />
+
             <TextView
+                android:id="@+id/directionsButtonText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:id="@+id/directionsButtonText"
-                android:paddingTop="8dp"
-                android:duplicateParentState="true"
-                android:textColor="@color/text_color_selector"
                 android:layout_gravity="center_horizontal"
+                android:duplicateParentState="true"
+                android:paddingTop="8dp"
                 android:text="@string/nearby_directions"
-                />
+                android:textColor="@color/text_color_selector" />
         </LinearLayout>
+
         <LinearLayout
             android:id="@+id/wikidataButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:padding="16dp"
-            android:clickable="true"
             android:background="@drawable/button_background_selector"
+            android:clickable="true"
             android:orientation="vertical"
-            >
+            android:padding="16dp">
+
             <ImageView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
                 android:duplicateParentState="true"
                 app:srcCompat="@drawable/ic_wikidata_logo_24dp" />
+
             <TextView
+                android:id="@+id/wikidataButtonText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:id="@+id/wikidataButtonText"
-                android:paddingTop="8dp"
-                android:duplicateParentState="true"
-                android:textColor="@color/text_color_selector"
                 android:layout_gravity="center_horizontal"
+                android:duplicateParentState="true"
+                android:paddingTop="8dp"
                 android:text="@string/nearby_wikidata"
-                />
+                android:textColor="@color/text_color_selector" />
         </LinearLayout>
 
         <LinearLayout
@@ -118,29 +118,27 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:padding="16dp"
-            android:clickable="true"
             android:background="@drawable/button_background_selector"
+            android:clickable="true"
             android:orientation="vertical"
-            >
+            android:padding="16dp">
+
             <ImageView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
                 android:duplicateParentState="true"
-                app:srcCompat="@drawable/ic_wikipedia_logo_24dp"
-                />
+                app:srcCompat="@drawable/ic_wikipedia_logo_24dp" />
+
             <TextView
+                android:id="@+id/wikipediaButtonText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:id="@+id/wikipediaButtonText"
-                android:paddingTop="8dp"
-                android:duplicateParentState="true"
-                android:textColor="@color/text_color_selector"
                 android:layout_gravity="center_horizontal"
+                android:duplicateParentState="true"
+                android:paddingTop="8dp"
                 android:text="@string/nearby_wikipedia"
-
-                />
+                android:textColor="@color/text_color_selector" />
         </LinearLayout>
 
         <LinearLayout
@@ -148,44 +146,44 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:padding="16dp"
-            android:clickable="true"
             android:background="@drawable/button_background_selector"
+            android:clickable="true"
             android:orientation="vertical"
-            >
+            android:padding="16dp">
+
             <ImageView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
                 android:duplicateParentState="true"
-                app:srcCompat="@drawable/ic_commons_icon_vector"
-                />
+                app:srcCompat="@drawable/ic_commons_icon_vector" />
+
             <TextView
+                android:id="@+id/commonsButtonText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:id="@+id/commonsButtonText"
-                android:paddingTop="8dp"
-                android:duplicateParentState="true"
-                android:textColor="@color/text_color_selector"
                 android:layout_gravity="center_horizontal"
+                android:duplicateParentState="true"
+                android:paddingTop="8dp"
                 android:text="@string/nearby_commons"
-
-                />
+                android:textColor="@color/text_color_selector" />
         </LinearLayout>
     </LinearLayout>
+
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginTop="7dp"
         android:layout_marginBottom="8dp"
-        android:background="@android:color/darker_gray"/>
+        android:layout_marginTop="7dp"
+        android:background="@android:color/darker_gray" />
+
     <TextView
         android:id="@+id/description"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
         android:layout_marginLeft="72dp"
         android:layout_marginRight="16dp"
-        android:layout_marginBottom="16dp"
         android:textSize="16sp" />
 
 

--- a/app/src/main/res/layout/bottom_sheet_details.xml
+++ b/app/src/main/res/layout/bottom_sheet_details.xml
@@ -8,7 +8,7 @@
     app:layout_behavior="@string/bottom_sheet_behavior"
     app:behavior_peekHeight="72dp"
     app:behavior_hideable="true"
-    android:visibility="visible"
+    android:visibility="gone"
 
     >
 

--- a/app/src/main/res/layout/bottom_sheet_details.xml
+++ b/app/src/main/res/layout/bottom_sheet_details.xml
@@ -5,7 +5,7 @@
     android:layout_height="wrap_content"
     android:background="?attr/mainBackground"
     android:orientation="vertical"
-    android:visibility="visible"
+    android:visibility="gone"
     app:behavior_hideable="true"
     app:behavior_peekHeight="72dp"
     app:layout_behavior="@string/bottom_sheet_behavior">


### PR DESCRIPTION
## Description

Fixes #1399 

1. Removed overlapping problem for the bottom sheet view for large title of places.
2. Changed Linear Layout height from 72dp to wrap_content to accomodate title which crosses more than three lines or else it will get hidden.

## Tests performed
Moto g4 plus Android 7.0.0

## Screenshots showing what changed
 
![whatsapp image 2018-04-01 at 11 49 05 pm](https://user-images.githubusercontent.com/17095817/38176152-5f40d716-3607-11e8-8d8c-9245cefcb2a1.jpeg)
![whatsapp image 2018-04-01 at 11 48 54 pm](https://user-images.githubusercontent.com/17095817/38176154-63bf98d6-3607-11e8-8e03-41f154f6c0c3.jpeg)
