### PR TITLE
Fixfor #1444 Link in "This image will be licensed ..." is too sensitive 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
@@ -14,7 +14,9 @@ import android.support.annotation.NonNull;
 import android.support.v4.view.ViewCompat;
 import android.support.v7.app.AlertDialog;
 import android.text.Editable;
+import android.text.Html;
 import android.text.TextWatcher;
+import android.text.method.LinkMovementMethod;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -225,18 +227,6 @@ public class SingleUploadFragment extends CommonsDaggerSupportFragment {
                 .commit();
     }
 
-    @OnTouch(R.id.share_license_summary)
-    boolean showLicence(View view, MotionEvent motionEvent) {
-        if (motionEvent.getActionMasked() == ACTION_DOWN) {
-            Intent intent = new Intent();
-            intent.setAction(Intent.ACTION_VIEW);
-            intent.setData(Uri.parse(licenseUrlFor(license)));
-            startActivity(intent);
-            return true;
-        } else {
-            return false;
-        }
-    }
 
     @OnClick(R.id.titleDescButton)
     void setTitleDescButton() {
@@ -294,8 +284,10 @@ public class SingleUploadFragment extends CommonsDaggerSupportFragment {
 
     @SuppressLint("StringFormatInvalid")
     private void setLicenseSummary(String license) {
-        licenseSummaryView.setText(getString(R.string.share_license_summary, getString(Utils.licenseNameFor(license))));
-    }
+        String licenseHyperLink = "<a href='" + licenseUrlFor(license)+"'>"+ getString(Utils.licenseNameFor(license)) + "</a><br>";
+        licenseSummaryView.setMovementMethod(LinkMovementMethod.getInstance());
+        licenseSummaryView.setText(Html.fromHtml(getString(R.string.share_license_summary, licenseHyperLink)));
+ }
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {

--- a/app/src/main/res/layout/fragment_single_upload.xml
+++ b/app/src/main/res/layout/fragment_single_upload.xml
@@ -74,6 +74,8 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/standard_gap"
             android:gravity="center"
+            android:clickable="true"
+            android:textColorLink="@color/button_blue"
             android:text="@string/share_license_summary" />
 
         <fr.free.nrw.commons.ui.widget.HtmlTextView


### PR DESCRIPTION

Fixes  #1444 

This image will be licensed under Attribution-ShareAlike 4.0 was too sensitive.
Now the link is attached to only the specific word like Attribution-ShareAlike 4.0.

 
Device: Xiaomi Redmi Note 4
Android version: 7.0

![screenshot-1523822107444](https://user-images.githubusercontent.com/31107831/38782911-84f41038-4118-11e8-9034-aea11b9885c0.jpg)


