### PR TITLE
Bug fix for uploaded images count in achievements activity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/achievements/Achievements.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/Achievements.java
@@ -60,65 +60,6 @@ public class Achievements {
     }
 
     /**
-     * Builder class for Achievements class
-     */
-    public class AchievementsBuilder {
-        private int nestedUniqueUsedImages;
-        private int nestedArticlesUsingImages;
-        private int nestedThanksReceived;
-        private int nestedImagesEditedBySomeoneElse;
-        private int nestedFeaturedImages;
-        private int nestedImagesUploaded;
-        private int nestedRevertCount;
-
-        public AchievementsBuilder setUniqueUsedImages(int uniqueUsedImages) {
-            this.nestedUniqueUsedImages = uniqueUsedImages;
-            return this;
-        }
-
-        public AchievementsBuilder setArticlesUsingImages(int articlesUsingImages) {
-            this.nestedArticlesUsingImages = articlesUsingImages;
-            return this;
-        }
-
-        public AchievementsBuilder setThanksReceived(int thanksReceived) {
-            this.nestedThanksReceived = thanksReceived;
-            return this;
-        }
-
-        public AchievementsBuilder setImagesEditedBySomeoneElse(int imagesEditedBySomeoneElse) {
-            this.nestedImagesEditedBySomeoneElse = imagesEditedBySomeoneElse;
-            return this;
-        }
-
-        public AchievementsBuilder setFeaturedImages(int featuredImages) {
-            this.nestedFeaturedImages = featuredImages;
-            return this;
-        }
-
-        public AchievementsBuilder setImagesUploaded(int imagesUploaded) {
-            this.nestedImagesUploaded = imagesUploaded;
-            return this;
-        }
-
-        public AchievementsBuilder setRevertCount( int revertCount){
-            this.nestedRevertCount = revertCount;
-            return this;
-        }
-
-        public Achievements createAchievements(){
-            return new Achievements(nestedUniqueUsedImages,
-                    nestedArticlesUsingImages,
-                    nestedThanksReceived,
-                    nestedImagesEditedBySomeoneElse,
-                    nestedFeaturedImages,
-                    nestedImagesUploaded,
-                    nestedRevertCount);
-        }
-
-    }
-
-    /**
      * getter function to get count of images uploaded
      * @return
      */

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -341,4 +341,6 @@
   <string name="images_uploaded_explanation">The number of images you have uploaded to Commons, via any upload software</string>
   <string name="images_reverted_explanation">The percentage of images you have uploaded to Commons that were not deleted</string>
   <string name="images_used_explanation">The number of images you have uploaded to Commons that were used in Wikimedia articles</string>
+
+  <string name="error_occurred">Error occurred!</string>
 </resources>


### PR DESCRIPTION
## Title (required)

Fixes upload count in achievements activity

## Description (required)

Fixes the usage of `Achievements` object. Making it local instead of global. 

## Screenshot

![device-2018-09-06-210913](https://user-images.githubusercontent.com/3069373/45168546-2507e100-b219-11e8-9a6e-a636594d8094.png)
