### PR TITLE
Fix forever spinning nearby notification

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -20,7 +20,6 @@ import android.support.v4.content.CursorLoader;
 import android.support.v4.content.Loader;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.widget.CursorAdapter;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -102,7 +101,7 @@ public class ContributionsFragment
     private LatLng curLatLng;
 
     private boolean firstLocationUpdate = true;
-    private LocationServiceManager locationManager;
+    public LocationServiceManager locationManager;
 
     private boolean isFragmentAttachedBefore = false;
 
@@ -546,7 +545,7 @@ public class ContributionsFragment
 
 
     private void updateClosestNearbyCardViewInfo() {
-
+        Timber.d("Fetch and update closest nearby info");
         curLatLng = locationManager.getLastLocation();
 
         placesDisposable = Observable.fromCallable(() -> nearbyController

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -100,7 +100,7 @@ public class ContributionsFragment
     private Disposable placesDisposable;
     private LatLng curLatLng;
 
-    private boolean firstLocationUpdate = true;
+    public boolean firstLocationUpdate = true;
     public LocationServiceManager locationManager;
 
     private boolean isFragmentAttachedBefore = false;
@@ -573,6 +573,12 @@ public class ContributionsFragment
     }
 
     @Override
+    public void onDestroyView() {
+        nearbyNoificationCardView.nearbyNotificationHandler.removeCallbacksAndMessages(null);
+        super.onDestroyView();
+    }
+
+                        @Override
     public void onDestroy() {
         compositeDisposable.clear();
         getChildFragmentManager().removeOnBackStackChangedListener(this);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyNoificationCardView.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyNoificationCardView.java
@@ -46,6 +46,8 @@ public class NearbyNoificationCardView  extends CardView{
     public CardViewVisibilityState cardViewVisibilityState;
 
     public PermissionType permissionType;
+    public Handler nearbyNotificationHandler;
+    public Runnable nearbyNotificationRunnable;
 
     float x1,x2;
 
@@ -149,7 +151,19 @@ public class NearbyNoificationCardView  extends CardView{
             @Override
             public void onClick(View view) {
                 if (!((MainActivity)context).isFinishing()) {
+                    ((ContributionsFragment)(((MainActivity) context).contributionsActivityPagerAdapter.getItem(0))).firstLocationUpdate = true;
                     ((ContributionsFragment)(((MainActivity) context).contributionsActivityPagerAdapter.getItem(0))).locationManager.registerLocationManager();
+
+                    cardViewVisibilityState = CardViewVisibilityState.LOADING;
+                    cardViewVisibilityState = CardViewVisibilityState.LOADING;
+                    permissionRequestButton.setVisibility(GONE);
+                    retryButton.setVisibility(GONE);
+                    contentLayout.setVisibility(VISIBLE);
+                    // Set visibility of elements in content layout once it become visible
+                    progressBar.setVisibility(VISIBLE);
+                    notificationTitle.setVisibility(GONE);
+                    notificationDistance.setVisibility(GONE);
+                    notificationIcon.setVisibility(GONE);
                 }
             }
         });
@@ -217,13 +231,13 @@ public class NearbyNoificationCardView  extends CardView{
 
             permissionRequestButton.setVisibility(GONE);
 
-            Handler nearbyNotificationHandler = new Handler();
-            Runnable nearbyNotificationRunnable = new Runnable() {
+            nearbyNotificationHandler = new Handler();
+            nearbyNotificationRunnable = new Runnable() {
                 @Override
                 public void run() {
                     if (cardViewVisibilityState != NearbyNoificationCardView.CardViewVisibilityState.READY
-                            || cardViewVisibilityState != NearbyNoificationCardView.CardViewVisibilityState.ASK_PERMISSION
-                            || cardViewVisibilityState != NearbyNoificationCardView.CardViewVisibilityState.INVISIBLE) {
+                            && cardViewVisibilityState != NearbyNoificationCardView.CardViewVisibilityState.ASK_PERMISSION
+                            && cardViewVisibilityState != NearbyNoificationCardView.CardViewVisibilityState.INVISIBLE) {
                         // If after 30 seconds, card view is not ready
                         displayRetryButton();
                     }

--- a/app/src/main/res/layout/nearby_card_view.xml
+++ b/app/src/main/res/layout/nearby_card_view.xml
@@ -23,6 +23,22 @@
             style="@style/Widget.AppCompat.Button.Borderless"/>
             />
 
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/retry_button"
+            android:text="@string/tab_to_retry_nearby_notification"
+            android:layout_centerInParent="true"
+            android:layout_marginLeft="8dp"
+            android:layout_marginRight="8dp"
+            android:layout_marginTop="8dp"
+            android:minWidth="48dp"
+            android:textColor="@android:color/white"
+            android:singleLine="true"
+            android:theme="?attr/mainScreenNearbyPermissionbutton"
+            style="@style/Widget.AppCompat.Button.Borderless"/>
+        />
+
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -360,6 +360,7 @@
   <string name="notifications">Notifications</string>
   <string name="display_nearby_notification">Display nearby notification</string>
   <string name="display_nearby_notification_summary">Tap here to see the nearest place that needs pictures</string>
+  <string name="tab_to_retry_nearby_notification">Some problems occured, tab to retry</string>
   <string name="no_close_nearby">No nearby places found close to you</string>
   <string name="list_sheet">List</string>
 


### PR DESCRIPTION
**Description (required)**

Fixes #2001 New main UI - progress bar in Nearby card view sometimes runs forever.

I couldn't reproduced the error. But this should show a retry button after 30 seconds. And retry button should work in theory. But as I said, I couldn't reproduce the issue. 

If you reproduce the issue again @misaochan , and recognize retry button is not working, we can just display an error message without retry.

**Tests performed (required)**

Tested ProdDebug on API 26 Emulator

