### PR TITLE
Fix of #1581 Crash after granting permission.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
@@ -106,6 +106,9 @@ public class LocationServiceManager implements LocationListener {
             if (lastKL == null) {
                 lastKL = locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
             }
+            if (lastKL == null) {
+                return null;
+            }
             return LatLng.from(lastKL);
         } else {
             return null;

--- a/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
@@ -102,14 +102,11 @@ public class LocationServiceManager implements LocationListener {
     @SuppressLint("MissingPermission")
     public LatLng getLKL() {
         if (isLocationPermissionGranted()) {
-            Location lastKL = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER);
-            if (lastKL == null) {
-                lastKL = locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
+            lastLocation = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER);
+            if (lastLocation == null) {
+                lastLocation = locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
             }
-            if (lastKL == null) {
-                return null;
-            }
-            return LatLng.from(lastKL);
+            return(getLastLocation());
         } else {
             return null;
         }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyActivity.java
@@ -265,6 +265,7 @@ public class NearbyActivity extends NavigationBaseActivity implements LocationUp
                                 Intent callGPSSettingIntent = new Intent(
                                         android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS);
                                 Timber.d("Loaded settings page");
+                                dialog.dismiss();
                                 startActivityForResult(callGPSSettingIntent, 1);
                             })
                     .setNegativeButton(R.string.menu_cancel_upload, (dialog, id) -> {


### PR DESCRIPTION
## Title: 
location permission fix for 2.8-release

Fixes #1581 Crash after granting permission
Fixes bug of GPS enable dialog not dismissed 

## Description:
area: NearbyActivity, LocationServiceManager

Null check in LatLing getLKL method with replacing content of return with calling method that already exists "getLastLocation()".
- App will not crash 1st time granting permission.

Fixing bug in NearbyActivity. Dialog (enable gps) was not dismissed in activity after pressing positive button and turning on gps.
- Dialog (enable gps) will disappear and if gps is disabled again it will reappear. 

{In case it is usable please assign me to #1581 and mark as resolved, so that i can show it to my teacher in class as proof. Thank you.}

## Tested:
on API 27 & Nexus 5X (emulator), with {BetaDebug}