### PR TITLE
Bug fix issue #1839, changes

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
@@ -2,6 +2,7 @@ package fr.free.nrw.commons;
 
 import android.support.annotation.Nullable;
 
+import android.text.TextUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -161,7 +162,11 @@ public class MediaDataExtractor {
             Node node = nodes.item(i);
             if (node.getNodeName().equals("template")) {
                 String foundTitle = getTemplateTitle(node);
-                if (title.equals(new PageTitle(foundTitle).getDisplayText())) {
+                String displayText = new PageTitle(foundTitle).getDisplayText();
+                //replaced equals with contains because multiple sources had multiple formats
+                //say from two sources I had {{Location|12.958117388888889|77.6440805}} & {{Location dec|47.99081|7.845416|heading:255.9}},
+                //So exact string match would show null results for uploads via web
+                if (!(TextUtils.isEmpty(displayText)) && displayText.contains(title)) {
                     return node;
                 }
             }


### PR DESCRIPTION
* Extracted out PageTitle object's member varaible, displayText in a variable in findTemplate() in MediaDataExtractor
* added null checks for the same varaible [Lets be safe side]
* replaced equals with contains, ie. displayText.contains(title), so that uploads from multiple sources which have different formats still show up coordinates which was not being shown earlier

## Coordinates not showing up in "My Recent Uploads" picture

Fixes #{GitHub issue number #1839 and title Coordinates not showing up in "My Recent Uploads" picture } 

## Description
Fixes #{#1839}

The getTemplate() function in MediaDataExtractor used to extract data by searching for the elements to be shown in the ui. One of which is location. Now location for images uploaded from web and mobile had different formats for an example see 
One uploaded from the app:
    {{Location|12.958117388888889|77.6440805}}
One uploaded from elsewhere:
{{Location dec|47.99081|7.845416|heading:255.9}}

Clearly an exact string match for string Location would show null results for the later. So added contains instead of equals to solve the same. 
## Tests performed (required)

Tested on {27 & Samsung s7}, with {ProdDebug}.

## Screenshots showing what changed (optional)
 
![device-2018-08-21-232201](https://user-images.githubusercontent.com/17375274/44419572-37d3b200-a599-11e8-839b-e7a7ff4fa02b.png)

{Only for user interface changes, otherwise remove this section. See [how to take a screenshot](https://android.stackexchange.com/questions/1759/how-to-take-a-screenshot-with-an-android-device)}

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._