### PR TITLE
Introducing a brief exp of Image License

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/SingleUploadFragment.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Color;
+import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
@@ -13,6 +14,7 @@ import android.text.Editable;
 import android.text.Html;
 import android.text.TextWatcher;
 import android.text.method.LinkMovementMethod;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -29,6 +31,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import java.util.ArrayList;
+import java.util.Locale;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -341,5 +344,18 @@ public class SingleUploadFragment extends CommonsDaggerSupportFragment {
                 .setNeutralButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
                 .create()
                 .show();
+    }
+
+    /**
+     * To launch the Commons:Licensing
+     * @param view
+     */
+    @OnClick(R.id.licenseInfo)
+    public void launchLicenseInfo(View view){
+        Log.i("Language", Locale.getDefault().getLanguage());
+        UrlLicense urlLicense = new UrlLicense();
+        urlLicense.initialize();
+        String url = urlLicense.getLicenseUrl(Locale.getDefault().getLanguage());
+        Utils.handleWebUrl(getActivity() , Uri.parse(url));
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/upload/UrlLicense.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UrlLicense.java
@@ -1,0 +1,72 @@
+package fr.free.nrw.commons.upload;
+
+import java.util.HashMap;
+import java.util.Locale;
+
+/**
+ * This is a Util class which provides the necessary token to open the Commons License
+ * info in the user language
+ */
+public class UrlLicense {
+    HashMap<String,String> urlLicense = new HashMap<String, String>();
+    public void initialize(){
+        urlLicense.put("en","https://commons.wikimedia.org/wiki/Commons:Licensing");
+        urlLicense.put("ar","https://commons.wikimedia.org/wiki/Commons:Licensing/ar");
+        urlLicense.put("ast","https://commons.wikimedia.org/wiki/Commons:Licensing/ast");
+        urlLicense.put("az","https://commons.wikimedia.org/wiki/Commons:Licensing/az");
+        urlLicense.put("be","https://commons.wikimedia.org/wiki/Commons:Licensing/be");
+        urlLicense.put("bg","https://commons.wikimedia.org/wiki/Commons:Licensing/bg");
+        urlLicense.put("bn","https://commons.wikimedia.org/wiki/Commons:Licensing/bn");
+        urlLicense.put("ca","https://commons.wikimedia.org/wiki/Commons:Licensing/ca");
+        urlLicense.put("cs","https://commons.wikimedia.org/wiki/Commons:Licensing/cs");
+        urlLicense.put("da","https://commons.wikimedia.org/wiki/Commons:Licensing/da");
+        urlLicense.put("de","https://commons.wikimedia.org/wiki/Commons:Licensing/de");
+        urlLicense.put("el","https://commons.wikimedia.org/wiki/Commons:Licensing/el");
+        urlLicense.put("eo","https://commons.wikimedia.org/wiki/Commons:Licensing/eo");
+        urlLicense.put("es","https://commons.wikimedia.org/wiki/Commons:Licensing/es");
+        urlLicense.put("eu","https://commons.wikimedia.org/wiki/Commons:Licensing/eu");
+        urlLicense.put("fa","https://commons.wikimedia.org/wiki/Commons:Licensing/fa");
+        urlLicense.put("fi","https://commons.wikimedia.org/wiki/Commons:Licensing/fi");
+        urlLicense.put("fr","https://commons.wikimedia.org/wiki/Commons:Licensing/fr");
+        urlLicense.put("gl","https://commons.wikimedia.org/wiki/Commons:Licensing/gl");
+        urlLicense.put("gsw","https://commons.wikimedia.org/wiki/Commons:Licensing/gsw");
+        urlLicense.put("he","https://commons.wikimedia.org/wiki/Commons:Licensing/he");
+        urlLicense.put("hi","https://commons.wikimedia.org/wiki/Commons:Licensing/hi");
+        urlLicense.put("hu","https://commons.wikimedia.org/wiki/Commons:Licensing/hu");
+        urlLicense.put("id","https://commons.wikimedia.org/wiki/Commons:Licensing/id");
+        urlLicense.put("is","https://commons.wikimedia.org/wiki/Commons:Licensing/is");
+        urlLicense.put("it","https://commons.wikimedia.org/wiki/Commons:Licensing/it");
+        urlLicense.put("ja","https://commons.wikimedia.org/wiki/Commons:Licensing/ja");
+        urlLicense.put("ka","https://commons.wikimedia.org/wiki/Commons:Licensing/ka");
+        urlLicense.put("km","https://commons.wikimedia.org/wiki/Commons:Licensing/km");
+        urlLicense.put("ko","https://commons.wikimedia.org/wiki/Commons:Licensing/ko");
+        urlLicense.put("ku","https://commons.wikimedia.org/wiki/Commons:Licensing/ku");
+        urlLicense.put("mk","https://commons.wikimedia.org/wiki/Commons:Licensing/mk");
+        urlLicense.put("mr","https://commons.wikimedia.org/wiki/Commons:Licensing/mr");
+        urlLicense.put("ms","https://commons.wikimedia.org/wiki/Commons:Licensing/ms");
+        urlLicense.put("my","https://commons.wikimedia.org/wiki/Commons:Licensing/my");
+        urlLicense.put("nl","https://commons.wikimedia.org/wiki/Commons:Licensing/nl");
+        urlLicense.put("oc","https://commons.wikimedia.org/wiki/Commons:Licensing/oc");
+        urlLicense.put("pl","https://commons.wikimedia.org/wiki/Commons:Licensing/pl");
+        urlLicense.put("pt","https://commons.wikimedia.org/wiki/Commons:Licensing/pt");
+        urlLicense.put("pt-br","https://commons.wikimedia.org/wiki/Commons:Licensing/pt-br");
+        urlLicense.put("ro","https://commons.wikimedia.org/wiki/Commons:Licensing/ro");
+        urlLicense.put("ru","https://commons.wikimedia.org/wiki/Commons:Licensing/ru");
+        urlLicense.put("scn","https://commons.wikimedia.org/wiki/Commons:Licensing/scn");
+        urlLicense.put("sk","https://commons.wikimedia.org/wiki/Commons:Licensing/sk");
+        urlLicense.put("sl","https://commons.wikimedia.org/wiki/Commons:Licensing/sl");
+        urlLicense.put("sv","https://commons.wikimedia.org/wiki/Commons:Licensing/sv");
+        urlLicense.put("tr","https://commons.wikimedia.org/wiki/Commons:Licensing/tr");
+        urlLicense.put("uk","https://commons.wikimedia.org/wiki/Commons:Licensing/uk");
+        urlLicense.put("ur","https://commons.wikimedia.org/wiki/Commons:Licensing/ur");
+        urlLicense.put("vi","https://commons.wikimedia.org/wiki/Commons:Licensing/vi");
+        urlLicense.put("zh","https://commons.wikimedia.org/wiki/Commons:Licensing/zh");
+    }
+    public String getLicenseUrl ( String language){
+        if(urlLicense.containsKey(language)) {
+            return urlLicense.get(language);
+        } else {
+            return urlLicense.get("en");
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_single_upload.xml
+++ b/app/src/main/res/layout/fragment_single_upload.xml
@@ -55,11 +55,23 @@
         </android.support.design.widget.TextInputLayout>
 
 
-        <Spinner
-            android:id="@+id/licenseSpinner"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:theme="?attr/spinnerTheme" />
+            android:layout_height="wrap_content">
+            <Spinner
+                android:id="@+id/licenseSpinner"
+                android:layout_width="0dp"
+                android:layout_weight="15"
+                android:layout_height="wrap_content"
+                android:theme="?attr/spinnerTheme" />
+            <TextView
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:id="@+id/licenseInfo"
+                android:layout_height="wrap_content"
+                android:text="(?)"
+                android:textColor="@color/primaryTextColor"/>
+        </LinearLayout>
 
         <Button
             android:id="@+id/titleDescButton"


### PR DESCRIPTION
## Introducing a brief explanation of Image License

Fixes #1316 

## Description (required)
Added a (?) link at the right of spinner, that opens https://commons.wikimedia.org/wiki/Commons:First_steps/License_selection in the user's language

## Tests performed (required)

Tested on ProdDebug with languages English and Hindi.

## Screenshots showing what changed (optional)

<img src="https://user-images.githubusercontent.com/29161745/41093278-895e3954-6a68-11e8-8afe-9d9b7d50eda6.png" width="50%" height="50%" >


_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._