### PR TITLE
Add missing lost dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,7 @@ dependencies {
         exclude group: 'com.google.android', module: 'android'
     }
 
+    implementation "com.mapzen.android:lost:3.0.4"
     implementation('com.mapbox.mapboxsdk:mapbox-android-sdk:5.5.0@aar') {
         transitive = true
     }


### PR DESCRIPTION
As this post(https://github.com/mapbox/mapbox-gl-native/issues/10484#issuecomment-345319647) said, lost is not included in Mapbox android SDK from version 5.2.0. This patch added explicit dependency to lost. This fixes build error "Failed to find byte code for com/mapzen/android/lost/api/LostApiClient$ConnectionCallbacks".

**Description (required)**

Fixes #2027

**Tests performed (required)**

Tested BetaDebug on Pixel 2 XL with API level 28.
