### PR TITLE
Log P18 edits with custom tag

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -394,12 +394,13 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
      * @param property the property to be edited, for eg P18 for images
      * @param snaktype the type of value stored for that property
      * @param value the actual value to be stored for the property, for eg filename in case of P18
-     * @return returns true if the claim is successfully created
+     * @return returns revisionId if the claim is successfully created else returns null
      * @throws IOException
      */
     @Nullable
     @Override
-    public boolean wikidatCreateClaim(String entityId, String property, String snaktype, String value) throws IOException {
+    public String wikidatCreateClaim(String entityId, String property, String snaktype, String value) throws IOException {
+        Timber.d("Filename is %s", value);
         ApiResult result = wikidataApi.action("wbcreateclaim")
                 .param("entity", entityId)
                 .param("centralauthtoken", getCentralAuthToken())
@@ -410,13 +411,39 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
                 .post();
 
         if (result == null || result.getNode("api") == null) {
-            return false;
+            return null;
         }
 
         Node node = result.getNode("api").getDocument();
         Element element = (Element) node;
 
         if (element != null && element.getAttribute("success").equals("1")) {
+            return result.getString("api/pageinfo/@lastrevid");
+        } else {
+            Timber.e(result.getString("api/error/@code") + " " + result.getString("api/error/@info"));
+        }
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public boolean addWikidataEditTag(String revisionId) throws IOException {
+        ApiResult result = wikidataApi.action("tag")
+                .param("revid", revisionId)
+                .param("centralauthtoken", getCentralAuthToken())
+                .param("token", getWikidataCsrfToken())
+                .param("add", "wikimedia-commons-app")
+                .param("reason", "Add tag for edits made using Android Commons app")
+                .post();
+
+        if (result == null || result.getNode("api") == null) {
+            return false;
+        }
+
+        Node node = result.getNode("api").getDocument();
+        Element element = (Element) node;
+
+        if (element != null && element.getAttribute("status").equals("success")) {
             return true;
         } else {
             Timber.e(result.getString("api/error/@code") + " " + result.getString("api/error/@info"));

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -425,6 +425,12 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
         return null;
     }
 
+    /**
+     * Adds the wikimedia-commons-app tag to the edits made on wikidata
+     * @param revisionId
+     * @return
+     * @throws IOException
+     */
     @Nullable
     @Override
     public boolean addWikidataEditTag(String revisionId) throws IOException {

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
@@ -54,7 +54,10 @@ public interface MediaWikiApi {
     String appendEdit(String editToken, String processedPageContent, String filename, String summary) throws IOException;
 
     @Nullable
-    boolean wikidatCreateClaim(String entityId, String property, String snaktype, String value) throws IOException;
+    String wikidatCreateClaim(String entityId, String property, String snaktype, String value) throws IOException;
+
+    @Nullable
+    boolean addWikidataEditTag(String revisionId) throws IOException;
 
     @NonNull
     MediaResult fetchMediaByFilename(String filename) throws IOException;

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
@@ -18,6 +18,11 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 import timber.log.Timber;
 
+/**
+ * This class is meant to handle the Wikidata edits made through the app
+ * It will talk with MediaWikiApi to make necessary API calls, log the edits and fire listeners
+ * on successful edits
+ */
 @Singleton
 public class WikidataEditService {
 
@@ -37,6 +42,11 @@ public class WikidataEditService {
         this.directPrefs = directPrefs;
     }
 
+    /**
+     * Create a P18 claim and log the edit with custom tag
+     * @param wikidataEntityId
+     * @param fileName
+     */
     public void createClaimWithLogging(String wikidataEntityId, String fileName) {
         editWikidataProperty(wikidataEntityId, fileName);
     }
@@ -75,6 +85,10 @@ public class WikidataEditService {
         }
     }
 
+    /**
+     * Log the Wikidata edit by adding Wikimedia Commons App tag to the edit
+     * @param revisionId
+     */
     @SuppressLint("CheckResult")
     private void logEdit(String revisionId) {
         Observable.fromCallable(() -> mediaWikiApi.addWikidataEditTag(revisionId))
@@ -91,6 +105,9 @@ public class WikidataEditService {
                 });
     }
 
+    /**
+     * Show a success toast when the edit is made successfully
+     */
     private void showSuccessToast() {
         String title = directPrefs.getString("Title", "");
         String successStringTemplate = context.getString(R.string.successful_wikidata_edit);

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
@@ -1,0 +1,113 @@
+package fr.free.nrw.commons.wikidata;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import java.util.Locale;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.mwapi.MediaWikiApi;
+import fr.free.nrw.commons.utils.ViewUtil;
+import io.reactivex.Observable;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
+import timber.log.Timber;
+
+@Singleton
+public class WikidataEditService {
+
+    private final Context context;
+    private final MediaWikiApi mediaWikiApi;
+    private final WikidataEditListener wikidataEditListener;
+    private final SharedPreferences directPrefs;
+
+    @Inject
+    public WikidataEditService(Context context,
+                               MediaWikiApi mediaWikiApi,
+                               WikidataEditListener wikidataEditListener,
+                               @Named("direct_nearby_upload_prefs") SharedPreferences directPrefs) {
+        this.context = context;
+        this.mediaWikiApi = mediaWikiApi;
+        this.wikidataEditListener = wikidataEditListener;
+        this.directPrefs = directPrefs;
+    }
+
+    public void createClaimWithLogging(String wikidataEntityId, String fileName) {
+        editWikidataProperty(wikidataEntityId, fileName);
+    }
+
+    /**
+     * Edits the wikidata entity by adding the P18 property to it.
+     * Adding the P18 edit requires calling the wikidata API to create a claim against the entity
+     *
+     * @param wikidataEntityId
+     * @param fileName
+     */
+    @SuppressLint("CheckResult")
+    private void editWikidataProperty(String wikidataEntityId, String fileName) {
+        Timber.d("Upload successful with wiki data entity id as %s", wikidataEntityId);
+        Timber.d("Attempting to edit Wikidata property %s", wikidataEntityId);
+        Observable.fromCallable(() -> {
+            String propertyValue = getFileName(fileName);
+            return mediaWikiApi.wikidatCreateClaim(wikidataEntityId, "P18", "value", propertyValue);
+        })
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(revisionId -> handleClaimResult(wikidataEntityId, revisionId), throwable -> {
+                    Timber.e(throwable, "Error occurred while making claim");
+                    ViewUtil.showLongToast(context, context.getString(R.string.wikidata_edit_failure));
+                });
+    }
+
+    private void handleClaimResult(String wikidataEntityId, String revisionId) {
+        if (revisionId != null) {
+            wikidataEditListener.onSuccessfulWikidataEdit();
+            showSuccessToast();
+            logEdit(revisionId);
+        } else {
+            Timber.d("Unable to make wiki data edit for entity %s", wikidataEntityId);
+            ViewUtil.showLongToast(context, context.getString(R.string.wikidata_edit_failure));
+        }
+    }
+
+    @SuppressLint("CheckResult")
+    private void logEdit(String revisionId) {
+        Observable.fromCallable(() -> mediaWikiApi.addWikidataEditTag(revisionId))
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(result -> {
+                    if (result) {
+                        Timber.d("Wikidata edit was tagged successfully");
+                    } else {
+                        Timber.d("Wikidata edit couldn't be tagged");
+                    }
+                }, throwable -> {
+                    Timber.e(throwable, "Error occurred while adding tag to the edit");
+                });
+    }
+
+    private void showSuccessToast() {
+        String title = directPrefs.getString("Title", "");
+        String successStringTemplate = context.getString(R.string.successful_wikidata_edit);
+        String successMessage = String.format(Locale.getDefault(), successStringTemplate, title);
+        ViewUtil.showLongToast(context, successMessage);
+    }
+
+    /**
+     * Formats and returns the filename as accepted by the wiki base API
+     * https://www.mediawiki.org/wiki/Wikibase/API#wbcreateclaim
+     *
+     * @param fileName
+     * @return
+     */
+    private String getFileName(String fileName) {
+        fileName = String.format("\"%s\"", fileName.replace("File:", ""));
+        Timber.d("Wikidata property name is %s", fileName);
+        return fileName;
+    }
+}


### PR DESCRIPTION
## Title (required)

Fixes #923 

## Description (required)

We would be logging the Wikidata edits made through the app with `wikimedia-commons-app` tag. The recent edits can be viewed here. https://www.wikidata.org/w/index.php?hidebots=1&translations=filter&hidecategorization=1&tagfilter=wikimedia-commons-app&limit=500&days=30&hideWikibase=1&title=Special:RecentChanges&urlversion=2 

## Tests performed (required)

Tested on`prodDebug` build. The edits are being logged properly with relevant tags. 