### PR TITLE
Preferences: move upload limit into appearance section

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -11,6 +11,13 @@
             android:summary="@string/preference_theme_summary"
             android:key="theme" />
 
+        <EditTextPreference
+            android:key="uploads"
+            android:defaultValue="100"
+            android:title= "@string/set_limit"
+            android:inputType="numberDecimal"
+            android:maxLength="3" />
+
     </PreferenceCategory>
 
     <PreferenceCategory
@@ -28,13 +35,6 @@
             android:title="@string/use_external_storage"
             android:defaultValue="true"
             android:summary="@string/use_external_storage_summary" />
-
-        <EditTextPreference
-            android:key="uploads"
-            android:defaultValue="100"
-            android:title= "@string/set_limit"
-            android:inputType="numberDecimal"
-            android:maxLength="3" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
## Description (required)
Related to #1039.

The 'Upload limit' preference seems to fit more appropriately into the 'Appearance' section of the preferences rather than the 'General' section.

## Tests performed (required)

Tested on API 22 (Samsung Galaxy J1 ace with BetaDebug.

## Screenshots showing what changed (optional)
![screenshot_2018-05-22-18-48-59](https://user-images.githubusercontent.com/12448084/40364994-3403669c-5df1-11e8-9a5b-c86e9687df97.png)
