### PR TITLE
Fixes #1284 Enhanced share feature

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
@@ -135,9 +135,10 @@ public class AboutActivity extends NavigationBaseActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.share_app_icon:
+                String shareText = "Upload photos to Wikimedia Commons on your phone\nDownload the Commons app: http://play.google.com/store/apps/details?id=fr.free.nrw.commons";
                 Intent sendIntent = new Intent();
                 sendIntent.setAction(Intent.ACTION_SEND);
-                sendIntent.putExtra(Intent.EXTRA_TEXT, "http://play.google.com/store/apps/details?id=fr.free.nrw.commons");
+                sendIntent.putExtra(Intent.EXTRA_TEXT, shareText);
                 sendIntent.setType("text/plain");
                 startActivity(Intent.createChooser(sendIntent, "Share app via..."));
                 return true;

--- a/app/src/main/res/drawable/ic_share_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_share_black_24dp.xml
@@ -1,5 +1,5 @@
-<vector android:alpha="0.84" android:height="32dp"
+<vector android:alpha="0.84" android:height="24dp"
     android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="32dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#ffffffff" android:pathData="M18,16.08c-0.76,0 -1.44,0.3 -1.96,0.77L8.91,12.7c0.05,-0.23 0.09,-0.46 0.09,-0.7s-0.04,-0.47 -0.09,-0.7l7.05,-4.11c0.54,0.5 1.25,0.81 2.04,0.81 1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3c0,0.24 0.04,0.47 0.09,0.7L8.04,9.81C7.5,9.31 6.79,9 6,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3c0.79,0 1.5,-0.31 2.04,-0.81l7.12,4.16c-0.05,0.21 -0.08,0.43 -0.08,0.65 0,1.61 1.31,2.92 2.92,2.92 1.61,0 2.92,-1.31 2.92,-2.92s-1.31,-2.92 -2.92,-2.92z"/>
 </vector>

--- a/app/src/main/res/menu/menu_about.xml
+++ b/app/src/main/res/menu/menu_about.xml
@@ -7,7 +7,7 @@
 
     <item
         android:id="@+id/share_app_icon"
-        android:title="@string/refresh_button"
+        android:title="@string/share_app_title"
         android:icon="@drawable/ic_share_black_24dp"
         android:orderInCategory="1"
         app:showAsAction="ifRoom"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -269,4 +269,5 @@
   <string name="about_translate_proceed">Proceed</string>
   <string name="about_translate_cancel">Cancel</string>
   <string name="retry">Retry</string>
+  <string name="share_app_title">Share App</string>
 </resources>


### PR DESCRIPTION
## Description

Fixes #1284
1. Changed the text from "Google Play link"  to "Upload photos to Wikimedia Commons on your phone
Download the Commons app: Google play link"
2. Decreased size of share icon from 32 to 24dp (as 24 dp is recommended by Google for icons). Also, it looks much better now. Please give your suggestions on this.  

## Tests performed

Tested Manually on API 25(Moto G5S+), with debug variant.

## Screenshots showing what changed
After updating image.

![screenshot_20180501-152636](https://user-images.githubusercontent.com/19607555/39469312-2d317216-4d55-11e8-8f93-5f170df5c095.png)

