### PR TITLE
Bug fix #2042

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -185,6 +185,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
      * which then calls parseJson when results are fetched
      */
     private void setAchievements() {
+        progressBar.setVisibility(View.VISIBLE);
         if (checkAccount()) {
             compositeDisposable.add(mediaWikiApi
                     .getAchievements(Objects.requireNonNull(sessionManager.getCurrentAccount()).name)
@@ -195,15 +196,21 @@ public class AchievementsActivity extends NavigationBaseActivity {
                                 if (response != null) {
                                     setUploadCount(Achievements.from(response));
                                 } else {
-                                    onError();
+                                    showSnackBarWithRetry();
                                 }
                             },
                             t -> {
                                 Timber.e(t, "Fetching achievements statistics failed");
-                                onError();
+                                showSnackBarWithRetry();
                             }
                     ));
         }
+    }
+
+    private void showSnackBarWithRetry() {
+        progressBar.setVisibility(View.GONE);
+        ViewUtil.showDismissibleSnackBar(findViewById(android.R.id.content),
+            R.string.achievements_fetch_failed, R.string.retry, view -> setAchievements());
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/pictures/BookmarkPicturesController.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/pictures/BookmarkPicturesController.java
@@ -36,7 +36,7 @@ public class BookmarkPicturesController {
         for (Bookmark bookmark : bookmarks) {
             List<Media> tmpMedias = mediaWikiApi.searchImages(bookmark.getMediaName(), 0);
             for (Media m : tmpMedias) {
-                if (m.getCreator().equals(bookmark.getMediaCreator())) {
+                if (m.getCreator().trim().equals(bookmark.getMediaCreator().trim())) {
                     medias.add(m);
                     break;
                 }

--- a/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
@@ -9,6 +9,7 @@ import com.google.gson.GsonBuilder;
 
 import java.io.File;
 
+import java.util.concurrent.TimeUnit;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -30,9 +31,11 @@ public class NetworkingModule {
     @Singleton
     public OkHttpClient provideOkHttpClient(Context context) {
         File dir = new File(context.getCacheDir(), "okHttpCache");
-        return new OkHttpClient.Builder()
-                .cache(new Cache(dir, OK_HTTP_CACHE_SIZE))
-                .build();
+        return new OkHttpClient.Builder().connectTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .cache(new Cache(dir, OK_HTTP_CACHE_SIZE))
+            .build();
     }
 
     @Provides

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -271,7 +271,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
             menu.clear(); // see http://stackoverflow.com/a/8495697/17865
             inflater.inflate(R.menu.fragment_image_detail, menu);
             if (pager != null) {
-                MediaDetailProvider provider = (MediaDetailProvider) getParentFragment();
+                MediaDetailProvider provider = getMediaDetailProvider();
                 if(provider == null) {
                     return;
                 }

--- a/app/src/main/java/fr/free/nrw/commons/utils/ViewUtil.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ViewUtil.java
@@ -87,4 +87,24 @@ public class ViewUtil {
         popup.showAsDropDown(anchorView);
     }
 
+    /**
+     * A snack bar which has an action button which on click dismisses the snackbar and invokes the
+     * listener passed
+     */
+    public static void showDismissibleSnackBar(View view, int messageResourceId,
+        int actionButtonResourceId, View.OnClickListener onClickListener) {
+        if (view.getContext() == null) {
+            return;
+        }
+        ExecutorUtils.uiExecutor().execute(() -> {
+            Snackbar snackbar = Snackbar.make(view, view.getContext().getString(messageResourceId),
+                Snackbar.LENGTH_INDEFINITE);
+            snackbar.setAction(view.getContext().getString(actionButtonResourceId), v -> {
+                snackbar.dismiss();
+                onClickListener.onClick(v);
+            });
+            snackbar.show();
+        });
+    }
+
 }


### PR DESCRIPTION
**Description (required)**
When the api call to fetch the achievements somehow fails, a blank screen shows up and user is left with no option to retry.
Fixes #2042 Achievements is blank for some users.

What changes did you make and why?
 * Added a snack with retry when api in AA fails
    * Increased connection timeouts in okhttpclient builder

**Tests performed (required)**

Tested {build variant, ProdDebug} on {One Plus 3T} with API level {27}.

**Screenshots showing what changed (optional - for UI changes)**
![device-2018-11-29-230404](https://user-images.githubusercontent.com/17375274/49240730-f2424300-f42b-11e8-9d86-e4a343c8a752.png)

