### PR TITLE
Fix for #1959 - Crash on notification and fails on image upload

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationRenderer.java
@@ -57,7 +57,7 @@ public class NotificationRenderer extends Renderer<Notification> {
      * @param notificationText
      */
     private void setTitle(String notificationText) {
-        notificationText = notificationText.trim().replaceAll("(^\\h*)|(\\h*$)", "");
+        notificationText = notificationText.trim().replaceAll("(^\\s*)|(\\s*$)", "");
         notificationText = Html.fromHtml(notificationText).toString();
         notificationText = notificationText.concat(" ");
         title.setText(notificationText);


### PR DESCRIPTION
## Fix for #1959 

Fixes #1959 -  Crash on notification and fails on image upload 

## Description

Error while uploading images is already fixed and is yet to be available on F-droid as discussed in the comments.

Crash after clicking 'Notification' in Android 5.0 happened because of this exception:

java.util.regex.PatternSyntaxException: Unrecognized backslash escape sequence in pattern near index 4:
(^\h*)|(\h*$)
(Full stack trace is in the defect's comments)

Apparently '\s' is the suggested character sequence for white space. '\h' is not getting recognized by Pattern class of Android 5 and 6

## Tests performed

Tested on the following: 

1. API 22 - Android 5.1 - Custom emulator - 1 GB RAM
2. API 23 - Android 6.0 -  Custom emulator - 1 GB RAM
3. API 25 - Android 7.1.1 -  Nexus 5X

## Screenshots showing what changed

No UI changes