### PR TITLE
Fixes#1621 Bug back button and share icon size changed to 24dp

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
@@ -113,6 +113,7 @@ public class CategoryImagesActivity
             supportFragmentManager.executePendingTransactions();
         }
         mediaDetails.showImage(i);
+        initBackButton();
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -135,6 +135,7 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
             supportFragmentManager.executePendingTransactions();
         }
         mediaDetails.showImage(index);
+        initBackButton();
     }
 
 

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -127,7 +127,10 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
         Media m = provider.getMediaAtPosition(pager.getCurrentItem());
         switch (item.getItemId()) {
             case R.id.menu_share_current_image:
-                // Share - intent set in onCreateOptionsMenu, around line 252
+                Intent shareIntent = new Intent(Intent.ACTION_SEND);
+                shareIntent.setType("text/plain");
+                shareIntent.putExtra(Intent.EXTRA_TEXT, m.getDisplayTitle() + " \n" + m.getFilePageTitle().getCanonicalUri());
+                startActivity(Intent.createChooser(shareIntent, "Share image via..."));
                 return true;
             case R.id.menu_browser_current_image:
                 // View in browser
@@ -239,20 +242,21 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                     menu.findItem(R.id.menu_browser_current_image).setEnabled(true).setVisible(true);
                     menu.findItem(R.id.menu_share_current_image).setEnabled(true).setVisible(true);
                     menu.findItem(R.id.menu_download_current_image).setEnabled(true).setVisible(true);
+                    menu.findItem(R.id.menu_download_current_image).setEnabled(true).setVisible(true);
 
                     // Set ShareActionProvider Intent
-                    ShareActionProvider mShareActionProvider = (ShareActionProvider) MenuItemCompat.getActionProvider(menu.findItem(R.id.menu_share_current_image));
-                    // On some phones null is returned for some reason:
-                    // https://github.com/commons-app/apps-android-commons/issues/413
-                    if (mShareActionProvider != null) {
-                        Intent shareIntent = new Intent(Intent.ACTION_SEND);
-                        shareIntent.setType("text/plain");
-                        shareIntent.putExtra(Intent.EXTRA_TEXT,
-                                m.getDisplayTitle() + " \n" + m.getFilePageTitle().getCanonicalUri());
-                        mShareActionProvider.setShareIntent(shareIntent);
-                    }
+//                    ShareActionProvider mShareActionProvider = (ShareActionProvider) MenuItemCompat.getActionProvider(menu.findItem(R.id.menu_share_current_image));
+//                    // On some phones null is returned for some reason:
+//                    // https://github.com/commons-app/apps-android-commons/issues/413
+//                    if (mShareActionProvider != null) {
+//                        Intent shareIntent = new Intent(Intent.ACTION_SEND);
+//                        shareIntent.setType("text/plain");
+//                        shareIntent.putExtra(Intent.EXTRA_TEXT,
+//                                m.getDisplayTitle() + " \n" + m.getFilePageTitle().getCanonicalUri());
+//                        mShareActionProvider.setShareIntent(shareIntent);
+//                    }
 
-                    if (m instanceof Contribution) {
+                    if (m instanceof Contribution ) {
                         Contribution c = (Contribution) m;
                         switch (c.getState()) {
                             case Contribution.STATE_FAILED:

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -242,19 +242,6 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                     menu.findItem(R.id.menu_browser_current_image).setEnabled(true).setVisible(true);
                     menu.findItem(R.id.menu_share_current_image).setEnabled(true).setVisible(true);
                     menu.findItem(R.id.menu_download_current_image).setEnabled(true).setVisible(true);
-                    menu.findItem(R.id.menu_download_current_image).setEnabled(true).setVisible(true);
-
-                    // Set ShareActionProvider Intent
-//                    ShareActionProvider mShareActionProvider = (ShareActionProvider) MenuItemCompat.getActionProvider(menu.findItem(R.id.menu_share_current_image));
-//                    // On some phones null is returned for some reason:
-//                    // https://github.com/commons-app/apps-android-commons/issues/413
-//                    if (mShareActionProvider != null) {
-//                        Intent shareIntent = new Intent(Intent.ACTION_SEND);
-//                        shareIntent.setType("text/plain");
-//                        shareIntent.putExtra(Intent.EXTRA_TEXT,
-//                                m.getDisplayTitle() + " \n" + m.getFilePageTitle().getCanonicalUri());
-//                        mShareActionProvider.setShareIntent(shareIntent);
-//                    }
 
                     if (m instanceof Contribution ) {
                         Contribution c = (Contribution) m;

--- a/app/src/main/res/menu/fragment_image_detail.xml
+++ b/app/src/main/res/menu/fragment_image_detail.xml
@@ -4,7 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/menu_share_current_image"
-        app:actionProviderClass="android.support.v7.widget.ShareActionProvider"
+        android:icon="@drawable/ic_share_black_24dp"
         android:title="@string/menu_share"
         app:showAsAction="ifRoom" />
     <item


### PR DESCRIPTION
## Title 
Fixes #1621 (Add a back button in Media Details fragment when opening from Explore, Search) 

## Description 
- initialized back button on navigation base activity when media Details Fragment is Opened in Explore, Search
- Decreased size of share icon from 32 to 24dp (as 24 dp is recommended by Google for icons). 

## Tests performed

Manually Tested on API 25& MotoG5 S+, with {build variant, e.g. ProdDebug}.

## Screenshots showing what changed (optional)
 
Left Image -> Before and Right Image->After
<table>
<tr>
<td>

![screenshot_20180528-125328](https://user-images.githubusercontent.com/19607555/41330189-8ac88034-6eef-11e8-85d6-7612e387cc70.png)

</td>
<td>

![screenshot_20180613-095158](https://user-images.githubusercontent.com/19607555/41330265-1610c8fe-6ef0-11e8-98cf-cf162d4b3175.png)

</td>
</tr>
</table>