### PR TITLE
In media search results, rotating screen triggers crash fixed #1753

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -114,6 +114,7 @@
         <activity
             android:name=".explore.SearchActivity"
             android:label="@string/title_activity_search"
+            android:configChanges="orientation|keyboardHidden"
             android:parentActivityName=".contributions.ContributionsActivity"
             />
 

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -1,5 +1,6 @@
 package fr.free.nrw.commons.explore;
 
+import android.content.res.Configuration;
 import android.database.DataSetObserver;
 import android.os.Bundle;
 import android.support.design.widget.TabLayout;
@@ -193,6 +194,10 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
         }
         mediaDetails.showImage(index);
         forceInitBackButton();
+    }
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
     }
 
     /**


### PR DESCRIPTION
## Title (required)
In media search results, rotating screen triggers crash

Fixes #1753 

## Description (required)

Fixes #1753 

## Tests performed (required)

Xiaomi Mi A1 (Android 8.1.0, API 27)

## Screenshots showing what changed (optional)
 
![20180802_233456](https://user-images.githubusercontent.com/36266597/43602255-117fd386-96ad-11e8-8866-ad98b05f64ea.gif)
