### PR TITLE
Fix for #1437 : Button that opens Google Maps shows always only the coordinates of the first chosen mark

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -666,7 +666,7 @@ public class NearbyMapFragment extends DaggerFragment {
 
         directionsButton.setOnClickListener(view -> {
             //Open map app at given position
-            Intent mapIntent = new Intent(Intent.ACTION_VIEW, place.location.getGmmIntentUri());
+            Intent mapIntent = new Intent(Intent.ACTION_VIEW, this.place.location.getGmmIntentUri());
             if (mapIntent.resolveActivity(getActivity().getPackageManager()) != null) {
                 startActivity(mapIntent);
             }


### PR DESCRIPTION
Fixes #1437
Google maps now receive updated location

Tested on Xiomi Redmi 4a device



