### PR TITLE
Fixes #1914 The info dialog for image description opens only on touch of info icon.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
@@ -184,8 +184,8 @@ class DescriptionsAdapter extends RecyclerView.Adapter<DescriptionsAdapter.ViewH
                 if (ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_LTR) {
                     value = etDescriptionText.getRight() - etDescriptionText
                             .getCompoundDrawables()[2]
-                            .getBounds().width();
-                    if (motionEvent.getAction() == ACTION_UP && motionEvent.getRawX() >= value) {
+                            .getBounds().width() - etDescriptionText.getPaddingRight();
+                    if (motionEvent.getAction() == ACTION_UP && motionEvent.getX() >= value) {
                         callback.showAlert(R.string.media_detail_description,
                                 R.string.description_info);
                         return true;


### PR DESCRIPTION

## Title (required)

Fixes #1914 Description info dialog opens when tapped on the EditText in the blank space between hint and info icon.

## Description (required)

Fixes #1914 

The motionEvent.getRawX() used inside the onTouch callback won't work properly if the EditText's parent is not aligned with the left of the screen. Using motionEvent.getX() instead will give the correct value. This will allow the icon to be considered only where it is seen and the dialog is opened on tapping the 'i' icon.
## Tests performed (required)

Tested on Moto G4 Plus (Android 7.0 API 24), with 2.8.3-debug-master build.

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._