### PR TITLE
Remove libraries from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,37 +11,12 @@ Initially started by the Wikimedia Foundation, this app is now maintained by gra
 
 ## Documentation
 
-We try to have an extensive documentation at [our wiki here at Github][5]:
+We try to have an extensive documentation at [our wiki here at Github][4]:
 
-* [User Documentation][6]
-* [Contributor Documentation][7]
-  * [Volunteers Welcome!][9]
+* [User Documentation][5]
+* [Contributor Documentation][6]
+  * [Volunteers Welcome!][7]
 * [Developer Documentation][8]
-
-## Libraries Used ##
-
-* [Picasso][11]
-* [RSS-Parser][12]
-* [ViewPagerIndicator][13]
-* [PhotoView][14]
-* [Acra][15]
-* [Renderers][16]
-* [Gson][17]
-* [Timber][18]
-* [Java-String-Similarity][19]
-* [ReadMoreTextView][20]
-* [MaterialShowcaseView][21]
-* [Butterknife][22]
-* [OKHttp][23]
-* [Okio][24]
-* [RxJava][25]
-* [JSoup][26]
-* [Fresco][27]
-* [Stetho][28]
-* [Dagger][29]
-* [Java-HTTP-Fluent][30]
-* [CircleProgressBar][31]
-* [Leak Canary][32]
 
 ## Contributors ##
 
@@ -60,37 +35,17 @@ Thank you all for your work!
 
 ## License ##
 
-This software is open source, licensed under the [Apache License 2.0][4].
-
+This software is open source, licensed under the [Apache License 2.0][9].
 
 
 [1]: https://play.google.com/store/apps/details?id=fr.free.nrw.commons
 [2]: https://commons-app.github.io/
 [3]: https://github.com/commons-app/apps-android-commons/issues
-[4]: https://www.apache.org/licenses/LICENSE-2.0
-[5]: https://github.com/commons-app/apps-android-commons/wiki
-[6]: https://github.com/commons-app/apps-android-commons/wiki#user-documentation
-[7]: https://github.com/commons-app/apps-android-commons/wiki#contributor-documentation
+
+[4]: https://github.com/commons-app/apps-android-commons/wiki
+[5]: https://github.com/commons-app/apps-android-commons/wiki#user-documentation
+[6]: https://github.com/commons-app/apps-android-commons/wiki#contributor-documentation
+[7]: https://github.com/commons-app/apps-android-commons/wiki/Volunteers-welcome%21
 [8]: https://github.com/commons-app/apps-android-commons/wiki#developer-documentation
