### PR TITLE
getAdapter() in CategoryImagesListFragment now returns the instance o…

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
@@ -263,10 +263,7 @@ public class CategoryImagesListFragment extends DaggerFragment {
      * @return  GridView Adapter
      */
     public ListAdapter getAdapter() {
-        if(gridView == null) {
-            return null;
-        }
-        return gridView.getAdapter();
+        return gridAdapter;
     }
 
 }


### PR DESCRIPTION
…f the adapter instead of the gridview itself [Issue#1722]

## Memory leak in CategoryDetailsActivity

Fixes #1722 [1.5 MB memory leak in CategoryDetailsActivity]

## Description (required)

Fixes #1722 [1.5 MB memory leak in CategoryDetailsActivity]

In order to access the media displayed in CategoryImagesListFragment, the getAdapter() function in CategoryImagesListFragment used to return gridView.getAdapter(). I have replaced that with return gridAdapter.Holding a reference of a ui element for accessing a dao object has never been recommended. Hope this solves the leak to some extent.

## Tests performed (required)

Tested on {27 & google pixel emulator}, with {build variant, betaDebug}.

## Screenshots showing what changed (optional)
 NA
_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._