### PR TITLE
Fixing issue #2090 Searching night mode

### DIFF
--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -23,8 +23,6 @@
         <android.support.v7.widget.Toolbar
             android:id="@+id/toolbar_search"
             android:layout_width="match_parent"
-            app:navigationIcon="@drawable/ic_arrow_back_primary_24dp"
-            android:background="@color/item_white_background"
             android:layout_height="wrap_content">
             <SearchView
                 android:id="@+id/searchBox"

--- a/app/src/main/res/layout/item_recent_searches.xml
+++ b/app/src/main/res/layout/item_recent_searches.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView android:id="@+id/textView1"
     android:layout_width="match_parent"
-    android:background="@color/item_white_background"
     android:layout_height="wrap_content"
     android:textAppearance="?android:attr/textAppearanceMedium"
     android:padding="@dimen/standard_gap"
     android:text="@string/search_commons"
-    xmlns:android="http://schemas.android.com/apk/res/android" />
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -4,7 +4,7 @@
         <item name="contributionsListBackground">@color/contributionListDarkBackground</item>
         <item name="mainTabBackground">@color/contributionListDarkBackground</item>
         <item name="mainBackground">@color/main_background_dark</item>
-        <item name="colorPrimary">@color/primaryColor</item>
+        <item name="colorPrimary">@color/primaryDarkColor</item>
         <item name="colorPrimaryDark">@color/primaryDarkColor</item>
         <item name="colorAccent">@color/primaryColor</item>
         <item name="colorButtonNormal">@color/primaryColor</item>
@@ -23,6 +23,8 @@
         <item name="textEnabled">@color/enabled_button_text_color_dark</item>
         <item name="mainCardBackground">@color/main_background_dark</item>
         <item name="mainScreenNearbyPermissionbutton">@style/DarkFlatNearbyPermissionButton</item>
+        <item name="navigationIcon">@drawable/ic_arrow_back_white</item>
+
 
     </style>
 
@@ -48,6 +50,7 @@
         <item name="textEnabled">@color/enabled_button_text_color_light</item>
         <item name="mainCardBackground">@color/primaryDarkColor</item>
         <item name="mainScreenNearbyPermissionbutton">@style/LightFlatNearbyPermissionButton</item>
+        <item name="navigationIcon">@drawable/ic_arrow_back_primary_24dp</item>
 
     </style>
 


### PR DESCRIPTION
Searching for images or categories in night mode works but the words doesn't show neither the recent researches.

Fixes #2090 Searching on Night Mode

What changes did you make and why?
Ux changes to be more clean on night mode 

**Tests performed (required)**
Exploratory testing

**Screenshots showing what changed (optional - for UI changes)**

![image](https://user-images.githubusercontent.com/9344161/49700070-9066a380-fbb8-11e8-9713-0eccac3c5e2e.png)
