### PR TITLE
added null check before initialising LatLng after receiving location …

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
@@ -106,6 +106,9 @@ public class LocationServiceManager implements LocationListener {
             if (lastKL == null) {
                 lastKL = locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
             }
+            if (null == lastKL) {
+                return null;
+            }
             return LatLng.from(lastKL);
         } else {
             return null;

--- a/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
@@ -106,7 +106,7 @@ public class LocationServiceManager implements LocationListener {
             if (lastKL == null) {
                 lastKL = locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
             }
-            if (null == lastKL) {
+            if (lastKL == null) {
                 return null;
             }
             return LatLng.from(lastKL);


### PR DESCRIPTION
…permission

## Nearby crash fix

Fixes #1735 [Nearby crash when LatLng is null] 

## Description (required)
After receiving location permission from user, while fetching last known location, we used to initialise LatLng from last known location which could be fetched from either GPS_PROVIDER or NETWORK_PROVIDER. There was a null check on the one fetched from GPS_PROVIDER but not on the one fetched from NETWORK_PROVIDER.

Fixes #1735 [Nearby crash when LatLng is null] 
Added a null check on the last known location fetched from NETWORK_PROVIDER

## Tests performed (required)

Tested on {27  & emulator google pixel}, with {build variant, betaDebug}.

## Screenshots showing what changed (optional)

NA
