### PR TITLE
Get rid of legacy URL

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -709,7 +709,7 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
     @NonNull
     public Single<Integer> getUploadCount(String userName) {
         final String uploadCountUrlTemplate =
-                wikiMediaToolforgeUrl + "urbanecmbot/uploadsbyuser/uploadsbyuser.py";
+                wikiMediaToolforgeUrl + "urbanecmbot/commonsmisc/uploadsbyuser.py";
 
         return Single.fromCallable(() -> {
             String url = String.format(


### PR DESCRIPTION
This URL still works but intended as legacy.
As there are more separate API endpoints,
I've renamed the folder to commonsmisc to
enable me to add all endpoints to one folder
and to reduce potentional damage that can be caused
by fogotting the symlink is there for a reason,
I'm renaming it in the Commons app as well