### PR TITLE
Remove unused mediawiki api dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,6 @@ dependencies {
 
     implementation 'ch.acra:acra:4.9.2'
 
-    implementation 'org.mediawiki:api:1.3'
     implementation 'commons-codec:commons-codec:1.10'
     implementation 'com.github.pedrovgs:renderers:3.3.3'
     implementation 'com.google.code.gson:gson:2.8.5'


### PR DESCRIPTION
**Description (required)**

Fixes #1990 Mediawiki API gradle dependency not used

What changes did you make and why?
- Removed unused mediawiki api dependency

**Tests performed (required)**

All automated tests pass

Tutorial, login, home, upload media (only on beta), view media, nearby, achievements, notifications, settings, about

Tested `2.8.5-debug-update-libraries-docs~ccf03c78 (beta)` on `Samsung Galaxy S6` with API level `25`.
Tested `2.8.5-debug-update-libraries-docs~ccf03c78 (prod)` on `Samsung Galaxy S6` with API level `25`.
Tested `2.8.5-debug-remove-mwapi-dep~b101b58f (prod)` on `Samsung Galaxy S6` with API level `25`.
Tested `2.8.5-debug-remove-mwapi-dep~b101b58f (beta)` on `Galaxy Nexus (emulator)` with API level `28`.
Tested `2.8.5-debug-remove-mwapi-dep~b101b58f (prod)` on `Galaxy Nexus (emulator)` with API level `28`.

All working