### PR TITLE
Bugfix/duplicate categories

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
@@ -31,9 +31,9 @@ public class NetworkingModule {
     @Singleton
     public OkHttpClient provideOkHttpClient(Context context) {
         File dir = new File(context.getCacheDir(), "okHttpCache");
-        return new OkHttpClient.Builder().connectTimeout(30, TimeUnit.SECONDS)
-            .writeTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(30, TimeUnit.SECONDS)
+        return new OkHttpClient.Builder().connectTimeout(60, TimeUnit.SECONDS)
+            .writeTimeout(60, TimeUnit.SECONDS)
+            .readTimeout(60, TimeUnit.SECONDS)
             .cache(new Cache(dir, OK_HTTP_CACHE_SIZE))
             .build();
     }

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -347,6 +347,7 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
     @Override
     @NonNull
     public Observable<String> searchCategories(String filterValue, int searchCatsLimit) {
+        List<String> categories = new ArrayList<>();
         return Single.fromCallable(() -> {
             List<CustomApiResult> categoryNodes = null;
             try {
@@ -367,11 +368,12 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
                 return new ArrayList<String>();
             }
 
-            List<String> categories = new ArrayList<>();
             for (CustomApiResult categoryNode : categoryNodes) {
                 String cat = categoryNode.getDocument().getTextContent();
                 String catString = cat.replace("Category:", "");
-                categories.add(catString);
+                if (!categories.contains(catString)) {
+                    categories.add(catString);
+                }
             }
 
             return categories;


### PR DESCRIPTION
**Description (required)**
Categories search used to display duplicate categories.

Fixes  #1550 (Duplicate categories) & #2066 (Increase timeout for achievements)

What changes did you make and why?
*  filtered duplicate categories
*  Increased timeout to 60 seconds

**Tests performed (required)**

Tested {build variant,  ProdDebug} on {One Plus 6T} with API level {27}.
* Achievements Activity showed data for user "Ainali", for whom the bug was reported
* Duplicate categories were not being shown

**Screenshots showing what changed (optional - for UI changes)**
NA
Need help? See https://support.google.com/android/answer/9075928