### PR TITLE
Allow for settings titles to expand across multiple lines instead of being truncated

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitleEditTextPreference.java
+++ b/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitleEditTextPreference.java
@@ -1,0 +1,35 @@
+package fr.free.nrw.commons.ui.LongTitlePreferences;
+
+import android.content.Context;
+import android.preference.EditTextPreference;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.TextView;
+
+/**
+ * Created by seannemann on 6/27/2018.
+ */
+
+public class LongTitleEditTextPreference extends EditTextPreference {
+    public LongTitleEditTextPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public LongTitleEditTextPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public LongTitleEditTextPreference(Context context) {
+
+        super(context);
+    }
+
+    @Override
+    protected void onBindView(View view)
+    {
+        super.onBindView(view);
+
+        TextView title= view.findViewById(android.R.id.title);
+        title.setSingleLine(false);
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitleEditTextPreference.java
+++ b/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitleEditTextPreference.java
@@ -30,6 +30,8 @@ public class LongTitleEditTextPreference extends EditTextPreference {
         super.onBindView(view);
 
         TextView title= view.findViewById(android.R.id.title);
-        title.setSingleLine(false);
+        if (title != null) {
+            title.setSingleLine(false);
+        }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitleListPreference.java
+++ b/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitleListPreference.java
@@ -1,0 +1,30 @@
+package fr.free.nrw.commons.ui.LongTitlePreferences;
+
+import android.content.Context;
+import android.preference.ListPreference;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.TextView;
+
+/**
+ * Created by seannemann on 6/27/2018.
+ */
+
+public class LongTitleListPreference extends ListPreference {
+    public LongTitleListPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public LongTitleListPreference(Context context) {
+        super(context);
+    }
+
+    @Override
+    protected void onBindView(View view)
+    {
+        super.onBindView(view);
+
+        TextView title= view.findViewById(android.R.id.title);
+        title.setSingleLine(false);
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitleListPreference.java
+++ b/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitleListPreference.java
@@ -25,6 +25,8 @@ public class LongTitleListPreference extends ListPreference {
         super.onBindView(view);
 
         TextView title= view.findViewById(android.R.id.title);
-        title.setSingleLine(false);
+        if (title != null) {
+            title.setSingleLine(false);
+        }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitlePreference.java
+++ b/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitlePreference.java
@@ -1,0 +1,34 @@
+package fr.free.nrw.commons.ui.LongTitlePreferences;
+
+import android.content.Context;
+import android.preference.Preference;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.TextView;
+
+/**
+ * Created by seannemann on 6/27/2018.
+ */
+
+public class LongTitlePreference extends Preference {
+    public LongTitlePreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public LongTitlePreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public LongTitlePreference(Context context) {
+        super(context);
+    }
+
+    @Override
+    protected void onBindView(View view)
+    {
+        super.onBindView(view);
+
+        TextView title= view.findViewById(android.R.id.title);
+        title.setSingleLine(false);
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitlePreference.java
+++ b/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitlePreference.java
@@ -29,6 +29,8 @@ public class LongTitlePreference extends Preference {
         super.onBindView(view);
 
         TextView title= view.findViewById(android.R.id.title);
-        title.setSingleLine(false);
+        if (title != null) {
+            title.setSingleLine(false);
+        }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitlePreferenceCategory.java
+++ b/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitlePreferenceCategory.java
@@ -1,0 +1,34 @@
+package fr.free.nrw.commons.ui.LongTitlePreferences;
+
+import android.content.Context;
+import android.preference.PreferenceCategory;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.TextView;
+
+/**
+ * Created by seannemann on 6/27/2018.
+ */
+
+public class LongTitlePreferenceCategory extends PreferenceCategory {
+    public LongTitlePreferenceCategory(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public LongTitlePreferenceCategory(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public LongTitlePreferenceCategory(Context context) {
+        super(context);
+    }
+
+    @Override
+    protected void onBindView(View view)
+    {
+        super.onBindView(view);
+
+        TextView title= view.findViewById(android.R.id.title);
+        title.setSingleLine(false);
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitlePreferenceCategory.java
+++ b/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitlePreferenceCategory.java
@@ -29,6 +29,8 @@ public class LongTitlePreferenceCategory extends PreferenceCategory {
         super.onBindView(view);
 
         TextView title= view.findViewById(android.R.id.title);
-        title.setSingleLine(false);
+        if (title != null) {
+            title.setSingleLine(false);
+        }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitleSwitchPreference.java
+++ b/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitleSwitchPreference.java
@@ -1,0 +1,34 @@
+package fr.free.nrw.commons.ui.LongTitlePreferences;
+
+import android.content.Context;
+import android.preference.SwitchPreference;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.TextView;
+
+/**
+ * Created by seannemann on 6/27/2018.
+ */
+
+public class LongTitleSwitchPreference extends SwitchPreference {
+    public LongTitleSwitchPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public LongTitleSwitchPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public LongTitleSwitchPreference(Context context) {
+        super(context);
+    }
+
+    @Override
+    protected void onBindView(View view)
+    {
+        super.onBindView(view);
+
+        TextView title= view.findViewById(android.R.id.title);
+        title.setSingleLine(false);
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitleSwitchPreference.java
+++ b/app/src/main/java/fr/free/nrw/commons/ui/LongTitlePreferences/LongTitleSwitchPreference.java
@@ -29,6 +29,8 @@ public class LongTitleSwitchPreference extends SwitchPreference {
         super.onBindView(view);
 
         TextView title= view.findViewById(android.R.id.title);
-        title.setSingleLine(false);
+        if (title != null) {
+            title.setSingleLine(false);
+        }
     }
 }

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -2,66 +2,66 @@
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <PreferenceCategory
+    <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreferenceCategory
         android:title="@string/preference_category_appearance">
 
-        <SwitchPreference
+        <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleSwitchPreference
             android:title="@string/preference_theme"
             android:defaultValue="false"
             android:summary="@string/preference_theme_summary"
             android:key="theme" />
 
-    </PreferenceCategory>
+    </fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreferenceCategory>
 
-    <PreferenceCategory
+    <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreferenceCategory
         android:title="@string/preference_category_general">
 
-        <ListPreference
+        <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleListPreference
             android:key="defaultLicense"
             android:title="@string/preference_license"
             android:entries="@array/pref_defaultLicense_entries"
             android:entryValues="@array/pref_defaultLicense_values"
             android:defaultValue="@string/license_pref_cc_by_sa_4_0" />
 
-        <SwitchPreference
+        <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleSwitchPreference
             android:key="useExternalStorage"
             android:title="@string/use_external_storage"
             android:defaultValue="true"
             android:summary="@string/use_external_storage_summary" />
 
-        <EditTextPreference
+        <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleEditTextPreference
             android:key="uploads"
             android:defaultValue="100"
             android:title= "@string/set_limit"
             android:inputType="numberDecimal"
             android:maxLength="3" />
 
-    </PreferenceCategory>
+    </fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreferenceCategory>
 
-    <PreferenceCategory
+    <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreferenceCategory
         android:title="@string/preference_category_location">
 
-        <SwitchPreference
+        <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleSwitchPreference
             android:key="allowGps"
             android:title="@string/allow_gps"
             android:defaultValue="false"
             android:summary="@string/allow_gps_summary" />
 
-    </PreferenceCategory>
+    </fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreferenceCategory>
 
-    <PreferenceCategory
+    <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreferenceCategory
         android:title="@string/preference_category_feedback">
 
-        <Preference
+        <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreference
             android:key="becomeBetaTester"
             android:title="@string/become_a_tester_title"
             android:summary="@string/become_a_tester_description">
-        </Preference>
+        </fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreference>
 
-        <Preference
+        <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreference
             android:key="sendLogFile"
             android:title="@string/send_log_file"
             android:summary="@string/send_log_file_description"/>
 
-    </PreferenceCategory>
+    </fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
## Expand settings title across multiple lines

Fixes #1670 

## Description

Allow for settings titles to expand across multiple lines instead of being truncated

Fixes #1670, Setting text is truncated when space is not available 

## Tests performed (required)

Tested on API level 24 on Samsung Galaxy S6, with ProdDebug.

## Screenshots showing what changed
Note that I only changed the setting title to show what a long title would look like. I reverted the title to the correct one before creating the pull request
![image](https://user-images.githubusercontent.com/32438079/41988390-f1b6b5d4-7a09-11e8-8d56-2fea06dbc1e5.png)
