### PR TITLE
Remove libraries section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ We try to have an extensive documentation at [our wiki here at Github][4]:
 * [Contributor Documentation][6]
   * [Volunteers Welcome!][7]
 * [Developer Documentation][8]
+  * [Libraries Used][9]
 
 ## Contributors ##
 
@@ -35,7 +36,7 @@ Thank you all for your work!
 
 ## License ##
 
-This software is open source, licensed under the [Apache License 2.0][9].
+This software is open source, licensed under the [Apache License 2.0][10].
 
 
 [1]: https://play.google.com/store/apps/details?id=fr.free.nrw.commons
@@ -47,5 +48,6 @@ This software is open source, licensed under the [Apache License 2.0][9].
 [6]: https://github.com/commons-app/apps-android-commons/wiki#contributor-documentation
 [7]: https://github.com/commons-app/apps-android-commons/wiki/Volunteers-welcome%21
 [8]: https://github.com/commons-app/apps-android-commons/wiki#developer-documentation
+[9]: https://github.com/commons-app/apps-android-commons/wiki/Libraries-used
 
-[9]: https://www.apache.org/licenses/LICENSE-2.0
+[10]: https://www.apache.org/licenses/LICENSE-2.0

--- a/README.md
+++ b/README.md
@@ -11,37 +11,12 @@ Initially started by the Wikimedia Foundation, this app is now maintained by gra
 
 ## Documentation
 
-We try to have an extensive documentation at [our wiki here at Github][5]:
+We try to have an extensive documentation at [our wiki here at Github][4]:
 
-* [User Documentation][6]
-* [Contributor Documentation][7]
-  * [Volunteers Welcome!][9]
+* [User Documentation][5]
+* [Contributor Documentation][6]
+  * [Volunteers Welcome!][7]
 * [Developer Documentation][8]
-
-## Libraries Used ##
-
-* [Picasso][11]
-* [RSS-Parser][12]
-* [ViewPagerIndicator][13]
-* [PhotoView][14]
-* [Acra][15]
-* [Renderers][16]
-* [Gson][17]
-* [Timber][18]
-* [Java-String-Similarity][19]
-* [ReadMoreTextView][20]
-* [MaterialShowcaseView][21]
-* [Butterknife][22]
-* [OKHttp][23]
-* [Okio][24]
-* [RxJava][25]
-* [JSoup][26]
-* [Fresco][27]
-* [Stetho][28]
-* [Dagger][29]
-* [Java-HTTP-Fluent][30]
-* [CircleProgressBar][31]
-* [Leak Canary][32]
 
 ## Contributors ##
 
@@ -60,37 +35,17 @@ Thank you all for your work!
 
 ## License ##
 
-This software is open source, licensed under the [Apache License 2.0][4].
-
+This software is open source, licensed under the [Apache License 2.0][9].
 
 
 [1]: https://play.google.com/store/apps/details?id=fr.free.nrw.commons
 [2]: https://commons-app.github.io/
 [3]: https://github.com/commons-app/apps-android-commons/issues
-[4]: https://www.apache.org/licenses/LICENSE-2.0
-[5]: https://github.com/commons-app/apps-android-commons/wiki
-[6]: https://github.com/commons-app/apps-android-commons/wiki#user-documentation
-[7]: https://github.com/commons-app/apps-android-commons/wiki#contributor-documentation
+
+[4]: https://github.com/commons-app/apps-android-commons/wiki
+[5]: https://github.com/commons-app/apps-android-commons/wiki#user-documentation
+[6]: https://github.com/commons-app/apps-android-commons/wiki#contributor-documentation
+[7]: https://github.com/commons-app/apps-android-commons/wiki/Volunteers-welcome%21
 [8]: https://github.com/commons-app/apps-android-commons/wiki#developer-documentation
-[9]: https://github.com/commons-app/apps-android-commons/wiki/Volunteers-welcome%21
-[10]: https://meta.wikimedia.org/wiki/Grants:Project/Improve_%27Upload_to_Commons%27_Android_App/Renewal
-[11]: https://github.com/square/picasso
-[13]: https://github.com/avianey/Android-ViewPagerIndicator
-[14]: https://github.com/chrisbanes/PhotoView
-[15]: https://github.com/ACRA/acra
-[16]: https://github.com/pedrovgs/Renderers
-[17]: https://github.com/google/gson
-[18]: https://github.com/JakeWharton/timber
-[19]: https://github.com/tdebatty/java-string-similarity
-[20]: https://github.com/bravoborja/ReadMoreTextView
-[21]: https://github.com/deano2390/MaterialShowcaseView
-[22]: https://github.com/JakeWharton/butterknife
-[23]: https://github.com/square/okhttp
-[24]: https://github.com/square/okio
-[25]: https://github.com/ReactiveX/RxJava
-[27]: https://github.com/facebook/fresco
-[28]: https://github.com/facebook/stetho
-[29]: https://github.com/google/dagger
-[30]: https://github.com/yuvipanda/java-http-fluent/blob/master/src/main/java/in/yuvi/http/fluent/Http.java
-[31]: https://github.com/dinuscxj/CircleProgressBar
-[32]: https://github.com/square/leakcanary
+
+[9]: https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
**Description (required)**

Fixes #1985 Update libraries used in README

What changes did you make and why?
- Moved list of libraries to [wiki](https://github.com/commons-app/apps-android-commons/wiki/Libraries-used) top avoid clutter in README
- Updated list of libraries to include ones that were missing and remove ones that weren't being used

**Tests performed (required)**

Checked all the links are up to date and work in library list