### PR TITLE
Fix for #1942 - App crashing when selecting some specific images

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/utils/ContributionUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ContributionUtils.java
@@ -112,9 +112,9 @@ public class ContributionUtils {
             out = new FileOutputStream(new File(destinationFilename));
 
             byte[] buf = new byte[1024];
-            int len;
-            while ((len=in.read(buf)) > 0) {
-                out.write(buf, 0, len);
+            int length;
+            while ((length = in.read(buf)) > 0) {
+                out.write(buf, 0, length);
             }
         } catch (FileNotFoundException e) {
             e.printStackTrace();
@@ -123,6 +123,11 @@ public class ContributionUtils {
         } finally {
             try {
                 if (out != null) out.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+            try {
                 if (in != null) in.close();
             } catch (IOException e) {
                 e.printStackTrace();


### PR DESCRIPTION
Fixes #1942 - App crashing when selecting some specific images

**Description**
Main reason for the failure is unknown but since stack trace showed the close() call on the null output stream object, null check is required which is recently done via #1918 PR for some other issue but that can be improved upon so that an exception during close of input stream stream should not stop the close of output stream so having a separate try catch block for each.

Also I suspect the main reason why output stream was null and exception could not come in the stack trace was because catch block is handling just the checked exceptions. So I believe expanding it to handle all Exceptions will help us tackle such issues in future.

**Tests performed**

Tested the upload of the image to rule out any regression.

**Screenshots showing what changed**

No UI changes
