### PR TITLE
Fix #1704 "Parent categories" should not show message about subcategories

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/SubCategoryListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/SubCategoryListFragment.java
@@ -138,7 +138,7 @@ public class SubCategoryListFragment extends CommonsDaggerSupportFragment {
             Timber.e(throwable, "Error occurred while loading queried subcategories");
             ViewUtil.showSnackbar(categoriesRecyclerView,R.string.error_loading_categories);
         }else {
-            Timber.e(throwable, "Error occurred while loading queried subcategories");
+            Timber.e(throwable, "Error occurred while loading queried parentcategories");
             ViewUtil.showSnackbar(categoriesRecyclerView,R.string.error_loading_categories);
         }
     }
@@ -149,7 +149,12 @@ public class SubCategoryListFragment extends CommonsDaggerSupportFragment {
     private void initEmptyView() {
         progressBar.setVisibility(GONE);
         categoriesNotFoundView.setVisibility(VISIBLE);
-        categoriesNotFoundView.setText(getString(R.string.no_subcategory_found));
+        if (!isParentCategory){
+            categoriesNotFoundView.setText(getString(R.string.no_subcategory_found));
+        }else {
+            categoriesNotFoundView.setText(getString(R.string.no_parentcategory_found));
+        }
+
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,6 +199,7 @@
   <string name="mediaimage_failed">Media Image Failed</string>
   <string name="no_image_found">No Image Found</string>
   <string name="no_subcategory_found">No Subcategory Found</string>
+  <string name="no_parentcategory_found">No Parentcategory Found</string>
   <string name="upload_image">Upload Image</string>
   <string name="welcome_image_mount_zao">Mount Zao</string>
   <string name="welcome_image_llamas">Llamas</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,7 +199,7 @@
   <string name="mediaimage_failed">Media Image Failed</string>
   <string name="no_image_found">No Image Found</string>
   <string name="no_subcategory_found">No Subcategory Found</string>
-  <string name="no_parentcategory_found">No Parentcategory Found</string>
+  <string name="no_parentcategory_found">No Parent Categories Found</string>
   <string name="upload_image">Upload Image</string>
   <string name="welcome_image_mount_zao">Mount Zao</string>
   <string name="welcome_image_llamas">Llamas</string>


### PR DESCRIPTION
## Title (required)

Fix #1704 "Parent categories" should not show message about subcategories

## Description (required)

Fixes #1704

Added a string and if else to solve this issue.

## Tests performed (required)

Xiaomi Mi A1 (Android 8.0.0, API 26), with 2.7.2-debug-master~fa6353b3

## Screenshots showing what changed (optional)
 
![screenshot_20180713-235159](https://user-images.githubusercontent.com/36266597/42707496-04acc8d6-86f8-11e8-913e-10e1de93e4f5.png)
