### PR TITLE
Add button on image details to copy wikicode to clipboard

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -1,6 +1,8 @@
 package fr.free.nrw.commons.media;
 
 import android.app.AlertDialog;
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.DataSetObserver;
@@ -50,6 +52,7 @@ import fr.free.nrw.commons.mwapi.MediaWikiApi;
 import fr.free.nrw.commons.ui.widget.CompatTextView;
 import timber.log.Timber;
 
+import static android.content.Context.CLIPBOARD_SERVICE;
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 import static android.widget.Toast.LENGTH_SHORT;
@@ -349,6 +352,17 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         if (media.getCoordinates() != null) {
             openMap(media.getCoordinates());
         }
+    }
+
+    @OnClick(R.id.copyWikicode)
+    public void onCopyWikicodeClicked(){
+        String data = "[[" + media.getFilename() + "|thumb|" + media.getDescription() + "]]";
+        ClipboardManager clipboard = (ClipboardManager) getContext().getApplicationContext().getSystemService(CLIPBOARD_SERVICE);
+        clipboard.setPrimaryClip(ClipData.newPlainText("wikiCode", data));
+
+        Timber.d("Generated wikidata copy code: %s", data);
+
+        Toast.makeText(getContext(), getString(R.string.wikicode_copied), Toast.LENGTH_SHORT).show();
     }
 
     @OnClick(R.id.nominateDeletion)

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -313,6 +313,14 @@
                 </LinearLayout>
 
                 <Button
+                    android:id="@+id/copyWikicode"
+                    android:textColor="@color/primaryTextColor"
+                    android:layout_margin="@dimen/standard_gap"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/copy_wikicode"/>
+
+                <Button
                     android:id="@+id/nominateDeletion"
                     android:background="@drawable/bg_delete_button"
                     android:textColor="@color/primaryTextColor"

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -314,11 +314,12 @@
 
                 <Button
                     android:id="@+id/copyWikicode"
-                    android:textColor="@color/primaryTextColor"
-                    android:layout_margin="@dimen/standard_gap"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/copy_wikicode"/>
+                    android:layout_margin="@dimen/standard_gap"
+                    android:background="@color/button_blue"
+                    android:text="@string/copy_wikicode"
+                    android:textColor="@color/primaryTextColor" />
 
                 <Button
                     android:id="@+id/nominateDeletion"
@@ -327,8 +328,7 @@
                     android:layout_margin="@dimen/standard_gap"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/nominate_deletion"
-                    android:visibility="gone"/>
+                    android:text="@string/nominate_deletion"/>
             </LinearLayout>
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -252,6 +252,8 @@
   <string name="skip_login_title">Do you really want to skip login?</string>
   <string name="skip_login_message">You will not be able to upload pictures.</string>
   <string name="login_alert_message">Please log in to use this feature</string>
+  <string name="copy_wikicode">Copy Wikicode to clipboard</string>
+  <string name="wikicode_copied">Wikicode copied to clipboard</string>
 
   <string name="nearby_location_has_not_changed">Location has not changed.</string>
   <string name="nearby_location_not_available">Location not available.</string>


### PR DESCRIPTION
## Add button on image details to copy wikicode to clipboard

Fixes https://github.com/commons-app/apps-android-commons/issues/1843 Add text field to media details view for users to copy image template into Wikipedia

## Description (required)

Fixes https://github.com/commons-app/apps-android-commons/issues/1843 Add text field to media details view for users to copy image template into Wikipedia

- Added a button to copy wikicode to clipboard in the details section
- Added strings for copy button and for toast text
- Added action on copy button to copy to clipboard on click

## Tests performed (required)

Tested on API 24, Android 7.0, Samsung S6 device

## Screenshots showing what changed (optional)
 
![screenshot_20180822-142002](https://user-images.githubusercontent.com/12453997/44492034-f46c5880-a617-11e8-91d1-d0782dc7448d.png)
![screenshot_20180822-142159](https://user-images.githubusercontent.com/12453997/44492035-f46c5880-a617-11e8-80e6-f5aad2ff16aa.png)
![screenshot_20180822-142205](https://user-images.githubusercontent.com/12453997/44492037-f504ef00-a617-11e8-996d-e539b36f11d0.png)
