### PR TITLE
Fix for issue #1436 list icon allows user only to show the list, but not to make it disappear

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -10,17 +10,14 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.BottomSheetBehavior;
-
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AlertDialog;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
-import android.widget.Toast;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -31,7 +28,6 @@ import javax.inject.Inject;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
-
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.location.LatLng;
 import fr.free.nrw.commons.location.LocationServiceManager;
@@ -39,13 +35,11 @@ import fr.free.nrw.commons.location.LocationUpdateListener;
 import fr.free.nrw.commons.theme.NavigationBaseActivity;
 import fr.free.nrw.commons.utils.NetworkUtils;
 import fr.free.nrw.commons.utils.UriSerializer;
-
 import fr.free.nrw.commons.utils.ViewUtil;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
-
 import timber.log.Timber;
 
 
@@ -81,7 +75,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
 
     private final String NETWORK_INTENT_ACTION = "android.net.conn.CONNECTIVITY_CHANGE";
     private BroadcastReceiver broadcastReceiver;
-
+    boolean opened;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -92,6 +86,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
 
         initBottomSheetBehaviour();
         initDrawer();
+        opened=false;
     }
 
     private void resumeFragment() {
@@ -136,11 +131,19 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+
         // Handle item selection
         switch (item.getItemId()) {
             case R.id.action_display_list:
-                bottomSheetBehaviorForDetails.setState(BottomSheetBehavior.STATE_HIDDEN);
-                bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+                if(!opened){
+                    bottomSheetBehaviorForDetails.setState(BottomSheetBehavior.STATE_HIDDEN);
+                    bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+                    opened=true;
+                }else{
+                    bottomSheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+                    opened=false;
+                }
+
                 return true;
             default:
                 return super.onOptionsItemSelected(item);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -75,7 +75,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
 
     private final String NETWORK_INTENT_ACTION = "android.net.conn.CONNECTIVITY_CHANGE";
     private BroadcastReceiver broadcastReceiver;
-    boolean opened;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -86,7 +86,6 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
 
         initBottomSheetBehaviour();
         initDrawer();
-        opened=false;
     }
 
     private void resumeFragment() {
@@ -135,13 +134,11 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
         // Handle item selection
         switch (item.getItemId()) {
             case R.id.action_display_list:
-                if(!opened){
+                if(bottomSheetBehavior.getState()==BottomSheetBehavior.STATE_COLLAPSED || bottomSheetBehavior.getState()==BottomSheetBehavior.STATE_HIDDEN){
                     bottomSheetBehaviorForDetails.setState(BottomSheetBehavior.STATE_HIDDEN);
                     bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
-                    opened=true;
-                }else{
+                }else if(bottomSheetBehavior.getState()==BottomSheetBehavior.STATE_EXPANDED){
                     bottomSheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
-                    opened=false;
                 }
 
                 return true;


### PR DESCRIPTION
…the current state of the list. It is false by default when you open the nearby activity.

## Description

Fixes #1436 

{Describe the changes made and why they were made.}
Created a boolean variable that defaults to false (because the list is collapsed by default) when the nearby activity is opened. Then, it changes value according to the current state of the list.
## Tests performed
Tested on LG V10, API 24, master 2.7.x
Tested on {API level & name of device/emulator}, with {build variant, e.g. ProdDebug}.

{Please test your PR at least once before submitting.}
tested several times and seems to work properly.
## Screenshots showing what changed
