### PR TITLE
Correct name is "Wikidata", not "wiki data"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -284,7 +284,7 @@
   <string name="error_fetching_nearby_places">Error fetching nearby places.</string>
 
   <string name="successful_wikidata_edit">Image successfully added to %1$s on Wikidata!</string>
-  <string name="wikidata_edit_failure">Failed to update corresponding wiki data entity!</string>
+  <string name="wikidata_edit_failure">Failed to update corresponding Wikidata entity!</string>
   <string name="menu_set_wallpaper">Set wallpaper</string>
   <string name="wallpaper_set_successfully">Wallpaper set successfully!</string>
 </resources>


### PR DESCRIPTION
Reported at https://phabricator.wikimedia.org/T196439