### PR TITLE
Hotfix for overwrite issue in 2.8.0 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -130,8 +130,8 @@ public class Utils {
         }
 
         // If extension is still null, make it jpg. But be careful this if is not tested well
-        // Check if title has an extension to cover Sample.jpg case too.
-        if (extension == null && title.lastIndexOf(".")>0) {
+        // If title has an extension in it, if won't be true
+        if (extension == null && title.lastIndexOf(".")<=0) {
            extension = "jpg";
            title += "." + extension;
         }

--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -111,7 +111,7 @@ public class Utils {
     }
 
     /**
-     * Fixing incorrect extension
+     * Adds extension to filename. Converts to .jpg if system provides .jpeg, adds .jpg if no extension detected
      * @param title File name
      * @param extension Correct extension
      * @return File with correct extension
@@ -129,8 +129,9 @@ public class Utils {
             title += "." + extension;
         }
 
-        // If extension is still null, make it jpg. But be careful this if is not tested well
+        // If extension is still null, make it jpg. (Hotfix for https://github.com/commons-app/apps-android-commons/issues/228)
         // If title has an extension in it, if won't be true
+        // FIXME: .png uploads fail when uploaded via Share
         if (extension == null && title.lastIndexOf(".")<=0) {
            extension = "jpg";
            title += "." + extension;

--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -128,6 +128,13 @@ public class Utils {
                 .endsWith("." + extension.toLowerCase(Locale.ENGLISH))) {
             title += "." + extension;
         }
+
+        // If extension is still null, make it jpg. But be careful this if is not tested well
+        if (extension == null) {
+           extension = "jpg";
+           title += "." + extension;
+        }
+
         return title;
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -130,7 +130,8 @@ public class Utils {
         }
 
         // If extension is still null, make it jpg. But be careful this if is not tested well
-        if (extension == null) {
+        // Check if title has an extension to cover Sample.jpg case too.
+        if (extension == null && title.lastIndexOf(".")>0) {
            extension = "jpg";
            title += "." + extension;
         }

--- a/app/src/test/kotlin/fr/free/nrw/commons/UtilsFixExtensionTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/UtilsFixExtensionTest.kt
@@ -65,4 +65,16 @@ class UtilsFixExtensionTest {
     fun inWordJpegToJpgResultsInJpg() {
         assertEquals("X.jpeg.SAMPLE.jpg", fixExtension("X.jpeg.SAMPLE", "jpg"))
     }
+
+
+    @Test
+    fun noExtensionShouldResultInJpg() {
+        assertEquals("Sample.jpg", fixExtension("Sample", null))
+    }
+
+
+    @Test
+    fun extensionAlreadyInTitleShouldRemain() {
+        assertEquals("Sample.jpg", fixExtension("Sample.jpg", null))
+    }
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/UtilsFixExtensionTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/UtilsFixExtensionTest.kt
@@ -66,12 +66,10 @@ class UtilsFixExtensionTest {
         assertEquals("X.jpeg.SAMPLE.jpg", fixExtension("X.jpeg.SAMPLE", "jpg"))
     }
 
-
     @Test
     fun noExtensionShouldResultInJpg() {
         assertEquals("Sample.jpg", fixExtension("Sample", null))
     }
-
 
     @Test
     fun extensionAlreadyInTitleShouldRemain() {


### PR DESCRIPTION

## Title (required)

Fixes #228 Override happens

## Description (required)

Fixes #228  What I did is checking the extension, and if it is null, adding .jpg suffix. Because commons files always have suffixes, and we should compare file names after adding suffixes. Otherwise overrides are possible.


## Tests performed (required)

BetaDebug, API level 19 (this was the only emulator that I could reproduce the issue)

Fixedthe problem for me.