-[9]: https://github.com/commons-app/apps-android-commons/wiki/Volunteers-welcome%21
-[10]: https://meta.wikimedia.org/wiki/Grants:Project/Improve_%27Upload_to_Commons%27_Android_App/Renewal
-[11]: https://github.com/square/picasso
-[13]: https://github.com/avianey/Android-ViewPagerIndicator
-[14]: https://github.com/chrisbanes/PhotoView
-[15]: https://github.com/ACRA/acra
-[16]: https://github.com/pedrovgs/Renderers
-[17]: https://github.com/google/gson
-[18]: https://github.com/JakeWharton/timber
-[19]: https://github.com/tdebatty/java-string-similarity
-[20]: https://github.com/bravoborja/ReadMoreTextView
-[21]: https://github.com/deano2390/MaterialShowcaseView
-[22]: https://github.com/JakeWharton/butterknife
-[23]: https://github.com/square/okhttp
-[24]: https://github.com/square/okio
-[25]: https://github.com/ReactiveX/RxJava
-[27]: https://github.com/facebook/fresco
-[28]: https://github.com/facebook/stetho
-[29]: https://github.com/google/dagger
-[30]: https://github.com/yuvipanda/java-http-fluent/blob/master/src/main/java/in/yuvi/http/fluent/Http.java
-[31]: https://github.com/dinuscxj/CircleProgressBar
-[32]: https://github.com/square/leakcanary
+
+[9]: https://www.apache.org/licenses/LICENSE-2.0

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,34 +10,27 @@ dependencies {
     implementation 'fr.avianey.com.viewpagerindicator:library:2.4.1.1@aar'
     implementation 'in.yuvi:http.fluent:1.3'
     implementation 'com.github.chrisbanes:PhotoView:2.0.0'
-
     implementation 'ch.acra:acra:4.9.2'
-
-    implementation 'org.mediawiki:api:1.3'
     implementation 'commons-codec:commons-codec:1.10'
     implementation 'com.github.pedrovgs:renderers:3.3.3'
     implementation 'com.google.code.gson:gson:2.8.5'
-    implementation 'com.jakewharton.timber:timber:4.4.0'
     implementation 'info.debatty:java-string-similarity:0.24'
     implementation 'com.borjabravo:readmoretextview:2.1.0'
+    implementation('com.mapbox.mapboxsdk:mapbox-android-sdk:5.5.0@aar') {
+        transitive = true
+    }
+    implementation 'com.github.deano2390:MaterialShowcaseView:1.2.0'
+    implementation 'com.dinuscxj:circleprogressbar:1.1.1'
+    implementation 'com.karumi:dexter:5.0.0'
+    implementation files('libs/simplemagic-1.9.jar')
 
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-
+    // Logging
+    implementation 'com.jakewharton.timber:timber:4.4.0'
     implementation 'org.slf4j:slf4j-api:1.7.25'
     api ("com.github.tony19:logback-android-classic:1.1.1-6") {
         exclude group: 'com.google.android', module: 'android'
     }
 
-    implementation('com.mapbox.mapboxsdk:mapbox-android-sdk:5.5.0@aar') {
-        transitive = true
-    }
-    implementation 'com.github.deano2390:MaterialShowcaseView:1.2.0'
-    //noinspection GradleCompatible
-    implementation "com.android.support:support-v4:$SUPPORT_LIB_VERSION"
-    implementation "com.android.support:appcompat-v7:$SUPPORT_LIB_VERSION"
-    implementation "com.android.support:design:$SUPPORT_LIB_VERSION"
-    implementation "com.android.support:customtabs:$SUPPORT_LIB_VERSION"
-    implementation "com.android.support:cardview-v7:$SUPPORT_LIB_VERSION"
     implementation "com.jakewharton:butterknife:$BUTTERKNIFE_VERSION"
     kapt "com.jakewharton:butterknife-compiler:$BUTTERKNIFE_VERSION"
     implementation 'com.squareup.okhttp3:okhttp:3.10.0'
@@ -50,6 +43,7 @@ dependencies {
     implementation 'com.jakewharton.rxbinding2:rxbinding-support-v4:2.1.1'
     implementation 'com.jakewharton.rxbinding2:rxbinding-appcompat-v7:2.1.1'
     implementation 'com.jakewharton.rxbinding2:rxbinding-design:2.1.1'
+    implementation 'com.tspoon.traceur:traceur:1.0.1'
     implementation 'com.facebook.fresco:fresco:1.10.0'
     implementation 'com.facebook.stetho:stetho:1.5.0'
     implementation "com.google.dagger:dagger:$DAGGER_VERSION"
@@ -62,24 +56,23 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:3.7.1'
     testImplementation 'com.nhaarman:mockito-kotlin:1.5.0'
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
-    implementation 'com.dinuscxj:circleprogressbar:1.1.1'
-
-    implementation 'com.tspoon.traceur:traceur:1.0.1'
 
     androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
-    androidTestImplementation "com.android.support:support-annotations:$SUPPORT_LIB_VERSION"
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation "com.android.support:support-annotations:$SUPPORT_LIB_VERSION"
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     debugImplementation "com.squareup.leakcanary:leakcanary-android:$LEAK_CANARY"
     releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$LEAK_CANARY"
     testImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$LEAK_CANARY"
 
-    //For handling runtime permissions
-    implementation 'com.karumi:dexter:5.0.0'
-
-    implementation files('libs/simplemagic-1.9.jar')
+    implementation "com.android.support:support-v4:$SUPPORT_LIB_VERSION"
+    implementation "com.android.support:appcompat-v7:$SUPPORT_LIB_VERSION"
+    implementation "com.android.support:design:$SUPPORT_LIB_VERSION"
+    implementation "com.android.support:customtabs:$SUPPORT_LIB_VERSION"
+    implementation "com.android.support:cardview-v7:$SUPPORT_LIB_VERSION"
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 }
 
 android {


### PR DESCRIPTION
**Description (required)**

Fixes #1985 Update libraries used in README

What changes did you make and why?
- Moved list of libraries to [wiki](https://github.com/commons-app/apps-android-commons/wiki/Libraries-used) top avoid clutter in README
- Updated list of libraries to include ones that were missing and remove ones that weren't being used
- Reordered parts of `app/build.gradle` so libraries used for similar purposes roughly grouped together
- Removed unused mediawiki api dependency

**Tests performed (required)**

Checked all the links are up to date and work in library list

All automated tests pass

Tutorial, login, home, upload media (only on beta), view media, nearby, achievements, notifications, settings, about

Tested `2.8.5-debug-update-libraries-docs~ccf03c78 (beta)` on `Samsung Galaxy S6` with API level `25`.
Tested `2.8.5-debug-update-libraries-docs~ccf03c78 (prod)` on `Samsung Galaxy S6` with API level `25`.

All working