### PR TITLE
Fixes#1598 Fixed screen rotation issue on Explore and Search activity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
@@ -59,11 +59,6 @@ public class CategoryImagesActivity
         supportFragmentManager = getSupportFragmentManager();
         setCategoryImagesFragment();
         supportFragmentManager.addOnBackStackChangedListener(this);
-        if (savedInstanceState != null) {
-            mediaDetails = (MediaDetailPagerFragment) supportFragmentManager
-                    .findFragmentById(R.id.fragmentContainer);
-
-        }
         requestAuthToken();
         initDrawer();
         setPageTitle();
@@ -113,6 +108,16 @@ public class CategoryImagesActivity
             supportFragmentManager.executePendingTransactions();
         }
         mediaDetails.showImage(i);
+    }
+
+    @Override
+    protected void onResume() {
+        if (supportFragmentManager.getBackStackEntryCount()==1){
+            //FIXME: Temporary fix for screen rotation inside media details. If we don't call onBackPressed then fragment stack is increasing every time.
+            //FIXME: Similar issue like this https://github.com/commons-app/apps-android-commons/issues/894
+            onBackPressed();
+        }
+        super.onResume();
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -137,6 +137,17 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
         mediaDetails.showImage(index);
     }
 
+    @Override
+    protected void onResume() {
+        if (supportFragmentManager.getBackStackEntryCount()==1){
+            //FIXME: Temporary fix for screen rotation inside media details. If we don't call onBackPressed then fragment stack is increasing every time.
+            //FIXME: Similar issue like this https://github.com/commons-app/apps-android-commons/issues/894
+            // This is called on screen rotation when user is inside media details. Ideally it should show Media Details but since we are not saving the state now. We are throwing the user to search screen otherwise the app was crashing.
+            // 
+            onBackPressed();
+        }
+        super.onResume();
+    }
 
     @Override
     public void onBackPressed() {


### PR DESCRIPTION
## Title (required)
Fixes #1579 (Explore crashes when rotating screen)
Fixes #1598 (ClassCastException: CategoryImagesListFragment cannot be cast to MediaDetailPagerFragment) 
Both are actually same issues

## Description (required)
- Removed line that was creating issue.
- implemented onBackPressed in onResume as this will be called on screen rotation. Checking if user is inside Media Detail Fragment if yes we are returning to list.

Please read comments for more details.

## Tests performed (required)
Manually Tested on API 25, with ProdDebug variant.