### PR TITLE
Adds Parent category in category details page

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -44,6 +44,7 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
     private FragmentManager supportFragmentManager;
     private CategoryImagesListFragment categoryImagesListFragment;
     private SubCategoryListFragment subCategoryListFragment;
+    private SubCategoryListFragment parentCategoryListFragment;
     private MediaDetailPagerFragment mediaDetails;
     private String categoryName;
     @BindView(R.id.mediaContainer) FrameLayout mediaContainer;
@@ -60,6 +61,7 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
         supportFragmentManager = getSupportFragmentManager();
         viewPagerAdapter = new ViewPagerAdapter(getSupportFragmentManager());
         viewPager.setAdapter(viewPagerAdapter);
+        viewPager.setOffscreenPageLimit(2);
         tabLayout.setupWithViewPager(viewPager);
         setTabs();
         setPageTitle();
@@ -72,17 +74,25 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
         List<String> titleList = new ArrayList<>();
         categoryImagesListFragment = new CategoryImagesListFragment();
         subCategoryListFragment = new SubCategoryListFragment();
+        parentCategoryListFragment = new SubCategoryListFragment();
         categoryName = getIntent().getStringExtra("categoryName");
         if (getIntent() != null && categoryName != null) {
             Bundle arguments = new Bundle();
             arguments.putString("categoryName", categoryName);
+            arguments.putBoolean("isParentCategory", false);
             categoryImagesListFragment.setArguments(arguments);
             subCategoryListFragment.setArguments(arguments);
+            Bundle parentCategoryArguments = new Bundle();
+            parentCategoryArguments.putString("categoryName", categoryName);
+            parentCategoryArguments.putBoolean("isParentCategory", true);
+            parentCategoryListFragment.setArguments(parentCategoryArguments);
         }
         fragmentList.add(categoryImagesListFragment);
         titleList.add("MEDIA");
         fragmentList.add(subCategoryListFragment);
         titleList.add("SUBCATEGORIES");
+        fragmentList.add(parentCategoryListFragment);
+        titleList.add("PARENT CATEGORIES");
         viewPagerAdapter.setTabData(fragmentList, titleList);
         viewPagerAdapter.notifyDataSetChanged();
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
@@ -12,7 +12,9 @@ import android.widget.AdapterView;
 import android.widget.GridView;
 import android.widget.ListAdapter;
 import android.widget.ProgressBar;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -48,7 +50,7 @@ public class CategoryImagesListFragment extends DaggerFragment {
     TextView statusTextView;
     @BindView(R.id.loadingImagesProgressBar) ProgressBar progressBar;
     @BindView(R.id.categoryImagesList) GridView gridView;
-
+    @BindView(R.id.parentLayout) RelativeLayout parentLayout;
     private boolean hasMoreImages = true;
     private boolean isLoading;
     private String categoryName = null;
@@ -123,7 +125,7 @@ public class CategoryImagesListFragment extends DaggerFragment {
             statusTextView.setVisibility(VISIBLE);
             statusTextView.setText(getString(R.string.no_internet));
         } else {
-            ViewUtil.showSnackbar(gridView, R.string.no_internet);
+            ViewUtil.showSnackbar(parentLayout, R.string.no_internet);
         }
     }
 
@@ -132,7 +134,8 @@ public class CategoryImagesListFragment extends DaggerFragment {
      * @param throwable
      */
     private void handleError(Throwable throwable) {
-        Timber.e(throwable, "Error occurred while loading featured images");
+        Timber.e(throwable, "Error occurred while loading images inside a category");
+        ViewUtil.showSnackbar(parentLayout, R.string.error_loading_images);
         initErrorView();
     }
 
@@ -145,7 +148,6 @@ public class CategoryImagesListFragment extends DaggerFragment {
             statusTextView.setVisibility(VISIBLE);
             statusTextView.setText(getContext().getString(R.string.no_images_found));
         } else {
-            ViewUtil.showSnackbar(gridView, R.string.error_loading_images);
             statusTextView.setVisibility(GONE);
         }
     }
@@ -175,6 +177,9 @@ public class CategoryImagesListFragment extends DaggerFragment {
                 if (hasMoreImages && !isLoading && (firstVisibleItem + visibleItemCount >= totalItemCount)) {
                     isLoading = true;
                     fetchMoreImages();
+                }else {
+                    isLoading = false;
+                    progressBar.setVisibility(GONE);
                 }
             }
         });
@@ -213,6 +218,10 @@ public class CategoryImagesListFragment extends DaggerFragment {
         if(gridAdapter == null) {
             setAdapter(collection);
         } else {
+            if (gridAdapter.containsAll(collection)){
+                hasMoreImages = false;
+                return;
+            }
             gridAdapter.addItems(collection);
         }
 

--- a/app/src/main/java/fr/free/nrw/commons/category/GridViewAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/GridViewAdapter.java
@@ -2,6 +2,7 @@ package fr.free.nrw.commons.category;
 
 import android.app.Activity;
 import android.content.Context;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -40,6 +41,18 @@ public class GridViewAdapter extends ArrayAdapter {
         }
         data.addAll(images);
         notifyDataSetChanged();
+    }
+
+    /**
+     * Check the last item in the new list with old list and returns true if they are same
+     * Its triggered on successful response of the fetch images API.
+     * @param images
+     */
+    public boolean containsAll(List<Media> images){
+        if (data == null) {
+            data = new ArrayList<>();
+        }
+        return images.get(images.size()-1).getFilename().equals(data.get(data.size()-1).getFilename());
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
@@ -43,6 +43,8 @@ public interface MediaWikiApi {
 
     List<String> getSubCategoryList(String categoryName);
 
+    List<String> getParentCategoryList(String categoryName);
+
     @NonNull
     List<Media> searchImages(String title, int offset);
 

--- a/app/src/main/res/layout/fragment_category_images.xml
+++ b/app/src/main/res/layout/fragment_category_images.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/parentLayout"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"


### PR DESCRIPTION
## Title (required)
- Fixes #1642  (Add a category details page in app)
- Fixes #1699 ("No media" even though category contains pictures)

## Description (required)
- API added for receiving Parent categories of a particular category
 - Reused SubcategoryList fragment for getting parent category list using isParentCategory boolean
- Fixed edge case issue for not showing images

## Tests performed (required)
Manually Tested on API 25 & Moto G5S+, with ProdDebug  variant

## Screenshots showing what changed (optional)
 
<table>
<tr>
<td>

![screenshot_20180710-165643](https://user-images.githubusercontent.com/19607555/42507578-438d001c-8463-11e8-9874-4e1ad35dc19f.png)

</td>
<td>

![screenshot_20180710-165647](https://user-images.githubusercontent.com/19607555/42507577-4318b392-8463-11e8-9498-01732a758464.png)

</td>
</tr>
</table>