### PR TITLE
Added an onclick to the middle text of a Notification

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationRenderer.java
@@ -1,6 +1,12 @@
 package fr.free.nrw.commons.notification;
 
+import android.graphics.Color;
+import android.graphics.drawable.PictureDrawable;
 import android.text.Html;
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.TextPaint;
+import android.text.style.ClickableSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -60,7 +66,25 @@ public class NotificationRenderer extends Renderer<Notification> {
         notificationText = notificationText.trim().replaceAll("(^\\h*)|(\\h*$)", "");
         notificationText = Html.fromHtml(notificationText).toString();
         notificationText = notificationText.concat(" ");
-        title.setText(notificationText);
+
+        SpannableString ss = new SpannableString(notificationText);
+        ClickableSpan clickableSpan = new ClickableSpan() {
+            @Override
+            public void onClick(View view) {
+                listener.notificationClicked(getContent());
+            }
+
+            @Override
+            public void updateDrawState(TextPaint ds) {
+                super.updateDrawState(ds);
+                ds.setUnderlineText(false);
+                ds.setColor(Color.BLACK);
+            }
+        };
+
+        ss.setSpan(clickableSpan, 0, notificationText.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        title.setText(ss, TextView.BufferType.SPANNABLE);
+
     }
 
     public interface NotificationClicked{

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationRenderer.java
@@ -1,7 +1,6 @@
 package fr.free.nrw.commons.notification;
 
 import android.graphics.Color;
-import android.graphics.drawable.PictureDrawable;
 import android.text.Html;
 import android.text.SpannableString;
 import android.text.Spanned;
@@ -82,9 +81,9 @@ public class NotificationRenderer extends Renderer<Notification> {
             }
         };
 
+        // Attach a ClickableSpan to the range (start:0, end:notificationText.length()) of the String
         ss.setSpan(clickableSpan, 0, notificationText.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         title.setText(ss, TextView.BufferType.SPANNABLE);
-
     }
 
     public interface NotificationClicked{


### PR DESCRIPTION
## Enhancement issue #1862 
Used a SpannableString to setup a ClickableSpan in the middle text of a Notification item so it works the same as when you click at the date in the right side or in the icon at the left.