### PR TITLE
Corrected grammar in the login screen

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -238,7 +238,7 @@
   <string name="give_permission">Give permission</string>
   <string name="use_external_storage">Use external storage</string>
   <string name="use_external_storage_summary">Save pictures taken with the in-app camera on your device</string>
-  <string name="login_to_your_account">Login to your account</string>
+  <string name="login_to_your_account">Log in to your account</string>
   <string name="send_log_file">Send log file</string>
   <string name="send_log_file_description">Send log file to developers via email</string>
   <string name="no_web_browser">No web browser found to open URL</string>


### PR DESCRIPTION
## Grammar correction

Fixes #1783 

## Description (required)

Fixes #1783 

Changed the phrase "Login to your account" to "Log in to your account" in the login screen.

## Tests performed (required)

Tested on device Motorola Moto G(5) (Android 7.0, API 24), with build variant betaDebug.

## Screenshots showing what changed (optional)

https://drive.google.com/open?id=0B1FTrr-5uV6WWEtfbVdrUXk5bWpFVi1GMkNBVzQxQnRZQ25n