### PR TITLE
Bug fix issue #2042 (Blank Achievements Activity)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -9,7 +9,6 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.design.widget.Snackbar;
 import android.support.v4.content.res.ResourcesCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
@@ -88,6 +87,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
     MediaWikiApi mediaWikiApi;
 
     private CompositeDisposable compositeDisposable = new CompositeDisposable();
+    private View.OnClickListener onClickListener;
 
     /**
      * This method helps in the creation Achievement screen and
@@ -204,19 +204,15 @@ public class AchievementsActivity extends NavigationBaseActivity {
         }
     }
 
-    /**
-     * As there would be no other way to refresh data when api call fails, lets give him an option
-     * to retry using the snackbar
-     */
     private void showSnackBarWithRetry() {
-        progressBar.setVisibility(View.GONE);
-        Snackbar snackbar = Snackbar.make(findViewById(android.R.id.content),
-            getString(R.string.achievements_fetch_failed), Snackbar.LENGTH_INDEFINITE);
-        snackbar.setAction(getString(R.string.retry), view -> {
-            snackbar.dismiss();
-            setAchievements();
-        });
-        snackbar.show();
+        if (onClickListener == null) {
+            onClickListener = view -> {
+                setAchievements();
+                progressBar.setVisibility(View.GONE);
+            };
+        }
+        ViewUtil.showDismissibleSnackBar(findViewById(android.R.id.content),
+            R.string.achievements_fetch_failed, R.string.retry, onClickListener);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -87,7 +87,6 @@ public class AchievementsActivity extends NavigationBaseActivity {
     MediaWikiApi mediaWikiApi;
 
     private CompositeDisposable compositeDisposable = new CompositeDisposable();
-    private View.OnClickListener onClickListener;
 
     /**
      * This method helps in the creation Achievement screen and
@@ -206,13 +205,8 @@ public class AchievementsActivity extends NavigationBaseActivity {
 
     private void showSnackBarWithRetry() {
         progressBar.setVisibility(View.GONE);
-        if (onClickListener == null) {
-            onClickListener = view -> {
-                setAchievements();
-            };
-        }
         ViewUtil.showDismissibleSnackBar(findViewById(android.R.id.content),
-            R.string.achievements_fetch_failed, R.string.retry, onClickListener);
+            R.string.achievements_fetch_failed, R.string.retry, view -> setAchievements());
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -205,10 +205,10 @@ public class AchievementsActivity extends NavigationBaseActivity {
     }
 
     private void showSnackBarWithRetry() {
+        progressBar.setVisibility(View.GONE);
         if (onClickListener == null) {
             onClickListener = view -> {
                 setAchievements();
-                progressBar.setVisibility(View.GONE);
             };
         }
         ViewUtil.showDismissibleSnackBar(findViewById(android.R.id.content),

--- a/app/src/main/java/fr/free/nrw/commons/utils/ViewUtil.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ViewUtil.java
@@ -10,6 +10,7 @@ import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.PopupWindow;
 import android.widget.Toast;
+import fr.free.nrw.commons.R;
 
 public class ViewUtil {
 
@@ -87,4 +88,28 @@ public class ViewUtil {
         popup.showAsDropDown(anchorView);
     }
 
+    /**
+     * A snack bar which has an action button which on click dismisses the snackbar and invokes the listener passed
+     * @param view
+     * @param messageResourceId
+     * @param retryButtonResourceId
+     * @param onClickListener
+     */
+    public static void showDismissibleSnackBar(View view, int messageResourceId,
+        int retryButtonResourceId, View.OnClickListener onClickListener) {
+        if (view.getContext() == null) {
+            return;
+        }
+
+        ExecutorUtils.uiExecutor().execute(() -> {
+            Snackbar snackbar =
+                Snackbar.make(view, view.getContext().getString(messageResourceId),
+                    Snackbar.LENGTH_INDEFINITE);
+            snackbar.setAction(view.getContext().getString(retryButtonResourceId), v -> {
+                snackbar.dismiss();
+                onClickListener.onClick(v);
+            });
+            snackbar.show();
+        });
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/utils/ViewUtil.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ViewUtil.java
@@ -92,11 +92,11 @@ public class ViewUtil {
      * A snack bar which has an action button which on click dismisses the snackbar and invokes the listener passed
      * @param view
      * @param messageResourceId
-     * @param retryButtonResourceId
+     * @param actionButtonResourceId
      * @param onClickListener
      */
     public static void showDismissibleSnackBar(View view, int messageResourceId,
-        int retryButtonResourceId, View.OnClickListener onClickListener) {
+        int actionButtonResourceId, View.OnClickListener onClickListener) {
         if (view.getContext() == null) {
             return;
         }
@@ -105,7 +105,7 @@ public class ViewUtil {
             Snackbar snackbar =
                 Snackbar.make(view, view.getContext().getString(messageResourceId),
                     Snackbar.LENGTH_INDEFINITE);
-            snackbar.setAction(view.getContext().getString(retryButtonResourceId), v -> {
+            snackbar.setAction(view.getContext().getString(actionButtonResourceId), v -> {
                 snackbar.dismiss();
                 onClickListener.onClick(v);
             });

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -431,5 +431,6 @@ Upload your first media by touching the camera or gallery icon above.</string>
   <string name="never_ask_again">Never ask this again</string>
   <string name="display_location_permission_title">Display location permission</string>
   <string name="display_location_permission_explanation">Ask for location permission when needed for nearby notification card view feature.</string>
+  <string name="achievements_fetch_failed">Something went wrong, we could not fetch your achievements</string>
 
 </resources>


### PR DESCRIPTION
**Description (required)**
When the api call to fetch the achievements somehow fails, a blank screen shows up and user is left with no option to retry.
Fixes #2042 Achievements is blank for some users.

What changes did you make and why?
* Added a sticky snack bar in achievements activity which shows up when fetch api fails
* Snackbar comes with an action button which on click retries fetch. This way user is never shown a blank screen and always has an option to retry fetches

**Tests performed (required)**

Tested {build variant, ProdDebug} on {One Plus 3T} with API level {27}.

**Screenshots showing what changed (optional - for UI changes)**
![device-2018-11-29-230404](https://user-images.githubusercontent.com/17375274/49240730-f2424300-f42b-11e8-9d86-e4a343c8a752.png)

