### PR TITLE
Added category details page in app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -98,6 +98,11 @@
             android:parentActivityName=".contributions.ContributionsActivity" />
 
         <activity
+            android:name=".category.CategoryDetailsActivity"
+            android:label="@string/title_activity_featured_images"
+            android:parentActivityName=".contributions.ContributionsActivity" />
+
+        <activity
             android:name=".explore.SearchActivity"
             android:label="@string/title_activity_search"
             android:parentActivityName=".contributions.ContributionsActivity"

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -48,7 +48,7 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
         setCategoryImagesFragment();
         setPageTitle();
         initDrawer();
-        initBackButton();
+        forceInitBackButton();
     }
 
     /**
@@ -90,7 +90,7 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
             supportFragmentManager.executePendingTransactions();
         }
         mediaDetails.showImage(i);
-        initBackButton();
+        forceInitBackButton();
     }
 
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -19,6 +19,7 @@ import fr.free.nrw.commons.PageTitle;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.auth.AuthenticatedActivity;
 import fr.free.nrw.commons.media.MediaDetailPagerFragment;
+import fr.free.nrw.commons.theme.NavigationBaseActivity;
 
 import static android.widget.Toast.LENGTH_SHORT;
 
@@ -30,9 +31,8 @@ import static android.widget.Toast.LENGTH_SHORT;
  */
 
 public class CategoryDetailsActivity
-        extends AuthenticatedActivity
-        implements FragmentManager.OnBackStackChangedListener,
-                    MediaDetailPagerFragment.MediaDetailProvider,
+        extends NavigationBaseActivity
+        implements MediaDetailPagerFragment.MediaDetailProvider,
                     AdapterView.OnItemClickListener{
 
 
@@ -40,16 +40,6 @@ public class CategoryDetailsActivity
     private CategoryImagesListFragment categoryImagesListFragment;
     private MediaDetailPagerFragment mediaDetails;
     private String categoryName;
-
-    @Override
-    protected void onAuthCookieAcquired(String authCookie) {
-
-    }
-
-    @Override
-    protected void onAuthFailure() {
-
-    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -60,9 +50,8 @@ public class CategoryDetailsActivity
         // Activity can call methods in the fragment by acquiring a
         // reference to the Fragment from FragmentManager, using findFragmentById()
         supportFragmentManager = getSupportFragmentManager();
+//        supportFragmentManager.addOnBackStackChangedListener(this);
         setCategoryImagesFragment();
-        supportFragmentManager.addOnBackStackChangedListener(this);
-        requestAuthToken();
         setPageTitle();
         initDrawer();
         initBackButton();
@@ -79,23 +68,18 @@ public class CategoryDetailsActivity
             arguments.putString("categoryName", categoryName);
             categoryImagesListFragment.setArguments(arguments);
             FragmentTransaction transaction = supportFragmentManager.beginTransaction();
-            transaction
-                    .add(R.id.fragmentContainer, categoryImagesListFragment)
-                    .commit();
+            transaction.replace(R.id.fragmentContainer, categoryImagesListFragment)
+            .commit();
         }
     }
 
     /**
-     * Gets the passed title from the intents and displays it as the page title
+     * Gets the passed categoryName from the intents and displays it as the page title
      */
     private void setPageTitle() {
-        if (getIntent() != null && getIntent().getStringExtra("title") != null) {
-            setTitle(getIntent().getStringExtra("title"));
+        if (getIntent() != null && getIntent().getStringExtra("categoryName") != null) {
+            setTitle(getIntent().getStringExtra("categoryName"));
         }
-    }
-
-    @Override
-    public void onBackStackChanged() {
     }
 
     @Override
@@ -106,7 +90,8 @@ public class CategoryDetailsActivity
             FragmentManager supportFragmentManager = getSupportFragmentManager();
             supportFragmentManager
                     .beginTransaction()
-                    .replace(R.id.fragmentContainer, mediaDetails)
+                    .hide(supportFragmentManager.getFragments().get(supportFragmentManager.getBackStackEntryCount()))
+                    .add(R.id.fragmentContainer, mediaDetails)
                     .addToBackStack(null)
                     .commit();
             supportFragmentManager.executePendingTransactions();
@@ -115,27 +100,15 @@ public class CategoryDetailsActivity
         initBackButton();
     }
 
