### PR TITLE
Fix for issue #1508 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -271,11 +271,11 @@ public class LoginActivity extends AccountAuthenticatorActivity {
             showMessageAndCancelDialog(R.string.login_failed_network);
         } else if (result.toLowerCase(Locale.getDefault()).contains("nosuchuser".toLowerCase()) || result.toLowerCase().contains("noname".toLowerCase())) {
             // Matches nosuchuser, nosuchusershort, noname
-            showMessageAndCancelDialog(R.string.login_failed_username);
+            showMessageAndCancelDialog(R.string.login_failed_wrong_credentials);
             emptySensitiveEditFields();
         } else if (result.toLowerCase(Locale.getDefault()).contains("wrongpassword".toLowerCase())) {
             // Matches wrongpassword, wrongpasswordempty
-            showMessageAndCancelDialog(R.string.login_failed_password);
+            showMessageAndCancelDialog(R.string.login_failed_wrong_credentials);
             emptySensitiveEditFields();
         } else if (result.toLowerCase(Locale.getDefault()).contains("throttle".toLowerCase())) {
             // Matches unknown throttle error codes

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,8 +46,8 @@
   <string name="add_title_toast">Please provide a title for this file</string>
   <string name="share_description_hint">Description</string>
   <string name="login_failed_network">Unable to login - network failure</string>
-  <string name="login_failed_username">Unable to login - please check your username</string>
-  <string name="login_failed_password">Unable to login - please check your password</string>
+  <string name="login_failed_username">Unable to login - please check your username and password</string>
+  <string name="login_failed_password">Unable to login - please check your username and password</string>
   <string name="login_failed_throttled">Too many unsuccessful attempts. Please try again in a few minutes.</string>
   <string name="login_failed_blocked">Sorry, this user has been blocked on Commons</string>
   <string name="login_failed_2fa_needed">You must provide your two factor authentication code.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,8 +46,7 @@
   <string name="add_title_toast">Please provide a title for this file</string>
   <string name="share_description_hint">Description</string>
   <string name="login_failed_network">Unable to login - network failure</string>
-  <string name="login_failed_username">Unable to login - please check your username and password</string>
-  <string name="login_failed_password">Unable to login - please check your username and password</string>
+  <string name="login_failed_wrong_credentials">Unable to login - please check your username and password</string>
   <string name="login_failed_throttled">Too many unsuccessful attempts. Please try again in a few minutes.</string>
   <string name="login_failed_blocked">Sorry, this user has been blocked on Commons</string>
   <string name="login_failed_2fa_needed">You must provide your two factor authentication code.</string>


### PR DESCRIPTION
Made changes to the error message displayed when user enters wrong login credentials.
Changed "Unable to login - Please check your username" to "Unable to login - Please check your username and password".
Changed "Unable to login - Please check your password" to "Unable to login - Please check your username and password".

Changed to a common error message string for the two cases where user either entered a wrong username or a wrong password to reduce the work for translators.