### PR TITLE
Bug fix issue #2023

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -223,6 +223,9 @@ public class UploadActivity extends AuthenticatedActivity implements UploadView,
         bottomCardSubtitle.setText(cardSubTitle);
         categoryTitle.setText(cardTitle);
         licenseTitle.setText(cardTitle);
+        if (currentStep == stepCount) {
+            dismissKeyboard();
+        }
         if(isShowingItem) {
             descriptionsAdapter.setItems(uploadItem.title, uploadItem.descriptions);
             rvDescriptions.setAdapter(descriptionsAdapter);


### PR DESCRIPTION
**Description (required)**
While uploading an image, keyboard should automatically be dismissed when user presses next to reach the final step of the upload process
Fixes #2023, title: Keypad needs to be invisible in final step of upload screen (2.9-release branch) 

What changes did you make and why?
* Explicitly dismiss keyboard when user reaches the step 3(final step) of image upload

**Tests performed (required)**

Tested {build variant, ProdDebug} on {One Plus 3T} with API level {27}.
* Keyboard dismisses itself when next button in step 2 is clicked

**Screenshots showing what changed (optional - for UI changes)**
NA