### PR TITLE
Fix tamil translation of app name

### DIFF
--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="app_name">விக்கிமீடியா காமன்சு</string>
+  <string name="app_name">காமன்சு</string>
   <string name="menu_settings">அமைப்புகள்</string>
   <string name="username">பயனர் பெயர்</string>
   <string name="password">கடவுச்சொல்</string>


### PR DESCRIPTION
## Description (required)
The app name has been 'Commons' (and not 'Wikimedia Commons') for a
very long time. For completely unknown reasons, the Tamil (ta)
translation of the app name stuck with the translation for 'Wikimedia
Commons' regardless of the fact that the translation had been
corrected at translatewiki.net in the year 2016. The correction
somehow didn't reflect here during the localisation updates from
tranlsatewiki.net.

Ignoring the weirdness, correct the translation of the app name
to reflect it's current name.