### PR TITLE
Fixes #1550 Duplicated category suggestions

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
@@ -28,6 +28,7 @@ import java.util.Calendar;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -194,6 +195,20 @@ public class CategorizationFragment extends CommonsDaggerSupportFragment {
         onCategoriesSaveHandler = (OnCategoriesSaveHandler) getActivity();
         getActivity().setTitle(R.string.categories_activity_title);
     }
+    void removeduplicates(RVRendererAdapter<CategoryItem> categoriesAdapter){
+        List<CategoryItem> al = new ArrayList<>();
+        // add elements to al, including duplicates
+        for (int i = 0; i<categoriesAdapter.getItemCount();i++){
+            al.add(categoriesAdapter.getItem(i));
+        }
+        //Linked Hash Set contains only single valued items and the order is maintained
+        LinkedHashSet<CategoryItem> hs = new LinkedHashSet<>();
+        hs.addAll(al);
+        al.clear();
+        al.addAll(hs);
+        categoriesAdapter.clear();
+        categoriesAdapter.addAll(al);
+    }
 
     private void updateCategoryList(String filter) {
         Observable.fromIterable(selectedCategories)
@@ -220,6 +235,7 @@ public class CategorizationFragment extends CommonsDaggerSupportFragment {
                         s -> categoriesAdapter.add(s),
                         Timber::e,
                         () -> {
+                            removeduplicates(categoriesAdapter);
                             categoriesAdapter.notifyDataSetChanged();
                             categoriesSearchInProgress.setVisibility(View.GONE);
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
@@ -198,22 +198,21 @@ public class CategorizationFragment extends CommonsDaggerSupportFragment {
     
     /**
      * Removes duplicates from a RVRendererAdapter<CategoryItem> in place, while maintaining order
-     * @param Category adapter to remove duplicates from
+     * @param catAdapter Category adapter to remove duplicates from
      */
     private void removeDuplicates(RVRendererAdapter<CategoryItem> catAdapter) {
-        List<CategoryItem> catList = new ArrayList<>();
-        // add elements to catList, including duplicates
+        // Copy adapter items into an ArrayList
+        ArrayList<CategoryItem> catList = new ArrayList<CategoryItem>();
         for (int i = 0; i < catAdapter.getItemCount(); i++) {
-            al.add(catAdapter.getItem(i));
+            catList.add(catAdapter.getItem(i));
         }
-        
-        // Linked Hash Set contains only single valued items and the order is maintained
-        LinkedHashSet<CategoryItem> catSet = new LinkedHashSet<>();
-        catSet.addAll(catList);
-        catList.clear();
-        catList.addAll(catSet);
+
+        // Convert ArrayList to LinkedHashSet, to remove duplicates but maintain order
+        LinkedHashSet<CategoryItem> catSet = new LinkedHashSet<>(catList);
+
+        // Clear the adapter and then add all the elements of catSet back to it
         catAdapter.clear();
-        catAdapter.addAll(catList);
+        catAdapter.addAll(catSet);
     }
 
     private void updateCategoryList(String filter) {

--- a/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategorizationFragment.java
@@ -195,19 +195,25 @@ public class CategorizationFragment extends CommonsDaggerSupportFragment {
         onCategoriesSaveHandler = (OnCategoriesSaveHandler) getActivity();
         getActivity().setTitle(R.string.categories_activity_title);
     }
-    void removeduplicates(RVRendererAdapter<CategoryItem> categoriesAdapter){
-        List<CategoryItem> al = new ArrayList<>();
-        // add elements to al, including duplicates
-        for (int i = 0; i<categoriesAdapter.getItemCount();i++){
-            al.add(categoriesAdapter.getItem(i));
+    
+    /**
+     * Removes duplicates from a RVRendererAdapter<CategoryItem> in place, while maintaining order
+     * @param Category adapter to remove duplicates from
+     */
+    private void removeDuplicates(RVRendererAdapter<CategoryItem> catAdapter) {
+        List<CategoryItem> catList = new ArrayList<>();
+        // add elements to catList, including duplicates
+        for (int i = 0; i < catAdapter.getItemCount(); i++) {
+            al.add(catAdapter.getItem(i));
         }
-        //Linked Hash Set contains only single valued items and the order is maintained
-        LinkedHashSet<CategoryItem> hs = new LinkedHashSet<>();
-        hs.addAll(al);
-        al.clear();
-        al.addAll(hs);
-        categoriesAdapter.clear();
-        categoriesAdapter.addAll(al);
+        
+        // Linked Hash Set contains only single valued items and the order is maintained
+        LinkedHashSet<CategoryItem> catSet = new LinkedHashSet<>();
+        catSet.addAll(catList);
+        catList.clear();
+        catList.addAll(catSet);
+        catAdapter.clear();
+        catAdapter.addAll(catList);
     }
 
     private void updateCategoryList(String filter) {
@@ -235,7 +241,7 @@ public class CategorizationFragment extends CommonsDaggerSupportFragment {
                         s -> categoriesAdapter.add(s),
                         Timber::e,
                         () -> {
-                            removeduplicates(categoriesAdapter);
+                            removeDuplicates(categoriesAdapter);
                             categoriesAdapter.notifyDataSetChanged();
                             categoriesSearchInProgress.setVisibility(View.GONE);
 


### PR DESCRIPTION
## Duplicated category suggestions

Fixes #1550 

## Description (required)

Before calling notifydatasetchanged on categories adapter, I have removed the duplicates from categoriesAdapter by using linked hash set which has the property that it contains unique values and maintains the order of categories adapter.
And All this work is done in O(n) time.
Now Duplicates are not present.
{Describe the changes made and why they were made.}

## Tests performed (required)

Manually tested on [API 24 Redmi Note 4] with ProdDebug,BetaDebug

## Screenshots showing what changed (optional)

![screenshot from 2018-05-26 13-09-38](https://user-images.githubusercontent.com/31107831/40574079-d61a07e2-60e9-11e8-894b-4a667f11c168.png)