### PR TITLE
Fix incorrect Fresco initialization.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/quiz/QuizActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/quiz/QuizActivity.java
@@ -13,7 +13,6 @@ import android.widget.ProgressBar;
 import android.widget.RadioButton;
 import android.widget.TextView;
 
-import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.drawee.drawable.ProgressBarDrawable;
 import com.facebook.drawee.generic.GenericDraweeHierarchy;
 import com.facebook.drawee.generic.GenericDraweeHierarchyBuilder;
@@ -45,7 +44,6 @@ public class QuizActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_quiz);
-        Fresco.initialize(this);
 
         quizController.initialize(this);
         ButterKnife.bind(this);


### PR DESCRIPTION
Fresco only needs to be initialized once, in the Application class. Initializing it again can lead to undefined behavior, including crashes.