### PR TITLE
Show nominate for deletion only for own uploads

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -23,9 +23,6 @@ import android.widget.ScrollView;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -35,6 +32,9 @@ import java.util.Locale;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
 import fr.free.nrw.commons.License;
 import fr.free.nrw.commons.LicenseList;
 import fr.free.nrw.commons.Media;
@@ -56,16 +56,16 @@ import static android.widget.Toast.LENGTH_SHORT;
 public class MediaDetailFragment extends CommonsDaggerSupportFragment {
 
     private boolean editable;
-    private boolean isFeaturedMedia;
+    private boolean isCategoryImage;
     private MediaDetailPagerFragment.MediaDetailProvider detailProvider;
     private int index;
 
-    public static MediaDetailFragment forMedia(int index, boolean editable, boolean isFeaturedMedia) {
+    public static MediaDetailFragment forMedia(int index, boolean editable, boolean isCategoryImage) {
         MediaDetailFragment mf = new MediaDetailFragment();
 
         Bundle state = new Bundle();
         state.putBoolean("editable", editable);
-        state.putBoolean("isFeaturedMedia", isFeaturedMedia);
+        state.putBoolean("isCategoryImage", isCategoryImage);
         state.putInt("index", index);
         state.putInt("listIndex", 0);
         state.putInt("listTop", 0);
@@ -128,7 +128,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         super.onSaveInstanceState(outState);
         outState.putInt("index", index);
         outState.putBoolean("editable", editable);
-        outState.putBoolean("isFeaturedMedia", isFeaturedMedia);
+        outState.putBoolean("isCategoryImage", isCategoryImage);
 
         getScrollPosition();
         outState.putInt("listTop", initialListTop);
@@ -144,12 +144,12 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
 
         if (savedInstanceState != null) {
             editable = savedInstanceState.getBoolean("editable");
-            isFeaturedMedia = savedInstanceState.getBoolean("isFeaturedMedia");
+            isCategoryImage = savedInstanceState.getBoolean("isCategoryImage");
             index = savedInstanceState.getInt("index");
             initialListTop = savedInstanceState.getInt("listTop");
         } else {
             editable = getArguments().getBoolean("editable");
-            isFeaturedMedia = getArguments().getBoolean("isFeaturedMedia");
+            isCategoryImage = getArguments().getBoolean("isCategoryImage");
             index = getArguments().getInt("index");
             initialListTop = 0;
         }
@@ -161,7 +161,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
 
         ButterKnife.bind(this,view);
 
-        if (isFeaturedMedia){
+        if (isCategoryImage){
             authorLayout.setVisibility(VISIBLE);
         } else {
             authorLayout.setVisibility(GONE);
@@ -328,7 +328,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         if (!TextUtils.isEmpty(licenseLink(media))) {
             openWebBrowser(licenseLink(media));
         } else {
-            if(isFeaturedMedia) {
+            if(isCategoryImage) {
                 Timber.d("Unable to fetch license URL for %s", media.getLicense());
             } else {
                 Toast toast = Toast.makeText(getContext(), getString(R.string.null_url), Toast.LENGTH_SHORT);
@@ -503,8 +503,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         if (media.getRequestedDeletion()){
             delete.setVisibility(GONE);
             nominatedForDeletion.setVisibility(VISIBLE);
-        }
-        else{
+        } else if (!isCategoryImage) {
             delete.setVisibility(VISIBLE);
             nominatedForDeletion.setVisibility(GONE);
         }


### PR DESCRIPTION
## Description (required)

Fixes #1516

## Tests performed (required)

Tested manually on Redmi 7.1.2. The "Nominate for deletion" button now shows up only for images uploaded by the logged in user. 