### PR TITLE
Issue #1408: Try to get the localized version of the wikipedia article

### DIFF
--- a/app/src/main/resources/queries/nearby_query.rq
+++ b/app/src/main/resources/queries/nearby_query.rq
@@ -39,6 +39,12 @@ SELECT
        # Get emoji
        OPTIONAL { ?classId wdt:P487 ?emoji0. }
        OPTIONAL { ?classId wdt:P279*/wdt:P487 ?emoji1. }
+
+       OPTIONAL {
+           ?wikipediaArticle   schema:about ?item ;
+                               schema:isPartOf <https://${LANG}.wikipedia.org/> .
+           SERVICE wikibase:label { bd:serviceParam wikibase:language "${LANG}" }
+         }
        OPTIONAL {
            ?wikipediaArticle   schema:about ?item ;
                                schema:isPartOf <https://en.wikipedia.org/> .


### PR DESCRIPTION
Tested with Spanish on physical Android device.

Other notes:
Difficulties building with gradle due to dexcount plugin: https://github.com/KeepSafe/dexcount-gradle-plugin/issues/234. In testing, disabled the plugin.

## Description

Fixes #1408

Add another optional query to try to fetch the wikipedia article. Will fall back if language of article does not exist.

## Tests performed

Tested on API 24 on Samsung S6 with Android 7.0, with Debug

Tested by going to a nearby location with articles in English only.
Tested by going to a nearby location with articles in English and Spanish.
Confirmed Spanish page appears when Spanish is available. Otherwise English appears.
N/A
