### PR TITLE
Force login when no active session is found while uploading an image

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/SessionManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/SessionManager.java
@@ -5,6 +5,8 @@ import android.accounts.AccountManager;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import javax.annotation.Nullable;
+
 import fr.free.nrw.commons.mwapi.MediaWikiApi;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
@@ -31,6 +33,7 @@ public class SessionManager {
     /**
      * @return Account|null
      */
+    @Nullable
     public Account getCurrentAccount() {
         if (currentAccount == null) {
             AccountManager accountManager = AccountManager.get(context);

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadController.java
@@ -1,5 +1,6 @@
 package fr.free.nrw.commons.upload;
 
+import android.accounts.Account;
 import android.content.ComponentName;
 import android.content.ContentResolver;
 import android.content.Context;
@@ -13,6 +14,7 @@ import android.os.AsyncTask;
 import android.os.IBinder;
 import android.provider.MediaStore;
 import android.text.TextUtils;
+import android.widget.Toast;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -22,9 +24,11 @@ import java.util.concurrent.Executors;
 
 import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.HandlerService;
+import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.auth.SessionManager;
 import fr.free.nrw.commons.contributions.Contribution;
 import fr.free.nrw.commons.settings.Prefs;
+import fr.free.nrw.commons.utils.ViewUtil;
 import timber.log.Timber;
 
 public class UploadController {
@@ -95,8 +99,15 @@ public class UploadController {
         Contribution contribution;
 
         //TODO: Modify this to include coords
+        Account currentAccount = sessionManager.getCurrentAccount();
+        if(currentAccount == null) {
+            Timber.d("Current account is null");
+            ViewUtil.showLongToast(context, context.getString(R.string.user_not_logged_in));
+            sessionManager.forceLogin(context);
+            return;
+        }
         contribution = new Contribution(mediaUri, null, title, description, -1,
-                null, null, sessionManager.getCurrentAccount().name,
+                null, null, currentAccount.name,
                 CommonsApplication.DEFAULT_EDIT_SUMMARY, decimalCoords);
 
         contribution.setTag("mimeType", mimeType);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -287,4 +287,6 @@
   <string name="wikidata_edit_failure">Failed to update corresponding Wikidata entity!</string>
   <string name="menu_set_wallpaper">Set wallpaper</string>
   <string name="wallpaper_set_successfully">Wallpaper set successfully!</string>
+
+  <string name="user_not_logged_in">No active session found for this user.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -288,5 +288,5 @@
   <string name="menu_set_wallpaper">Set wallpaper</string>
   <string name="wallpaper_set_successfully">Wallpaper set successfully!</string>
 
-  <string name="user_not_logged_in">No active session found for this user.</string>
+  <string name="user_not_logged_in">Login session expired, please log in again.</string>
 </resources>


### PR DESCRIPTION
## Title (required)

Fixes part of #1545. 

## Description (required)

The only could that could be null in the `startUpload` method of `UploadController` is `name` field of `CurrentAccount`. Have added a null check for the same and will be redirecting the user to login if the session is null. 

## Tests performed (required)

Unable to reproduce the issue but this check should ideally prevent the crash and redirect the user to login. 