### PR TITLE
Bug fix, issue #2029

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -146,8 +146,11 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        detailProvider = (MediaDetailPagerFragment.MediaDetailProvider) (getParentFragment().getParentFragment());
-
+        if (getParentFragment() != null
+            && getParentFragment() instanceof MediaDetailPagerFragment) {
+            detailProvider =
+                ((MediaDetailPagerFragment) getParentFragment()).getMediaDetailProvider();
+        }
         if (savedInstanceState != null) {
             editable = savedInstanceState.getBoolean("editable");
             isCategoryImage = savedInstanceState.getBoolean("isCategoryImage");
@@ -212,7 +215,12 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
     @Override
     public void onResume() {
         super.onResume();
-        ((ContributionsFragment)(getParentFragment().getParentFragment())).nearbyNoificationCardView.setVisibility(View.GONE);
+        if(getParentFragment()!=null && getParentFragment().getParentFragment()!=null) {
+            //Added a check because, not necessarily, the parent fragment will have a parent fragment, say
+            // in the case when MediaDetailPagerFragment is directly started by the CategoryImagesActivity
+            ((ContributionsFragment) (getParentFragment().getParentFragment())).nearbyNoificationCardView
+                .setVisibility(View.GONE);
+        }
         media = detailProvider.getMediaAtPosition(index);
         if (media == null) {
             // Ask the detail provider to ping us when we're ready

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -69,6 +69,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
     private boolean isFeaturedImage;
     MediaDetailAdapter adapter;
     private Bookmark bookmark;
+    private MediaDetailProvider provider;
 
     public MediaDetailPagerFragment() {
         this(false, false);
@@ -128,6 +129,23 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
             isFeaturedImage = savedInstanceState.getBoolean("isFeaturedImage");
         }
         setHasOptionsMenu(true);
+        initProvider();
+    }
+
+    /**
+     * initialise the provider, based on from where the fragment was started, as in from an activity
+     * or a fragment
+     */
+    private void initProvider() {
+        if (getParentFragment() != null) {
+            provider = (MediaDetailProvider) getParentFragment();
+        } else {
+            provider = (MediaDetailProvider) getActivity();
+        }
+    }
+
+    public MediaDetailProvider getMediaDetailProvider() {
+        return provider;
     }
 
     @Override
@@ -136,7 +154,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
             Timber.d("Returning as activity is destroyed!");
             return true;
         }
-        MediaDetailProvider provider = (MediaDetailProvider) getParentFragment();
+
         Media m = provider.getMediaAtPosition(pager.getCurrentItem());
         switch (item.getItemId()) {
             case R.id.menu_bookmark_current_image:
@@ -325,7 +343,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
 
     @Override
     public void onPageScrolled(int i, float v, int i2) {
-        if(getParentFragment().getActivity() == null) {
+        if (getActivity() == null) {
             Timber.d("Returning as activity is destroyed!");
             return;
         }
@@ -346,7 +364,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                 e.printStackTrace();
             }
         }
-        getParentFragment().getActivity().supportInvalidateOptionsMenu();
+        getActivity().invalidateOptionsMenu();
     }
 
     @Override
@@ -380,11 +398,11 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
         public Fragment getItem(int i) {
             if (i == 0) {
                 // See bug https://code.google.com/p/android/issues/detail?id=27526
-                if(getParentFragment().getActivity() == null) {
+                if (getActivity() == null) {
                     Timber.d("Skipping getItem. Returning as activity is destroyed!");
                     return null;
                 }
-                pager.postDelayed(() -> getParentFragment().getActivity().supportInvalidateOptionsMenu(), 5);
+                pager.postDelayed(() -> getActivity().invalidateOptionsMenu(), 5);
             }
             return MediaDetailFragment.forMedia(i, editable, isFeaturedImage);
         }
@@ -395,7 +413,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                 Timber.d("Skipping getCount. Returning as activity is destroyed!");
                 return 0;
             }
-            return ((MediaDetailProvider) getParentFragment()).getTotalMediaCount();
+            return provider.getTotalMediaCount();
         }
     }
 }


### PR DESCRIPTION
**Description (required)**
Media Details used to crashed when opened via Explore

Fixes #2029 NPE after tapping image in Explore

What changes did you make and why?
Initialise MediaDetailProvider based on its type as in activity or fragment
**Tests performed (required)**
Tested {build variant,  ProdDebug} on {OnePlus 3T} with API level {27}.
* Media Details via explore opens without any crashes

**Screenshots showing what changed (optional - for UI changes)**
NA