### PR TITLE
Give a useful label for the share intent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,7 +45,7 @@
             android:name=".upload.ShareActivity"
             android:icon="@drawable/ic_launcher"
             android:label="@string/app_name">
-            <intent-filter>
+            <intent-filter android:label="@string/intent_share_upload_label">
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />
@@ -57,7 +57,7 @@
             android:name=".upload.MultipleShareActivity"
             android:icon="@drawable/ic_launcher"
             android:label="@string/app_name">
-            <intent-filter>
+            <intent-filter android:label="@string/intent_share_upload_label">
                 <action android:name="android.intent.action.SEND_MULTIPLE" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
   <string name="app_name">Commons</string>
   <string name="bullet">&#8226;  </string>
   <string name="menu_settings">Settings</string>
+  <string name="intent_share_upload_label">Upload to Commons</string>
   <string name="username">Username</string>
   <string name="password">Password</string>
   <string name="login_credential">Log in to your Commons Beta account</string>


### PR DESCRIPTION
## Description (required)
It's better to give a useful label that would indicate what would
happen when sharing using the app rather than letting it default
to the app name.

## Tests performed (required)
Tested on API 22 on Samsung Galaxy j1 ace with ProdDebug

## Screenshots showing what changed (optional)
![screenshot_2018-06-29-17-38-36](https://user-images.githubusercontent.com/12448084/42091592-969dcece-7bc3-11e8-804f-9c76ae2e6eca.png)
