### PR TITLE
Fix title/desc prefill bug

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
@@ -95,7 +95,7 @@ public class ContributionController {
 
     public void handleImagePicked(int requestCode, @Nullable Uri uri, boolean isDirectUpload, String wikiDataEntityId) {
         FragmentActivity activity = fragment.getActivity();
-        Timber.d("handleImagePicked() called with onActivityResult()");
+        Timber.d("handleImagePicked() called with onActivityResult(). Boolean isDirectUpload: " + isDirectUpload + "String wikiDataEntityId: " + wikiDataEntityId);
         Intent shareIntent = new Intent(activity, ShareActivity.class);
         shareIntent.setAction(ACTION_SEND);
         switch (requestCode) {
@@ -119,14 +119,21 @@ public class ContributionController {
                 break;
         }
         Timber.i("Image selected");
+
+        shareIntent.putExtra("isDirectUpload", isDirectUpload);
+        Timber.d("Successfully put extra into intent, isDirectUpload is " + isDirectUpload);
+
         try {
-            shareIntent.putExtra("isDirectUpload", isDirectUpload);
             if (wikiDataEntityId != null && !wikiDataEntityId.equals("")) {
                 shareIntent.putExtra(WIKIDATA_ENTITY_ID_PREF, wikiDataEntityId);
             }
-            activity.startActivity(shareIntent);
         } catch (SecurityException e) {
             Timber.e(e, "Security Exception");
+        }
+        try {
+            activity.startActivity(shareIntent);
+        } catch (NullPointerException e) {
+            Timber.e(e, "Null Pointer Exception");
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
@@ -113,15 +113,14 @@ public class ContributionController {
                 shareIntent.setType("image/jpeg");
                 shareIntent.putExtra(EXTRA_STREAM, lastGeneratedCaptureUri);
                 shareIntent.putExtra(EXTRA_SOURCE, SOURCE_CAMERA);
-
                 break;
             default:
                 break;
         }
-        Timber.i("Image selected");
 
+        Timber.i("Image selected");
         shareIntent.putExtra("isDirectUpload", isDirectUpload);
-        Timber.d("Successfully put extra into intent, isDirectUpload is " + isDirectUpload);
+        Timber.d("Put extras into image intent, isDirectUpload is " + isDirectUpload);
 
         try {
             if (wikiDataEntityId != null && !wikiDataEntityId.equals("")) {
@@ -130,10 +129,9 @@ public class ContributionController {
         } catch (SecurityException e) {
             Timber.e(e, "Security Exception");
         }
-        try {
+
+        if (activity != null) {
             activity.startActivity(shareIntent);
-        } catch (NullPointerException e) {
-            Timber.e(e, "Null Pointer Exception");
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -360,8 +360,7 @@ public class ShareActivity
                 source = Contribution.SOURCE_EXTERNAL;
             }
 
-            Bundle extras = intent.getExtras();
-            boolean isDirectUpload = extras.getBoolean("isDirectUpload");
+            boolean isDirectUpload = intent.getBooleanExtra("isDirectUpload", false);
 
             if (isDirectUpload) {
                 Timber.d("This was initiated by a direct upload from Nearby");

--- a/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ShareActivity.java
@@ -351,9 +351,7 @@ public class ShareActivity
 
         if (Intent.ACTION_SEND.equals(intent.getAction())) {
             mediaUri = intent.getParcelableExtra(Intent.EXTRA_STREAM);
-
             contentProviderUri = mediaUri;
-
             mediaUri = ContributionUtils.saveFileBeingUploadedTemporarily(this, mediaUri);
 
             if (intent.hasExtra(UploadService.EXTRA_SOURCE)) {
@@ -361,7 +359,11 @@ public class ShareActivity
             } else {
                 source = Contribution.SOURCE_EXTERNAL;
             }
-            if (intent.hasExtra("isDirectUpload")) {
+
+            Bundle extras = intent.getExtras();
+            boolean isDirectUpload = extras.getBoolean("isDirectUpload");
+
+            if (isDirectUpload) {
                 Timber.d("This was initiated by a direct upload from Nearby");
                 isNearbyUpload = true;
                 wikiDataEntityId = intent.getStringExtra(WIKIDATA_ENTITY_ID_PREF);


### PR DESCRIPTION
Fixes #1779 . Tested with API 24 emulator Nexus One. Does not prefill title and desc fields when upload initiated from ContributionsList, but prefills when upload initiated from Nearby.