### PR TITLE
add parameters to sort featured images by order of recency

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -480,6 +480,8 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
                     .param("format", "xml")
                     .param("gcmtype", "file")
                     .param("gcmtitle", categoryName)
+                    .param("gcmsort", "timestamp")
+                    .param("gcmdir", "desc")
                     .param("prop", "imageinfo")
                     .param("gcmlimit", "10")
                     .param("iiprop", "url|extmetadata");

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -480,8 +480,8 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
                     .param("format", "xml")
                     .param("gcmtype", "file")
                     .param("gcmtitle", categoryName)
-                    .param("gcmsort", "timestamp")
-                    .param("gcmdir", "desc")
+                    .param("gcmsort", "timestamp")//property to sort by;timestamp
+                    .param("gcmdir", "desc")//in which direction to sort;descending
                     .param("prop", "imageinfo")
                     .param("gcmlimit", "10")
                     .param("iiprop", "url|extmetadata");


### PR DESCRIPTION
## Change order of featured images to recently uploaded

Fixes #1564 

## Changed the order of featured images by adding the *gcmsort* and *gcmdir* parameters in the api request

Fixes #1564 Featured pictures: Show in recency or random order, rather than alphabetical order

Added  *gcmsort* and *gcmdir* parameters in  **fr.free.nrw.commons.mwapi.ApacheHttpClientMediaWikiApi#getCategoryImages**  method 

1. Made an api call on a browser and compared the timestamps returned by the query
2.Built a **prod** flavour for the app and observed the order of featured images before and after the change.

Tested on {API level 23, Samsung SM-G532F}, with  **prod** flavour.