### PR TITLE
Fix for issue #1678 "Give permissions" dialog in Nearby activity keeps flickering

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -22,6 +22,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
+import android.widget.Toast;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -227,6 +228,9 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
                     //If permission not granted, go to page that says Nearby Places cannot be displayed
                     hideProgressBar();
                     showLocationPermissionDeniedErrorDialog();
+                    Toast contriAct = Toast.makeText(this, "Location permission needed to search for nearby places", Toast.LENGTH_LONG);
+                    contriAct.show();
+                    finish();
                 }
             }
             break;

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -302,22 +302,13 @@ public class ShareActivity
                     .add(R.id.single_upload_fragment_container, shareView, "shareView")
                     .commitAllowingStateLoss();
         }
+        uploadController.prepareService();
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (needsToRequestStoragePermission()) {
-                requestPermissions(new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
-                        REQUEST_PERM_ON_SUBMIT_STORAGE);
-                finish();
-            }
-        } else {
-            uploadController.prepareService();
-
-            ContentResolver contentResolver = this.getContentResolver();
-            fileObj = new FileProcessor(mediaUri, contentResolver, this);
-            checkIfFileExists();
-            gpsObj = fileObj.processFileCoordinates(locationPermitted);
-            decimalCoords = fileObj.getDecimalCoords();
-        }
+        ContentResolver contentResolver = this.getContentResolver();
+        fileObj = new FileProcessor(mediaUri, contentResolver, this);
+        checkIfFileExists();
+        gpsObj = fileObj.processFileCoordinates(locationPermitted);
+        decimalCoords = fileObj.getDecimalCoords();
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -302,13 +302,22 @@ public class ShareActivity
                     .add(R.id.single_upload_fragment_container, shareView, "shareView")
                     .commitAllowingStateLoss();
         }
-        uploadController.prepareService();
 
-        ContentResolver contentResolver = this.getContentResolver();
-        fileObj = new FileProcessor(mediaUri, contentResolver, this);
-        checkIfFileExists();
-        gpsObj = fileObj.processFileCoordinates(locationPermitted);
-        decimalCoords = fileObj.getDecimalCoords();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (needsToRequestStoragePermission()) {
+                requestPermissions(new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
+                        REQUEST_PERM_ON_SUBMIT_STORAGE);
+                finish();
+            }
+        } else {
+            uploadController.prepareService();
+
+            ContentResolver contentResolver = this.getContentResolver();
+            fileObj = new FileProcessor(mediaUri, contentResolver, this);
+            checkIfFileExists();
+            gpsObj = fileObj.processFileCoordinates(locationPermitted);
+            decimalCoords = fileObj.getDecimalCoords();
+        }
     }
 
     /**


### PR DESCRIPTION
## Title (required)

"Give permissions" dialog in Nearby activity keeps flickering. You cannot select the "give permissions" option while it is doing that, and eventually it crashes.

## Description (required)

#1678 
"Give permissions" dialog in Nearby activity keeps flickering. You cannot select the "give permissions" option while it is doing that, and eventually it crashes.

I have added a toast to display a message and after that finished the activity so that the user is directed to the ContributionActivity.

## Tests performed (required)

Xiaomi Mi A1 (Android 8.0.0, API 26), with 2.7.2-debug-master~fa6353b3

## Screenshots showing what changed (optional)
 
![screenshot_20180711-221256](https://user-images.githubusercontent.com/36266597/42587661-0ed438a8-8559-11e8-9b0c-f41a366a380f.png)
![screenshot_20180711-221301](https://user-images.githubusercontent.com/36266597/42587662-0f0508d4-8559-11e8-96a9-f507c49373a6.png)
