### PR TITLE
Fixes #1801  (Media details view for Browse is lacking author field)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -250,4 +250,24 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
         }
         super.onBackPressed();
     }
+
+    /**
+     * This method is called on success of API call for Images inside a category.
+     * The viewpager will notified that number of items have changed.
+     */
+    public void viewPagerNotifyDataSetChanged() {
+        if (mediaDetails!=null){
+            mediaDetails.notifyDataSetChanged();
+        }
+    }
+
+    /**
+     * This method is called when viewPager has reached its end.
+     * Fetches more images using search query and adds it to the grid view and viewpager adapter
+     */
+    public void requestMoreImages() {
+        if (categoryImagesListFragment!=null){
+            categoryImagesListFragment.fetchMoreImagesViewPager();
+        }
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
@@ -171,6 +171,16 @@ public class CategoryImagesActivity
     }
 
     /**
+     * This method is called on success of API call for featured Images.
+     * The viewpager will notified that number of items have changed.
+     */
+    public void viewPagerNotifyDataSetChanged() {
+        if (mediaDetails!=null){
+            mediaDetails.notifyDataSetChanged();
+        }
+    }
+
+    /**
      * This method is called on from getCount of MediaDetailPagerFragment
      * The viewpager will contain same number of media items as that of media elements in adapter.
      * @return Total Media count in the adapter
@@ -234,6 +244,16 @@ public class CategoryImagesActivity
                 return true;
             default:
                 return super.onOptionsItemSelected(item);
+        }
+    }
+
+    /**
+     * This method is called when viewPager has reached its end.
+     * Fetches more images using search query and adds it to the gridView and viewpager adapter
+     */
+    public void requestMoreImages() {
+        if (categoryImagesListFragment!=null){
+            categoryImagesListFragment.fetchMoreImagesViewPager();
         }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
@@ -191,6 +191,20 @@ public class CategoryImagesListFragment extends DaggerFragment {
     }
 
     /**
+     * This method is called when viewPager has reached its end.
+     * Fetches more images for the category and adds it to the grid view and viewpager adapter
+     */
+    public void fetchMoreImagesViewPager(){
+        if (hasMoreImages && !isLoading) {
+            isLoading = true;
+            fetchMoreImages();
+        }
+        if (!hasMoreImages){
+            progressBar.setVisibility(GONE);
+        }
+    }
+
+    /**
      * Fetches more images for the category and adds it to the grid view adapter
      */
     @SuppressLint("CheckResult")
@@ -228,8 +242,17 @@ public class CategoryImagesListFragment extends DaggerFragment {
                 return;
             }
             gridAdapter.addItems(collection);
+            try {
+                ((CategoryImagesActivity) getContext()).viewPagerNotifyDataSetChanged();
+            }catch (Exception e){
+                e.printStackTrace();
+            }
+            try {
+                ((CategoryDetailsActivity) getContext()).viewPagerNotifyDataSetChanged();
+            }catch (Exception e){
+                e.printStackTrace();
+            }
         }
-
         progressBar.setVisibility(GONE);
         isLoading = false;
         statusTextView.setVisibility(GONE);

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -53,6 +53,7 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
     private FragmentManager supportFragmentManager;
     private MediaDetailPagerFragment mediaDetails;
     ViewPagerAdapter viewPagerAdapter;
