### PR TITLE
Crash fix due to bookmarks authority on prod variant

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -153,8 +153,8 @@ android {
             buildConfigField "String", "MODIFICATION_AUTHORITY", "\"fr.free.nrw.commons.modifications.contentprovider\""
             buildConfigField "String", "CATEGORY_AUTHORITY", "\"fr.free.nrw.commons.categories.contentprovider\""
             buildConfigField "String", "RECENT_SEARCH_AUTHORITY", "\"fr.free.nrw.commons.explore.recentsearches.contentprovider\""
-            buildConfigField "String", "BOOKMARK_AUTHORITY", "\"fr.free.nrw.commons.beta.bookmarks.contentprovider\""
-            buildConfigField "String", "BOOKMARK_LOCATIONS_AUTHORITY", "\"fr.free.nrw.commons.beta.bookmarks.locations.contentprovider\""
+            buildConfigField "String", "BOOKMARK_AUTHORITY", "\"fr.free.nrw.commons.bookmarks.contentprovider\""
+            buildConfigField "String", "BOOKMARK_LOCATIONS_AUTHORITY", "\"fr.free.nrw.commons.bookmarks.locations.contentprovider\""
 
             dimension 'tier'
         }


### PR DESCRIPTION
## Title (required)

Fixes #1967

## Description (required)

The authority for prod variant wasn't set properly as a result of which the app was crashing. 

## Tests performed (required)

Tested on prodDebug variant. Crash no longer happens.