### PR TITLE
Remove current location retrieval from upload process entirely

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.java
@@ -111,7 +111,7 @@ public class FileProcessor implements SimilarImageDialogFragment.onResponse {
             } else {
                 String filePath = getPathOfMediaOrCopy();
                 if (filePath != null) {
-                    imageObj = new GPSExtractor(filePath, context, prefs);
+                    imageObj = new GPSExtractor(filePath, prefs);
                 }
             }
 
@@ -165,7 +165,7 @@ public class FileProcessor implements SimilarImageDialogFragment.onResponse {
                     }
                 } else {
                     if (filePath != null) {
-                        tempImageObj = new GPSExtractor(file.getAbsolutePath(), context, prefs);
+                        tempImageObj = new GPSExtractor(file.getAbsolutePath(), prefs);
                     }
                 }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.java
@@ -119,7 +119,7 @@ public class FileProcessor implements SimilarImageDialogFragment.onResponse {
             if (decimalCoords == null || !imageObj.imageCoordsExists) {
                 //Find other photos taken around the same time which has gps coordinates
                 if (!haveCheckedForOtherImages)
-                    findOtherImages(gpsEnabled);// Do not do repeat the process
+                    findOtherImages();// Do not do repeat the process
             } else {
                 useImageCoords();
             }
@@ -137,9 +137,8 @@ public class FileProcessor implements SimilarImageDialogFragment.onResponse {
     /**
      * Find other images around the same location that were taken within the last 20 sec
      *
-     * @param gpsEnabled True if GPS is enabled
      */
-    private void findOtherImages(boolean gpsEnabled) {
+    private void findOtherImages() {
         Timber.d("filePath" + getPathOfMediaOrCopy());
 
         long timeOfCreation = new File(filePath).lastModified();//Time when the original image was created

--- a/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.java
@@ -106,12 +106,12 @@ public class FileProcessor implements SimilarImageDialogFragment.onResponse {
             ParcelFileDescriptor descriptor = contentResolver.openFileDescriptor(mediaUri, "r");
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 if (descriptor != null) {
-                    imageObj = new GPSExtractor(descriptor.getFileDescriptor(), prefs);
+                    imageObj = new GPSExtractor(descriptor.getFileDescriptor());
                 }
             } else {
                 String filePath = getPathOfMediaOrCopy();
                 if (filePath != null) {
-                    imageObj = new GPSExtractor(filePath, prefs);
+                    imageObj = new GPSExtractor(filePath);
                 }
             }
 
@@ -161,11 +161,11 @@ public class FileProcessor implements SimilarImageDialogFragment.onResponse {
                 }
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                     if (descriptor != null) {
-                        tempImageObj = new GPSExtractor(descriptor.getFileDescriptor(), prefs);
+                        tempImageObj = new GPSExtractor(descriptor.getFileDescriptor());
                     }
                 } else {
                     if (filePath != null) {
-                        tempImageObj = new GPSExtractor(file.getAbsolutePath(), prefs);
+                        tempImageObj = new GPSExtractor(file.getAbsolutePath());
                     }
                 }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.java
@@ -106,7 +106,7 @@ public class FileProcessor implements SimilarImageDialogFragment.onResponse {
             ParcelFileDescriptor descriptor = contentResolver.openFileDescriptor(mediaUri, "r");
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 if (descriptor != null) {
-                    imageObj = new GPSExtractor(descriptor.getFileDescriptor(), context, prefs);
+                    imageObj = new GPSExtractor(descriptor.getFileDescriptor(), prefs);
                 }
             } else {
                 String filePath = getPathOfMediaOrCopy();
@@ -161,7 +161,7 @@ public class FileProcessor implements SimilarImageDialogFragment.onResponse {
                 }
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                     if (descriptor != null) {
-                        tempImageObj = new GPSExtractor(descriptor.getFileDescriptor(), context, prefs);
+                        tempImageObj = new GPSExtractor(descriptor.getFileDescriptor(), prefs);
                     }
                 } else {
                     if (filePath != null) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.java
@@ -115,7 +115,7 @@ public class FileProcessor implements SimilarImageDialogFragment.onResponse {
                 }
             }
 
-            decimalCoords = imageObj.getCoords(gpsEnabled);
+            decimalCoords = imageObj.getCoords();
             if (decimalCoords == null || !imageObj.imageCoordsExists) {
                 //Find other photos taken around the same time which has gps coordinates
                 if (!haveCheckedForOtherImages)
@@ -170,8 +170,8 @@ public class FileProcessor implements SimilarImageDialogFragment.onResponse {
                 }
 
                 if (tempImageObj != null) {
-                    Timber.d("not null fild EXIF" + tempImageObj.imageCoordsExists + " coords" + tempImageObj.getCoords(gpsEnabled));
-                    if (tempImageObj.getCoords(gpsEnabled) != null && tempImageObj.imageCoordsExists) {
+                    Timber.d("not null fild EXIF" + tempImageObj.imageCoordsExists + " coords" + tempImageObj.getCoords());
+                    if (tempImageObj.getCoords() != null && tempImageObj.imageCoordsExists) {
                         // Current image has gps coordinates and it's not current gps locaiton
                         Timber.d("This file has image coords:" + file.getAbsolutePath());
                         SimilarImageDialogFragment newFragment = new SimilarImageDialogFragment();
@@ -250,7 +250,7 @@ public class FileProcessor implements SimilarImageDialogFragment.onResponse {
     @Override
     public void onPositiveResponse() {
         imageObj = tempImageObj;
-        decimalCoords = imageObj.getCoords(false);// Not necessary to use gps as image already ha EXIF data
+        decimalCoords = imageObj.getCoords();// Not necessary to use gps as image already ha EXIF data
         Timber.d("EXIF from tempImageObj");
         useImageCoords();
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
@@ -1,10 +1,7 @@
 package fr.free.nrw.commons.upload;
 
 import android.content.SharedPreferences;
-import android.location.Location;
-import android.location.LocationListener;
 import android.media.ExifInterface;
-import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.RequiresApi;
@@ -24,8 +21,6 @@ public class GPSExtractor {
     private ExifInterface exif;
     private double decLatitude;
     private double decLongitude;
-    private Double currentLatitude = null;
-    private Double currentLongitude = null;
     public boolean imageCoordsExists;
 
     /**
@@ -58,11 +53,10 @@ public class GPSExtractor {
 
     /**
      * Extracts geolocation (either of image from EXIF data, or of user)
-     * @param useGPS set to true if location permissions allowed (by API 23), false if disallowed
      * @return coordinates as string (needs to be passed as a String in API query)
      */
     @Nullable
-    public String getCoords(boolean useGPS) {
+    public String getCoords() {
         String latitude;
         String longitude;
         String latitudeRef;

--- a/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
@@ -71,9 +71,9 @@ public class GPSExtractor {
      * @return true if enabled, false if disabled
      */
     private boolean gpsPreferenceEnabled() {
-        boolean gpsPref = prefs.getBoolean("allowGps", false);
-        Timber.d("Gps pref set to: %b", gpsPref);
-        return gpsPref;
+        //TODO: Hotfix for #1599
+        //Stopgap measure prior to implementing category suggestions without adding location template
+        return false;
     }
 
     /**
@@ -134,8 +134,7 @@ public class GPSExtractor {
                 // explicitly set by MyLocationListener
                 // and do not default to (0.0,0.0)
                 if (gpsPrefEnabled && currentLatitude != null && currentLongitude != null) {
-                    Timber.d("Current location values: Lat = %f Long = %f",
-                            currentLatitude, currentLongitude);
+                    Timber.d("Current location values: Lat = %f Long = %f", currentLatitude, currentLongitude);
                     return String.valueOf(currentLatitude) + "|" + String.valueOf(currentLongitude);
                 } else {
                     // No coords found

--- a/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
@@ -120,6 +120,7 @@ public class GPSExtractor {
         String decimalCoords;
 
         //If image has no EXIF data and user has enabled GPS setting, get user's location
+        //TODO: Always return null as a temporary fix for #1599
         if (exif == null || exif.getAttribute(ExifInterface.TAG_GPS_LATITUDE) == null) {
             return null;
         } else {

--- a/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
@@ -3,7 +3,6 @@ package fr.free.nrw.commons.upload;
 import android.content.SharedPreferences;
 import android.location.Location;
 import android.location.LocationListener;
-import android.location.LocationManager;
 import android.media.ExifInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -17,8 +16,7 @@ import timber.log.Timber;
 
 /**
  * Extracts geolocation to be passed to API for category suggestions. If a picture with geolocation
- * is uploaded, extract latitude and longitude from EXIF data of image. If a picture without
- * geolocation is uploaded, retrieve user's location (if enabled in Settings).
+ * is uploaded, extract latitude and longitude from EXIF data of image.
  */
 public class GPSExtractor {
 
@@ -29,8 +27,6 @@ public class GPSExtractor {
     private Double currentLatitude = null;
     private Double currentLongitude = null;
     public boolean imageCoordsExists;
-    private MyLocationListener myLocationListener;
-    private LocationManager locationManager;
 
     /**
      * Construct from the file descriptor of the image (only for API 24 or newer).

--- a/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
@@ -1,8 +1,6 @@
 package fr.free.nrw.commons.upload;
 
-import android.content.Context;
 import android.content.SharedPreferences;
-import android.location.Criteria;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
@@ -51,9 +49,9 @@ public class GPSExtractor {
     /**
      * Construct from the file path of the image.
      * @param path file path of the image
-     * @param context the context
+     *
      */
-    public GPSExtractor(@NonNull String path, Context context, SharedPreferences prefs) {
+    public GPSExtractor(@NonNull String path, SharedPreferences prefs) {
         this.prefs = prefs;
         try {
             exif = new ExifInterface(path);

--- a/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
@@ -67,46 +67,6 @@ public class GPSExtractor {
     }
 
     /**
-     * Check if user enabled retrieval of their current location in Settings
-     * @return true if enabled, false if disabled
-     */
-    private boolean gpsPreferenceEnabled() {
-        //TODO: Hotfix for #1599
-        //Stopgap measure prior to implementing category suggestions without adding location template
-        return false;
-    }
-
-    /**
-     * Registers a LocationManager to listen for current location
-     */
-    protected void registerLocationManager() {
-        locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
-        Criteria criteria = new Criteria();
-        String provider = locationManager.getBestProvider(criteria, true);
-        myLocationListener = new MyLocationListener();
-
-        try {
-            locationManager.requestLocationUpdates(provider, 400, 1, myLocationListener);
-            Location location = locationManager.getLastKnownLocation(provider);
-            if (location != null) {
-                myLocationListener.onLocationChanged(location);
-            }
-        } catch (IllegalArgumentException e) {
-            Timber.e(e, "Illegal argument exception");
-        } catch (SecurityException e) {
-            Timber.e(e, "Security exception");
-        }
-    }
-
-    protected void unregisterLocationManager() {
-        try {
-            locationManager.removeUpdates(myLocationListener);
-        } catch (SecurityException e) {
-            Timber.e(e, "Security exception");
-        }
-    }
-
-    /**
      * Extracts geolocation (either of image from EXIF data, or of user)
      * @param useGPS set to true if location permissions allowed (by API 23), false if disallowed
      * @return coordinates as string (needs to be passed as a String in API query)

--- a/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
@@ -16,8 +16,7 @@ import timber.log.Timber;
  * is uploaded, extract latitude and longitude from EXIF data of image.
  */
 public class GPSExtractor {
-
-    private SharedPreferences prefs;
+    
     private ExifInterface exif;
     private double decLatitude;
     private double decLongitude;
@@ -28,8 +27,7 @@ public class GPSExtractor {
      * @param fileDescriptor the file descriptor of the image
      */
     @RequiresApi(24)
-    public GPSExtractor(@NonNull FileDescriptor fileDescriptor, SharedPreferences prefs) {
-        this.prefs = prefs;
+    public GPSExtractor(@NonNull FileDescriptor fileDescriptor) {
         try {
             exif = new ExifInterface(fileDescriptor);
         } catch (IOException | IllegalArgumentException e) {
@@ -42,8 +40,7 @@ public class GPSExtractor {
      * @param path file path of the image
      *
      */
-    public GPSExtractor(@NonNull String path, SharedPreferences prefs) {
-        this.prefs = prefs;
+    public GPSExtractor(@NonNull String path) {
         try {
             exif = new ExifInterface(path);
         } catch (IOException | IllegalArgumentException e) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.upload;
 
-import android.content.SharedPreferences;
 import android.media.ExifInterface;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -16,7 +15,7 @@ import timber.log.Timber;
  * is uploaded, extract latitude and longitude from EXIF data of image.
  */
 public class GPSExtractor {
-    
+
     private ExifInterface exif;
     private double decLatitude;
     private double decLongitude;

--- a/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
@@ -121,28 +121,7 @@ public class GPSExtractor {
 
         //If image has no EXIF data and user has enabled GPS setting, get user's location
         if (exif == null || exif.getAttribute(ExifInterface.TAG_GPS_LATITUDE) == null) {
-            if (useGPS) {
-                registerLocationManager();
-
-                imageCoordsExists = false;
-                Timber.d("EXIF data has no location info");
-
-                //Check what user's preference is for automatic location detection
-                boolean gpsPrefEnabled = gpsPreferenceEnabled();
-
-                //Check that currentLatitude and currentLongitude have been
-                // explicitly set by MyLocationListener
-                // and do not default to (0.0,0.0)
-                if (gpsPrefEnabled && currentLatitude != null && currentLongitude != null) {
-                    Timber.d("Current location values: Lat = %f Long = %f", currentLatitude, currentLongitude);
-                    return String.valueOf(currentLatitude) + "|" + String.valueOf(currentLongitude);
-                } else {
-                    // No coords found
-                    return null;
-                }
-            } else {
-                return null;
-            }
+            return null;
         } else {
             //If image has EXIF data, extract image coords
             imageCoordsExists = true;

--- a/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
@@ -95,33 +95,6 @@ public class GPSExtractor {
         }
     }
 
-    /**
-     * Listen for user's location when it changes
-     */
-    private class MyLocationListener implements LocationListener {
-
-        @Override
-        public void onLocationChanged(Location location) {
-            currentLatitude = location.getLatitude();
-            currentLongitude = location.getLongitude();
-        }
-
-        @Override
-        public void onStatusChanged(String provider, int status, Bundle extras) {
-            Timber.d("%s's status changed to %d", provider, status);
-        }
-
-        @Override
-        public void onProviderEnabled(String provider) {
-            Timber.d("Provider %s enabled", provider);
-        }
-
-        @Override
-        public void onProviderDisabled(String provider) {
-            Timber.d("Provider %s disabled", provider);
-        }
-    }
-
     public double getDecLatitude() {
         return decLatitude;
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
@@ -24,7 +24,6 @@ import timber.log.Timber;
  */
 public class GPSExtractor {
 
-    private final Context context;
     private SharedPreferences prefs;
     private ExifInterface exif;
     private double decLatitude;
@@ -38,11 +37,9 @@ public class GPSExtractor {
     /**
      * Construct from the file descriptor of the image (only for API 24 or newer).
      * @param fileDescriptor the file descriptor of the image
-     * @param context the context
      */
     @RequiresApi(24)
-    public GPSExtractor(@NonNull FileDescriptor fileDescriptor, Context context, SharedPreferences prefs) {
-        this.context = context;
+    public GPSExtractor(@NonNull FileDescriptor fileDescriptor, SharedPreferences prefs) {
         this.prefs = prefs;
         try {
             exif = new ExifInterface(fileDescriptor);
@@ -63,7 +60,6 @@ public class GPSExtractor {
         } catch (IOException | IllegalArgumentException e) {
             Timber.w(e);
         }
-        this.context = context;
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/MultipleShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/MultipleShareActivity.java
@@ -329,12 +329,12 @@ public class MultipleShareActivity extends AuthenticatedActivity
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 ParcelFileDescriptor fd = getContentResolver().openFileDescriptor(imageUri,"r");
                 if (fd != null) {
-                    gpsExtractor = new GPSExtractor(fd.getFileDescriptor(), prefs);
+                    gpsExtractor = new GPSExtractor(fd.getFileDescriptor());
                 }
             } else {
                 String filePath = FileUtils.getPath(this,imageUri);
                 if (filePath != null) {
-                    gpsExtractor = new GPSExtractor(filePath, prefs);
+                    gpsExtractor = new GPSExtractor(filePath);
                 }
             }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/MultipleShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/MultipleShareActivity.java
@@ -329,12 +329,12 @@ public class MultipleShareActivity extends AuthenticatedActivity
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 ParcelFileDescriptor fd = getContentResolver().openFileDescriptor(imageUri,"r");
                 if (fd != null) {
-                    gpsExtractor = new GPSExtractor(fd.getFileDescriptor(),this,prefs);
+                    gpsExtractor = new GPSExtractor(fd.getFileDescriptor(), prefs);
                 }
             } else {
                 String filePath = FileUtils.getPath(this,imageUri);
                 if (filePath != null) {
-                    gpsExtractor = new GPSExtractor(filePath,this,prefs);
+                    gpsExtractor = new GPSExtractor(filePath, prefs);
                 }
             }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/MultipleShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/MultipleShareActivity.java
@@ -340,7 +340,7 @@ public class MultipleShareActivity extends AuthenticatedActivity
 
             if (gpsExtractor != null) {
                 //get image coordinates from exif data or user location
-                return gpsExtractor.getCoords(locationPermitted);
+                return gpsExtractor.getCoords();
             }
 
         } catch (FileNotFoundException fnfe) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -453,12 +453,6 @@ public class ShareActivity
     @Override
     public void onPause() {
         super.onPause();
-        try {
-            gpsObj.unregisterLocationManager();
-            Timber.d("Unregistered locationManager");
-        } catch (NullPointerException e) {
-            Timber.d("locationManager does not exist, not unregistered");
-        }
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -275,22 +275,6 @@ public class ShareActivity
         Timber.d("Uri: %s", mediaUri.toString());
         Timber.d("Ext storage dir: %s", Environment.getExternalStorageDirectory());
 
-        useNewPermissions = false;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            useNewPermissions = true;
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
-                locationPermitted = true;
-            }
-        }
-
-        // Check location permissions if M or newer for category suggestions, request via snackbar if not present
-        if (!locationPermitted) {
-            requestPermissionUsingSnackBar(
-                    getString(R.string.location_permission_rationale),
-                    new String[]{Manifest.permission.ACCESS_FINE_LOCATION},
-                    REQUEST_PERM_ON_CREATE_LOCATION);
-        }
-
         SingleUploadFragment shareView = (SingleUploadFragment) getSupportFragmentManager().findFragmentByTag("shareView");
         categorizationFragment = (CategorizationFragment) getSupportFragmentManager().findFragmentByTag("categorization");
         if (shareView == null && categorizationFragment == null) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -381,14 +381,6 @@ public class ShareActivity
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         switch (requestCode) {
-            case REQUEST_PERM_ON_CREATE_LOCATION: {
-                if (grantResults.length >= 1 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    locationPermitted = true;
-                    checkIfFileExists();
-                }
-                return;
-            }
-
             // Storage (from submit button) - this needs to be separate from (1) because only the
             // submit button should bring user to next screen
             case REQUEST_PERM_ON_SUBMIT_STORAGE: {

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -74,7 +74,6 @@ public class ShareActivity
         extends AuthenticatedActivity
         implements SingleUploadFragment.OnUploadActionInitiated,
         OnCategoriesSaveHandler {
-    private static final int REQUEST_PERM_ON_CREATE_LOCATION = 2;
     private static final int REQUEST_PERM_ON_SUBMIT_STORAGE = 4;
     //Had to make them class variables, to extract out the click listeners, also I see no harm in this
     final Rect startBounds = new Rect();

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -21,9 +21,7 @@ import android.os.Environment;
 import android.support.annotation.NonNull;
 import android.support.annotation.RequiresApi;
 import android.support.design.widget.FloatingActionButton;
-import android.support.design.widget.Snackbar;
 import android.support.graphics.drawable.VectorDrawableCompat;
-import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.view.MenuItem;
 import android.view.View;
@@ -64,7 +62,6 @@ import fr.free.nrw.commons.mwapi.MediaWikiApi;
 import fr.free.nrw.commons.utils.ViewUtil;
 import timber.log.Timber;
 
-import android.support.design.widget.FloatingActionButton;
 import static fr.free.nrw.commons.upload.ExistingFileAsync.Result.DUPLICATE_PROCEED;
 import static fr.free.nrw.commons.upload.ExistingFileAsync.Result.NO_DUPLICATE;
 import static fr.free.nrw.commons.upload.FileUtils.getSHA1;

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -130,7 +130,6 @@ public class ShareActivity
     private String title;
     private String description;
     private String wikiDataEntityId;
-    private Snackbar snackbar;
     private boolean duplicateCheckPassed = false;
     private boolean isNearbyUpload = false;
     private Animator CurrentAnimator;
@@ -373,7 +372,7 @@ public class ShareActivity
     }
 
     /**
-     * Handles BOTH snackbar permission request (for location) and submit button permission request (for storage)
+     * Handles submit button permission request (for storage)
      *
      * @param requestCode  type of request
      * @param permissions  permissions requested
@@ -394,27 +393,13 @@ public class ShareActivity
             // submit button should bring user to next screen
             case REQUEST_PERM_ON_SUBMIT_STORAGE: {
                 if (grantResults.length >= 1 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    //It is OK to call this at both (1) and (4) because if perm had been granted at
-                    //snackbar, user should not be prompted at submit button
                     checkIfFileExists();
 
                     //Uploading only begins if storage permission granted from arrow icon
                     uploadBegins();
-                    snackbar.dismiss();
                 }
             }
         }
-    }
-
-    /**
-     * Displays Snackbar to ask for location permissions
-     */
-    private Snackbar requestPermissionUsingSnackBar(String rationale, final String[] perms, final int code) {
-        Snackbar snackbar = Snackbar.make(findViewById(android.R.id.content), rationale,
-                Snackbar.LENGTH_INDEFINITE).setAction(R.string.ok,
-                view -> ActivityCompat.requestPermissions(ShareActivity.this, perms, code));
-        snackbar.show();
-        return snackbar;
     }
 
     /**

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -38,6 +38,9 @@
 
     </PreferenceCategory>
 
+    <!-- The key 'allowGps' was used before and has since been removed based on the discussion at #1599.
+          Do not reuse this key unless you revive the same feature with the changes mentioned at #1599.-->
+
     <PreferenceCategory
         android:title="@string/preference_category_feedback">
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -39,17 +39,6 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:title="@string/preference_category_location">
-
-        <SwitchPreference
-            android:key="allowGps"
-            android:title="@string/allow_gps"
-            android:defaultValue="false"
-            android:summary="@string/allow_gps_summary" />
-
-    </PreferenceCategory>
-
-    <PreferenceCategory
         android:title="@string/preference_category_feedback">
 
         <Preference


### PR DESCRIPTION
Temporary fix for #1599 . We are concerned that people who enabled the "automatically get current location" setting prior to the subtext change may not realize that their location is being added to the image's location template. This removes current location retrieval entirely from the upload process, and removes the Setting as well.

Where possible, I have left methods intact so that in the future if we decide to reimplement this (retrieving current location solely for category suggestions but not adding it to the template), we will not need to rewrite code. However, I have removed most of the method calls, and methods that would affect the user (e.g. the snackbar requesting location permissions).

As an added bonus, this should fix #1515 since the LocationListener will not be registered in ShareActivity.

Tested on Nexus S emulator running API 25 on betaDebug. To test:
- Make sure GPS is on and your image has no geotagged coordinates
- Upload that image
- Check your uploaded image and make sure no location template was added to it