### PR TITLE
Feature/nearby io fix

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
@@ -2,6 +2,7 @@ package fr.free.nrw.commons;
 
 import android.support.annotation.Nullable;
 
+import android.text.TextUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -161,7 +162,11 @@ public class MediaDataExtractor {
             Node node = nodes.item(i);
             if (node.getNodeName().equals("template")) {
                 String foundTitle = getTemplateTitle(node);
-                if (title.equals(new PageTitle(foundTitle).getDisplayText())) {
+                String displayText = new PageTitle(foundTitle).getDisplayText();
+                //replaced equals with contains because multiple sources had multiple formats
+                //say from two sources I had {{Location|12.958117388888889|77.6440805}} & {{Location dec|47.99081|7.845416|heading:255.9}},
+                //So exact string match would show null results for uploads via web
+                if (!(TextUtils.isEmpty(displayText)) && displayText.contains(title)) {
                     return node;
                 }
             }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyController.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyController.java
@@ -55,7 +55,7 @@ public class NearbyController {
         }
         List<Place> places = nearbyPlaces.getFromWikidataQuery(curLatLng, Locale.getDefault().getLanguage());
 
-        if (places.size() > 0) {
+        if (null != places && places.size() > 0) {
             LatLng[] boundaryCoordinates = {places.get(0).location,   // south
                     places.get(0).location, // north
                     places.get(0).location, // west

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
@@ -45,7 +45,12 @@ public class NearbyPlaces {
 
             // increase the radius gradually to find a satisfactory number of nearby places
             while (radius <= MAX_RADIUS) {
-                places = getFromWikidataQuery(curLatLng, lang, radius);
+                try {
+                    places = getFromWikidataQuery(curLatLng, lang, radius);
+                }catch (Exception e){
+                    Timber.d("exception in fetching nearby places", e.getLocalizedMessage());
+                    return null;
+                }
                 Timber.d("%d results at radius: %f", places.size(), radius);
                 if (places.size() >= MIN_RESULTS) {
                     break;

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.InterruptedIOException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
@@ -47,7 +48,7 @@ public class NearbyPlaces {
             while (radius <= MAX_RADIUS) {
                 try {
                     places = getFromWikidataQuery(curLatLng, lang, radius);
-                } catch (Exception e) {
+                } catch (InterruptedIOException e) {
                     Timber.d("exception in fetching nearby places", e.getLocalizedMessage());
                     return places;
                 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
@@ -47,7 +47,7 @@ public class NearbyPlaces {
             while (radius <= MAX_RADIUS) {
                 try {
                     places = getFromWikidataQuery(curLatLng, lang, radius);
-                }catch (Exception e){
+                } catch (Exception e) {
                     Timber.d("exception in fetching nearby places", e.getLocalizedMessage());
                     return null;
                 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
@@ -49,7 +49,7 @@ public class NearbyPlaces {
                     places = getFromWikidataQuery(curLatLng, lang, radius);
                 } catch (Exception e) {
                     Timber.d("exception in fetching nearby places", e.getLocalizedMessage());
-                    return null;
+                    return places;
                 }
                 Timber.d("%d results at radius: %f", places.size(), radius);
                 if (places.size() >= MIN_RESULTS) {


### PR DESCRIPTION
## Nearby crashes when Home [From the Nav Drawer] is pressed while nearby is still loading data.

Fixes #{#1846, Nearby crashes when Home [From the Nav Drawer] is pressed while nearby is still loading data } 

## Description (required)
While nearby is still loading, and home from the nav drawer is clicked, the app used to crash with InterruptedIOException.

{Describe the changes made and why they were made.}
For fixing the same, I have catched the exception  the function getFromWikidataQuery(curLatLng, lang, radius) in NearbyPlaces. The cause of the exception could be anything, primarily IO. After catching the exception I returned null for places, for which I had to handle null for places in loadAttractionsFromLocation(LatLng curLatLng).

Tested on {27 & samsung s7}, with { ProdDebug}.
Tested for stability, Nearby no longer crashes in the mentioned scenario.

## Screenshots showing what changed (optional)
 NA