### PR TITLE
Fix for #1702 & #1704 typo in subcategory and parent category

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/SubCategoryListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/SubCategoryListFragment.java
@@ -138,7 +138,7 @@ public class SubCategoryListFragment extends CommonsDaggerSupportFragment {
             Timber.e(throwable, "Error occurred while loading queried subcategories");
             ViewUtil.showSnackbar(categoriesRecyclerView,R.string.error_loading_categories);
         }else {
-            Timber.e(throwable, "Error occurred while loading queried subcategories");
+            Timber.e(throwable, "Error occurred while loading queried parentcategories");
             ViewUtil.showSnackbar(categoriesRecyclerView,R.string.error_loading_categories);
         }
     }
@@ -149,7 +149,12 @@ public class SubCategoryListFragment extends CommonsDaggerSupportFragment {
     private void initEmptyView() {
         progressBar.setVisibility(GONE);
         categoriesNotFoundView.setVisibility(VISIBLE);
-        categoriesNotFoundView.setText(getString(R.string.no_subcategory_found));
+        if (!isParentCategory){
+            categoriesNotFoundView.setText(getString(R.string.no_subcategory_found));
+        }else {
+            categoriesNotFoundView.setText(getString(R.string.no_parentcategory_found));
+        }
+
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,6 +199,7 @@
   <string name="mediaimage_failed">Media Image Failed</string>
   <string name="no_image_found">No Image Found</string>
   <string name="no_subcategory_found">No Subcategory Found</string>
+  <string name="no_parentcategory_found">No Parentcategory Found</string>
   <string name="upload_image">Upload Image</string>
   <string name="welcome_image_mount_zao">Mount Zao</string>
   <string name="welcome_image_llamas">Llamas</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,7 +198,7 @@
   <string name="background_image">Background Image</string>
   <string name="mediaimage_failed">Media Image Failed</string>
   <string name="no_image_found">No Image Found</string>
-  <string name="no_subcategory_found">No Subcategory Found</string>
+  <string name="no_subcategory_found">No subcategories found</string>
   <string name="no_parentcategory_found">No Parent Categories Found</string>
   <string name="upload_image">Upload Image</string>
   <string name="welcome_image_mount_zao">Mount Zao</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,7 +199,7 @@
   <string name="mediaimage_failed">Media Image Failed</string>
   <string name="no_image_found">No Image Found</string>
   <string name="no_subcategory_found">No subcategories found</string>
-  <string name="no_parentcategory_found">No Parent Categories Found</string>
+  <string name="no_parentcategory_found">No parent categories found</string>
   <string name="upload_image">Upload Image</string>
   <string name="welcome_image_mount_zao">Mount Zao</string>
   <string name="welcome_image_llamas">Llamas</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,7 +199,7 @@
   <string name="mediaimage_failed">Media Image Failed</string>
   <string name="no_image_found">No Image Found</string>
   <string name="no_subcategory_found">No Subcategory Found</string>
-  <string name="no_parentcategory_found">No Parentcategory Found</string>
+  <string name="no_parentcategory_found">No Parent Categories Found</string>
   <string name="upload_image">Upload Image</string>
   <string name="welcome_image_mount_zao">Mount Zao</string>
   <string name="welcome_image_llamas">Llamas</string>


### PR DESCRIPTION
## Title (required)

Fixes #1702 & #1704 
Typo: Should be "No subcategories found"
"Parent categories" should not show message about subcategories

## Description (required)

Fixes #1702 and #1704 

Add a string and if else statement

## Tests performed (required)

Xiaomi Mi A1 (Android 8.0.0, API 26), with 2.7.2-debug-master~fa6353b3

## Screenshots showing what changed (optional)
 
![screenshot_20180714-002216](https://user-images.githubusercontent.com/36266597/42708808-fffe948c-86fb-11e8-8b05-83e1c0222430.png)
![screenshot_20180714-002223](https://user-images.githubusercontent.com/36266597/42708809-0031831a-86fc-11e8-9b1c-d7c8c5c7d816.png)
