### PR TITLE
Revert to using target SDK hotfix for 2.8.4

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -5,9 +5,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.sqlite.SQLiteDatabase;
 import android.support.multidex.MultiDexApplication;
-import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.annotation.RequiresApi;
 
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.imagepipeline.core.ImagePipelineConfig;
@@ -104,22 +101,10 @@ public class CommonsApplication extends MultiDexApplication {
             Stetho.initializeWithDefaults(this);
         }
 
-        createNotificationChannel(this);
         // Fire progress callbacks for every 3% of uploaded content
         System.setProperty("in.yuvi.http.fluent.PROGRESS_TRIGGER_THRESHOLD", "3.0");
     }
 
-    public static void createNotificationChannel(@NonNull Context context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-            NotificationChannel channel = manager.getNotificationChannel(NOTIFICATION_CHANNEL_ID_ALL);
-            if (channel == null) {
-                channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID_ALL,
-                        context.getString(R.string.notifications_channel_name_all), NotificationManager.IMPORTANCE_DEFAULT);
-                manager.createNotificationChannel(channel);
-            }
-        }
-    }
 
     /**
      * Helps in setting up LeakCanary library

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -122,7 +122,7 @@ public class UploadService extends HandlerService<Contribution> {
     @Override
     public void onCreate() {
         super.onCreate();
-        CommonsApplication.createNotificationChannel(getApplicationContext());
+
         notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,8 @@ android.useDeprecatedNdk=true
 BUTTERKNIFE_VERSION=8.6.0
 org.gradle.jvmargs=-Xmx1536M
 buildToolsVersion=27.0.0
-targetSdkVersion=27
+#TODO: Change back to 27 in v2.9, see https://github.com/commons-app/apps-android-commons/issues/1877
+targetSdkVersion=26
 
 #TODO: Temporary disabled. https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#aapt2
 #Refer to PR: https://github.com/commons-app/apps-android-commons/pull/932

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ BUTTERKNIFE_VERSION=8.6.0
 org.gradle.jvmargs=-Xmx1536M
 buildToolsVersion=27.0.0
 #TODO: Change back to 27 in v2.9, see https://github.com/commons-app/apps-android-commons/issues/1877
-targetSdkVersion=26
+targetSdkVersion=25
 
 #TODO: Temporary disabled. https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#aapt2
 #Refer to PR: https://github.com/commons-app/apps-android-commons/pull/932


### PR DESCRIPTION
Sorry, I've been having issues getting the ideal fix for #1877 to work in 2.8-release, and have been very strapped for time this week. 😞 In the meantime we have been getting a high number of crashes and low ratings due to that.

Faced with the prospect of either having users crash consistently over the next 3 days (long weekend here) or otherwise derailing my RL commitments to spend more time working on the problem, I decided that the lesser evil would be to just change the target sdk for the hotfix so that users can stop crashing immediately. 

The proper fix by Dmitry will remain in master where it already works, and will be released in 2.9 with the target sdk re-incremented. So from a user point of view the fix wil be continuous, the target sdk will not affect them.

I'm not a fan either of the hackish nature of the fix, but it seems like the best way to tie all the moving parts together. I really did not want users to have to crash for 3 more days or however long it took me to figure it out.

Tested all upload flows with this on API 27 emulator.