### PR TITLE
Subcategory list added in category details

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -98,6 +98,11 @@
             android:parentActivityName=".contributions.ContributionsActivity" />
 
         <activity
+            android:name=".category.CategoryDetailsActivity"
+            android:label="@string/title_activity_featured_images"
+            android:parentActivityName=".contributions.ContributionsActivity" />
+
+        <activity
             android:name=".explore.SearchActivity"
             android:label="@string/title_activity_search"
             android:parentActivityName=".contributions.ContributionsActivity"

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -48,7 +48,7 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
         setCategoryImagesFragment();
         setPageTitle();
         initDrawer();
-        initBackButton();
+        forceInitBackButton();
     }
 
     /**
@@ -90,7 +90,7 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
             supportFragmentManager.executePendingTransactions();
         }
         mediaDetails.showImage(i);
-        initBackButton();
+        forceInitBackButton();
     }
 
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -19,6 +19,7 @@ import fr.free.nrw.commons.PageTitle;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.auth.AuthenticatedActivity;
 import fr.free.nrw.commons.media.MediaDetailPagerFragment;
+import fr.free.nrw.commons.theme.NavigationBaseActivity;
 
 import static android.widget.Toast.LENGTH_SHORT;
 
@@ -30,9 +31,8 @@ import static android.widget.Toast.LENGTH_SHORT;
  */
 
 public class CategoryDetailsActivity
-        extends AuthenticatedActivity
-        implements FragmentManager.OnBackStackChangedListener,
-                    MediaDetailPagerFragment.MediaDetailProvider,
+        extends NavigationBaseActivity
+        implements MediaDetailPagerFragment.MediaDetailProvider,
                     AdapterView.OnItemClickListener{
 
 
@@ -40,16 +40,6 @@ public class CategoryDetailsActivity
     private CategoryImagesListFragment categoryImagesListFragment;
     private MediaDetailPagerFragment mediaDetails;
     private String categoryName;
-
-    @Override
-    protected void onAuthCookieAcquired(String authCookie) {
-
-    }
-
-    @Override
-    protected void onAuthFailure() {
-
-    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -60,9 +50,8 @@ public class CategoryDetailsActivity
         // Activity can call methods in the fragment by acquiring a
         // reference to the Fragment from FragmentManager, using findFragmentById()
         supportFragmentManager = getSupportFragmentManager();
+//        supportFragmentManager.addOnBackStackChangedListener(this);
         setCategoryImagesFragment();
-        supportFragmentManager.addOnBackStackChangedListener(this);
-        requestAuthToken();
         setPageTitle();
         initDrawer();
         initBackButton();
@@ -79,23 +68,18 @@ public class CategoryDetailsActivity
             arguments.putString("categoryName", categoryName);
             categoryImagesListFragment.setArguments(arguments);
             FragmentTransaction transaction = supportFragmentManager.beginTransaction();
-            transaction
-                    .add(R.id.fragmentContainer, categoryImagesListFragment)
-                    .commit();
+            transaction.replace(R.id.fragmentContainer, categoryImagesListFragment)
+            .commit();
         }
     }
 
     /**
-     * Gets the passed title from the intents and displays it as the page title
+     * Gets the passed categoryName from the intents and displays it as the page title
      */
     private void setPageTitle() {
-        if (getIntent() != null && getIntent().getStringExtra("title") != null) {
-            setTitle(getIntent().getStringExtra("title"));
+        if (getIntent() != null && getIntent().getStringExtra("categoryName") != null) {
+            setTitle(getIntent().getStringExtra("categoryName"));
         }
-    }
-
-    @Override
-    public void onBackStackChanged() {
     }
 
     @Override
@@ -106,7 +90,8 @@ public class CategoryDetailsActivity
             FragmentManager supportFragmentManager = getSupportFragmentManager();
             supportFragmentManager
                     .beginTransaction()
-                    .replace(R.id.fragmentContainer, mediaDetails)
+                    .hide(supportFragmentManager.getFragments().get(supportFragmentManager.getBackStackEntryCount()))
+                    .add(R.id.fragmentContainer, mediaDetails)
                     .addToBackStack(null)
                     .commit();
             supportFragmentManager.executePendingTransactions();
@@ -115,27 +100,15 @@ public class CategoryDetailsActivity
         initBackButton();
     }
 
-    @Override
-    protected void onResume() {
-        initBackButton();
-        if (supportFragmentManager.getBackStackEntryCount()==1){
-            //FIXME: Temporary fix for screen rotation inside media details. If we don't call onBackPressed then fragment stack is increasing every time.
-            //FIXME: Similar issue like this https://github.com/commons-app/apps-android-commons/issues/894
-            onBackPressed();
-        }
-        super.onResume();
-    }
 
     /**
      * Consumers should be simply using this method to use this activity.
      * @param context
-     * @param title Page title
      * @param categoryName Name of the category for displaying its images
      */
