### PR TITLE
Fix crash(es) due to uninitialized notification channel.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.support.annotation.RequiresApi;
 
 import com.facebook.drawee.backends.pipeline.Fresco;
@@ -122,23 +123,21 @@ public class CommonsApplication extends Application {
             Stetho.initializeWithDefaults(this);
         }
 
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            createNotificationChannel();
-        }
+        createNotificationChannel(this);
 
         // Fire progress callbacks for every 3% of uploaded content
         System.setProperty("in.yuvi.http.fluent.PROGRESS_TRIGGER_THRESHOLD", "3.0");
     }
 
-    @RequiresApi(26)
-    private void createNotificationChannel() {
-        NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-        NotificationChannel channel = manager.getNotificationChannel(NOTIFICATION_CHANNEL_ID_ALL);
-        if (channel == null) {
-            channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID_ALL,
-                    getString(R.string.notifications_channel_name_all), NotificationManager.IMPORTANCE_NONE);
-            manager.createNotificationChannel(channel);
+    public static void createNotificationChannel(@NonNull Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+            NotificationChannel channel = manager.getNotificationChannel(NOTIFICATION_CHANNEL_ID_ALL);
+            if (channel == null) {
+                channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID_ALL,
+                        context.getString(R.string.notifications_channel_name_all), NotificationManager.IMPORTANCE_DEFAULT);
+                manager.createNotificationChannel(channel);
+            }
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -123,7 +123,7 @@ public class CommonsApplication extends Application {
         }
 
 
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             createNotificationChannel();
         }
 
@@ -133,11 +133,13 @@ public class CommonsApplication extends Application {
 
     @RequiresApi(26)
     private void createNotificationChannel() {
-        NotificationChannel channel = new NotificationChannel(
-                NOTIFICATION_CHANNEL_ID_ALL,
-                getString(R.string.notifications_channel_name_all), NotificationManager.IMPORTANCE_NONE);
         NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-        manager.createNotificationChannel(channel);
+        NotificationChannel channel = manager.getNotificationChannel(NOTIFICATION_CHANNEL_ID_ALL);
+        if (channel == null) {
+            channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID_ALL,
+                    getString(R.string.notifications_channel_name_all), NotificationManager.IMPORTANCE_NONE);
+            manager.createNotificationChannel(channel);
+        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -121,7 +121,7 @@ public class UploadService extends HandlerService<Contribution> {
     @Override
     public void onCreate() {
         super.onCreate();
-
+        CommonsApplication.createNotificationChannel(getApplicationContext());
         notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
     }
 


### PR DESCRIPTION
The notification channel needs to be created for API versions greater than OR EQUAL to 26 (O).  Also, the channel does not need to be reinitialized if it already exists.
This will likely fix #1877 