### PR TITLE
Fix crash(es) due to uninitialized notification channel.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -123,7 +123,7 @@ public class CommonsApplication extends Application {
         }
 
 
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             createNotificationChannel();
         }
 
@@ -133,11 +133,13 @@ public class CommonsApplication extends Application {
 
     @RequiresApi(26)
     private void createNotificationChannel() {
-        NotificationChannel channel = new NotificationChannel(
-                NOTIFICATION_CHANNEL_ID_ALL,
-                getString(R.string.notifications_channel_name_all), NotificationManager.IMPORTANCE_NONE);
         NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-        manager.createNotificationChannel(channel);
+        NotificationChannel channel = manager.getNotificationChannel(NOTIFICATION_CHANNEL_ID_ALL);
+        if (channel == null) {
+            channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID_ALL,
+                    getString(R.string.notifications_channel_name_all), NotificationManager.IMPORTANCE_NONE);
+            manager.createNotificationChannel(channel);
+        }
     }
 
     /**


### PR DESCRIPTION
The notification channel needs to be created for API versions greater than OR EQUAL to 26 (O).  Also, the channel does not need to be reinitialized if it already exists.
This will likely fix #1877 