### PR TITLE
Fix explore crash

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -9,6 +9,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
+import android.os.Handler;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
@@ -267,7 +268,9 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
     }
 
     public void showImage(int i) {
-        pager.setCurrentItem(i);
+        Handler handler =  new Handler();
+        handler.postDelayed(() -> pager.setCurrentItem(i), 10);
+
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -270,7 +270,6 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
     public void showImage(int i) {
         Handler handler =  new Handler();
         handler.postDelayed(() -> pager.setCurrentItem(i), 10);
-
     }
 
     @Override


### PR DESCRIPTION
## Title (required)
Fixes #1741 (Attempt to invoke virtual method 'void android.support.v4.view.ViewPager.setCurrentItem(int)' on a null object reference)

## Description (required)
- Handler for 0.01 sec added because viewpager was null immidiiately after oncreate. (I couldn't find any other solution till now)

## Tests performed (required)
Manually Tested on API 25 & Moto G5S+  with {ProdDebug variant}.