-    @Override
-    protected void onResume() {
-        initBackButton();
-        if (supportFragmentManager.getBackStackEntryCount()==1){
-            //FIXME: Temporary fix for screen rotation inside media details. If we don't call onBackPressed then fragment stack is increasing every time.
-            //FIXME: Similar issue like this https://github.com/commons-app/apps-android-commons/issues/894
-            onBackPressed();
-        }
-        super.onResume();
-    }
 
     /**
      * Consumers should be simply using this method to use this activity.
      * @param context
-     * @param title Page title
      * @param categoryName Name of the category for displaying its images
      */
-    public static void startYourself(Context context, String title, String categoryName) {
+    public static void startYourself(Context context, String categoryName) {
         Intent intent = new Intent(context, CategoryDetailsActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-        intent.putExtra("title", title);
         intent.putExtra("categoryName", categoryName);
         context.startActivity(intent);
     }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -6,14 +6,22 @@ import android.database.DataSetObserver;
 import android.os.Bundle;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
+import android.widget.Toast;
 
 import butterknife.ButterKnife;
 import fr.free.nrw.commons.Media;
+import fr.free.nrw.commons.PageTitle;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.auth.AuthenticatedActivity;
 import fr.free.nrw.commons.media.MediaDetailPagerFragment;
+import fr.free.nrw.commons.theme.NavigationBaseActivity;
+
+import static android.widget.Toast.LENGTH_SHORT;
 
 /**
  * This activity displays pictures of a particular category
@@ -32,6 +40,7 @@ public class CategoryDetailsActivity
     private FragmentManager supportFragmentManager;
     private CategoryImagesListFragment categoryImagesListFragment;
     private MediaDetailPagerFragment mediaDetails;
+    private String categoryName;
 
     @Override
     protected void onAuthCookieAcquired(String authCookie) {
@@ -51,12 +60,12 @@ public class CategoryDetailsActivity
 
         // Activity can call methods in the fragment by acquiring a
         // reference to the Fragment from FragmentManager, using findFragmentById()
-        initDrawer();
         supportFragmentManager = getSupportFragmentManager();
         setCategoryImagesFragment();
         supportFragmentManager.addOnBackStackChangedListener(this);
         requestAuthToken();
         setPageTitle();
+        initDrawer();
     }
 
     /**
@@ -64,7 +73,7 @@ public class CategoryDetailsActivity
      */
     private void setCategoryImagesFragment() {
         categoryImagesListFragment = new CategoryImagesListFragment();
-        String categoryName = getIntent().getStringExtra("categoryName");
+        categoryName = getIntent().getStringExtra("categoryName");
         if (getIntent() != null && categoryName != null) {
             Bundle arguments = new Bundle();
             arguments.putString("categoryName", categoryName);
@@ -108,6 +117,7 @@ public class CategoryDetailsActivity
 
     @Override
     protected void onResume() {
+        initBackButton();
         if (supportFragmentManager.getBackStackEntryCount()==1){
             //FIXME: Temporary fix for screen rotation inside media details. If we don't call onBackPressed then fragment stack is increasing every time.
             //FIXME: Similar issue like this https://github.com/commons-app/apps-android-commons/issues/894
@@ -155,11 +165,39 @@ public class CategoryDetailsActivity
 
     @Override
     public void registerDataSetObserver(DataSetObserver observer) {
-
     }
 
     @Override
     public void unregisterDataSetObserver(DataSetObserver observer) {
 
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.fragment_category_detail, menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+
+        // Handle item selection
+        switch (item.getItemId()) {
+            case R.id.menu_browser_current_category:
+                Intent viewIntent = new Intent();
+                viewIntent.setAction(Intent.ACTION_VIEW);
+                viewIntent.setData(new PageTitle(categoryName).getCanonicalUri());
+                //check if web browser available
+                if (viewIntent.resolveActivity(this.getPackageManager()) != null) {
+                    startActivity(viewIntent);
+                } else {
+                    Toast toast = Toast.makeText(this, getString(R.string.no_web_browser), LENGTH_SHORT);
+                    toast.show();
+                }
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -1,0 +1,165 @@
+package fr.free.nrw.commons.category;
+
+import android.content.Context;
+import android.content.Intent;
+import android.database.DataSetObserver;
+import android.os.Bundle;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
+import android.view.View;
+import android.widget.AdapterView;
+
+import butterknife.ButterKnife;
+import fr.free.nrw.commons.Media;
+import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.auth.AuthenticatedActivity;
+import fr.free.nrw.commons.media.MediaDetailPagerFragment;
+
+/**
+ * This activity displays pictures of a particular category
+ * Its generic and simply takes the name of category name in its start intent to load all images in
+ * a particular category. This activity is currently being used to display a list of featured images,
+ * which is nothing but another category on wikimedia commons.
+ */
+
+public class CategoryDetailsActivity
+        extends AuthenticatedActivity
+        implements FragmentManager.OnBackStackChangedListener,
+                    MediaDetailPagerFragment.MediaDetailProvider,
+                    AdapterView.OnItemClickListener{
+
+
+    private FragmentManager supportFragmentManager;
+    private CategoryImagesListFragment categoryImagesListFragment;
+    private MediaDetailPagerFragment mediaDetails;
+
+    @Override
+    protected void onAuthCookieAcquired(String authCookie) {
+
+    }
+
+    @Override
+    protected void onAuthFailure() {
+
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_category_images);
+        ButterKnife.bind(this);
+
+        // Activity can call methods in the fragment by acquiring a
+        // reference to the Fragment from FragmentManager, using findFragmentById()
+        initDrawer();
+        supportFragmentManager = getSupportFragmentManager();
+        setCategoryImagesFragment();
+        supportFragmentManager.addOnBackStackChangedListener(this);
+        requestAuthToken();
+        setPageTitle();
+    }
+
+    /**
+     * Gets the categoryName from the intent and initializes the fragment for showing images of that category
+     */
+    private void setCategoryImagesFragment() {
+        categoryImagesListFragment = new CategoryImagesListFragment();
+        String categoryName = getIntent().getStringExtra("categoryName");
+        if (getIntent() != null && categoryName != null) {
+            Bundle arguments = new Bundle();
+            arguments.putString("categoryName", categoryName);
+            categoryImagesListFragment.setArguments(arguments);
+            FragmentTransaction transaction = supportFragmentManager.beginTransaction();
+            transaction
+                    .add(R.id.fragmentContainer, categoryImagesListFragment)
+                    .commit();
+        }
+    }
+
+    /**
+     * Gets the passed title from the intents and displays it as the page title
+     */
+    private void setPageTitle() {
+        if (getIntent() != null && getIntent().getStringExtra("title") != null) {
+            setTitle(getIntent().getStringExtra("title"));
+        }
+    }
+
+    @Override
+    public void onBackStackChanged() {
+    }
+
+    @Override
+    public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
+        if (mediaDetails == null || !mediaDetails.isVisible()) {
+            // set isFeaturedImage true for featured images, to include author field on media detail
+            mediaDetails = new MediaDetailPagerFragment(false, true);
+            FragmentManager supportFragmentManager = getSupportFragmentManager();
+            supportFragmentManager
+                    .beginTransaction()
+                    .replace(R.id.fragmentContainer, mediaDetails)
+                    .addToBackStack(null)
+                    .commit();
+            supportFragmentManager.executePendingTransactions();
+        }
+        mediaDetails.showImage(i);
+        initBackButton();
+    }
+
+    @Override
+    protected void onResume() {
+        if (supportFragmentManager.getBackStackEntryCount()==1){
+            //FIXME: Temporary fix for screen rotation inside media details. If we don't call onBackPressed then fragment stack is increasing every time.
+            //FIXME: Similar issue like this https://github.com/commons-app/apps-android-commons/issues/894
+            onBackPressed();
+        }
+        super.onResume();
+    }
+
+    /**
+     * Consumers should be simply using this method to use this activity.
+     * @param context
+     * @param title Page title
+     * @param categoryName Name of the category for displaying its images
+     */
+    public static void startYourself(Context context, String title, String categoryName) {
+        Intent intent = new Intent(context, CategoryDetailsActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        intent.putExtra("title", title);
+        intent.putExtra("categoryName", categoryName);
+        context.startActivity(intent);
+    }
+
+    @Override
+    public Media getMediaAtPosition(int i) {
+        if (categoryImagesListFragment.getAdapter() == null) {
+            // not yet ready to return data
+            return null;
+        } else {
+            return (Media) categoryImagesListFragment.getAdapter().getItem(i);
+        }
+    }
+
+    @Override
+    public int getTotalMediaCount() {
+        if (categoryImagesListFragment.getAdapter() == null) {
+            return 0;
+        }
+        return categoryImagesListFragment.getAdapter().getCount();
+    }
+
+    @Override
+    public void notifyDatasetChanged() {
+
+    }
+
+    @Override
+    public void registerDataSetObserver(DataSetObserver observer) {
+
+    }
+
+    @Override
+    public void unregisterDataSetObserver(DataSetObserver observer) {
+
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -19,7 +19,6 @@ import fr.free.nrw.commons.PageTitle;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.auth.AuthenticatedActivity;
 import fr.free.nrw.commons.media.MediaDetailPagerFragment;
-import fr.free.nrw.commons.theme.NavigationBaseActivity;
 
 import static android.widget.Toast.LENGTH_SHORT;
 
@@ -66,6 +65,7 @@ public class CategoryDetailsActivity
         requestAuthToken();
         setPageTitle();
         initDrawer();
+        initBackButton();
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -24,14 +24,12 @@ import fr.free.nrw.commons.theme.NavigationBaseActivity;
 import static android.widget.Toast.LENGTH_SHORT;
 
 /**
- * This activity displays pictures of a particular category
- * Its generic and simply takes the name of category name in its start intent to load all images in
- * a particular category. This activity is currently being used to display a list of featured images,
- * which is nothing but another category on wikimedia commons.
+ * This activity displays details of a particular category
+ * Its generic and simply takes the name of category name in its start intent to load all images, subcategories in
+ * a particular category on wikimedia commons.
  */
 
-public class CategoryDetailsActivity
-        extends NavigationBaseActivity
+public class CategoryDetailsActivity extends NavigationBaseActivity
         implements MediaDetailPagerFragment.MediaDetailProvider,
                     AdapterView.OnItemClickListener{
 
@@ -46,11 +44,7 @@ public class CategoryDetailsActivity
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_category_images);
         ButterKnife.bind(this);
-
-        // Activity can call methods in the fragment by acquiring a
-        // reference to the Fragment from FragmentManager, using findFragmentById()
         supportFragmentManager = getSupportFragmentManager();
-//        supportFragmentManager.addOnBackStackChangedListener(this);
         setCategoryImagesFragment();
         setPageTitle();
         initDrawer();
@@ -85,7 +79,6 @@ public class CategoryDetailsActivity
     @Override
     public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
         if (mediaDetails == null || !mediaDetails.isVisible()) {
-            // set isFeaturedImage true for featured images, to include author field on media detail
             mediaDetails = new MediaDetailPagerFragment(false, true);
             FragmentManager supportFragmentManager = getSupportFragmentManager();
             supportFragmentManager
@@ -104,7 +97,7 @@ public class CategoryDetailsActivity
     /**
      * Consumers should be simply using this method to use this activity.
      * @param context
-     * @param categoryName Name of the category for displaying its images
+     * @param categoryName Name of the category for displaying its details
      */
     public static void startYourself(Context context, String categoryName) {
         Intent intent = new Intent(context, CategoryDetailsActivity.class);

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
@@ -1,7 +1,5 @@
 package fr.free.nrw.commons.category;
 
-import android.util.Log;
-
 import org.jsoup.Jsoup;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
@@ -1,5 +1,7 @@
 package fr.free.nrw.commons.category;
 
+import android.util.Log;
+
 import org.jsoup.Jsoup;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -27,7 +29,9 @@ public class CategoryImageUtils {
         List<Media> categoryImages = new ArrayList<>();
         for (int i = 0; i < childNodes.getLength(); i++) {
             Node node = childNodes.item(i);
-            categoryImages.add(getMediaFromPage(node));
+            if (getMediaFromPage(node).getFilename().substring(0,5).equals("File:")){
+                categoryImages.add(getMediaFromPage(node));
+            }
         }
 
         return categoryImages;

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
@@ -49,6 +49,12 @@ public class CategoryImagesActivity
     }
 
     @Override
+    public void onBackPressed() {
+        initDrawer();
+        super.onBackPressed();
+    }
+
+    @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_category_images);
@@ -102,7 +108,8 @@ public class CategoryImagesActivity
             FragmentManager supportFragmentManager = getSupportFragmentManager();
             supportFragmentManager
                     .beginTransaction()
-                    .replace(R.id.fragmentContainer, mediaDetails)
+                    .hide(supportFragmentManager.getFragments().get(supportFragmentManager.getBackStackEntryCount()))
+                    .add(R.id.fragmentContainer, mediaDetails)
                     .addToBackStack(null)
                     .commit();
             supportFragmentManager.executePendingTransactions();

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
@@ -115,7 +115,7 @@ public class CategoryImagesActivity
             supportFragmentManager.executePendingTransactions();
         }
         mediaDetails.showImage(i);
-        initBackButton();
+        forceInitBackButton();
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
@@ -143,7 +143,7 @@ public class CategoryImagesListFragment extends DaggerFragment {
         progressBar.setVisibility(GONE);
         if (gridAdapter == null || gridAdapter.isEmpty()) {
             statusTextView.setVisibility(VISIBLE);
-            statusTextView.setText(getString(R.string.no_images_found));
+            statusTextView.setText(getContext().getString(R.string.no_images_found));
         } else {
             ViewUtil.showSnackbar(gridView, R.string.error_loading_images);
             statusTextView.setVisibility(GONE);

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
@@ -140,12 +140,12 @@ public class CategoryImagesListFragment extends DaggerFragment {
      * Handles the UI updates for a error scenario
      */
     private void initErrorView() {
-        ViewUtil.showSnackbar(gridView, R.string.error_loading_images);
         progressBar.setVisibility(GONE);
         if (gridAdapter == null || gridAdapter.isEmpty()) {
             statusTextView.setVisibility(VISIBLE);
             statusTextView.setText(getString(R.string.no_images_found));
         } else {
+            ViewUtil.showSnackbar(gridView, R.string.error_loading_images);
             statusTextView.setVisibility(GONE);
         }
     }
@@ -225,13 +225,4 @@ public class CategoryImagesListFragment extends DaggerFragment {
         return gridView.getAdapter();
     }
 
-    /**
-     * This method will be called on back pressed of CategoryImagesActivity.
-     * It initializes the grid view by setting adapter.
-     */
-    @Override
-    public void onResume() {
-        gridView.setAdapter(gridAdapter);
-        super.onResume();
-    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
@@ -172,7 +172,7 @@ public class CategoryImagesListFragment extends DaggerFragment {
 
             @Override
             public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
-                if (hasMoreImages && !isLoading && (firstVisibleItem + visibleItemCount + 1 >= totalItemCount)) {
+                if (hasMoreImages && !isLoading && (firstVisibleItem + visibleItemCount >= totalItemCount)) {
                     isLoading = true;
                     fetchMoreImages();
                 }

--- a/app/src/main/java/fr/free/nrw/commons/category/GridViewAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/GridViewAdapter.java
@@ -66,7 +66,7 @@ public class GridViewAdapter extends ArrayAdapter {
         MediaWikiImageView imageView = convertView.findViewById(R.id.categoryImageView);
         TextView fileName = convertView.findViewById(R.id.categoryImageTitle);
         TextView author = convertView.findViewById(R.id.categoryImageAuthor);
-        fileName.setText(item.getFilename());
+        fileName.setText(item.getDisplayTitle());
         setAuthorView(item, author);
         imageView.setMedia(item);
         return convertView;

--- a/app/src/main/java/fr/free/nrw/commons/di/ActivityBuilderModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/ActivityBuilderModule.java
@@ -6,6 +6,7 @@ import fr.free.nrw.commons.AboutActivity;
 import fr.free.nrw.commons.WelcomeActivity;
 import fr.free.nrw.commons.auth.LoginActivity;
 import fr.free.nrw.commons.auth.SignupActivity;
+import fr.free.nrw.commons.category.CategoryDetailsActivity;
 import fr.free.nrw.commons.contributions.ContributionsActivity;
 import fr.free.nrw.commons.category.CategoryImagesActivity;
 import fr.free.nrw.commons.explore.SearchActivity;
@@ -54,4 +55,7 @@ public abstract class ActivityBuilderModule {
 
     @ContributesAndroidInjector
     abstract SearchActivity bindSearchActivity();
+
+    @ContributesAndroidInjector
+    abstract CategoryDetailsActivity bindCategoryDetailsActivity();
 }

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -103,13 +103,16 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
                             //update image list
                             if (!TextUtils.isEmpty(query)) {
                                 viewPager.setVisibility(View.VISIBLE);
+                                tabLayout.setVisibility(View.VISIBLE);
                                 searchHistoryContainer.setVisibility(View.GONE);
                                 this.query = query.toString();
                                 searchImageFragment.updateImageList(query.toString());
                                 searchCategoryFragment.updateCategoryList(query.toString());
                             }else {
                                 viewPager.setVisibility(View.GONE);
+                                tabLayout.setVisibility(View.GONE);
                                 searchHistoryContainer.setVisibility(View.VISIBLE);
+                                recentSearchesFragment.updateRecentSearches();
                                 // open search history fragment
                             }
                         }
@@ -164,7 +167,7 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
             supportFragmentManager.executePendingTransactions();
         }
         mediaDetails.showImage(index);
-        initBackButton();
+        forceInitBackButton();
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesRenderer.java
@@ -47,7 +47,7 @@ class SearchCategoriesRenderer extends Renderer<String> {
     @Override
     public void render() {
         String item = getContent();
-        tvCategoryName.setText(item);
+        tvCategoryName.setText(item.replaceFirst("^Category:", ""));
     }
 
     interface CategoryClickedListener {

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -27,6 +27,7 @@ import javax.inject.Named;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.category.CategoryDetailsActivity;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.explore.recentsearches.RecentSearch;
 import fr.free.nrw.commons.explore.recentsearches.RecentSearchesDao;
@@ -66,6 +67,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
 
     private final SearchCategoriesAdapterFactory adapterFactory = new SearchCategoriesAdapterFactory(item -> {
         // Open Category Details activity
+        CategoryDetailsActivity.startYourself(getContext(), item, item);
         saveQuery(query);
     });
 

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -67,7 +67,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
 
     private final SearchCategoriesAdapterFactory adapterFactory = new SearchCategoriesAdapterFactory(item -> {
         // Open Category Details activity
-        CategoryDetailsActivity.startYourself(getContext(), item, item);
+        CategoryDetailsActivity.startYourself(getContext(), item);
         saveQuery(query);
     });
 

--- a/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImagesRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImagesRenderer.java
@@ -52,7 +52,7 @@ class SearchImagesRenderer extends Renderer<Media> {
     @Override
     public void render() {
         Media item = getContent();
-        tvImageName.setText(item.getFilename());
+        tvImageName.setText(item.getDisplayTitle());
         browseImage.setMedia(item);
         setAuthorView(item, categoryImageAuthor);
     }

--- a/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
@@ -72,4 +72,11 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
         adapter.notifyDataSetChanged();
         super.onResume();
     }
+
+    public void updateRecentSearches() {
+        recentSearches = recentSearchesDao.recentSearches(10);
+        adapter = new ArrayAdapter<String>(getContext(),R.layout.item_recent_searches, recentSearches);
+        recentSearchesList.setAdapter(adapter);
+        adapter.notifyDataSetChanged();
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -434,8 +434,6 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
                 Intent intent = new Intent(getContext(), CategoryDetailsActivity.class);
                 intent.putExtra("categoryName", selectedCategoryTitle);
                 getContext().startActivity(intent);
-
-//                CategoryDetailsActivity.startYourself(getContext(),  selectedCategoryTitle);
             });
         }
         return item;

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -45,6 +45,7 @@ import fr.free.nrw.commons.MediaDataExtractor;
 import fr.free.nrw.commons.MediaWikiImageView;
 import fr.free.nrw.commons.PageTitle;
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.category.CategoryDetailsActivity;
 import fr.free.nrw.commons.delete.DeleteTask;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.location.LatLng;
@@ -430,16 +431,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         if (categoriesLoaded && categoriesPresent) {
             textView.setOnClickListener(view -> {
                 String selectedCategoryTitle = "Category:" + catName;
-                Intent viewIntent = new Intent();
-                viewIntent.setAction(Intent.ACTION_VIEW);
-                viewIntent.setData(new PageTitle(selectedCategoryTitle).getCanonicalUri());
-                //check if web browser available
-                if (viewIntent.resolveActivity(getActivity().getPackageManager()) != null) {
-                    startActivity(viewIntent);
-                } else {
-                    Toast toast = Toast.makeText(getContext(), getString(R.string.no_web_browser), LENGTH_SHORT);
-                    toast.show();
-                }
+                CategoryDetailsActivity.startYourself(getContext(), selectedCategoryTitle, selectedCategoryTitle);
             });
         }
         return item;

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -431,7 +431,11 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         if (categoriesLoaded && categoriesPresent) {
             textView.setOnClickListener(view -> {
                 String selectedCategoryTitle = "Category:" + catName;
-                CategoryDetailsActivity.startYourself(getContext(), selectedCategoryTitle, selectedCategoryTitle);
+                Intent intent = new Intent(getContext(), CategoryDetailsActivity.class);
+                intent.putExtra("categoryName", selectedCategoryTitle);
+                getContext().startActivity(intent);
+
+//                CategoryDetailsActivity.startYourself(getContext(),  selectedCategoryTitle);
             });
         }
         return item;

--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -77,6 +77,12 @@ public abstract class NavigationBaseActivity extends BaseActivity
     }
 
     public void initBackButton() {
+        int backStackEntryCount = getSupportFragmentManager().getBackStackEntryCount();
+        toggle.setDrawerIndicatorEnabled(backStackEntryCount == 0);
+        toggle.setToolbarNavigationClickListener(v -> onBackPressed());
+    }
+
+    public void forceInitBackButton() {
         toggle.setDrawerIndicatorEnabled(false);
         toggle.setToolbarNavigationClickListener(v -> onBackPressed());
     }

--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -77,8 +77,7 @@ public abstract class NavigationBaseActivity extends BaseActivity
     }
 
     public void initBackButton() {
-        int backStackEntryCount = getSupportFragmentManager().getBackStackEntryCount();
-        toggle.setDrawerIndicatorEnabled(backStackEntryCount == 0);
+        toggle.setDrawerIndicatorEnabled(false);
         toggle.setToolbarNavigationClickListener(v -> onBackPressed());
     }
 

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -44,6 +44,7 @@
         </android.support.v7.widget.Toolbar>
         <android.support.design.widget.TabLayout
             android:id="@+id/tabLayout"
+            android:visibility="gone"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:tabTextAppearance="@android:style/TextAppearance.Widget.TabWidget"

--- a/app/src/main/res/menu/fragment_category_detail.xml
+++ b/app/src/main/res/menu/fragment_category_detail.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/menu_browser_current_category"
+        android:title="@string/menu_open_in_browser"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,7 @@
   <string name="title_activity_settings">Settings</string>
   <string name="title_activity_signup">Sign Up</string>
   <string name="title_activity_featured_images">Featured Images</string>
+  <string name="title_activity_category_details">Category</string>
   <string name="menu_about">About</string>
   <string name="about_license">The Wikimedia Commons app is an open-source app created and maintained by grantees and volunteers of the Wikimedia community. The Wikimedia Foundation is not involved in the creation, development, or maintenance of the app. </string>
   <string name="trademarked_name" translatable="false">Wikimedia Commons</string>


### PR DESCRIPTION
## Title (required)

Fixes #1642  (Add a category details page in app)
Fixes #1252 (Details activity: Open category in-app)
Fixes #1673  (Hopping from category to category does not always work )
Fixes #1674  (Inconsistent Back arrow in category details)

## Description (required)

- Added new activity for category details (currently showing only images inside a category)
- added activity in manifest, ActivityBuilderModule.java
- Fixed back button issue in explore, category details (Similar to #1664 )
- Made changes in CategoryImageUtils.java to show only images instead of all pages like categories.
- opened category details from search results, from media details.
- Added menu for opening category details page in browser.
## Tests performed (required)

Manually Tested on {API level 25 & name of device/emulator}, with {ProdDebug variant}.

## Screenshots showing what changed (optional)

<table>
<tr>
<td>

![screenshot_20180628-171055](https://user-images.githubusercontent.com/19607555/42032318-d726592a-7af6-11e8-99ec-4c42412a834e.png)

</td>
<td>

![screenshot_20180628-171036](https://user-images.githubusercontent.com/19607555/42032320-d790a708-7af6-11e8-869d-62ca22c0c25e.png)

</td>
<td>

![screenshot_20180628-171028](https://user-images.githubusercontent.com/19607555/42032321-d7de0318-7af6-11e8-8e50-a5831ef787c5.png)

</td>
</tr>
</table>
