### PR TITLE
Fixes #1624 feat: support for landscape mode added

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
@@ -2,8 +2,10 @@ package fr.free.nrw.commons.explore.images;
 
 
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -86,7 +88,12 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,Bundle savedInstanceState) {
         View rootView = inflater.inflate(R.layout.fragment_browse_image, container, false);
         ButterKnife.bind(this, rootView);
-        imagesRecyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        if(getActivity().getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT){
+            imagesRecyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        }
+        else{
+            imagesRecyclerView.setLayoutManager(new GridLayoutManager(getContext(), 2));
+        }
         ArrayList<Media> items = new ArrayList<>();
         imagesAdapter = adapterFactory.create(items);
         imagesRecyclerView.setAdapter(imagesAdapter);


### PR DESCRIPTION
## Title 
Fixes #1624 (Show 2 images per row instead of 1 in landscape mode while searching)

## Description (required)

- Checked if Configuration is protrait or landscape and changed the Layout Manager to Linear or Grid accordingly.

## Tests performed (required)
Manually Tested on API 25 & MotoG5S+, with ProdDebug variant.

## Screenshots showing what changed

<table>
<tr>
<td>

![screenshot_20180613-203217](https://user-images.githubusercontent.com/19607555/41360006-5e4ba25c-6f49-11e8-9bff-53d056ef99d5.png)

Before
</td>
<td>

![screenshot_20180612-135416](https://user-images.githubusercontent.com/19607555/41360466-7a63403e-6f4a-11e8-9ea1-d8b309931416.png)

After
</td>
</tr>
</table>
