### PR TITLE
Fix security exception crash while accessing network location provider

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
@@ -75,6 +75,13 @@ public class LocationServiceManager implements LocationListener {
                 LOCATION_REQUEST);
     }
 
+    /**
+     * The permission explanation dialog box is now displayed just once for a particular activity. We are subscribing
+     * to updates from multiple providers so its important to show the dialog just once. Otherwise it will be displayed
+     * once for every provider, which in our case currently is 2.
+     * @param activity
+     * @return
+     */
     public boolean isPermissionExplanationRequired(Activity activity) {
         if (activity.isFinishing()) {
             return false;

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -388,6 +388,9 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
         }
     }
 
+    /**
+     * This method first checks if the location permissions has been granted and then register the location manager for updates.
+     */
     private void registerLocationUpdates() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             if (locationManager.isLocationPermissionGranted()) {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -266,7 +266,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
     protected void onStart() {
         super.onStart();
         locationManager.addLocationListener(this);
-        locationManager.registerLocationManager();
+        registerLocationUpdates();
     }
 
     @Override
@@ -344,7 +344,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
             return;
         }
 
-        locationManager.registerLocationManager();
+        registerLocationUpdates();
         LatLng lastLocation = locationManager.getLastLocation();
 
         if (curLatLng != null && curLatLng.equals(lastLocation)) { //refresh view only if location has changed
@@ -385,6 +385,36 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
             String gsonCurLatLng = gson.toJson(curLatLng);
             bundle.putString("CurLatLng", gsonCurLatLng);
             updateMapFragment(true);
+        }
+    }
+
+    private void registerLocationUpdates() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (locationManager.isLocationPermissionGranted()) {
+                locationManager.registerLocationManager();
+            } else {
+                // Should we show an explanation?
+                if (locationManager.isPermissionExplanationRequired(this)) {
+                    new AlertDialog.Builder(this)
+                            .setMessage(getString(R.string.location_permission_rationale_nearby))
+                            .setPositiveButton("OK", (dialog, which) -> {
+                                requestLocationPermissions();
+                                dialog.dismiss();
+                            })
+                            .setNegativeButton("Cancel", (dialog, id) -> {
+                                showLocationPermissionDeniedErrorDialog();
+                                dialog.cancel();
+                            })
+                            .create()
+                            .show();
+
+                } else {
+                    // No explanation needed, we can request the permission.
+                    requestLocationPermissions();
+                }
+            }
+        } else {
+            locationManager.registerLocationManager();
         }
     }
 
@@ -429,7 +459,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
             locationManager.removeLocationListener(this);
         } else {
             lockNearbyView = false;
-            locationManager.registerLocationManager();
+            registerLocationUpdates();
             locationManager.addLocationListener(this);
         }
     }


### PR DESCRIPTION
## Description

Fixes #1480

The app was not asking for permissions before subscribing to location updates from the network provider. This was leading to a security exception. 

## Tests performed

Unable to reproduce the crash using the steps mentioned in the issue. 

@neslihanturan @misaochan Can you guys help in testing if its reproducible on your end. 