### PR TITLE
Add a string to tell the user to name their multi image set

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/MultipleUploadListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/MultipleUploadListFragment.java
@@ -207,7 +207,7 @@ public class MultipleUploadListFragment extends Fragment {
         switch (item.getItemId()) {
             case R.id.menu_upload_multiple:
                 if (baseTitle.getText().toString().trim().isEmpty()) {
-                    Toast.makeText(getContext(), R.string.add_title_toast, Toast.LENGTH_LONG).show();
+                    Toast.makeText(getContext(), R.string.add_set_name_toast, Toast.LENGTH_LONG).show();
                     return false;
                 }
                 multipleUploadInitiatedHandler.OnMultipleUploadInitiated();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
   <string name="login_failed_generic">Login failed</string>
   <string name="share_upload_button">Upload</string>
   <string name="multiple_share_base_title">Name this set</string>
+  <string name="add_set_name_toast">Please provide a name for this set</string>
   <string name="provider_modifications">Modifications</string>
   <string name="menu_upload_single">Upload</string>
   <string name="categories_search_text_hint">Search categories</string>


### PR DESCRIPTION
## Title (required)

Fixes comment on [PR](https://github.com/commons-app/apps-android-commons/pull/176)

## Description (required)

Fixes comment on [PR](https://github.com/commons-app/apps-android-commons/pull/176)

Added a new string to be more specific to the scenario of not naming a set rather than reusing an existing string.

## Tests performed (required)

Tested on Samsung Nexus 6 with API 24 Android 7.0

## Screenshots showing what changed (optional)
 
![screenshot_20180731-122430](https://user-images.githubusercontent.com/12453997/43482264-0d0c1b8a-94bd-11e8-951b-dfb08acd87c7.png)
