### PR TITLE
resolves #1464 : MediaDataExtractor is making inefficient (redundant) server calls

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
@@ -61,8 +61,8 @@ public class MediaDataExtractor {
         }
 
         try{
-            Timber.d("Nominated for deletion: " + mediaWikiApi.pageExists("Commons:Deletion_requests/"+filename));
-            deletionStatus = mediaWikiApi.pageExists("Commons:Deletion_requests/"+filename);
+            deletionStatus = mediaWikiApi.pageExists("Commons:Deletion_requests/" + filename);
+            Timber.d("Nominated for deletion: " + deletionStatus);
         }
         catch (Exception e){
             Timber.d(e.getMessage());


### PR DESCRIPTION
Fix for: `MediaDataExtractor` is making inefficient (redundant) server calls

## Description

Fixes #1464 

Removed the redundant server call and reused the `deletionStatus` variable for logging.

## Tests performed

Tested on `Pixel 2 XL`, with `Android 8.1 API 27`.
