### PR TITLE
Refreshed listview after delete

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
@@ -44,6 +44,10 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
                 .setPositiveButton("YES", (dialog, which) -> {
                     recentSearchesDao.deleteAll(recentSearches);
                     Toast.makeText(getContext(),getString(R.string.search_history_deleted),Toast.LENGTH_SHORT).show();
+                    recentSearches = recentSearchesDao.recentSearches(10);
+                    adapter = new ArrayAdapter<String>(getContext(),R.layout.item_recent_searches, recentSearches);
+                    recentSearchesList.setAdapter(adapter);
+                    adapter.notifyDataSetChanged();
                     dialog.dismiss();
                 })
                 .setNegativeButton("NO", null)


### PR DESCRIPTION
## Title (required)

Fixes #1633  (Crash when clearing search history twice )

## Description (required)
- refreshing listview on delete fixes this bug

## Tests performed (required)

Manually Tested on {API25 & MotoG5S+}, with { ProdDebug variant}.
