### PR TITLE
Fix nearby crash by updating to Mapbox version that includes telem 2.2.10

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'info.debatty:java-string-similarity:0.24'
     implementation 'com.borjabravo:readmoretextview:2.1.0'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
-    implementation('com.mapbox.mapboxsdk:mapbox-android-sdk:5.4.1@aar') {
+    implementation('com.mapbox.mapboxsdk:mapbox-android-sdk:5.5.0@aar') {
         transitive = true
     }
     implementation 'com.github.deano2390:MaterialShowcaseView:1.2.0'


### PR DESCRIPTION
## Fix nearby crash

Fixes #1659 NoSuchMethodError: No static method toHumanReadableAscii(Ljava/lang/String;)Ljava/lang/String; in class Lokhttp3/internal/Util

## Description

Does not crash anymore

## Tests performed

ProdDebug tested on Android 7.1.2, solves crash.