### PR TITLE
Alignment of language selection dialog in About>Translate

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
@@ -144,11 +144,12 @@ public class AboutActivity extends NavigationBaseActivity {
     @OnClick(R.id.about_translate)
     public void launchTranslate(View view) {
         final ArrayAdapter<String> languageAdapter = new ArrayAdapter<String>(AboutActivity.this,
-                android.R.layout.simple_spinner_item, language);
+                android.R.layout.simple_spinner_dropdown_item, language);
         final Spinner spinner = new Spinner(AboutActivity.this);
         spinner.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT));
         spinner.setAdapter(languageAdapter);
         spinner.setGravity(17);
+        spinner.setPadding(50,0,0,0);
 
         AlertDialog.Builder builder = new AlertDialog.Builder(AboutActivity.this);
         builder.setView(spinner);


### PR DESCRIPTION
## Title (required)

Fixes #1713 Alignment of language selection dialog in About>Translate

## Description (required)

Fixes #1713 

Alignment of language in about>translate

## Tests performed (required)

Xiaomi Mi A1 (Android 8.0.0, API 26),

## Screenshots showing what changed (optional)
 
![screenshot_20180801-222330](https://user-images.githubusercontent.com/36266597/43536219-b000911e-95d9-11e8-8ba3-a0f4bf5aa78b.png)
![screenshot_20180801-222343](https://user-images.githubusercontent.com/36266597/43536220-b0381fa8-95d9-11e8-8f8d-d28ff3f06b45.png)
