### PR TITLE
Fixes#1571 "Error occurred while loading images" on empty search

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
@@ -78,6 +78,7 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
      * Clearing imageAdapter every time new keyword is searched so that user can see only new results
      */
     public void updateImageList(String query) {
+        this.query = query;
         if(!NetworkUtils.isInternetConnectionEstablished(getContext())) {
             handleNoInternet();
             return;


### PR DESCRIPTION
Fixes#1571 "Error occurred while loading images" on empty search

## Description 
- Query variable in searchImage fragment was null. We are updating it in updateImageList Method now. 

## Tests performed 
Manually tested on MotoG5S+ in prodDebug version.

## Screenshots

![screenshot_20180528-125349](https://user-images.githubusercontent.com/19607555/40602590-c616b26c-6276-11e8-9010-a171caa99c78.png)
