### PR TITLE
Bugfix/nearbby zoomin

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -135,6 +135,8 @@ public class NearbyMapFragment extends DaggerFragment {
     @Inject
     BookmarkLocationsDao bookmarkLocationDao;
 
+    private static final double ZOOM_LEVEL = 12f;
+
     public NearbyMapFragment() {
     }
 
@@ -304,7 +306,7 @@ public class NearbyMapFragment extends DaggerFragment {
                                             curMapBoxLatLng.getLongitude())
                                     : curMapBoxLatLng ) // Sets the new camera position
                             .zoom(isBottomListSheetExpanded ?
-                                    11 // zoom level is fixed to 11 when bottom sheet is expanded
+                                    ZOOM_LEVEL // zoom level is fixed to 18 when bottom sheet is expanded
                                     :mapboxMap.getCameraPosition().zoom) // Same zoom level
                             .build();
                 }else {
@@ -314,7 +316,7 @@ public class NearbyMapFragment extends DaggerFragment {
                                             curMapBoxLatLng.getLongitude())
                                     : curMapBoxLatLng ) // Sets the new camera position
                             .zoom(isBottomListSheetExpanded ?
-                                    11 // zoom level is fixed to 11 when bottom sheet is expanded
+                                    ZOOM_LEVEL // zoom level is fixed to 18 when bottom sheet is expanded
                                     :mapboxMap.getCameraPosition().zoom) // Same zoom level
                             .build();
                 }
@@ -342,14 +344,14 @@ public class NearbyMapFragment extends DaggerFragment {
                             .target(new LatLng(curLatLng.getLatitude() - CAMERA_TARGET_SHIFT_FACTOR_PORTRAIT,
                                     curLatLng.getLongitude())) // Sets the new camera target above
                             // current to make it visible when sheet is expanded
-                            .zoom(11) // Fixed zoom level
+                            .zoom(ZOOM_LEVEL) // Fixed zoom level
                             .build();
                 } else {
                     position = new CameraPosition.Builder()
                             .target(new LatLng(curLatLng.getLatitude() - CAMERA_TARGET_SHIFT_FACTOR_LANDSCAPE,
                                     curLatLng.getLongitude())) // Sets the new camera target above
                             // current to make it visible when sheet is expanded
-                            .zoom(11) // Fixed zoom level
+                            .zoom(ZOOM_LEVEL) // Fixed zoom level
                             .build();
                 }
 
@@ -446,7 +448,7 @@ public class NearbyMapFragment extends DaggerFragment {
                                                 curLatLng.getLongitude())
                                         : new LatLng(curLatLng.getLatitude(), curLatLng.getLongitude(), 0)) // Sets the new camera position
                                 .zoom(isBottomListSheetExpanded ?
-                                        11 // zoom level is fixed to 11 when bottom sheet is expanded
+                                        ZOOM_LEVEL
                                         :mapboxMap.getCameraPosition().zoom) // Same zoom level
                                 .build();
                     }else {
@@ -456,7 +458,7 @@ public class NearbyMapFragment extends DaggerFragment {
                                                 curLatLng.getLongitude())
                                         : new LatLng(curLatLng.getLatitude(), curLatLng.getLongitude(), 0)) // Sets the new camera position
                                 .zoom(isBottomListSheetExpanded ?
-                                        11 // zoom level is fixed to 11 when bottom sheet is expanded
+                                        ZOOM_LEVEL
                                         :mapboxMap.getCameraPosition().zoom) // Same zoom level
                                 .build();
                     }
@@ -526,7 +528,7 @@ public class NearbyMapFragment extends DaggerFragment {
                 .attributionEnabled(false)
                 .camera(new CameraPosition.Builder()
                         .target(new LatLng(curLatLng.getLatitude(), curLatLng.getLongitude()))
-                        .zoom(11)
+                        .zoom(ZOOM_LEVEL)
                         .build());
 
         if (!getParentFragment().getActivity().isFinishing()) {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -306,7 +306,7 @@ public class NearbyMapFragment extends DaggerFragment {
                                             curMapBoxLatLng.getLongitude())
                                     : curMapBoxLatLng ) // Sets the new camera position
                             .zoom(isBottomListSheetExpanded ?
-                                    ZOOM_LEVEL // zoom level is fixed to 18 when bottom sheet is expanded
+                                    ZOOM_LEVEL // zoom level is fixed when bottom sheet is expanded
                                     :mapboxMap.getCameraPosition().zoom) // Same zoom level
                             .build();
                 }else {
@@ -316,7 +316,7 @@ public class NearbyMapFragment extends DaggerFragment {
                                             curMapBoxLatLng.getLongitude())
                                     : curMapBoxLatLng ) // Sets the new camera position
                             .zoom(isBottomListSheetExpanded ?
-                                    ZOOM_LEVEL // zoom level is fixed to 18 when bottom sheet is expanded
+                                    ZOOM_LEVEL // zoom level is fixed when bottom sheet is expanded
                                     :mapboxMap.getCameraPosition().zoom) // Same zoom level
                             .build();
                 }


### PR DESCRIPTION
**Description (required)**
Nearby is currently zoomed out to a level where the user has to zoom in every time he uses nearby. Whenever the user starts Nearby, the map should be zoomed in to a reasonable distance(which is mapped to zoom level)
Fixes #1987 { Start Nearby map zoomed in }
What changes did you make and why?
Increased the zoom level to 12 which was 11 before
**Tests performed (required)**
Tested {build variant,  ProdDebug} on {One Plus 1} with API level {26}.
Nearby zoom was appropriate (the markers were being shown properly[not too dense])
![device-2018-11-21-015901](https://user-images.githubusercontent.com/17375274/48801107-8415c600-ed31-11e8-8885-e114c56f5b7c.png)

**Screenshots showing what changed (optional - for UI change
