### PR TITLE
Fixes #1639 (Category search Added)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/di/FragmentBuilderModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/FragmentBuilderModule.java
@@ -5,6 +5,7 @@ import dagger.android.ContributesAndroidInjector;
 import fr.free.nrw.commons.category.CategorizationFragment;
 import fr.free.nrw.commons.contributions.ContributionsListFragment;
 import fr.free.nrw.commons.category.CategoryImagesListFragment;
+import fr.free.nrw.commons.explore.categories.SearchCategoryFragment;
 import fr.free.nrw.commons.explore.images.SearchImageFragment;
 import fr.free.nrw.commons.explore.recentsearches.RecentSearchesFragment;
 import fr.free.nrw.commons.media.MediaDetailFragment;
@@ -55,6 +56,9 @@ public abstract class FragmentBuilderModule {
 
     @ContributesAndroidInjector
     abstract SearchImageFragment bindBrowseImagesListFragment();
+
+    @ContributesAndroidInjector
+    abstract SearchCategoryFragment bindSearchCategoryListFragment();
 
     @ContributesAndroidInjector
     abstract RecentSearchesFragment bindRecentSearchesFragment();

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -84,7 +84,7 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
         searchImageFragment = new SearchImageFragment();
         searchCategoryFragment= new SearchCategoryFragment();
         fragmentList.add(searchImageFragment);
-        titleList.add("IMAGES");
+        titleList.add("MEDIA");
         fragmentList.add(searchCategoryFragment);
         titleList.add("CATEGORIES");
 

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -39,7 +39,6 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 public class SearchActivity extends NavigationBaseActivity implements MediaDetailPagerFragment.MediaDetailProvider{
 
     @BindView(R.id.toolbar_search) Toolbar toolbar;
-//    @BindView(R.id.fragmentContainer) FrameLayout resultsContainer;
     @BindView(R.id.searchHistoryContainer) FrameLayout searchHistoryContainer;
     @BindView(R.id.searchBox) SearchView searchView;
     @BindView(R.id.tabLayout) TabLayout tabLayout;
@@ -62,7 +61,6 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
         setTitle(getString(R.string.title_activity_search));
         toolbar.setNavigationOnClickListener(v->onBackPressed());
         supportFragmentManager = getSupportFragmentManager();
-//        setBrowseImagesFragment();
         setSearchHistoryFragment();
         viewPagerAdapter = new ViewPagerAdapter(getSupportFragmentManager());
         viewPager.setAdapter(viewPagerAdapter);
@@ -87,8 +85,8 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
         searchCategoryFragment= new SearchCategoryFragment();
         fragmentList.add(searchImageFragment);
         titleList.add("IMAGES");
-//        fragmentList.add(searchCategoryFragment);
-//        titleList.add("CATEGORIES");
+        fragmentList.add(searchCategoryFragment);
+        titleList.add("CATEGORIES");
 
         viewPagerAdapter.setTabData(fragmentList, titleList);
         viewPagerAdapter.notifyDataSetChanged();
@@ -111,13 +109,6 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
                             }
                         }
                 );
