### PR TITLE
Fix for issue #1694 crash when sharing a image from gallery

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -302,13 +302,22 @@ public class ShareActivity
                     .add(R.id.single_upload_fragment_container, shareView, "shareView")
                     .commitAllowingStateLoss();
         }
-        uploadController.prepareService();
 
-        ContentResolver contentResolver = this.getContentResolver();
-        fileObj = new FileProcessor(mediaUri, contentResolver, this);
-        checkIfFileExists();
-        gpsObj = fileObj.processFileCoordinates(locationPermitted);
-        decimalCoords = fileObj.getDecimalCoords();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (needsToRequestStoragePermission()) {
+                requestPermissions(new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
+                        REQUEST_PERM_ON_SUBMIT_STORAGE);
+                finish();
+            }
+        } else {
+            uploadController.prepareService();
+
+            ContentResolver contentResolver = this.getContentResolver();
+            fileObj = new FileProcessor(mediaUri, contentResolver, this);
+            checkIfFileExists();
+            gpsObj = fileObj.processFileCoordinates(locationPermitted);
+            decimalCoords = fileObj.getDecimalCoords();
+        }
     }
 
     /**


### PR DESCRIPTION
## Title 
App crashes when storage permission is not given and user tries to share a single image from gallery

Fixes 
#1694 

## Description (required)

Fixes #1694 {App crashes when storage permission is not given and user tries to share a single image from gallery}

The app was crashing so I added the code to grant permission when the user tries to share an image without previously giving storage permission. The app doesn't crashes now and asks the user to grant permission. When the user again tries to share the image after granting permission the app works and the image is uploaded.

## Tests performed (required)

Xiaomi Mi A1 (Android 8.0.0, API 26), with 2.7.2-debug-master~fa6353b3

## Screenshots showing what changed (optional)

![screenshot_20180708-022316](https://user-images.githubusercontent.com/36266597/42414630-6e89f32e-8256-11e8-88c4-869843d91625.png)
![screenshot_20180708-022320](https://user-images.githubusercontent.com/36266597/42414631-6eb8bc0e-8256-11e8-98da-b06e58a5c26f.png)
![screenshot_20180708-022329](https://user-images.githubusercontent.com/36266597/42414632-6eef5bba-8256-11e8-8a33-5a4fb4b8080b.png)


