### PR TITLE
Fixes #1572  Changed visibility to gone in case of successful Fetch

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
@@ -98,6 +98,7 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
      * @param mediaList
      */
     private void handleSuccess(List<Media> mediaList) {
+        imagesNotFoundView.setVisibility(GONE);
         queryList = mediaList;
         if(mediaList == null || mediaList.isEmpty()) {
             initErrorView();


### PR DESCRIPTION
Fixes #1572 "No images matching" message does not really disappear when performing new another search 
## Description 

- Changed visibility of noImageTextView to gone in case of success

## Tests performed 
Manually tested on MotoG5S+ in prodDebug version.