### PR TITLE
Fixes#1706  NullPointerException at SearchImageFragment.updateImageList

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
@@ -14,7 +14,6 @@ import android.widget.ListAdapter;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -135,8 +134,13 @@ public class CategoryImagesListFragment extends DaggerFragment {
      */
     private void handleError(Throwable throwable) {
         Timber.e(throwable, "Error occurred while loading images inside a category");
-        ViewUtil.showSnackbar(parentLayout, R.string.error_loading_images);
-        initErrorView();
+        try{
+            ViewUtil.showSnackbar(parentLayout, R.string.error_loading_images);
+            initErrorView();
+        }catch (Exception e){
+            e.printStackTrace();
+        }
+
     }
 
     /**
@@ -219,7 +223,6 @@ public class CategoryImagesListFragment extends DaggerFragment {
             setAdapter(collection);
         } else {
             if (gridAdapter.containsAll(collection)){
-                hasMoreImages = false;
                 return;
             }
             gridAdapter.addItems(collection);

--- a/app/src/main/java/fr/free/nrw/commons/category/GridViewAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/GridViewAdapter.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/app/src/main/java/fr/free/nrw/commons/category/GridViewAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/GridViewAdapter.java
@@ -2,13 +2,11 @@ package fr.free.nrw.commons.category;
 
 import android.app.Activity;
 import android.content.Context;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -189,8 +189,13 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
      */
     private void handleError(Throwable throwable) {
         Timber.e(throwable, "Error occurred while loading queried categories");
-        initErrorView();
-        ViewUtil.showSnackbar(categoriesRecyclerView, R.string.error_loading_categories);
+        try {
+            initErrorView();
+            ViewUtil.showSnackbar(categoriesRecyclerView, R.string.error_loading_categories);
+        }catch (Exception e){
+            e.printStackTrace();
+        }
+
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
@@ -187,8 +187,12 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
      */
     private void handleError(Throwable throwable) {
         Timber.e(throwable, "Error occurred while loading queried images");
-        initErrorView();
-        ViewUtil.showSnackbar(imagesRecyclerView, R.string.error_loading_images);
+        try {
+            initErrorView();
+            ViewUtil.showSnackbar(imagesRecyclerView, R.string.error_loading_images);
+        }catch (Exception e){
+            e.printStackTrace();
+        }
     }
 
     /**


### PR DESCRIPTION
## Title (required)
Fixes#1706 (NullPointerException at SearchImageFragment.updateImageList)

## Description (required)
- added try catch statements in case screen have changed between API call so it won't crash now.

## Tests performed (required)
Manually Tested on 25 API level & MOTO G5S+, with ProdDebug variant.