### PR TITLE
Empty screen if no upload fix

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsActivity.java
@@ -256,6 +256,9 @@ public  class       ContributionsActivity
             ((CursorAdapter) contributionsList.getAdapter()).swapCursor(cursor);
         }
 
+        if(contributionsList.getAdapter().getCount()>0){
+            contributionsList.changeEmptyScreen(false);
+        }
         contributionsList.clearSyncMessage();
         notifyAndMigrateDataSetObservers();
     }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -47,6 +47,8 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
     TextView waitingMessage;
     @BindView(R.id.loadingContributionsProgressBar)
     ProgressBar progressBar;
+    @BindView(R.id.noDataYet)
+    TextView noDataYet;
 
     @Inject
     @Named("prefs")
@@ -79,6 +81,7 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
             waitingMessage.setVisibility(GONE);
         }
 
+        changeEmptyScreen(true);
         changeProgressBarVisibility(true);
         return v;
     }
@@ -93,6 +96,10 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
         if(BuildConfig.FLAVOR.equalsIgnoreCase("beta")){
             ((ContributionsActivity) getActivity()).betaSetUploadCount(adapter.getCount());
         }
+    }
+
+    public void changeEmptyScreen(boolean isEmpty){
+        this.noDataYet.setVisibility(isEmpty ? View.VISIBLE : View.GONE);
     }
 
     public void changeProgressBarVisibility(boolean isVisible) {

--- a/app/src/main/res/layout/fragment_contributions.xml
+++ b/app/src/main/res/layout/fragment_contributions.xml
@@ -14,7 +14,10 @@
         android:text="@string/no_uploads"
         android:gravity="center"
         android:layout_centerInParent="true"
-        android:visibility="gone" />
+        android:visibility="gone"
+        android:layout_marginRight="@dimen/tiny_gap"
+        android:layout_marginEnd="@dimen/tiny_gap"
+        />
 
     <TextView
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_contributions.xml
+++ b/app/src/main/res/layout/fragment_contributions.xml
@@ -8,6 +8,15 @@
     >
 
     <TextView
+        android:id="@+id/noDataYet"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/no_uploads"
+        android:gravity="center"
+        android:layout_centerInParent="true"
+        android:visibility="gone" />
+
+    <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/waiting_first_sync"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -358,4 +358,5 @@
   <string name="write_storage_permission_rationale_for_image_share">We need your permission to access the external storage of your device in order to upload images.</string>
 
   <string name="log_collection_started">Log collection started. Please RESTART the app, perform action that you wish to log, and then tap \'Send Logs\' again</string>
+  <string name="no_uploads">No uploads yet, let\'s upload your first file!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -358,5 +358,6 @@
   <string name="write_storage_permission_rationale_for_image_share">We need your permission to access the external storage of your device in order to upload images.</string>
 
   <string name="log_collection_started">Log collection started. Please RESTART the app, perform action that you wish to log, and then tap \'Send Logs\' again</string>
-  <string name="no_uploads">No uploads yet, let\'s upload your first file!</string>
+  <string name="no_uploads">Welcome to Commons!\n
+Upload your first media by touching the camera or gallery icon above.</string>
 </resources>


### PR DESCRIPTION
## Title (required)

Fixes #1912 Empty screen if no upload

## Description (required)

Fixes #1912 Empty screen if no upload

Added text view for empty page showing welcome text in case there are no uploads. Once there are files the message is hid.

## Tests performed (required)

Tested on API 25 & Galaxy J5, with {BetaDebug}

## Screenshots showing what changed (optional)

Without and with uploads: 


![screenshot_20181017-123328](https://user-images.githubusercontent.com/43948534/47105619-bc167e80-d244-11e8-9cea-4f48f2e2e576.jpg)
![screenshot_20181017-123511](https://user-images.githubusercontent.com/43948534/47105630-c2a4f600-d244-11e8-8202-d0c0dde84762.jpg)
