### PR TITLE
Make the message "Send log file" consistent

### DIFF
--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -146,5 +146,5 @@
   <string name="successful_wikidata_edit">Message shown in a dialog (\"success toast\") after a contribution by the user.\n\nParameter:\n* %1$s - title of the target page on Wikidata</string>
   <string name="question">{{Identical|Question}}</string>
   <string name="result">{{Identical|Result}}</string>
-  <string name="log_collection_started">(\"Send Logs\" is probably {{msg-wm|Commons-android-strings-send log file}}, although it looks inconsistent at the moment. See also https://github.com/commons-app/apps-android-commons/issues/1946 .)</string>
+  <string name="log_collection_started">(\"Send log file\" is {{msg-wm|Commons-android-strings-send log file}}.)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -357,7 +357,7 @@
   <string name="storage_permission">Storage Permission</string>
   <string name="write_storage_permission_rationale_for_image_share">We need your permission to access the external storage of your device in order to upload images.</string>
 
-  <string name="log_collection_started">Log collection started. Please RESTART the app, perform action that you wish to log, and then tap \'Send Logs\' again</string>
+  <string name="log_collection_started">Log collection started. Please RESTART the app, perform action that you wish to log, and then tap \'Send log file\' again</string>
   <string name="no_uploads">Welcome to Commons!\n
 Upload your first media by touching the camera or gallery icon above.</string>
 </resources>


### PR DESCRIPTION
## Make the message "Send log file" consistent

Fixes #1946.

## Description (required)

Fixes #1946.

The title had different wording in different strings. Now it's consistent.

## Tests performed (required)

Trivial strings change :)