### PR TITLE
Add Traceur for getting meaningful RxJava stack traces

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.8.1'
     implementation 'com.dinuscxj:circleprogressbar:1.1.1'
 
+    implementation 'com.tspoon.traceur:traceur:1.0.1'
     implementation 'com.caverock:androidsvg:1.2.1'
     implementation 'com.github.bumptech.glide:glide:4.7.1'
     kapt 'com.github.bumptech.glide:compiler:4.7.1'

--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -10,6 +10,8 @@ import com.facebook.imagepipeline.core.ImagePipelineConfig;
 import com.facebook.stetho.Stetho;
 import com.squareup.leakcanary.LeakCanary;
 import com.squareup.leakcanary.RefWatcher;
+import com.tspoon.traceur.Traceur;
+import com.tspoon.traceur.TraceurConfig;
 
 import org.acra.ACRA;
 import org.acra.ReportingInteractionMode;
@@ -69,6 +71,8 @@ public class CommonsApplication extends MultiDexApplication {
     @Override
     public void onCreate() {
         super.onCreate();
+        Traceur.enableLogging();
+
         ApplicationlessInjection
                 .getInstance(this)
                 .getCommonsApplicationComponent()


### PR DESCRIPTION
## Title (required)

Fixes #1708

## Description (required)

Easier RxJava2 debugging with better stack traces. 
