### PR TITLE
Categories with pipe suffix

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -436,8 +436,18 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
     private void rebuildCatList() {
         categoryContainer.removeAllViews();
         // @fixme add the category items
-        for (String cat : categoryNames) {
-            View catLabel = buildCatLabel(cat, categoryContainer);
+
+        //As per issue #1826, some categories come suffixed with strings prefixed with |. As per the discussion
+        //that was meant for alphabetical sorting of the categories and can be safely removed.
+        for(int i=0;i<categoryNames.size();i++){
+            String categoryName = categoryNames.get(i);
+            //Removed everything after '|'
+            if (categoryName.indexOf('|') != -1) {
+                categoryName = categoryName.substring(0, categoryName.indexOf('|'));
+                //Set the updated category to the list as well
+                categoryNames.set(i, categoryName);
+            }
+            View catLabel = buildCatLabel(categoryName, categoryContainer);
             categoryContainer.addView(catLabel);
         }
     }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -437,13 +437,14 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         categoryContainer.removeAllViews();
         // @fixme add the category items
 
-        //As per issue #1826, some categories come suffixed with strings prefixed with |. As per the discussion
+        //As per issue #1826(see https://github.com/commons-app/apps-android-commons/issues/1826), some categories come suffixed with strings prefixed with |. As per the discussion
         //that was meant for alphabetical sorting of the categories and can be safely removed.
-        for(int i=0;i<categoryNames.size();i++){
+        for (int i = 0; i < categoryNames.size(); i++) {
             String categoryName = categoryNames.get(i);
             //Removed everything after '|'
-            if (categoryName.indexOf('|') != -1) {
-                categoryName = categoryName.substring(0, categoryName.indexOf('|'));
+            int indexOfPipe = categoryName.indexOf('|');
+            if (indexOfPipe != -1) {
+                categoryName = categoryName.substring(0, indexOfPipe);
                 //Set the updated category to the list as well
                 categoryNames.set(i, categoryName);
             }


### PR DESCRIPTION
## Categories with pipe suffix

Fixes {GitHub issue number #1826 and title Categories with pipe suffix} 

## Description (required)
Certain Categories in MediaDetailsFragment used to show up suffixed with pipe. Because of which , when such categories were clicked, the associated images did not show up, because server could not find any images associated because of the pipe suffix. 
Fixes {GitHub issue number #1826 and title Categories with pipe suffix}

Changes made :
-Certain category names used to show suffixed with strings prefixed with pipe '|'. Removed everything after the pipe. As per the discussion on the thread, its safe to remove everything after the pipe, including the pipe

{Describe the changes made and why they were made.}
As a fix, I have looped the category names list and and for each category name if it contains a pipe '|'. It removes everything from the string proceeding the pipe including the pipe. As a result of which, the categories would be shown without the pipe and the clicks on them would show appropriate images.
## Tests performed (required)

Tested on {27 & name of Pixel 2}, with {build variant, ProdDebug}.

## Screenshots showing what changed (optional)
![screenshot_1535870610](https://user-images.githubusercontent.com/17375274/44952965-a5d97c80-aea9-11e8-9165-5c08e6219777.png)