-    public static void startYourself(Context context, String title, String categoryName) {
+    public static void startYourself(Context context, String categoryName) {
         Intent intent = new Intent(context, CategoryDetailsActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-        intent.putExtra("title", title);
         intent.putExtra("categoryName", categoryName);
         context.startActivity(intent);
     }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -6,14 +6,22 @@ import android.database.DataSetObserver;
 import android.os.Bundle;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
+import android.widget.Toast;
 
 import butterknife.ButterKnife;
 import fr.free.nrw.commons.Media;
+import fr.free.nrw.commons.PageTitle;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.auth.AuthenticatedActivity;
 import fr.free.nrw.commons.media.MediaDetailPagerFragment;
+import fr.free.nrw.commons.theme.NavigationBaseActivity;
+
+import static android.widget.Toast.LENGTH_SHORT;
 
 /**
  * This activity displays pictures of a particular category
@@ -32,6 +40,7 @@ public class CategoryDetailsActivity
     private FragmentManager supportFragmentManager;
     private CategoryImagesListFragment categoryImagesListFragment;
     private MediaDetailPagerFragment mediaDetails;
+    private String categoryName;
 
     @Override
     protected void onAuthCookieAcquired(String authCookie) {
@@ -51,12 +60,12 @@ public class CategoryDetailsActivity
 
         // Activity can call methods in the fragment by acquiring a
         // reference to the Fragment from FragmentManager, using findFragmentById()
-        initDrawer();
         supportFragmentManager = getSupportFragmentManager();
         setCategoryImagesFragment();
         supportFragmentManager.addOnBackStackChangedListener(this);
         requestAuthToken();
         setPageTitle();
+        initDrawer();
     }
 
     /**
@@ -64,7 +73,7 @@ public class CategoryDetailsActivity
      */
     private void setCategoryImagesFragment() {
         categoryImagesListFragment = new CategoryImagesListFragment();
-        String categoryName = getIntent().getStringExtra("categoryName");
+        categoryName = getIntent().getStringExtra("categoryName");
         if (getIntent() != null && categoryName != null) {
             Bundle arguments = new Bundle();
             arguments.putString("categoryName", categoryName);
@@ -108,6 +117,7 @@ public class CategoryDetailsActivity
 
     @Override
     protected void onResume() {
+        initBackButton();
         if (supportFragmentManager.getBackStackEntryCount()==1){
             //FIXME: Temporary fix for screen rotation inside media details. If we don't call onBackPressed then fragment stack is increasing every time.
             //FIXME: Similar issue like this https://github.com/commons-app/apps-android-commons/issues/894
@@ -155,11 +165,39 @@ public class CategoryDetailsActivity
 
     @Override
     public void registerDataSetObserver(DataSetObserver observer) {
-
     }
 
     @Override
     public void unregisterDataSetObserver(DataSetObserver observer) {
 
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.fragment_category_detail, menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+
+        // Handle item selection
+        switch (item.getItemId()) {
+            case R.id.menu_browser_current_category:
+                Intent viewIntent = new Intent();
+                viewIntent.setAction(Intent.ACTION_VIEW);
+                viewIntent.setData(new PageTitle(categoryName).getCanonicalUri());
+                //check if web browser available
+                if (viewIntent.resolveActivity(this.getPackageManager()) != null) {
+                    startActivity(viewIntent);
+                } else {
+                    Toast toast = Toast.makeText(this, getString(R.string.no_web_browser), LENGTH_SHORT);
+                    toast.show();
+                }
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -82,7 +82,7 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
         fragmentList.add(categoryImagesListFragment);
         titleList.add("MEDIA");
         fragmentList.add(subCategoryListFragment);
-        titleList.add("CATEGORIES");
+        titleList.add("SUB-CATEGORIES");
         viewPagerAdapter.setTabData(fragmentList, titleList);
         viewPagerAdapter.notifyDataSetChanged();
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -1,0 +1,165 @@
+package fr.free.nrw.commons.category;
+
+import android.content.Context;
+import android.content.Intent;
+import android.database.DataSetObserver;
+import android.os.Bundle;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
+import android.view.View;
+import android.widget.AdapterView;
+
+import butterknife.ButterKnife;
+import fr.free.nrw.commons.Media;
+import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.auth.AuthenticatedActivity;
+import fr.free.nrw.commons.media.MediaDetailPagerFragment;
+
+/**
+ * This activity displays pictures of a particular category
+ * Its generic and simply takes the name of category name in its start intent to load all images in
+ * a particular category. This activity is currently being used to display a list of featured images,
+ * which is nothing but another category on wikimedia commons.
+ */
+
+public class CategoryDetailsActivity
+        extends AuthenticatedActivity
+        implements FragmentManager.OnBackStackChangedListener,
+                    MediaDetailPagerFragment.MediaDetailProvider,
+                    AdapterView.OnItemClickListener{
+
+
+    private FragmentManager supportFragmentManager;
+    private CategoryImagesListFragment categoryImagesListFragment;
+    private MediaDetailPagerFragment mediaDetails;
+
+    @Override
+    protected void onAuthCookieAcquired(String authCookie) {
+
+    }
+
+    @Override
+    protected void onAuthFailure() {
+
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_category_images);
+        ButterKnife.bind(this);
+
+        // Activity can call methods in the fragment by acquiring a
+        // reference to the Fragment from FragmentManager, using findFragmentById()
+        initDrawer();
+        supportFragmentManager = getSupportFragmentManager();
+        setCategoryImagesFragment();
+        supportFragmentManager.addOnBackStackChangedListener(this);
+        requestAuthToken();
+        setPageTitle();
+    }
+
+    /**
+     * Gets the categoryName from the intent and initializes the fragment for showing images of that category
+     */
+    private void setCategoryImagesFragment() {
+        categoryImagesListFragment = new CategoryImagesListFragment();
+        String categoryName = getIntent().getStringExtra("categoryName");
+        if (getIntent() != null && categoryName != null) {
+            Bundle arguments = new Bundle();
+            arguments.putString("categoryName", categoryName);
+            categoryImagesListFragment.setArguments(arguments);
+            FragmentTransaction transaction = supportFragmentManager.beginTransaction();
+            transaction
+                    .add(R.id.fragmentContainer, categoryImagesListFragment)
+                    .commit();
+        }
+    }
+
+    /**
+     * Gets the passed title from the intents and displays it as the page title
+     */
+    private void setPageTitle() {
+        if (getIntent() != null && getIntent().getStringExtra("title") != null) {
+            setTitle(getIntent().getStringExtra("title"));
+        }
+    }
+
+    @Override
+    public void onBackStackChanged() {
+    }
+
+    @Override
+    public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
+        if (mediaDetails == null || !mediaDetails.isVisible()) {
+            // set isFeaturedImage true for featured images, to include author field on media detail
+            mediaDetails = new MediaDetailPagerFragment(false, true);
+            FragmentManager supportFragmentManager = getSupportFragmentManager();
+            supportFragmentManager
+                    .beginTransaction()
+                    .replace(R.id.fragmentContainer, mediaDetails)
+                    .addToBackStack(null)
+                    .commit();
+            supportFragmentManager.executePendingTransactions();
+        }
+        mediaDetails.showImage(i);
+        initBackButton();
+    }
+
+    @Override
+    protected void onResume() {
+        if (supportFragmentManager.getBackStackEntryCount()==1){
+            //FIXME: Temporary fix for screen rotation inside media details. If we don't call onBackPressed then fragment stack is increasing every time.
+            //FIXME: Similar issue like this https://github.com/commons-app/apps-android-commons/issues/894
+            onBackPressed();
+        }
+        super.onResume();
+    }
+
+    /**
+     * Consumers should be simply using this method to use this activity.
+     * @param context
+     * @param title Page title
+     * @param categoryName Name of the category for displaying its images
+     */
+    public static void startYourself(Context context, String title, String categoryName) {
+        Intent intent = new Intent(context, CategoryDetailsActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        intent.putExtra("title", title);
+        intent.putExtra("categoryName", categoryName);
+        context.startActivity(intent);
+    }
+
+    @Override
+    public Media getMediaAtPosition(int i) {
+        if (categoryImagesListFragment.getAdapter() == null) {
+            // not yet ready to return data
+            return null;
+        } else {
+            return (Media) categoryImagesListFragment.getAdapter().getItem(i);
+        }
+    }
+
+    @Override
+    public int getTotalMediaCount() {
+        if (categoryImagesListFragment.getAdapter() == null) {
+            return 0;
+        }
+        return categoryImagesListFragment.getAdapter().getCount();
+    }
+
+    @Override
+    public void notifyDatasetChanged() {
+
+    }
+
+    @Override
+    public void registerDataSetObserver(DataSetObserver observer) {
+
+    }
+
+    @Override
+    public void unregisterDataSetObserver(DataSetObserver observer) {
+
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -19,7 +19,6 @@ import fr.free.nrw.commons.PageTitle;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.auth.AuthenticatedActivity;
 import fr.free.nrw.commons.media.MediaDetailPagerFragment;
-import fr.free.nrw.commons.theme.NavigationBaseActivity;
 
 import static android.widget.Toast.LENGTH_SHORT;
 
@@ -66,6 +65,7 @@ public class CategoryDetailsActivity
         requestAuthToken();
         setPageTitle();
         initDrawer();
+        initBackButton();
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -24,14 +24,12 @@ import fr.free.nrw.commons.theme.NavigationBaseActivity;
 import static android.widget.Toast.LENGTH_SHORT;
 
 /**
- * This activity displays pictures of a particular category
- * Its generic and simply takes the name of category name in its start intent to load all images in
- * a particular category. This activity is currently being used to display a list of featured images,
- * which is nothing but another category on wikimedia commons.
+ * This activity displays details of a particular category
+ * Its generic and simply takes the name of category name in its start intent to load all images, subcategories in
+ * a particular category on wikimedia commons.
  */
 
-public class CategoryDetailsActivity
-        extends NavigationBaseActivity
+public class CategoryDetailsActivity extends NavigationBaseActivity
         implements MediaDetailPagerFragment.MediaDetailProvider,
                     AdapterView.OnItemClickListener{
 
@@ -46,11 +44,7 @@ public class CategoryDetailsActivity
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_category_images);
         ButterKnife.bind(this);
-
-        // Activity can call methods in the fragment by acquiring a
-        // reference to the Fragment from FragmentManager, using findFragmentById()
         supportFragmentManager = getSupportFragmentManager();
-//        supportFragmentManager.addOnBackStackChangedListener(this);
         setCategoryImagesFragment();
         setPageTitle();
         initDrawer();
@@ -85,7 +79,6 @@ public class CategoryDetailsActivity
     @Override
     public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
         if (mediaDetails == null || !mediaDetails.isVisible()) {
-            // set isFeaturedImage true for featured images, to include author field on media detail
             mediaDetails = new MediaDetailPagerFragment(false, true);
             FragmentManager supportFragmentManager = getSupportFragmentManager();
             supportFragmentManager
@@ -104,7 +97,7 @@ public class CategoryDetailsActivity
     /**
      * Consumers should be simply using this method to use this activity.
      * @param context
-     * @param categoryName Name of the category for displaying its images
+     * @param categoryName Name of the category for displaying its details
      */
     public static void startYourself(Context context, String categoryName) {
         Intent intent = new Intent(context, CategoryDetailsActivity.class);

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
@@ -1,7 +1,5 @@
 package fr.free.nrw.commons.category;
 
-import android.util.Log;
-
 import org.jsoup.Jsoup;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
@@ -35,6 +35,18 @@ public class CategoryImageUtils {
         return categoryImages;
     }
 
+    public static List<String> getSubCategoryList(NodeList childNodes) {
+        List<String> subCategories = new ArrayList<>();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node node = childNodes.item(i);
+            if (getMediaFromPage(node).getFilename().substring(0,9).equals("Category:")){
+                subCategories.add(getMediaFromPage(node).getFilename());
+            }
+        }
+
+        return subCategories;
+    }
+
     /**
      * Creates a new Media object from the XML response as received by the API
      * @param node

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
@@ -39,9 +39,7 @@ public class CategoryImageUtils {
         List<String> subCategories = new ArrayList<>();
         for (int i = 0; i < childNodes.getLength(); i++) {
             Node node = childNodes.item(i);
-            if (getMediaFromPage(node).getFilename().substring(0,9).equals("Category:")){
-                subCategories.add(getMediaFromPage(node).getFilename());
-            }
+            subCategories.add(getMediaFromPage(node).getFilename());
         }
 
         return subCategories;

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
@@ -1,5 +1,7 @@
 package fr.free.nrw.commons.category;
 
+import android.util.Log;
+
 import org.jsoup.Jsoup;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -27,7 +29,9 @@ public class CategoryImageUtils {
         List<Media> categoryImages = new ArrayList<>();
         for (int i = 0; i < childNodes.getLength(); i++) {
             Node node = childNodes.item(i);
-            categoryImages.add(getMediaFromPage(node));
+            if (getMediaFromPage(node).getFilename().substring(0,5).equals("File:")){
+                categoryImages.add(getMediaFromPage(node));
+            }
         }
 
         return categoryImages;

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
@@ -49,6 +49,12 @@ public class CategoryImagesActivity
     }
 
     @Override
+    public void onBackPressed() {
+        initDrawer();
+        super.onBackPressed();
+    }
+
+    @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_category_images);
@@ -102,7 +108,8 @@ public class CategoryImagesActivity
             FragmentManager supportFragmentManager = getSupportFragmentManager();
             supportFragmentManager
                     .beginTransaction()
-                    .replace(R.id.fragmentContainer, mediaDetails)
+                    .hide(supportFragmentManager.getFragments().get(supportFragmentManager.getBackStackEntryCount()))
+                    .add(R.id.fragmentContainer, mediaDetails)
                     .addToBackStack(null)
                     .commit();
             supportFragmentManager.executePendingTransactions();

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
@@ -115,7 +115,7 @@ public class CategoryImagesActivity
             supportFragmentManager.executePendingTransactions();
         }
         mediaDetails.showImage(i);
-        initBackButton();
+        forceInitBackButton();
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
@@ -143,7 +143,7 @@ public class CategoryImagesListFragment extends DaggerFragment {
         progressBar.setVisibility(GONE);
         if (gridAdapter == null || gridAdapter.isEmpty()) {
             statusTextView.setVisibility(VISIBLE);
-            statusTextView.setText(getString(R.string.no_images_found));
+            statusTextView.setText(getContext().getString(R.string.no_images_found));
         } else {
             ViewUtil.showSnackbar(gridView, R.string.error_loading_images);
             statusTextView.setVisibility(GONE);

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
@@ -140,12 +140,12 @@ public class CategoryImagesListFragment extends DaggerFragment {
      * Handles the UI updates for a error scenario
      */
     private void initErrorView() {
-        ViewUtil.showSnackbar(gridView, R.string.error_loading_images);
         progressBar.setVisibility(GONE);
         if (gridAdapter == null || gridAdapter.isEmpty()) {
             statusTextView.setVisibility(VISIBLE);
             statusTextView.setText(getString(R.string.no_images_found));
         } else {
+            ViewUtil.showSnackbar(gridView, R.string.error_loading_images);
             statusTextView.setVisibility(GONE);
         }
     }
@@ -225,13 +225,4 @@ public class CategoryImagesListFragment extends DaggerFragment {
         return gridView.getAdapter();
     }
 
-    /**
-     * This method will be called on back pressed of CategoryImagesActivity.
-     * It initializes the grid view by setting adapter.
-     */
-    @Override
-    public void onResume() {
-        gridView.setAdapter(gridAdapter);
-        super.onResume();
-    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
@@ -172,7 +172,7 @@ public class CategoryImagesListFragment extends DaggerFragment {
 
             @Override
             public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
-                if (hasMoreImages && !isLoading && (firstVisibleItem + visibleItemCount + 1 >= totalItemCount)) {
+                if (hasMoreImages && !isLoading && (firstVisibleItem + visibleItemCount >= totalItemCount)) {
                     isLoading = true;
                     fetchMoreImages();
                 }

--- a/app/src/main/java/fr/free/nrw/commons/category/GridViewAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/GridViewAdapter.java
@@ -66,7 +66,7 @@ public class GridViewAdapter extends ArrayAdapter {
         MediaWikiImageView imageView = convertView.findViewById(R.id.categoryImageView);
         TextView fileName = convertView.findViewById(R.id.categoryImageTitle);
         TextView author = convertView.findViewById(R.id.categoryImageAuthor);
-        fileName.setText(item.getFilename());
+        fileName.setText(item.getDisplayTitle());
         setAuthorView(item, author);
         imageView.setMedia(item);
         return convertView;

--- a/app/src/main/java/fr/free/nrw/commons/category/SubCategoryListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/SubCategoryListFragment.java
@@ -1,0 +1,188 @@
+package fr.free.nrw.commons.category;
+
+
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.os.Bundle;
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.pedrogomez.renderers.RVRendererAdapter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
+import fr.free.nrw.commons.explore.categories.SearchCategoriesAdapterFactory;
+import fr.free.nrw.commons.mwapi.MediaWikiApi;
+import fr.free.nrw.commons.utils.NetworkUtils;
+import fr.free.nrw.commons.utils.ViewUtil;
+import io.reactivex.Observable;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
+import timber.log.Timber;
+
+import static android.view.View.GONE;
+import static android.view.View.VISIBLE;
+
+/**
+ * Displays the category search screen.
+ */
+
+public class SubCategoryListFragment extends CommonsDaggerSupportFragment {
+
+    private static int TIMEOUT_SECONDS = 15;
+
+    @BindView(R.id.imagesListBox)
+    RecyclerView categoriesRecyclerView;
+    @BindView(R.id.imageSearchInProgress)
+    ProgressBar progressBar;
+    @BindView(R.id.imagesNotFound)
+    TextView categoriesNotFoundView;
+
+    private String categoryName = null;
+    @Inject MediaWikiApi mwApi;
+
+    private RVRendererAdapter<String> categoriesAdapter;
+    private List<String> subCategoryList = new ArrayList<>();
+
+    private final SearchCategoriesAdapterFactory adapterFactory = new SearchCategoriesAdapterFactory(item -> {
+        // Open SubCategory Details page
+        Intent intent = new Intent(getContext(), CategoryDetailsActivity.class);
+        intent.putExtra("categoryName", item);
+        getContext().startActivity(intent);
+
+    });
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,Bundle savedInstanceState) {
+        View rootView = inflater.inflate(R.layout.fragment_browse_image, container, false);
+        ButterKnife.bind(this, rootView);
+        categoryName = getArguments().getString("categoryName");
+        initSubCategoryList();
+        if(getActivity().getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT){
+            categoriesRecyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        }
+        else{
+            categoriesRecyclerView.setLayoutManager(new GridLayoutManager(getContext(), 2));
+        }
+        ArrayList<String> items = new ArrayList<>();
+        categoriesAdapter = adapterFactory.create(items);
+        categoriesRecyclerView.setAdapter(categoriesAdapter);
+        categoriesRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
+            @Override
+            public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
+                super.onScrollStateChanged(recyclerView, newState);
+                // check if end of recycler view is reached, if yes then add more results to existing results
+                if (!recyclerView.canScrollVertically(1)) {
+                    addCategoriesToList();
+                }
+            }
+        });
+        return rootView;
+    }
+
+    /**
+     * Checks for internet connection and then initializes the recycler view with 25 categories of the searched query
+     * Clearing categoryAdapter every time new keyword is searched so that user can see only new results
+     */
+    public void initSubCategoryList() {
+        categoriesNotFoundView.setVisibility(GONE);
+        if(!NetworkUtils.isInternetConnectionEstablished(getContext())) {
+            handleNoInternet();
+            return;
+        }
+        progressBar.setVisibility(View.VISIBLE);
+//        subCategoryList.clear();
+//        categoriesAdapter.clear();
+
+        Observable.fromCallable(() -> mwApi.getSubCategoryList(categoryName))
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .subscribe(this::handleSuccess, this::handleError);
+    }
+
+
+    /**
+     * Adds more results to existing search results
+     */
+    public void addCategoriesToList() {
+        progressBar.setVisibility(View.VISIBLE);
+        Observable.fromCallable(() -> mwApi.getSubCategoryList(categoryName))
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .subscribe(this::handlePaginationSuccess, this::handleError);
+    }
+
+    /**
+     * Handles the success scenario
+     * it initializes the recycler view by adding items to the adapter
+     * @param subCategoryList
+     */
+    private void handlePaginationSuccess(List<String> subCategoryList) {
+        this.subCategoryList.addAll(subCategoryList);
+        progressBar.setVisibility(View.GONE);
+        categoriesAdapter.addAll(subCategoryList);
+        categoriesAdapter.notifyDataSetChanged();
+    }
+
+
+
+    /**
+     * Handles the success scenario
+     * it initializes the recycler view by adding items to the adapter
+     * @param subCategoryList
+     */
+    private void handleSuccess(List<String> subCategoryList) {
+        this.subCategoryList = subCategoryList;
+        if(subCategoryList == null || subCategoryList.isEmpty()) {
+            initErrorView();
+        }
+        else {
+            progressBar.setVisibility(View.GONE);
+            categoriesAdapter.addAll(subCategoryList);
+            categoriesAdapter.notifyDataSetChanged();
+        }
+    }
+
+    /**
+     * Logs and handles API error scenario
+     * @param throwable
+     */
+    private void handleError(Throwable throwable) {
+        Timber.e(throwable, "Error occurred while loading queried categories");
+        initErrorView();
+    }
+
+    /**
+     * Handles the UI updates for a error scenario
+     */
+    private void initErrorView() {
+        progressBar.setVisibility(GONE);
+        categoriesNotFoundView.setVisibility(VISIBLE);
+        categoriesNotFoundView.setText(getString(R.string.no_subcategory_found));
+    }
+
+    /**
+     * Handles the UI updates for no internet scenario
+     */
+    private void handleNoInternet() {
+        progressBar.setVisibility(GONE);
+        ViewUtil.showSnackbar(categoriesRecyclerView, R.string.no_internet);
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/category/SubCategoryListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/SubCategoryListFragment.java
@@ -12,7 +12,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.pedrogomez.renderers.RVRendererAdapter;
 
@@ -151,7 +150,7 @@ public class SubCategoryListFragment extends CommonsDaggerSupportFragment {
     private void handleSuccess(List<String> subCategoryList) {
         this.subCategoryList = subCategoryList;
         if(subCategoryList == null || subCategoryList.isEmpty()) {
-            initErrorView();
+            initEmptyView();
         }
         else {
             progressBar.setVisibility(View.GONE);
@@ -165,14 +164,13 @@ public class SubCategoryListFragment extends CommonsDaggerSupportFragment {
      * @param throwable
      */
     private void handleError(Throwable throwable) {
-        Timber.e(throwable, "Error occurred while loading queried categories");
-        initErrorView();
+        Timber.e(throwable, "Error occurred while loading queried subcategories");
     }
 
     /**
-     * Handles the UI updates for a error scenario
+     * Handles the UI updates for a empty results scenario
      */
-    private void initErrorView() {
+    private void initEmptyView() {
         progressBar.setVisibility(GONE);
         categoriesNotFoundView.setVisibility(VISIBLE);
         categoriesNotFoundView.setText(getString(R.string.no_subcategory_found));

--- a/app/src/main/java/fr/free/nrw/commons/di/ActivityBuilderModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/ActivityBuilderModule.java
@@ -6,6 +6,7 @@ import fr.free.nrw.commons.AboutActivity;
 import fr.free.nrw.commons.WelcomeActivity;
 import fr.free.nrw.commons.auth.LoginActivity;
 import fr.free.nrw.commons.auth.SignupActivity;
+import fr.free.nrw.commons.category.CategoryDetailsActivity;
 import fr.free.nrw.commons.contributions.ContributionsActivity;
 import fr.free.nrw.commons.category.CategoryImagesActivity;
 import fr.free.nrw.commons.explore.SearchActivity;
@@ -54,4 +55,7 @@ public abstract class ActivityBuilderModule {
 
     @ContributesAndroidInjector
     abstract SearchActivity bindSearchActivity();
+
+    @ContributesAndroidInjector
+    abstract CategoryDetailsActivity bindCategoryDetailsActivity();
 }

--- a/app/src/main/java/fr/free/nrw/commons/di/FragmentBuilderModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/FragmentBuilderModule.java
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.di;
 import dagger.Module;
 import dagger.android.ContributesAndroidInjector;
 import fr.free.nrw.commons.category.CategorizationFragment;
+import fr.free.nrw.commons.category.SubCategoryListFragment;
 import fr.free.nrw.commons.contributions.ContributionsListFragment;
 import fr.free.nrw.commons.category.CategoryImagesListFragment;
 import fr.free.nrw.commons.explore.categories.SearchCategoryFragment;
@@ -53,6 +54,9 @@ public abstract class FragmentBuilderModule {
 
     @ContributesAndroidInjector
     abstract CategoryImagesListFragment bindFeaturedImagesListFragment();
+
+    @ContributesAndroidInjector
+    abstract SubCategoryListFragment bindSubCategoryListFragment();
 
     @ContributesAndroidInjector
     abstract SearchImageFragment bindBrowseImagesListFragment();

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -103,13 +103,16 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
                             //update image list
                             if (!TextUtils.isEmpty(query)) {
                                 viewPager.setVisibility(View.VISIBLE);
+                                tabLayout.setVisibility(View.VISIBLE);
                                 searchHistoryContainer.setVisibility(View.GONE);
                                 this.query = query.toString();
                                 searchImageFragment.updateImageList(query.toString());
                                 searchCategoryFragment.updateCategoryList(query.toString());
                             }else {
                                 viewPager.setVisibility(View.GONE);
+                                tabLayout.setVisibility(View.GONE);
                                 searchHistoryContainer.setVisibility(View.VISIBLE);
+                                recentSearchesFragment.updateRecentSearches();
                                 // open search history fragment
                             }
                         }
@@ -164,7 +167,7 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
             supportFragmentManager.executePendingTransactions();
         }
         mediaDetails.showImage(index);
-        initBackButton();
+        forceInitBackButton();
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/explore/ViewPagerAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/ViewPagerAdapter.java
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * This adapter will be used to display fragments in a ViewPager
  */
-class ViewPagerAdapter extends FragmentPagerAdapter {
+public class ViewPagerAdapter extends FragmentPagerAdapter {
     private List<Fragment> fragmentList = new ArrayList<>();
     private List<String> fragmentTitleList = new ArrayList<>();
 

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesAdapterFactory.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesAdapterFactory.java
@@ -7,10 +7,10 @@ import com.pedrogomez.renderers.RendererBuilder;
 import java.util.Collections;
 import java.util.List;
 
-class SearchCategoriesAdapterFactory {
+public class SearchCategoriesAdapterFactory {
     private final SearchCategoriesRenderer.CategoryClickedListener listener;
 
-    SearchCategoriesAdapterFactory(SearchCategoriesRenderer.CategoryClickedListener listener) {
+    public SearchCategoriesAdapterFactory(SearchCategoriesRenderer.CategoryClickedListener listener) {
         this.listener = listener;
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesRenderer.java
@@ -50,7 +50,7 @@ class SearchCategoriesRenderer extends Renderer<String> {
         tvCategoryName.setText(item.replaceFirst("^Category:", ""));
     }
 
-    interface CategoryClickedListener {
+    public interface CategoryClickedListener {
         void categoryClicked(String item);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesRenderer.java
@@ -47,7 +47,7 @@ class SearchCategoriesRenderer extends Renderer<String> {
     @Override
     public void render() {
         String item = getContent();
-        tvCategoryName.setText(item);
+        tvCategoryName.setText(item.replaceFirst("^Category:", ""));
     }
 
     interface CategoryClickedListener {

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -27,6 +27,7 @@ import javax.inject.Named;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.category.CategoryDetailsActivity;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.explore.recentsearches.RecentSearch;
 import fr.free.nrw.commons.explore.recentsearches.RecentSearchesDao;
@@ -66,6 +67,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
 
     private final SearchCategoriesAdapterFactory adapterFactory = new SearchCategoriesAdapterFactory(item -> {
         // Open Category Details activity
+        CategoryDetailsActivity.startYourself(getContext(), item, item);
         saveQuery(query);
     });
 

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -67,7 +67,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
 
     private final SearchCategoriesAdapterFactory adapterFactory = new SearchCategoriesAdapterFactory(item -> {
         // Open Category Details activity
-        CategoryDetailsActivity.startYourself(getContext(), item, item);
+        CategoryDetailsActivity.startYourself(getContext(), item);
         saveQuery(query);
     });
 

--- a/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImagesRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImagesRenderer.java
@@ -52,7 +52,7 @@ class SearchImagesRenderer extends Renderer<Media> {
     @Override
     public void render() {
         Media item = getContent();
-        tvImageName.setText(item.getFilename());
+        tvImageName.setText(item.getDisplayTitle());
         browseImage.setMedia(item);
         setAuthorView(item, categoryImageAuthor);
     }

--- a/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
@@ -72,4 +72,11 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
         adapter.notifyDataSetChanged();
         super.onResume();
     }
+
+    public void updateRecentSearches() {
+        recentSearches = recentSearchesDao.recentSearches(10);
+        adapter = new ArrayAdapter<String>(getContext(),R.layout.item_recent_searches, recentSearches);
+        recentSearchesList.setAdapter(adapter);
+        adapter.notifyDataSetChanged();
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -434,8 +434,6 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
                 Intent intent = new Intent(getContext(), CategoryDetailsActivity.class);
                 intent.putExtra("categoryName", selectedCategoryTitle);
                 getContext().startActivity(intent);
-
-//                CategoryDetailsActivity.startYourself(getContext(),  selectedCategoryTitle);
             });
         }
         return item;

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -45,6 +45,7 @@ import fr.free.nrw.commons.MediaDataExtractor;
 import fr.free.nrw.commons.MediaWikiImageView;
 import fr.free.nrw.commons.PageTitle;
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.category.CategoryDetailsActivity;
 import fr.free.nrw.commons.delete.DeleteTask;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.location.LatLng;
@@ -430,16 +431,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         if (categoriesLoaded && categoriesPresent) {
             textView.setOnClickListener(view -> {
                 String selectedCategoryTitle = "Category:" + catName;
-                Intent viewIntent = new Intent();
-                viewIntent.setAction(Intent.ACTION_VIEW);
-                viewIntent.setData(new PageTitle(selectedCategoryTitle).getCanonicalUri());
-                //check if web browser available
-                if (viewIntent.resolveActivity(getActivity().getPackageManager()) != null) {
-                    startActivity(viewIntent);
-                } else {
-                    Toast toast = Toast.makeText(getContext(), getString(R.string.no_web_browser), LENGTH_SHORT);
-                    toast.show();
-                }
+                CategoryDetailsActivity.startYourself(getContext(), selectedCategoryTitle, selectedCategoryTitle);
             });
         }
         return item;

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -431,7 +431,11 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         if (categoriesLoaded && categoriesPresent) {
             textView.setOnClickListener(view -> {
                 String selectedCategoryTitle = "Category:" + catName;
-                CategoryDetailsActivity.startYourself(getContext(), selectedCategoryTitle, selectedCategoryTitle);
+                Intent intent = new Intent(getContext(), CategoryDetailsActivity.class);
+                intent.putExtra("categoryName", selectedCategoryTitle);
+                getContext().startActivity(intent);
+
+//                CategoryDetailsActivity.startYourself(getContext(),  selectedCategoryTitle);
             });
         }
         return item;

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -570,6 +570,60 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
     }
 
     /**
+     * The method takes categoryName as input and returns a List of Subcategories
+     * It uses the generator query API to get the subcategories in a category, 10 at a time.
+     * Uses the query continue values for fetching paginated responses
+     * @param categoryName Category name as defined on commons
+     * @return
+     */
+    @Override
+    @NonNull
+    public List<String> getSubCategoryList(String categoryName) {
+        ApiResult apiResult = null;
+        try {
+            MWApi.RequestBuilder requestBuilder = api.action("query")
+                    .param("generator", "categorymembers")
+                    .param("format", "xml")
+                    .param("gcmtype", "file")
+                    .param("gcmtitle", categoryName)
+                    .param("gcmsort", "timestamp")//property to sort by;timestamp
+                    .param("gcmdir", "desc")//in which direction to sort;descending
+                    .param("prop", "imageinfo")
+                    .param("gcmlimit", "10")
+                    .param("iiprop", "url|extmetadata");
+
+            QueryContinue queryContinueValues = getQueryContinueValues(categoryName);
+            if (queryContinueValues != null) {
+                requestBuilder.param("continue", queryContinueValues.getContinueParam());
+                requestBuilder.param("gcmcontinue", queryContinueValues.getGcmContinueParam());
+            }
+
+            apiResult = requestBuilder.get();
+        } catch (IOException e) {
+            Timber.e("Failed to obtain searchCategories", e);
+        }
+
+        if (apiResult == null) {
+            return new ArrayList<>();
+        }
+
+        ApiResult categoryImagesNode = apiResult.getNode("/api/query/pages");
+        if (categoryImagesNode == null
+                || categoryImagesNode.getDocument() == null
+                || categoryImagesNode.getDocument().getChildNodes() == null
+                || categoryImagesNode.getDocument().getChildNodes().getLength() == 0) {
+            return new ArrayList<>();
+        }
+
+        QueryContinue queryContinue = getQueryContinue(apiResult.getNode("/api/continue").getDocument());
+        setQueryContinueValues(categoryName, queryContinue);
+
+        NodeList childNodes = categoryImagesNode.getDocument().getChildNodes();
+        return CategoryImageUtils.getSubCategoryList(childNodes);
+    }
+
+
+    /**
      * The method takes categoryName as input and returns a List of Media objects
      * It uses the generator query API to get the images in a category, 10 at a time.
      * Uses the query continue values for fetching paginated responses

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -571,7 +571,7 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
 
     /**
      * The method takes categoryName as input and returns a List of Subcategories
-     * It uses the generator query API to get the subcategories in a category, 10 at a time.
+     * It uses the generator query API to get the subcategories in a category, 20 at a time.
      * Uses the query continue values for fetching paginated responses
      * @param categoryName Category name as defined on commons
      * @return
@@ -584,11 +584,9 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
             MWApi.RequestBuilder requestBuilder = api.action("query")
                     .param("generator", "categorymembers")
                     .param("format", "xml")
-                    .param("gcmtype", "file")
+                    .param("gcmtype","subcat")
                     .param("gcmtitle", categoryName)
-                    .param("gcmsort", "timestamp")//property to sort by;timestamp
-                    .param("gcmdir", "desc")//in which direction to sort;descending
-                    .param("prop", "imageinfo")
+                    .param("prop", "info")
                     .param("gcmlimit", "10")
                     .param("iiprop", "url|extmetadata");
 

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -587,7 +587,7 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
                     .param("gcmtype","subcat")
                     .param("gcmtitle", categoryName)
                     .param("prop", "info")
-                    .param("gcmlimit", "10")
+                    .param("gcmlimit", "20")
                     .param("iiprop", "url|extmetadata");
 
             QueryContinue queryContinueValues = getQueryContinueValues(categoryName);

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
@@ -41,6 +41,8 @@ public interface MediaWikiApi {
 
     List<Media> getCategoryImages(String categoryName);
 
+    List<String> getSubCategoryList(String categoryName);
+
     @NonNull
     List<Media> searchImages(String title, int offset);
 

--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -77,6 +77,12 @@ public abstract class NavigationBaseActivity extends BaseActivity
     }
 
     public void initBackButton() {
+        int backStackEntryCount = getSupportFragmentManager().getBackStackEntryCount();
+        toggle.setDrawerIndicatorEnabled(backStackEntryCount == 0);
+        toggle.setToolbarNavigationClickListener(v -> onBackPressed());
+    }
+
+    public void forceInitBackButton() {
         toggle.setDrawerIndicatorEnabled(false);
         toggle.setToolbarNavigationClickListener(v -> onBackPressed());
     }

--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -77,8 +77,7 @@ public abstract class NavigationBaseActivity extends BaseActivity
     }
 
     public void initBackButton() {
-        int backStackEntryCount = getSupportFragmentManager().getBackStackEntryCount();
-        toggle.setDrawerIndicatorEnabled(backStackEntryCount == 0);
+        toggle.setDrawerIndicatorEnabled(false);
         toggle.setToolbarNavigationClickListener(v -> onBackPressed());
     }
 

--- a/app/src/main/res/layout/activity_category_details.xml
+++ b/app/src/main/res/layout/activity_category_details.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <android.support.design.widget.AppBarLayout
+            android:id="@+id/toolbar_layout"
+            android:layout_width="match_parent"
+            android:background="@color/primaryDarkColor"
+            android:layout_height="wrap_content">
+            <include
+                android:id="@+id/toolbar"
+                layout="@layout/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <android.support.design.widget.TabLayout
+                android:id="@+id/tabLayout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:tabTextAppearance="@android:style/TextAppearance.Widget.TabWidget"
+                app:tabMode="scrollable"
+                app:tabSelectedTextColor="@color/white"
+                app:tabTextColor="@color/opak_middle_grey"
+                android:layout_below="@id/toolbar"
+                />
+        </android.support.design.widget.AppBarLayout>
+
+        <FrameLayout
+            android:visibility="gone"
+            xmlns:android="http://schemas.android.com/apk/res/android"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:id="@+id/mediaContainer"
+            android:orientation="horizontal"
+            android:layout_below="@id/toolbar_layout"
+            />
+
+        <android.support.v4.view.ViewPager
+            android:id="@+id/viewPager"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_below="@id/toolbar_layout"
+            />
+    </RelativeLayout>
+
+    <android.support.design.widget.NavigationView
+        android:id="@+id/navigation_view"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        app:headerLayout="@layout/drawer_header"
+        app:menu="@menu/drawer"/>
+
+</android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -44,6 +44,7 @@
         </android.support.v7.widget.Toolbar>
         <android.support.design.widget.TabLayout
             android:id="@+id/tabLayout"
+            android:visibility="gone"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:tabTextAppearance="@android:style/TextAppearance.Widget.TabWidget"

--- a/app/src/main/res/menu/fragment_category_detail.xml
+++ b/app/src/main/res/menu/fragment_category_detail.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/menu_browser_current_category"
+        android:title="@string/menu_open_in_browser"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,7 @@
   <string name="background_image">Background Image</string>
   <string name="mediaimage_failed">Media Image Failed</string>
   <string name="no_image_found">No Image Found</string>
+  <string name="no_subcategory_found">No Subcategory Found</string>
   <string name="upload_image">Upload Image</string>
   <string name="welcome_image_mount_zao">Mount Zao</string>
   <string name="welcome_image_llamas">Llamas</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,7 @@
   <string name="title_activity_settings">Settings</string>
   <string name="title_activity_signup">Sign Up</string>
   <string name="title_activity_featured_images">Featured Images</string>
+  <string name="title_activity_category_details">Category</string>
   <string name="menu_about">About</string>
   <string name="about_license">The Wikimedia Commons app is an open-source app created and maintained by grantees and volunteers of the Wikimedia community. The Wikimedia Foundation is not involved in the creation, development, or maintenance of the app. </string>
   <string name="trademarked_name" translatable="false">Wikimedia Commons</string>


### PR DESCRIPTION
## Title (required)

Fixes #1642 (Add a category details page in app) 

## Description (required)
- added subCategoryList fragment added.
- added new method for fetching subcategorylist from server
- maked changes in CategoryDetailsActivity to show 2 fragments instead of 1 (using viewpager, tablayout)

## Tests performed 
Manually Tested on API 25 & Moto G5S+, with ProdDebug variant

## Screenshots showing what changed
<table>
<tr>
<td>

![screenshot_20180628-171028](https://user-images.githubusercontent.com/19607555/42215053-eebc58fe-7eda-11e8-84f8-5f9479aa3fd6.png)
Before
</td>
<td>

![screenshot_20180703-155625](https://user-images.githubusercontent.com/19607555/42215052-ee58bcc2-7eda-11e8-99ed-d77133f92201.png)
After
</td>
</tr>
</table>