### PR TITLE
Fixes # 1604 SearchView Clear focus added

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -156,5 +156,8 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
 
     public void updateText(String query) {
         searchView.setQuery(query, true);;
+        // Clear focus of searchView now. searchView.clearFocus(); does not seem to work Check the below link for more details.
+        // https://stackoverflow.com/questions/6117967/how-to-remove-focus-without-setting-focus-to-another-control/15481511
+        resultsContainer.requestFocus();
     }
 }

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -51,6 +51,8 @@
             android:id="@+id/fragmentContainer"
             android:orientation="horizontal"
             android:layout_below="@id/toolbar_layout"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
             />
         <FrameLayout
             android:visibility="visible"


### PR DESCRIPTION
## Title 
Fixes #1604 (Single "Back" touch does not go back from search screen, need to touch "Back" twice)

## Description

- Made frameLayout focusable and shifted focus to frame layout so that we don't need to press back once more for removing searchViewFocus.

## Tests performed
Manually Tested on API 25 & MotoG5S+, with ProdDebug variant.