### PR TITLE
Bugfix(#1921)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -372,6 +372,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
 
     private void addNetworkBroadcastReceiver() {
         IntentFilter intentFilter = new IntentFilter(NETWORK_INTENT_ACTION);
+        Snackbar snackbar = Snackbar.make(transparentView , R.string.no_internet, Snackbar.LENGTH_INDEFINITE);
 
         broadcastReceiver = new BroadcastReceiver() {
 
@@ -379,8 +380,9 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
             public void onReceive(Context context, Intent intent) {
                 if (NetworkUtils.isInternetConnectionEstablished(NearbyActivity.this)) {
                     refreshView(LOCATION_SIGNIFICANTLY_CHANGED);
+                    snackbar.dismiss();
                 } else {
-                    Snackbar.make(transparentView , R.string.no_internet, Snackbar.LENGTH_INDEFINITE).show();
+                    snackbar.show();
                 }
             }
         };

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -13,6 +13,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.design.widget.BottomSheetBehavior;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AlertDialog;
 import android.view.Menu;
@@ -379,7 +380,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
                 if (NetworkUtils.isInternetConnectionEstablished(NearbyActivity.this)) {
                     refreshView(LOCATION_SIGNIFICANTLY_CHANGED);
                 } else {
-                    ViewUtil.showLongToast(NearbyActivity.this, getString(R.string.no_internet));
+                    Snackbar.make(transparentView , R.string.no_internet, Snackbar.LENGTH_INDEFINITE).show();
                 }
             }
         };


### PR DESCRIPTION
Title: Fixes #1921: When no internet, nearby stays grey, no spinner nor error 

Description: Fixes #1921: When no internet, nearby stays grey, no spinner nor error 

Area of change: 
NotificationActivity.java ... changed a toast message into a snackbar message which will remain on screen.

Details: 
The reported issue is that in the Nearby activity, the app does not communicate that there is no internet connection.
On investigation, it appears that a toast message does briefly display "No internet connection".
It looks like other activities have implemented this same message within the snackbar instead.
In order to have a consistent style of communication to the user, I removed the toast message and replace it with the snackbar message, as implemented in NotificationActivity.java.

Tests performed:

Tested on API 28 with Samsung Galaxy s8+ via USB Debugging.

1) Log into application		->	You are taken to the "My Recent Uploads" Activity.
2) Turn on airplane mode	->	Your device loses its internet connection.
3) Tap on "Nearby" 			->	The nearby activity will load  the "No Internet Connection" snackbar at the bottom.
								The snackbar message will remain on the screen.
4) Turn off airplane mode	->	Your device regains its internet connection. 
								The Nearby activity will automatically load its contents when the connection is re-established.