### PR TITLE
Add dependencies to com.android.support.test.rules and runner

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,6 +75,8 @@ dependencies {
     androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.8.1'
     androidTestImplementation "com.android.support:support-annotations:$SUPPORT_LIB_VERSION"
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 
     debugImplementation "com.squareup.leakcanary:leakcanary-android:$LEAK_CANARY"


### PR DESCRIPTION
## Add dependencies to com.android.support.test.rules and runner

Fixes #1574 (SettingsActivityTest fails due to undeclared dependencies).

## Description

* Adds dependencies needed for ActivityTestRule used in SettingsActivityTest.
  * Not sure why it was okay previously without them, but it is apparently required now as described in #1574.
  * The gradle lines were taken from https://developer.android.com/training/testing/packages#android-test-dependencies .

## Tests performed

* Local unit tests - no error
* Travis-CI tests (from my account) - pass