+    private String query;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -104,6 +105,7 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
                 .debounce(500, TimeUnit.MILLISECONDS)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe( query -> {
+                    this.query = query.toString();
                             //update image list
                             if (!TextUtils.isEmpty(query)) {
                                 viewPager.setVisibility(View.VISIBLE);
@@ -145,7 +147,16 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
      */
     @Override
     public void notifyDatasetChanged() {
+    }
 
+    /**
+     * This method is called on success of API call for image Search.
+     * The viewpager will notified that number of items have changed.
+     */
+    public void viewPagerNotifyDataSetChanged() {
+        if (mediaDetails!=null){
+            mediaDetails.notifyDataSetChanged();
+        }
     }
 
     /**
@@ -244,5 +255,15 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
         // Clear focus of searchView now. searchView.clearFocus(); does not seem to work Check the below link for more details.
         // https://stackoverflow.com/questions/6117967/how-to-remove-focus-without-setting-focus-to-another-control/15481511
         viewPager.requestFocus();
+    }
+
+    /**
+     * This method is called when viewPager has reached its end.
+     * Fetches more images using search query and adds it to the recycler view and viewpager adapter
+     */
+    public void requestMoreImages() {
+        if (searchImageFragment!=null){
+            searchImageFragment.addImagesToList(query);
+        }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
@@ -13,6 +13,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import android.widget.Toast;
+
 import com.pedrogomez.renderers.RVRendererAdapter;
 import java.util.ArrayList;
 import java.util.Date;
@@ -160,6 +162,7 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
         progressBar.setVisibility(View.GONE);
         imagesAdapter.addAll(mediaList);
         imagesAdapter.notifyDataSetChanged();
+        ((SearchActivity)getContext()).viewPagerNotifyDataSetChanged();
     }
 
 
@@ -179,6 +182,7 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
             progressBar.setVisibility(View.GONE);
             imagesAdapter.addAll(mediaList);
             imagesAdapter.notifyDataSetChanged();
+            ((SearchActivity)getContext()).viewPagerNotifyDataSetChanged();
 
             // check if user is waiting for 5 seconds if yes then save search query to history.
             Handler handler = new Handler();
@@ -239,7 +243,7 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
             return null;
         }
         else {
-            return new Media(imagesAdapter.getItem(i).getFilename());
+            return imagesAdapter.getItem(i);
         }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
@@ -158,11 +158,15 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
      * @param mediaList List of media to be added
      */
     private void handlePaginationSuccess(List<Media> mediaList) {
-        queryList.addAll(mediaList);
         progressBar.setVisibility(View.GONE);
-        imagesAdapter.addAll(mediaList);
-        imagesAdapter.notifyDataSetChanged();
-        ((SearchActivity)getContext()).viewPagerNotifyDataSetChanged();
+        if (mediaList.size()!=0){
+            if (!queryList.get(queryList.size()-1).getFilename().equals(mediaList.get(mediaList.size()-1).getFilename())) {
+                queryList.addAll(mediaList);
+                imagesAdapter.addAll(mediaList);
+                imagesAdapter.notifyDataSetChanged();
+                ((SearchActivity)getContext()).viewPagerNotifyDataSetChanged();
+            }
+        }
     }
 
 
@@ -197,7 +201,6 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
     private void handleError(Throwable throwable) {
         Timber.e(throwable, "Error occurred while loading queried images");
         try {
-            initErrorView();
             ViewUtil.showSnackbar(imagesRecyclerView, R.string.error_loading_images);
         }catch (Exception e){
             e.printStackTrace();

--- a/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImagesRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImagesRenderer.java
@@ -65,11 +65,11 @@ class SearchImagesRenderer extends Renderer<Media> {
      */
     private void setAuthorView(Media item, TextView author) {
         if (item.getCreator() != null && !item.getCreator().equals("")) {
-            author.setVisibility(View.GONE);
+            author.setVisibility(View.VISIBLE);
             String uploadedByTemplate = getContext().getString(R.string.image_uploaded_by);
             author.setText(String.format(uploadedByTemplate, item.getCreator()));
         } else {
-            author.setVisibility(View.VISIBLE);
+            author.setVisibility(View.GONE);
         }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -35,9 +35,12 @@ import javax.inject.Named;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.auth.SessionManager;
+import fr.free.nrw.commons.category.CategoryDetailsActivity;
+import fr.free.nrw.commons.category.CategoryImagesActivity;
 import fr.free.nrw.commons.contributions.Contribution;
 import fr.free.nrw.commons.contributions.ContributionsActivity;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
+import fr.free.nrw.commons.explore.SearchActivity;
 import fr.free.nrw.commons.mwapi.MediaWikiApi;
 import fr.free.nrw.commons.utils.ImageUtils;
 import timber.log.Timber;
@@ -62,6 +65,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
     ViewPager pager;
     private Boolean editable;
     private boolean isFeaturedImage;
+    MediaDetailAdapter adapter;
 
     public MediaDetailPagerFragment() {
         this(false, false);
@@ -81,7 +85,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
         ButterKnife.bind(this,view);
         pager.addOnPageChangeListener(this);
 
-        final MediaDetailAdapter adapter = new MediaDetailAdapter(getChildFragmentManager());
+        adapter = new MediaDetailAdapter(getChildFragmentManager());
 
         if (savedInstanceState != null) {
             final int pageNumber = savedInstanceState.getInt("current-page");
@@ -269,11 +273,35 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
 
     public void showImage(int i) {
         Handler handler =  new Handler();
-        handler.postDelayed(() -> pager.setCurrentItem(i), 10);
+        handler.postDelayed(() -> pager.setCurrentItem(i), 5);
+    }
+
+    /**
+     * The method notify the viewpager that number of items have changed.
+     */
+    public void notifyDataSetChanged(){
+        adapter.notifyDataSetChanged();
     }
 
     @Override
     public void onPageScrolled(int i, float v, int i2) {
+        if (i+1 >= adapter.getCount()){
+            try{
+                ((CategoryImagesActivity) getContext()).requestMoreImages();
+            }catch (Exception e){
+                e.printStackTrace();
+            }
+            try{
+                ((CategoryDetailsActivity) getContext()).requestMoreImages();
+            }catch (Exception e){
+                e.printStackTrace();
+            }
+            try{
+                ((SearchActivity) getContext()).requestMoreImages();
+            }catch (Exception e){
+                e.printStackTrace();
+            }
+        }
         getActivity().supportInvalidateOptionsMenu();
     }
 


### PR DESCRIPTION
## Fixes
- Fixes #1805 (Expected adapter item count: 20, found: 30)
- Fixes #1801  (Media details view for Browse is lacking author field)
- Fixes #1519  (Swiping featured images limited to 10 images) 


## Description (required)

- Changed parameters in API to receive image info too
- Changed visibility Conditions in render to show author name too
- notifiedViewPager onSuccess of each API response
- added listener to ViewPager to detect last page and calling API for more responses then.

Link to documentation: https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bsearch

API used: https://commons.wikimedia.org/w/api.php?action=query&generator=search&gsrsearch=iit%20ism%20dhanbad&gsrnamespace=6&gsrwhat=text&prop=imageinfo&format=xml

## Tests performed (required)

Manually Tested on API 25, with ProdDebug variant

## Screenshots showing what changed (optional)
 