### PR TITLE
Show Block Status

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/AuthenticatedActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/AuthenticatedActivity.java
@@ -4,8 +4,13 @@ import android.os.Bundle;
 
 import javax.inject.Inject;
 
+import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.mwapi.MediaWikiApi;
 import fr.free.nrw.commons.theme.NavigationBaseActivity;
+import fr.free.nrw.commons.utils.ViewUtil;
+import io.reactivex.Observable;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
 
 import static fr.free.nrw.commons.auth.AccountUtil.AUTH_COOKIE;
 
@@ -34,6 +39,8 @@ public abstract class AuthenticatedActivity extends NavigationBaseActivity {
         if (savedInstanceState != null) {
             authCookie = savedInstanceState.getString(AUTH_COOKIE);
         }
+
+        showBlockStatus();
     }
 
     @Override
@@ -45,4 +52,16 @@ public abstract class AuthenticatedActivity extends NavigationBaseActivity {
     protected abstract void onAuthCookieAcquired(String authCookie);
 
     protected abstract void onAuthFailure();
+
+    protected void showBlockStatus()
+    {
+        Observable.fromCallable(() -> mediaWikiApi.isUserBlocked())
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .filter(result -> result)
+                .subscribe(result -> {
+                            ViewUtil.showSnackbar(findViewById(android.R.id.content), R.string.block_notification);
+                        }
+                );
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/auth/AuthenticatedActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/AuthenticatedActivity.java
@@ -53,6 +53,10 @@ public abstract class AuthenticatedActivity extends NavigationBaseActivity {
 
     protected abstract void onAuthFailure();
 
+    /**
+     * Makes API call to check if user is blocked. If the user is blocked, a snackbar
+     * is created to notify the user
+     */
     protected void showBlockStatus()
     {
         Observable.fromCallable(() -> mediaWikiApi.isUserBlocked())

--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -162,6 +162,7 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         if (sessionManager.getCurrentAccount() != null
                 && sessionManager.isUserLoggedIn()
                 && sessionManager.getCachedAuthCookie() != null) {
+            sessionManager.revalidateAuthToken();
             startMainActivity();
         }
     }

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -615,6 +615,26 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
         });
     }
 
+    @Override
+    public boolean isUserBlocked() {
+        boolean userBlocked = false;
+        try {
+            ApiResult result = api.action("query")
+                    .param("action", "query")
+                    .param("format", "xml")
+                    .param("meta", "userinfo")
+                    .param("uiprop", "blockinfo")
+                    .get();
+            if(result != null) {
+                userBlocked = !result.getString("/api/query/userinfo/@blockexpiry").isEmpty();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return userBlocked;
+    }
+
     private Date parseMWDate(String mwDate) {
         SimpleDateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ENGLISH); // Assuming MW always gives me UTC
         try {

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -615,6 +615,10 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
         });
     }
 
+    /**
+     * Checks to see if a user is currently blocked
+     * @return whether or not the user is blocked
+     */
     @Override
     public boolean isUserBlocked() {
         boolean userBlocked = false;
@@ -626,6 +630,7 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
                     .param("uiprop", "blockinfo")
                     .get();
             if(result != null) {
+                // the blockexpiry field will only be present if the user is currently blocked
                 userBlocked = !result.getString("/api/query/userinfo/@blockexpiry").isEmpty();
             }
         } catch (Exception e) {

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
@@ -75,6 +75,8 @@ public interface MediaWikiApi {
     @NonNull
     Single<Integer> getUploadCount(String userName);
 
+    boolean isUserBlocked();
+
     interface ProgressListener {
         void onProgress(long transferred, long total);
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -283,5 +283,6 @@
   <string name="share_app_title">Share App</string>
   <string name="share_coordinates_not_present">Coordinates were not specified during image selection</string>
   <string name="error_fetching_nearby_places">Error fetching nearby places.</string>
+  <string name="block_notification">You are blocked from editing commons</string>
 
 </resources>

--- a/app/src/test/kotlin/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApiTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApiTest.kt
@@ -18,6 +18,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import java.net.URLDecoder
+import java.text.SimpleDateFormat
 import java.util.*
 
 @RunWith(RobolectricTestRunner::class)
@@ -243,7 +244,11 @@ class ApacheHttpClientMediaWikiApiTest {
 
     @Test
     fun isUserBlockedForTimeBlockedUser() {
-        server.enqueue(MockResponse().setBody("<?xml version=\"1.0\"?><api><query><userinfo id=\"1000\" name=\"testusername\" blockid=\"3000\" blockedby=\"blockerusername\" blockedbyid=\"1001\" blockreason=\"testing\" blockedtimestamp=\"2018-05-24T15:32:09Z\" blockexpiry=\"2014-09-18T12:34:56Z\"></userinfo></query></api>"))
+        val currentDate = Date()
+        val expiredDate = Date(currentDate.time + 10000)
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"))
+        server.enqueue(MockResponse().setBody("<?xml version=\"1.0\"?><api><query><userinfo id=\"1000\" name=\"testusername\" blockid=\"3000\" blockedby=\"blockerusername\" blockedbyid=\"1001\" blockreason=\"testing\" blockedtimestamp=\"2018-05-24T15:32:09Z\" blockexpiry=\"" + dateFormat.format(expiredDate) + "\"></userinfo></query></api>"))
 
         val result = testObject.isUserBlocked();
 
@@ -257,6 +262,28 @@ class ApacheHttpClientMediaWikiApiTest {
         }
 
         assertTrue(result)
+    }
+
+    @Test
+    fun isUserBlockedForExpiredBlockedUser() {
+        val currentDate = Date()
+        val expiredDate = Date(currentDate.time - 10000)
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"))
+        server.enqueue(MockResponse().setBody("<?xml version=\"1.0\"?><api><query><userinfo id=\"1000\" name=\"testusername\" blockid=\"3000\" blockedby=\"blockerusername\" blockedbyid=\"1001\" blockreason=\"testing\" blockedtimestamp=\"2018-05-24T15:32:09Z\" blockexpiry=\"" + dateFormat.format(expiredDate) + "\"></userinfo></query></api>"))
+
+        val result = testObject.isUserBlocked();
+
+        assertBasicRequestParameters(server, "GET").let { userBlockedRequest ->
+            parseQueryParams(userBlockedRequest).let { body ->
+                assertEquals("xml", body["format"])
+                assertEquals("query", body["action"])
+                assertEquals("userinfo", body["meta"])
+                assertEquals("blockinfo", body["uiprop"])
+            }
+        }
+
+        assertFalse(result)
     }
 
     @Test


### PR DESCRIPTION
## Inform user when she is blocked

Fixes #{1511} 

## Description

Fixes #{Inform user when she is blocked, 1511}

When an authenticated activity is created, a snackbar will be displayed if the user is blocked from Wikimedia Commons

## Tests performed

Tested on API level 27 on Nexus 5 Emulator, with betaDebug build.

## Screenshots showing what changed
Snackbar Popup
![blocked snackbar display](https://user-images.githubusercontent.com/32438079/40798185-6950502e-64d8-11e8-89cf-a0b4358f2351.PNG)

