### PR TITLE
Only do http logging if a debug build is run

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -94,7 +94,9 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
         ClientConnectionManager cm = new ThreadSafeClientConnManager(params, schemeRegistry);
         params.setParameter(CoreProtocolPNames.USER_AGENT, getUserAgent());
         httpClient = new DefaultHttpClient(cm, params);
-        httpClient.addRequestInterceptor(NetworkInterceptors.getHttpRequestInterceptor());
+        if (BuildConfig.DEBUG) {
+            httpClient.addRequestInterceptor(NetworkInterceptors.getHttpRequestInterceptor());
+        }
         api = new MWApi(apiURL, httpClient);
         wikidataApi = new MWApi(wikidatApiURL, httpClient);
         this.defaultPreferences = defaultPreferences;


### PR DESCRIPTION
We should not log cookie headers without informing users, due to privacy concerns. For the time being, http header logging should be restricted to debug builds (which will never be released, but can only be built manually via our repo). See https://github.com/commons-app/apps-android-commons/pull/1751/files#r205656568

Tested on Nexus One emulator on API 24, it displays http headers on debug and not on release.