-    }
-
-    private void setBrowseImagesFragment() {
-        searchImageFragment = new SearchImageFragment();
-        FragmentTransaction transaction = supportFragmentManager.beginTransaction();
-        transaction.add(R.id.fragmentContainer, searchImageFragment).commit();
-
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -12,6 +12,7 @@ import android.text.TextUtils;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.SearchView;
+import android.widget.Toast;
 
 import com.jakewharton.rxbinding2.view.RxView;
 import com.jakewharton.rxbinding2.widget.RxSearchView;
@@ -40,6 +41,7 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
 
     @BindView(R.id.toolbar_search) Toolbar toolbar;
     @BindView(R.id.searchHistoryContainer) FrameLayout searchHistoryContainer;
+    @BindView(R.id.mediaContainer) FrameLayout mediaContainer;
     @BindView(R.id.searchBox) SearchView searchView;
     @BindView(R.id.tabLayout) TabLayout tabLayout;
     @BindView(R.id.viewPager) ViewPager viewPager;
@@ -146,6 +148,9 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
     public void onSearchImageClicked(int index) {
         ViewUtil.hideKeyboard(this.findViewById(R.id.searchBox));
         toolbar.setVisibility(View.GONE);
+        tabLayout.setVisibility(View.GONE);
+        viewPager.setVisibility(View.GONE);
+        mediaContainer.setVisibility(View.VISIBLE);
         setNavigationBaseToolbarVisibility(true);
         if (mediaDetails == null || !mediaDetails.isVisible()) {
             // set isFeaturedImage true for featured images, to include author field on media detail
@@ -153,7 +158,7 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
             FragmentManager supportFragmentManager = getSupportFragmentManager();
             supportFragmentManager
                     .beginTransaction()
-                    .replace(R.id.fragmentContainer, mediaDetails)
+                    .replace(R.id.mediaContainer, mediaDetails)
                     .addToBackStack(null)
                     .commit();
             supportFragmentManager.executePendingTransactions();
@@ -179,6 +184,9 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
         if (getSupportFragmentManager().getBackStackEntryCount() == 1){
             // back to search so show search toolbar and hide navigation toolbar
             toolbar.setVisibility(View.VISIBLE);
+            tabLayout.setVisibility(View.VISIBLE);
+            viewPager.setVisibility(View.VISIBLE);
+            mediaContainer.setVisibility(View.GONE);
             setNavigationBaseToolbarVisibility(false);
             if (!TextUtils.isEmpty(query)) {
                 searchImageFragment.updateImageList(query);
@@ -191,7 +199,7 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
     }
 
     public void updateText(String query) {
-        searchView.setQuery(query, true);;
+        searchView.setQuery(query, true);
         // Clear focus of searchView now. searchView.clearFocus(); does not seem to work Check the below link for more details.
         // https://stackoverflow.com/questions/6117967/how-to-remove-focus-without-setting-focus-to-another-control/15481511
         viewPager.requestFocus();

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -2,6 +2,7 @@ package fr.free.nrw.commons.explore;
 
 import android.database.DataSetObserver;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.widget.Toolbar;
@@ -13,12 +14,15 @@ import android.widget.SearchView;
 import com.jakewharton.rxbinding2.view.RxView;
 import com.jakewharton.rxbinding2.widget.RxSearchView;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.explore.categories.SearchCategoryFragment;
 import fr.free.nrw.commons.explore.images.SearchImageFragment;
 import fr.free.nrw.commons.explore.recentsearches.RecentSearchesFragment;
 import fr.free.nrw.commons.media.MediaDetailPagerFragment;
@@ -41,6 +45,7 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
     private FragmentManager supportFragmentManager;
     private MediaDetailPagerFragment mediaDetails;
     private String query;
+    ViewPagerAdapter viewPagerAdapter;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -56,6 +61,27 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
         searchView.setQueryHint(getString(R.string.search_commons));
         searchView.onActionViewExpanded();
         searchView.clearFocus();
+
+    }
+
+    private void setSearchHistoryFragment() {
+        recentSearchesFragment = new RecentSearchesFragment();
+        FragmentTransaction transaction = supportFragmentManager.beginTransaction();
+        transaction.add(R.id.searchHistoryContainer, recentSearchesFragment).commit();
+    }
+
+    public void setTabs() {
+        List<Fragment> fragmentList = new ArrayList<>();
+        List<String> titleList = new ArrayList<>();
+        SearchImageFragment browseImageFragment = new SearchImageFragment();
+        SearchCategoryFragment browseCategoryFragment = new SearchCategoryFragment();
+        fragmentList.add(browseImageFragment);
+        titleList.add("IMAGES");
+        fragmentList.add(browseCategoryFragment);
+        titleList.add("CATEGORIES");
+
+        viewPagerAdapter.setTabData(fragmentList, titleList);
+        viewPagerAdapter.notifyDataSetChanged();
         RxSearchView.queryTextChanges(searchView)
                 .takeUntil(RxView.detaches(searchView))
                 .debounce(500, TimeUnit.MILLISECONDS)
@@ -67,6 +93,7 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
                                 searchHistoryContainer.setVisibility(View.GONE);
                                 this.query = query.toString();
                                 searchImageFragment.updateImageList(query.toString());
+                                browseCategoryFragment.updateCategoryList(filter.toString());
                             }else {
                                 resultsContainer.setVisibility(View.GONE);
                                 searchHistoryContainer.setVisibility(View.VISIBLE);
@@ -75,13 +102,6 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
                         }
                 );
     }
-
-    private void setSearchHistoryFragment() {
-        recentSearchesFragment = new RecentSearchesFragment();
-        FragmentTransaction transaction = supportFragmentManager.beginTransaction();
-        transaction.add(R.id.searchHistoryContainer, recentSearchesFragment).commit();
-    }
-
 
     private void setBrowseImagesFragment() {
         searchImageFragment = new SearchImageFragment();

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -78,6 +78,9 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
         transaction.add(R.id.searchHistoryContainer, recentSearchesFragment).commit();
     }
 
+    /**
+     * Sets the titles in the tabLayout and fragments in the viewPager
+     */
     public void setTabs() {
         List<Fragment> fragmentList = new ArrayList<>();
         List<String> titleList = new ArrayList<>();

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -2,9 +2,11 @@ package fr.free.nrw.commons.explore;
 
 import android.database.DataSetObserver;
 import android.os.Bundle;
+import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.view.ViewPager;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.view.View;
@@ -37,10 +39,14 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 public class SearchActivity extends NavigationBaseActivity implements MediaDetailPagerFragment.MediaDetailProvider{
 
     @BindView(R.id.toolbar_search) Toolbar toolbar;
-    @BindView(R.id.fragmentContainer) FrameLayout resultsContainer;
+//    @BindView(R.id.fragmentContainer) FrameLayout resultsContainer;
     @BindView(R.id.searchHistoryContainer) FrameLayout searchHistoryContainer;
     @BindView(R.id.searchBox) SearchView searchView;
+    @BindView(R.id.tabLayout) TabLayout tabLayout;
+    @BindView(R.id.viewPager) ViewPager viewPager;
+
     private SearchImageFragment searchImageFragment;
+    private SearchCategoryFragment searchCategoryFragment;
     private RecentSearchesFragment recentSearchesFragment;
     private FragmentManager supportFragmentManager;
     private MediaDetailPagerFragment mediaDetails;
@@ -56,8 +62,12 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
         setTitle(getString(R.string.title_activity_search));
         toolbar.setNavigationOnClickListener(v->onBackPressed());
         supportFragmentManager = getSupportFragmentManager();
-        setBrowseImagesFragment();
+//        setBrowseImagesFragment();
         setSearchHistoryFragment();
+        viewPagerAdapter = new ViewPagerAdapter(getSupportFragmentManager());
+        viewPager.setAdapter(viewPagerAdapter);
+        tabLayout.setupWithViewPager(viewPager);
+        setTabs();
         searchView.setQueryHint(getString(R.string.search_commons));
         searchView.onActionViewExpanded();
         searchView.clearFocus();
@@ -73,12 +83,12 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
     public void setTabs() {
         List<Fragment> fragmentList = new ArrayList<>();
         List<String> titleList = new ArrayList<>();
-        SearchImageFragment browseImageFragment = new SearchImageFragment();
-        SearchCategoryFragment browseCategoryFragment = new SearchCategoryFragment();
-        fragmentList.add(browseImageFragment);
+        searchImageFragment = new SearchImageFragment();
+        searchCategoryFragment= new SearchCategoryFragment();
+        fragmentList.add(searchImageFragment);
         titleList.add("IMAGES");
-        fragmentList.add(browseCategoryFragment);
-        titleList.add("CATEGORIES");
+//        fragmentList.add(searchCategoryFragment);
+//        titleList.add("CATEGORIES");
 
         viewPagerAdapter.setTabData(fragmentList, titleList);
         viewPagerAdapter.notifyDataSetChanged();
@@ -89,13 +99,13 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
                 .subscribe( query -> {
                             //update image list
                             if (!TextUtils.isEmpty(query)) {
-                                resultsContainer.setVisibility(View.VISIBLE);
+                                viewPager.setVisibility(View.VISIBLE);
                                 searchHistoryContainer.setVisibility(View.GONE);
                                 this.query = query.toString();
                                 searchImageFragment.updateImageList(query.toString());
-                                browseCategoryFragment.updateCategoryList(filter.toString());
+                                searchCategoryFragment.updateCategoryList(query.toString());
                             }else {
-                                resultsContainer.setVisibility(View.GONE);
+                                viewPager.setVisibility(View.GONE);
                                 searchHistoryContainer.setVisibility(View.VISIBLE);
                                 // open search history fragment
                             }
@@ -190,6 +200,6 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
         searchView.setQuery(query, true);;
         // Clear focus of searchView now. searchView.clearFocus(); does not seem to work Check the below link for more details.
         // https://stackoverflow.com/questions/6117967/how-to-remove-focus-without-setting-focus-to-another-control/15481511
-        resultsContainer.requestFocus();
+        viewPager.requestFocus();
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/explore/ViewPagerAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/ViewPagerAdapter.java
@@ -1,0 +1,44 @@
+package fr.free.nrw.commons.explore;
+
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+class ViewPagerAdapter extends FragmentPagerAdapter {
+    private List<Fragment> fragmentList = new ArrayList<>();
+    private List<String> fragmentTitleList = new ArrayList<>();
+
+    public ViewPagerAdapter(FragmentManager manager) {
+        super(manager);
+    }
+
+    @Override
+    public Fragment getItem(int position) {
+        return fragmentList.get(position);
+    }
+
+    @Override
+    public int getCount() {
+        return fragmentList.size();
+    }
+
+    public void setTabData(List<Fragment> fragmentList, List<String> fragmentTitleList) {
+        this.fragmentList = fragmentList;
+        this.fragmentTitleList = fragmentTitleList;
+    }
+
+    @Override
+    public CharSequence getPageTitle(int position) {
+        return fragmentTitleList.get(position);
+    }
+
+
+    @Override
+    public int getItemPosition(Object object) {
+        return POSITION_NONE;
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/explore/ViewPagerAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/ViewPagerAdapter.java
@@ -7,7 +7,9 @@ import android.support.v4.app.FragmentPagerAdapter;
 import java.util.ArrayList;
 import java.util.List;
 
-
+/**
+ * This adapter will be used to display fragments in a ViewPager
+ */
 class ViewPagerAdapter extends FragmentPagerAdapter {
     private List<Fragment> fragmentList = new ArrayList<>();
     private List<String> fragmentTitleList = new ArrayList<>();

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesAdapterFactory.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesAdapterFactory.java
@@ -7,9 +7,6 @@ import com.pedrogomez.renderers.RendererBuilder;
 import java.util.Collections;
 import java.util.List;
 
-import fr.free.nrw.commons.Media;
-
-
 class SearchCategoriesAdapterFactory {
     private final SearchCategoriesRenderer.ImageClickedListener listener;
 
@@ -17,11 +14,10 @@ class SearchCategoriesAdapterFactory {
         this.listener = listener;
     }
 
-    public RVRendererAdapter<Media> create(List<Media> searchImageItemList) {
-        RendererBuilder<Media> builder = new RendererBuilder<Media>()
-                .bind(Media.class, new SearchCategoriesRenderer(listener));
-        ListAdapteeCollection<Media> collection = new ListAdapteeCollection<>(
-                searchImageItemList != null ? searchImageItemList : Collections.<Media>emptyList());
+    public RVRendererAdapter<String> create(List<String> searchImageItemList) {
+        RendererBuilder<String> builder = new RendererBuilder<String>().bind(String.class, new SearchCategoriesRenderer(listener));
+        ListAdapteeCollection<String> collection = new ListAdapteeCollection<>(
+                searchImageItemList != null ? searchImageItemList : Collections.<String>emptyList());
         return new RVRendererAdapter<>(builder, collection);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesAdapterFactory.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesAdapterFactory.java
@@ -8,19 +8,18 @@ import java.util.Collections;
 import java.util.List;
 
 import fr.free.nrw.commons.Media;
-import fr.free.nrw.commons.explore.images.SearchImagesRenderer;
 
 
 class SearchCategoriesAdapterFactory {
-    private final SearchImagesRenderer.ImageClickedListener listener;
+    private final SearchCategoriesRenderer.ImageClickedListener listener;
 
-    SearchCategoriesAdapterFactory(SearchImagesRenderer.ImageClickedListener listener) {
+    SearchCategoriesAdapterFactory(SearchCategoriesRenderer.ImageClickedListener listener) {
         this.listener = listener;
     }
 
     public RVRendererAdapter<Media> create(List<Media> searchImageItemList) {
         RendererBuilder<Media> builder = new RendererBuilder<Media>()
-                .bind(Media.class, new SearchImagesRenderer(listener));
+                .bind(Media.class, new SearchCategoriesRenderer(listener));
         ListAdapteeCollection<Media> collection = new ListAdapteeCollection<>(
                 searchImageItemList != null ? searchImageItemList : Collections.<Media>emptyList());
         return new RVRendererAdapter<>(builder, collection);

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesAdapterFactory.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesAdapterFactory.java
@@ -8,9 +8,9 @@ import java.util.Collections;
 import java.util.List;
 
 class SearchCategoriesAdapterFactory {
-    private final SearchCategoriesRenderer.ImageClickedListener listener;
+    private final SearchCategoriesRenderer.CategoryClickedListener listener;
 
-    SearchCategoriesAdapterFactory(SearchCategoriesRenderer.ImageClickedListener listener) {
+    SearchCategoriesAdapterFactory(SearchCategoriesRenderer.CategoryClickedListener listener) {
         this.listener = listener;
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesAdapterFactory.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesAdapterFactory.java
@@ -1,0 +1,28 @@
+package fr.free.nrw.commons.explore.categories;
+
+import com.pedrogomez.renderers.ListAdapteeCollection;
+import com.pedrogomez.renderers.RVRendererAdapter;
+import com.pedrogomez.renderers.RendererBuilder;
+
+import java.util.Collections;
+import java.util.List;
+
+import fr.free.nrw.commons.Media;
+import fr.free.nrw.commons.explore.images.SearchImagesRenderer;
+
+
+class SearchCategoriesAdapterFactory {
+    private final SearchImagesRenderer.ImageClickedListener listener;
+
+    SearchCategoriesAdapterFactory(SearchImagesRenderer.ImageClickedListener listener) {
+        this.listener = listener;
+    }
+
+    public RVRendererAdapter<Media> create(List<Media> searchImageItemList) {
+        RendererBuilder<Media> builder = new RendererBuilder<Media>()
+                .bind(Media.class, new SearchImagesRenderer(listener));
+        ListAdapteeCollection<Media> collection = new ListAdapteeCollection<>(
+                searchImageItemList != null ? searchImageItemList : Collections.<Media>emptyList());
+        return new RVRendererAdapter<>(builder, collection);
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesRenderer.java
@@ -18,9 +18,9 @@ import fr.free.nrw.commons.R;
 class SearchCategoriesRenderer extends Renderer<String> {
     @BindView(R.id.textView1) TextView tvCategoryName;
 
-    private final ImageClickedListener listener;
+    private final CategoryClickedListener listener;
 
-    SearchCategoriesRenderer(ImageClickedListener listener) {
+    SearchCategoriesRenderer(CategoryClickedListener listener) {
         this.listener = listener;
     }
 
@@ -39,7 +39,7 @@ class SearchCategoriesRenderer extends Renderer<String> {
         view.setOnClickListener(v -> {
             String item = getContent();
             if (listener != null) {
-                listener.imageClicked(item);
+                listener.categoryClicked(item);
             }
         });
     }
@@ -50,8 +50,8 @@ class SearchCategoriesRenderer extends Renderer<String> {
         tvCategoryName.setText(item);
     }
 
-    interface ImageClickedListener {
-        void imageClicked(String item);
+    interface CategoryClickedListener {
+        void categoryClicked(String item);
     }
 
 }

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesRenderer.java
@@ -9,15 +9,14 @@ import com.pedrogomez.renderers.Renderer;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
 
 /**
- * presentation logic of individual image in search is handled here
+ * presentation logic of individual category in search is handled here
  */
 
-class SearchCategoriesRenderer extends Renderer<Media> {
-    @BindView(R.id.categoryImageTitle) TextView tvImageName;
+class SearchCategoriesRenderer extends Renderer<String> {
+    @BindView(R.id.textView1) TextView tvCategoryName;
 
     private final ImageClickedListener listener;
 
@@ -27,7 +26,7 @@ class SearchCategoriesRenderer extends Renderer<Media> {
 
     @Override
     protected View inflate(LayoutInflater layoutInflater, ViewGroup viewGroup) {
-        return layoutInflater.inflate(R.layout.layout_category_images, viewGroup, false);
+        return layoutInflater.inflate(R.layout.item_recent_searches, viewGroup, false);
     }
 
     @Override
@@ -38,7 +37,7 @@ class SearchCategoriesRenderer extends Renderer<Media> {
     @Override
     protected void hookListeners(View view) {
         view.setOnClickListener(v -> {
-            Media item = getContent();
+            String item = getContent();
             if (listener != null) {
                 listener.imageClicked(item);
             }
@@ -47,12 +46,12 @@ class SearchCategoriesRenderer extends Renderer<Media> {
 
     @Override
     public void render() {
-        Media item = getContent();
-        tvImageName.setText(item.getFilename());
+        String item = getContent();
+        tvCategoryName.setText(item);
     }
 
     interface ImageClickedListener {
-        void imageClicked(Media item);
+        void imageClicked(String item);
     }
 
 }

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesRenderer.java
@@ -10,7 +10,6 @@ import com.pedrogomez.renderers.Renderer;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import fr.free.nrw.commons.Media;
-import fr.free.nrw.commons.MediaWikiImageView;
 import fr.free.nrw.commons.R;
 
 /**
@@ -19,9 +18,6 @@ import fr.free.nrw.commons.R;
 
 class SearchCategoriesRenderer extends Renderer<Media> {
     @BindView(R.id.categoryImageTitle) TextView tvImageName;
-    @BindView(R.id.categoryImageAuthor) TextView categoryImageAuthor;
-    @BindView(R.id.categoryImageView)
-    MediaWikiImageView browseImage;
 
     private final ImageClickedListener listener;
 
@@ -53,24 +49,10 @@ class SearchCategoriesRenderer extends Renderer<Media> {
     public void render() {
         Media item = getContent();
         tvImageName.setText(item.getFilename());
-        browseImage.setMedia(item);
-        setAuthorView(item, categoryImageAuthor);
     }
 
     interface ImageClickedListener {
         void imageClicked(Media item);
     }
 
-    /**
-     * formats author name as "Uploaded by: authorName" and sets it in textview
-     */
-    private void setAuthorView(Media item, TextView author) {
-        if (item.getCreator() != null && !item.getCreator().equals("")) {
-            author.setVisibility(View.GONE);
-            String uploadedByTemplate = getContext().getString(R.string.image_uploaded_by);
-            author.setText(String.format(uploadedByTemplate, item.getCreator()));
-        } else {
-            author.setVisibility(View.VISIBLE);
-        }
-    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesRenderer.java
@@ -1,0 +1,76 @@
+package fr.free.nrw.commons.explore.categories;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import com.pedrogomez.renderers.Renderer;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import fr.free.nrw.commons.Media;
+import fr.free.nrw.commons.MediaWikiImageView;
+import fr.free.nrw.commons.R;
+
+/**
+ * presentation logic of individual image in search is handled here
+ */
+
+class SearchCategoriesRenderer extends Renderer<Media> {
+    @BindView(R.id.categoryImageTitle) TextView tvImageName;
+    @BindView(R.id.categoryImageAuthor) TextView categoryImageAuthor;
+    @BindView(R.id.categoryImageView)
+    MediaWikiImageView browseImage;
+
+    private final ImageClickedListener listener;
+
+    SearchCategoriesRenderer(ImageClickedListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    protected View inflate(LayoutInflater layoutInflater, ViewGroup viewGroup) {
+        return layoutInflater.inflate(R.layout.layout_category_images, viewGroup, false);
+    }
+
+    @Override
+    protected void setUpView(View view) {
+        ButterKnife.bind(this, view);
+    }
+
+    @Override
+    protected void hookListeners(View view) {
+        view.setOnClickListener(v -> {
+            Media item = getContent();
+            if (listener != null) {
+                listener.imageClicked(item);
+            }
+        });
+    }
+
+    @Override
+    public void render() {
+        Media item = getContent();
+        tvImageName.setText(item.getFilename());
+        browseImage.setMedia(item);
+        setAuthorView(item, categoryImageAuthor);
+    }
+
+    interface ImageClickedListener {
+        void imageClicked(Media item);
+    }
+
+    /**
+     * formats author name as "Uploaded by: authorName" and sets it in textview
+     */
+    private void setAuthorView(Media item, TextView author) {
+        if (item.getCreator() != null && !item.getCreator().equals("")) {
+            author.setVisibility(View.GONE);
+            String uploadedByTemplate = getContext().getString(R.string.image_uploaded_by);
+            author.setText(String.format(uploadedByTemplate, item.getCreator()));
+        } else {
+            author.setVisibility(View.VISIBLE);
+        }
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -164,7 +164,6 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
      * @param mediaList
      */
     private void handleSuccess(List<String> mediaList) {
-        categoriesNotFoundView.setVisibility(GONE);
         queryList = mediaList;
         if(mediaList == null || mediaList.isEmpty()) {
             initErrorView();

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -116,6 +116,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
      */
     public void updateCategoryList(String query) {
         this.query = query;
+        categoriesNotFoundView.setVisibility(GONE);
         if(!NetworkUtils.isInternetConnectionEstablished(getContext())) {
             handleNoInternet();
             return;

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -1,0 +1,241 @@
+package fr.free.nrw.commons.explore.categories;
+
+
+import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.os.Bundle;
+import android.os.Handler;
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import com.pedrogomez.renderers.RVRendererAdapter;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import fr.free.nrw.commons.Media;
+import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
+import fr.free.nrw.commons.explore.SearchActivity;
+import fr.free.nrw.commons.explore.images.SearchImagesAdapterFactory;
+import fr.free.nrw.commons.explore.recentsearches.RecentSearch;
+import fr.free.nrw.commons.explore.recentsearches.RecentSearchesDao;
+import fr.free.nrw.commons.mwapi.MediaWikiApi;
+import fr.free.nrw.commons.utils.NetworkUtils;
+import fr.free.nrw.commons.utils.ViewUtil;
+import io.reactivex.Observable;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
+import timber.log.Timber;
+
+import static android.view.View.GONE;
+import static android.view.View.VISIBLE;
+
+/**
+ * Displays the image search screen.
+ */
+
+public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
+
+    private static int TIMEOUT_SECONDS = 15;
+
+    @BindView(R.id.imagesListBox)
+    RecyclerView imagesRecyclerView;
+    @BindView(R.id.imageSearchInProgress)
+    ProgressBar progressBar;
+    @BindView(R.id.imagesNotFound)
+    TextView imagesNotFoundView;
+    String query;
+
+    @Inject RecentSearchesDao recentSearchesDao;
+    @Inject MediaWikiApi mwApi;
+    @Inject @Named("default_preferences") SharedPreferences prefs;
+
+    private RVRendererAdapter<Media> imagesAdapter;
+    private List<Media> queryList = new ArrayList<>();
+
+    private final SearchImagesAdapterFactory adapterFactory = new SearchImagesAdapterFactory(item -> {
+        int index = queryList.indexOf(item);
+        ((SearchActivity)getContext()).onSearchImageClicked(index);
+        saveQuery(query);
+    });
+
+    private void saveQuery(String query) {
+        RecentSearch recentSearch = recentSearchesDao.find(query);
+
+        // Newly searched query...
+        if (recentSearch == null) {
+            recentSearch = new RecentSearch(null, query, new Date());
+        }
+        else {
+            recentSearch.setLastSearched(new Date());
+        }
+
+        recentSearchesDao.save(recentSearch);
+
+    }
+
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,Bundle savedInstanceState) {
+        View rootView = inflater.inflate(R.layout.fragment_browse_image, container, false);
+        ButterKnife.bind(this, rootView);
+        if(getActivity().getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT){
+            imagesRecyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        }
+        else{
+            imagesRecyclerView.setLayoutManager(new GridLayoutManager(getContext(), 2));
+        }
+        ArrayList<Media> items = new ArrayList<>();
+        imagesAdapter = adapterFactory.create(items);
+        imagesRecyclerView.setAdapter(imagesAdapter);
+        imagesRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
+            @Override
+            public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
+                super.onScrollStateChanged(recyclerView, newState);
+                // check if end of recycler view is reached, if yes then add more results to existing results
+                if (!recyclerView.canScrollVertically(1)) {
+                    addImagesToList(query);
+                }
+            }
+        });
+        return rootView;
+    }
+
+    /**
+     * Checks for internet connection and then initializes the recycler view with 25 images of the searched query
+     * Clearing imageAdapter every time new keyword is searched so that user can see only new results
+     */
+    public void updateImageList(String query) {
+        this.query = query;
+        if(!NetworkUtils.isInternetConnectionEstablished(getContext())) {
+            handleNoInternet();
+            return;
+        }
+        progressBar.setVisibility(View.VISIBLE);
+        queryList.clear();
+        imagesAdapter.clear();
+        Observable.fromCallable(() -> mwApi.searchImages(query,queryList.size()))
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .subscribe(this::handleSuccess, this::handleError);
+    }
+
+
+    /**
+     * Adds more results to existing search results
+     */
+    public void addImagesToList(String query) {
+        this.query = query;
+        progressBar.setVisibility(View.VISIBLE);
+        Observable.fromCallable(() -> mwApi.searchImages(query,queryList.size()))
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .subscribe(this::handlePaginationSuccess, this::handleError);
+    }
+
+    /**
+     * Handles the success scenario
+     * it initializes the recycler view by adding items to the adapter
+     * @param mediaList
+     */
+    private void handlePaginationSuccess(List<Media> mediaList) {
+        queryList.addAll(mediaList);
+        progressBar.setVisibility(View.GONE);
+        imagesAdapter.addAll(mediaList);
+        imagesAdapter.notifyDataSetChanged();
+    }
+
+
+
+    /**
+     * Handles the success scenario
+     * it initializes the recycler view by adding items to the adapter
+     * @param mediaList
+     */
+    private void handleSuccess(List<Media> mediaList) {
+        imagesNotFoundView.setVisibility(GONE);
+        queryList = mediaList;
+        if(mediaList == null || mediaList.isEmpty()) {
+            initErrorView();
+        }
+        else {
+
+            progressBar.setVisibility(View.GONE);
+            imagesAdapter.addAll(mediaList);
+            imagesAdapter.notifyDataSetChanged();
+
+            // check if user is waiting for 5 seconds if yes then save search query to history.
+            Handler handler = new Handler();
+            handler.postDelayed(() -> saveQuery(query), 5000);
+        }
+    }
+
+    /**
+     * Logs and handles API error scenario
+     * @param throwable
+     */
+    private void handleError(Throwable throwable) {
+        Timber.e(throwable, "Error occurred while loading queried images");
+        initErrorView();
+        ViewUtil.showSnackbar(imagesRecyclerView, R.string.error_loading_images);
+    }
+
+    /**
+     * Handles the UI updates for a error scenario
+     */
+    private void initErrorView() {
+        progressBar.setVisibility(GONE);
+        imagesNotFoundView.setVisibility(VISIBLE);
+        imagesNotFoundView.setText(getString(R.string.images_not_found, query));
+    }
+
+    /**
+     * Handles the UI updates for no internet scenario
+     */
+    private void handleNoInternet() {
+        progressBar.setVisibility(GONE);
+        ViewUtil.showSnackbar(imagesRecyclerView, R.string.no_internet);
+    }
+
+    /**
+    * returns total number of images present in the recyclerview adapter.
+    */
+    public int getTotalImagesCount(){
+        if (imagesAdapter == null) {
+            return 0;
+        }
+        else {
+            return imagesAdapter.getItemCount();
+        }
+    }
+
+    /**
+     * returns Media Object at position
+     * @param i position of Media in the recyclerview adapter.
+     */
+    public Media getImageAtPosition(int i) {
+        if (imagesAdapter.getItem(i).getFilename() == null) {
+            // not yet ready to return data
+            return null;
+        }
+        else {
+            return new Media(imagesAdapter.getItem(i).getFilename());
+        }
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -26,7 +26,6 @@ import javax.inject.Named;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.explore.SearchActivity;
@@ -63,8 +62,8 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
     @Inject MediaWikiApi mwApi;
     @Inject @Named("default_preferences") SharedPreferences prefs;
 
-    private RVRendererAdapter<Media> imagesAdapter;
-    private List<Media> queryList = new ArrayList<>();
+    private RVRendererAdapter<String> imagesAdapter;
+    private List<String> queryList = new ArrayList<>();
 
     private final SearchCategoriesAdapterFactory adapterFactory = new SearchCategoriesAdapterFactory(item -> {
         int index = queryList.indexOf(item);
@@ -98,7 +97,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
         else{
             imagesRecyclerView.setLayoutManager(new GridLayoutManager(getContext(), 2));
         }
-        ArrayList<Media> items = new ArrayList<>();
+        ArrayList<String> items = new ArrayList<>();
         imagesAdapter = adapterFactory.create(items);
         imagesRecyclerView.setAdapter(imagesAdapter);
         imagesRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
@@ -127,7 +126,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
         progressBar.setVisibility(View.VISIBLE);
         queryList.clear();
         imagesAdapter.clear();
-        Observable.fromCallable(() -> mwApi.searchImages(query,queryList.size()))
+        Observable.fromCallable(() -> mwApi.searchCategory(query,queryList.size()))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
@@ -141,7 +140,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
     public void addImagesToList(String query) {
         this.query = query;
         progressBar.setVisibility(View.VISIBLE);
-        Observable.fromCallable(() -> mwApi.searchImages(query,queryList.size()))
+        Observable.fromCallable(() -> mwApi.searchCategory(query,queryList.size()))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
@@ -153,7 +152,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
      * it initializes the recycler view by adding items to the adapter
      * @param mediaList
      */
-    private void handlePaginationSuccess(List<Media> mediaList) {
+    private void handlePaginationSuccess(List<String> mediaList) {
         queryList.addAll(mediaList);
         progressBar.setVisibility(View.GONE);
         imagesAdapter.addAll(mediaList);
@@ -167,7 +166,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
      * it initializes the recycler view by adding items to the adapter
      * @param mediaList
      */
-    private void handleSuccess(List<Media> mediaList) {
+    private void handleSuccess(List<String> mediaList) {
         imagesNotFoundView.setVisibility(GONE);
         queryList = mediaList;
         if(mediaList == null || mediaList.isEmpty()) {
@@ -210,31 +209,5 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
     private void handleNoInternet() {
         progressBar.setVisibility(GONE);
         ViewUtil.showSnackbar(imagesRecyclerView, R.string.no_internet);
-    }
-
-    /**
-    * returns total number of images present in the recyclerview adapter.
-    */
-    public int getTotalImagesCount(){
-        if (imagesAdapter == null) {
-            return 0;
-        }
-        else {
-            return imagesAdapter.getItemCount();
-        }
-    }
-
-    /**
-     * returns Media Object at position
-     * @param i position of Media in the recyclerview adapter.
-     */
-    public Media getImageAtPosition(int i) {
-        if (imagesAdapter.getItem(i).getFilename() == null) {
-            // not yet ready to return data
-            return null;
-        }
-        else {
-            return new Media(imagesAdapter.getItem(i).getFilename());
-        }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -118,7 +118,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
      * Checks for internet connection and then initializes the recycler view with 25 images of the searched query
      * Clearing imageAdapter every time new keyword is searched so that user can see only new results
      */
-    public void updateImageList(String query) {
+    public void updateCategoryList(String query) {
         this.query = query;
         if(!NetworkUtils.isInternetConnectionEstablished(getContext())) {
             handleNoInternet();

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -30,7 +30,6 @@ import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.explore.SearchActivity;
-import fr.free.nrw.commons.explore.images.SearchImagesAdapterFactory;
 import fr.free.nrw.commons.explore.recentsearches.RecentSearch;
 import fr.free.nrw.commons.explore.recentsearches.RecentSearchesDao;
 import fr.free.nrw.commons.mwapi.MediaWikiApi;
@@ -67,7 +66,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
     private RVRendererAdapter<Media> imagesAdapter;
     private List<Media> queryList = new ArrayList<>();
 
-    private final SearchImagesAdapterFactory adapterFactory = new SearchImagesAdapterFactory(item -> {
+    private final SearchCategoriesAdapterFactory adapterFactory = new SearchCategoriesAdapterFactory(item -> {
         int index = queryList.indexOf(item);
         ((SearchActivity)getContext()).onSearchImageClicked(index);
         saveQuery(query);

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -42,7 +42,7 @@ import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 
 /**
- * Displays the image search screen.
+ * Displays the category search screen.
  */
 
 public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
@@ -54,7 +54,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
     @BindView(R.id.imageSearchInProgress)
     ProgressBar progressBar;
     @BindView(R.id.imagesNotFound)
-    TextView imagesNotFoundView;
+    TextView categoriesNotFoundView;
     String query;
 
     @Inject RecentSearchesDao recentSearchesDao;
@@ -103,7 +103,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
                 super.onScrollStateChanged(recyclerView, newState);
                 // check if end of recycler view is reached, if yes then add more results to existing results
                 if (!recyclerView.canScrollVertically(1)) {
-                    addImagesToList(query);
+                    addCategoriesToList(query);
                 }
             }
         });
@@ -111,8 +111,8 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
     }
 
     /**
-     * Checks for internet connection and then initializes the recycler view with 25 images of the searched query
-     * Clearing imageAdapter every time new keyword is searched so that user can see only new results
+     * Checks for internet connection and then initializes the recycler view with 25 categories of the searched query
+     * Clearing categoryAdapter every time new keyword is searched so that user can see only new results
      */
     public void updateCategoryList(String query) {
         this.query = query;
@@ -134,7 +134,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
     /**
      * Adds more results to existing search results
      */
-    public void addImagesToList(String query) {
+    public void addCategoriesToList(String query) {
         this.query = query;
         progressBar.setVisibility(View.VISIBLE);
         Observable.fromCallable(() -> mwApi.searchCategory(query,queryList.size()))
@@ -164,7 +164,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
      * @param mediaList
      */
     private void handleSuccess(List<String> mediaList) {
-        imagesNotFoundView.setVisibility(GONE);
+        categoriesNotFoundView.setVisibility(GONE);
         queryList = mediaList;
         if(mediaList == null || mediaList.isEmpty()) {
             initErrorView();
@@ -186,9 +186,9 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
      * @param throwable
      */
     private void handleError(Throwable throwable) {
-        Timber.e(throwable, "Error occurred while loading queried images");
+        Timber.e(throwable, "Error occurred while loading queried categories");
         initErrorView();
-        ViewUtil.showSnackbar(categoriesRecyclerView, R.string.error_loading_images);
+        ViewUtil.showSnackbar(categoriesRecyclerView, R.string.error_loading_categories);
     }
 
     /**
@@ -196,8 +196,8 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
      */
     private void initErrorView() {
         progressBar.setVisibility(GONE);
-        imagesNotFoundView.setVisibility(VISIBLE);
-        imagesNotFoundView.setText(getString(R.string.images_not_found, query));
+        categoriesNotFoundView.setVisibility(VISIBLE);
+        categoriesNotFoundView.setText(getString(R.string.categories_not_found, query));
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
@@ -116,6 +116,7 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
      */
     public void updateImageList(String query) {
         this.query = query;
+        imagesNotFoundView.setVisibility(GONE);
         if(!NetworkUtils.isInternetConnectionEstablished(getContext())) {
             handleNoInternet();
             return;
@@ -164,7 +165,6 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
      * @param mediaList
      */
     private void handleSuccess(List<Media> mediaList) {
-        imagesNotFoundView.setVisibility(GONE);
         queryList = mediaList;
         if(mediaList == null || mediaList.isEmpty()) {
             initErrorView();

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -660,6 +660,43 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
         return images;
     }
 
+    /**
+     * This method takes search keyword as input and returns a list of categories objects filtered using search query
+     * It uses the generator query API to get the images searched using a query, 25 at a time.
+     * @param query keyword to search images on commons
+     * @return
+     */
+    @Override
+    @NonNull
+    public List<String> searchCategory(String query, int offset) {
+        List<ApiResult> imageNodes = null;
+        try {
+            imageNodes = api.action("query")
+                    .param("format", "xml")
+                    .param("list", "search")
+                    .param("srwhat", "text")
+                    .param("srnamespace", "14")
+                    .param("srlimit", "25")
+                    .param("sroffset",offset)
+                    .param("srsearch", query)
+                    .get()
+                    .getNodes("/api/query/search/p/@title");
+        } catch (IOException e) {
+            Timber.e("Failed to obtain searchImages", e);
+        }
+
+        if (imageNodes == null) {
+            return new ArrayList<String>();
+        }
+
+        List<String> categories = new ArrayList<>();
+        for (ApiResult imageNode : imageNodes) {
+            String catName = imageNode.getDocument().getTextContent();
+            categories.add(catName);
+        }
+        return categories;
+    }
+
 
     /**
      * For APIs that return paginated responses, MediaWiki APIs uses the QueryContinue to facilitate fetching of subsequent pages

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -662,16 +662,16 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
 
     /**
      * This method takes search keyword as input and returns a list of categories objects filtered using search query
-     * It uses the generator query API to get the images searched using a query, 25 at a time.
-     * @param query keyword to search images on commons
+     * It uses the generator query API to get the categories searched using a query, 25 at a time.
+     * @param query keyword to search categories on commons
      * @return
      */
     @Override
     @NonNull
     public List<String> searchCategory(String query, int offset) {
-        List<ApiResult> imageNodes = null;
+        List<ApiResult> categoryNodes = null;
         try {
-            imageNodes = api.action("query")
+            categoryNodes = api.action("query")
                     .param("format", "xml")
                     .param("list", "search")
                     .param("srwhat", "text")
@@ -682,16 +682,16 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
                     .get()
                     .getNodes("/api/query/search/p/@title");
         } catch (IOException e) {
-            Timber.e("Failed to obtain searchImages", e);
+            Timber.e("Failed to obtain searchCategories", e);
         }
 
-        if (imageNodes == null) {
+        if (categoryNodes == null) {
             return new ArrayList<String>();
         }
 
         List<String> categories = new ArrayList<>();
-        for (ApiResult imageNode : imageNodes) {
-            String catName = imageNode.getDocument().getTextContent();
+        for (ApiResult categoryNode : categoryNodes) {
+            String catName = categoryNode.getDocument().getTextContent();
             categories.add(catName);
         }
         return categories;

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
@@ -45,6 +45,9 @@ public interface MediaWikiApi {
     List<Media> searchImages(String title, int offset);
 
     @NonNull
+    List<String> searchCategory(String title, int offset);
+
+    @NonNull
     UploadResult uploadFile(String filename, InputStream file, long dataLength, String pageContents, String editSummary, ProgressListener progressListener) throws IOException;
 
     @Nullable

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -40,19 +40,33 @@
                 android:iconifiedByDefault="false"
                 android:textSize="@dimen/normal_text"
                 />
-
+            <android.support.design.widget.TabLayout
+                android:id="@+id/tabLayout"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:tabTextAppearance="@android:style/TextAppearance.Widget.TabWidget"
+                android:background="@color/item_white_background"
+                app:tabMode="scrollable"
+                app:tabSelectedTextColor="@color/button_background_dark"
+                android:layout_below="@id/searchBox"
+                />
         </android.support.v7.widget.Toolbar>
         </android.support.design.widget.AppBarLayout>
-        <FrameLayout
-            android:visibility="gone"
-            xmlns:android="http://schemas.android.com/apk/res/android"
+        <!--<FrameLayout-->
+            <!--android:visibility="gone"-->
+            <!--xmlns:android="http://schemas.android.com/apk/res/android"-->
+            <!--android:layout_width="match_parent"-->
+            <!--android:layout_height="match_parent"-->
+            <!--android:id="@+id/fragmentContainer"-->
+            <!--android:orientation="horizontal"-->
+            <!--android:layout_below="@id/toolbar_layout"-->
+            <!--android:focusable="true"-->
+            <!--android:focusableInTouchMode="true"-->
+            <!--/>-->
+        <android.support.v4.view.ViewPager
+            android:id="@+id/viewPager"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:id="@+id/fragmentContainer"
-            android:orientation="horizontal"
-            android:layout_below="@id/toolbar_layout"
-            android:focusable="true"
-            android:focusableInTouchMode="true"
             />
         <FrameLayout
             android:visibility="visible"

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -54,6 +54,16 @@
             android:layout_below="@id/toolbar_search"
             />
         </android.support.design.widget.AppBarLayout>
+        <FrameLayout
+            android:visibility="gone"
+            xmlns:android="http://schemas.android.com/apk/res/android"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:id="@+id/mediaContainer"
+            android:orientation="horizontal"
+            android:layout_below="@id/toolbar_layout"
+            />
+
         <android.support.v4.view.ViewPager
             android:id="@+id/viewPager"
             android:layout_width="match_parent"
@@ -61,7 +71,7 @@
             android:layout_below="@id/toolbar_layout"
             />
         <FrameLayout
-            android:visibility="visible"
+            android:visibility="gone"
             xmlns:android="http://schemas.android.com/apk/res/android"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -39,6 +39,7 @@
                 android:singleLine="true"
                 android:iconifiedByDefault="false"
                 android:textSize="@dimen/normal_text"
+                android:voiceSearchMode="showVoiceSearchButton|launchRecognizer"
                 />
         </android.support.v7.widget.Toolbar>
         <android.support.design.widget.TabLayout

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -40,18 +40,18 @@
                 android:iconifiedByDefault="false"
                 android:textSize="@dimen/normal_text"
                 />
-            <android.support.design.widget.TabLayout
-                android:id="@+id/tabLayout"
-                android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                app:tabTextAppearance="@android:style/TextAppearance.Widget.TabWidget"
-                android:background="@color/item_white_background"
-                app:tabMode="scrollable"
-                app:tabSelectedTextColor="@color/button_background_dark"
-                android:layout_below="@id/searchBox"
-                />
         </android.support.v7.widget.Toolbar>
         </android.support.design.widget.AppBarLayout>
+        <android.support.design.widget.TabLayout
+            android:id="@+id/tabLayout"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:tabTextAppearance="@android:style/TextAppearance.Widget.TabWidget"
+            android:background="@color/item_white_background"
+            app:tabMode="scrollable"
+            app:tabSelectedTextColor="@color/button_background_dark"
+            android:layout_below="@id/toolbar_layout"
+            />
         <!--<FrameLayout-->
             <!--android:visibility="gone"-->
             <!--xmlns:android="http://schemas.android.com/apk/res/android"-->
@@ -67,6 +67,7 @@
             android:id="@+id/viewPager"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:layout_below="@id/tabLayout"
             />
         <FrameLayout
             android:visibility="visible"

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -41,33 +41,23 @@
                 android:textSize="@dimen/normal_text"
                 />
         </android.support.v7.widget.Toolbar>
-        </android.support.design.widget.AppBarLayout>
         <android.support.design.widget.TabLayout
             android:id="@+id/tabLayout"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
+            android:layout_height="wrap_content"
             app:tabTextAppearance="@android:style/TextAppearance.Widget.TabWidget"
             android:background="@color/item_white_background"
             app:tabMode="scrollable"
-            app:tabSelectedTextColor="@color/button_background_dark"
-            android:layout_below="@id/toolbar_layout"
+            app:tabSelectedTextColor="@color/primaryColor"
+            app:tabTextColor="@color/button_background_dark"
+            android:layout_below="@id/toolbar_search"
             />
-        <!--<FrameLayout-->
-            <!--android:visibility="gone"-->
-            <!--xmlns:android="http://schemas.android.com/apk/res/android"-->
-            <!--android:layout_width="match_parent"-->
-            <!--android:layout_height="match_parent"-->
-            <!--android:id="@+id/fragmentContainer"-->
-            <!--android:orientation="horizontal"-->
-            <!--android:layout_below="@id/toolbar_layout"-->
-            <!--android:focusable="true"-->
-            <!--android:focusableInTouchMode="true"-->
-            <!--/>-->
+        </android.support.design.widget.AppBarLayout>
         <android.support.v4.view.ViewPager
             android:id="@+id/viewPager"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_below="@id/tabLayout"
+            android:layout_below="@id/toolbar_layout"
             />
         <FrameLayout
             android:visibility="visible"

--- a/app/src/main/res/layout/fragment_browse_image.xml
+++ b/app/src/main/res/layout/fragment_browse_image.xml
@@ -5,7 +5,7 @@
     android:focusableInTouchMode="true"
     android:id="@+id/image_search_results_display"
     android:orientation="vertical"
-    android:paddingTop="@dimen/small_gap"
+    android:paddingTop="@dimen/tiny_gap"
     >
 
     <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -275,6 +275,7 @@
   <string name="showcase_view_plus_fab">You can upload a picture for any place from your gallery or camera</string>
   <string name="no_images_found">No images found!</string>
   <string name="error_loading_images">Error occurred while loading images.</string>
+  <string name="error_loading_categories">Error occurred while loading categories.</string>
   <string name="image_uploaded_by">Uploaded by: %1$s</string>
   <string name="share_app_title">Share App</string>
   <string name="share_coordinates_not_present">Coordinates were not specified during image selection</string>


### PR DESCRIPTION
## Add Search activity, image search feature 

Fixes #1639  (Add search categories from commons feature)
Fixes #1652  (Ghost "No categories matching" message browsing bug)
Fixes #1648  (ConcurrentModificationException at fr.free.nrw.commons.Media.setDescriptions)
Fixes #1651  (No view found for id 0x7f0f00ad at fr.free.nrw.commons.explore.SearchActivity.onSearchImageClicked)

## Description 

- Search Category Fragment added which has a recyclerview to show search results (categories)
- Made changes in Search Activity (added viewPagerAdapter, on text change notify search category fragment)
- Implemented API to search Categories
- SearchCategoryRenderer added (handles presentation of individual category)
- Strings added
- Onclick of category in search results, We are saving the search query to recent searches just like images. Once Category details page will be designed we will navigate it there.

## Tests performed

Manually tested on [API 25 Motog5S+] with ProdDebug
Please test on ProdDebug as betaDebug variant doesn't have many categories to search

## Screenshots showing what changed 

<table>
<tr>
<td>

![screenshot_20180619-151539](https://user-images.githubusercontent.com/19607555/41590068-bc8a631a-73d3-11e8-957c-56ebc1ce5a4a.png)

</td>
<td>

![screenshot_20180619-135827](https://user-images.githubusercontent.com/19607555/41590069-bd111734-73d3-11e8-8fed-cabb61288c1d.png)

</td>
</tr>
<tr>
<td>

![screenshot_20180619-135625](https://user-images.githubusercontent.com/19607555/41590072-bd64186c-73d3-11e8-81e5-9fef63599f78.png)

</td>
<td>

![screenshot_20180619-135620](https://user-images.githubusercontent.com/19607555/41590074-bdc01ac2-73d3-11e8-845c-1558c690d092.png)

</td>
</tr>

</table>
 



