### PR TITLE
Fix loading issue after upgrade from older version

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -19,7 +19,6 @@ import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatDelegate;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -28,7 +27,6 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import java.io.IOException;
 
@@ -160,7 +158,10 @@ public class LoginActivity extends AccountAuthenticatorActivity {
             WelcomeActivity.startYourself(this);
             prefs.edit().putBoolean("firstrun", false).apply();
         }
-        if (sessionManager.getCurrentAccount() != null) {
+
+        if (sessionManager.getCurrentAccount() != null
+                && sessionManager.isUserLoggedIn()
+                && sessionManager.getCachedAuthCookie() != null) {
             startMainActivity();
         }
     }

--- a/app/src/main/java/fr/free/nrw/commons/auth/SessionManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/SessionManager.java
@@ -61,18 +61,24 @@ public class SessionManager {
     }
 
     public String getAuthCookie() {
-        boolean isLoggedIn = sharedPreferences.getBoolean("isUserLoggedIn", false);
-
-        if (!isLoggedIn) {
+        if (!isUserLoggedIn()) {
             Timber.e("User is not logged in");
             return null;
         } else {
-            String authCookie = sharedPreferences.getString("getAuthCookie", null);
+            String authCookie = getCachedAuthCookie();
             if (authCookie == null) {
                 Timber.e("Auth cookie is null even after login");
             }
             return authCookie;
         }
+    }
+
+    public String getCachedAuthCookie() {
+        return sharedPreferences.getString("getAuthCookie", null);
+    }
+
+    public boolean isUserLoggedIn() {
+        return sharedPreferences.getBoolean("isUserLoggedIn", false);
     }
 
     public Completable clearAllAccounts() {


### PR DESCRIPTION
## Description

Fixes #1393

After the changes in how the `authCookie` is stored and used after the 2FA changes, we are forced to log out the user if he is coming from an older version. This PR checks for the cached values and if those values are not present, the user is asked to login again. 