### PR TITLE
Fixes #945 Check image coordinates for direct Nearby uploads in locations that the user is not currently in 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsFragment.java
@@ -34,6 +34,8 @@ import timber.log.Timber;
 
 import static android.app.Activity.RESULT_OK;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+import static fr.free.nrw.commons.wikidata.WikidataConstants.WIKIDATA_ENTITY_ID_PREF;
+import static fr.free.nrw.commons.wikidata.WikidataConstants.WIKIDATA_ITEM_LOCATION;
 
 public class BookmarkLocationsFragment extends DaggerFragment {
 
@@ -136,13 +138,14 @@ public class BookmarkLocationsFragment extends DaggerFragment {
         if (resultCode == RESULT_OK) {
             Timber.d("OnActivityResult() parameters: Req code: %d Result code: %d Data: %s",
                     requestCode, resultCode, data);
-            String wikidataEntityId = directPrefs.getString("WikiDataEntityId", null);
+            String wikidataEntityId = directPrefs.getString(WIKIDATA_ENTITY_ID_PREF, null);
+            String wikidataItemLocation = directPrefs.getString(WIKIDATA_ITEM_LOCATION, null);
             if (requestCode == ContributionController.SELECT_FROM_CAMERA) {
                 // If coming from camera, pass null as uri. Because camera photos get saved to a
                 // fixed directory
-                contributionController.handleImagePicked(requestCode, null, true, wikidataEntityId);
+                contributionController.handleImagePicked(requestCode, null, true, wikidataEntityId, wikidataItemLocation);
             } else {
-                contributionController.handleImagePicked(requestCode, data.getData(), true, wikidataEntityId);
+                contributionController.handleImagePicked(requestCode, data.getData(), true, wikidataEntityId, wikidataItemLocation);
             }
         } else {
             Timber.e("OnActivityResult() parameters: Req code: %d Result code: %d Data: %s",

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
@@ -30,6 +30,7 @@ import static fr.free.nrw.commons.contributions.Contribution.SOURCE_CAMERA;
 import static fr.free.nrw.commons.contributions.Contribution.SOURCE_GALLERY;
 import static fr.free.nrw.commons.upload.UploadService.EXTRA_SOURCE;
 import static fr.free.nrw.commons.wikidata.WikidataConstants.WIKIDATA_ENTITY_ID_PREF;
+import static fr.free.nrw.commons.wikidata.WikidataConstants.WIKIDATA_ITEM_LOCATION;
 
 public class ContributionController {
 
@@ -131,7 +132,7 @@ public class ContributionController {
         }
     }
 
-    public void handleImagePicked(int requestCode, @Nullable Uri uri, boolean isDirectUpload, String wikiDataEntityId) {
+    public void handleImagePicked(int requestCode, @Nullable Uri uri, boolean isDirectUpload, String wikiDataEntityId, String wikidateItemLocation) {
         FragmentActivity activity = fragment.getActivity();
         Timber.d("handleImagePicked() called with onActivityResult(). Boolean isDirectUpload: " + isDirectUpload + "String wikiDataEntityId: " + wikiDataEntityId);
         Intent shareIntent = new Intent(activity, UploadActivity.class);
@@ -163,6 +164,7 @@ public class ContributionController {
         try {
             if (wikiDataEntityId != null && !wikiDataEntityId.equals("")) {
                 shareIntent.putExtra(WIKIDATA_ENTITY_ID_PREF, wikiDataEntityId);
+                shareIntent.putExtra(WIKIDATA_ITEM_LOCATION, wikidateItemLocation);
             }
         } catch (SecurityException e) {
             Timber.e(e, "Security Exception");

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -255,11 +255,11 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
             if (requestCode == ContributionController.SELECT_FROM_CAMERA) {
                 // If coming from camera, pass null as uri. Because camera photos get saved to a
                 // fixed directory
-                controller.handleImagePicked(requestCode, null, false, null);
+                controller.handleImagePicked(requestCode, null, false, null, null);
             } else if (requestCode == ContributionController.PICK_IMAGE_MULTIPLE) {
                 handleMultipleImages(requestCode, data);
             } else if (requestCode == ContributionController.SELECT_FROM_GALLERY){
-                controller.handleImagePicked(requestCode, data.getData(), false, null);
+                controller.handleImagePicked(requestCode, data.getData(), false, null, null);
             }
         } else {
             Timber.e("OnActivityResult() parameters: Req code: %d Result code: %d Data: %s",
@@ -319,7 +319,7 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
             Log.v("LOG_TAG", "Selected Images" + mArrayUri.size());
             controller.handleImagesPicked(requestCode, mArrayUri);
         } else if(data.getData() != null) {
-            controller.handleImagePicked(SELECT_FROM_GALLERY, data.getData(), false, null);
+            controller.handleImagePicked(SELECT_FROM_GALLERY, data.getData(), false, null, null);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyListFragment.java
@@ -35,6 +35,8 @@ import timber.log.Timber;
 
 import static android.app.Activity.RESULT_OK;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+import static fr.free.nrw.commons.wikidata.WikidataConstants.WIKIDATA_ENTITY_ID_PREF;
+import static fr.free.nrw.commons.wikidata.WikidataConstants.WIKIDATA_ITEM_LOCATION;
 
 public class NearbyListFragment extends DaggerFragment {
     private Bundle bundleForUpdates; // Carry information from activity about changed nearby places and current location
@@ -159,13 +161,14 @@ public class NearbyListFragment extends DaggerFragment {
         if (resultCode == RESULT_OK) {
             Timber.d("OnActivityResult() parameters: Req code: %d Result code: %d Data: %s",
                     requestCode, resultCode, data);
-            String wikidataEntityId = directPrefs.getString("WikiDataEntityId", null);
+            String wikidataEntityId = directPrefs.getString(WIKIDATA_ENTITY_ID_PREF, null);
+            String wikidataItemLocation = directPrefs.getString(WIKIDATA_ITEM_LOCATION, null);
             if (requestCode == ContributionController.SELECT_FROM_CAMERA) {
                 // If coming from camera, pass null as uri. Because camera photos get saved to a
                 // fixed directory
-                controller.handleImagePicked(requestCode, null, true, wikidataEntityId);
+                controller.handleImagePicked(requestCode, null, true, wikidataEntityId, wikidataItemLocation);
             } else {
-                controller.handleImagePicked(requestCode, data.getData(), true, wikidataEntityId);
+                controller.handleImagePicked(requestCode, data.getData(), true, wikidataEntityId, wikidataItemLocation);
             }
         } else {
             Timber.e("OnActivityResult() parameters: Req code: %d Result code: %d Data: %s",

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -64,6 +64,7 @@ import fr.free.nrw.commons.bookmarks.locations.BookmarkLocationsDao;
 import fr.free.nrw.commons.contributions.ContributionController;
 import fr.free.nrw.commons.location.LocationServiceManager;
 import fr.free.nrw.commons.utils.LocationUtils;
+import fr.free.nrw.commons.utils.PlaceUtils;
 import fr.free.nrw.commons.utils.UriDeserializer;
 import fr.free.nrw.commons.utils.ViewUtil;
 import timber.log.Timber;
@@ -71,6 +72,7 @@ import timber.log.Timber;
 import static android.app.Activity.RESULT_OK;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 import static fr.free.nrw.commons.wikidata.WikidataConstants.WIKIDATA_ENTITY_ID_PREF;
+import static fr.free.nrw.commons.wikidata.WikidataConstants.WIKIDATA_ITEM_LOCATION;
 
 public class NearbyMapFragment extends DaggerFragment {
 
@@ -888,6 +890,7 @@ public class NearbyMapFragment extends DaggerFragment {
         editor.putString("Desc", place.getLongDescription());
         editor.putString("Category", place.getCategory());
         editor.putString(WIKIDATA_ENTITY_ID_PREF, place.getWikiDataEntityId());
+        editor.putString(WIKIDATA_ITEM_LOCATION, PlaceUtils.latLangToString(place.location));
         editor.apply();
     }
 
@@ -924,13 +927,14 @@ public class NearbyMapFragment extends DaggerFragment {
         if (resultCode == RESULT_OK) {
             Timber.d("OnActivityResult() parameters: Req code: %d Result code: %d Data: %s",
                     requestCode, resultCode, data);
-            String wikidataEntityId = directPrefs.getString("WikiDataEntityId", null);
+            String wikidataEntityId = directPrefs.getString(WIKIDATA_ENTITY_ID_PREF, null);
+            String wikidataItemLocation = directPrefs.getString(WIKIDATA_ITEM_LOCATION, null);
             if (requestCode == ContributionController.SELECT_FROM_CAMERA) {
                 // If coming from camera, pass null as uri. Because camera photos get saved to a
                 // fixed directory
-                controller.handleImagePicked(requestCode, null, true, wikidataEntityId);
+                controller.handleImagePicked(requestCode, null, true, wikidataEntityId, wikidataItemLocation);
             } else {
-                controller.handleImagePicked(requestCode, data.getData(), true, wikidataEntityId);
+                controller.handleImagePicked(requestCode, data.getData(), true, wikidataEntityId, wikidataItemLocation);
             }
         } else {
             Timber.e("OnActivityResult() parameters: Req code: %d Result code: %d Data: %s",

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceRenderer.java
@@ -30,10 +30,12 @@ import fr.free.nrw.commons.auth.LoginActivity;
 import fr.free.nrw.commons.bookmarks.locations.BookmarkLocationsDao;
 import fr.free.nrw.commons.contributions.ContributionController;
 import fr.free.nrw.commons.di.ApplicationlessInjection;
+import fr.free.nrw.commons.utils.PlaceUtils;
 import timber.log.Timber;
 
 import static fr.free.nrw.commons.theme.NavigationBaseActivity.startActivityWithFlags;
 import static fr.free.nrw.commons.wikidata.WikidataConstants.WIKIDATA_ENTITY_ID_PREF;
+import static fr.free.nrw.commons.wikidata.WikidataConstants.WIKIDATA_ITEM_LOCATION;
 
 public class PlaceRenderer extends Renderer<Place> {
 
@@ -193,6 +195,7 @@ public class PlaceRenderer extends Renderer<Place> {
         editor.putString("Desc", place.getLongDescription());
         editor.putString("Category", place.getCategory());
         editor.putString(WIKIDATA_ENTITY_ID_PREF, place.getWikiDataEntityId());
+        editor.putString(WIKIDATA_ITEM_LOCATION, PlaceUtils.latLangToString(place.location));
         editor.apply();
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/FileUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileUtils.java
@@ -82,7 +82,7 @@ public class FileUtils {
     /**
      * Get Geolocation of file from input stream
      */
-    static String getGeolocation(String filePath) {
+    static String getGeolocationOfFile(String filePath) {
 
         try {
             ExifInterface exifInterface=new ExifInterface(filePath);

--- a/app/src/main/java/fr/free/nrw/commons/upload/FileUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileUtils.java
@@ -6,6 +6,7 @@ import android.content.ContentUris;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.Cursor;
+import android.media.ExifInterface;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -75,6 +76,25 @@ public class FileUtils {
             } catch (IOException e) {
                 Timber.e(e, "Exception on closing MD5 input stream");
             }
+        }
+    }
+
+    /**
+     * Get Geolocation of file from input stream
+     */
+    static String getGeolocation(String filePath) {
+
+        try {
+            ExifInterface exifInterface=new ExifInterface(filePath);
+            GPSExtractor imageObj = new GPSExtractor(exifInterface);
+            if (imageObj.imageCoordsExists) { // If image has geolocation information in its EXIF
+                return imageObj.getCoords();
+            } else {
+                return "";
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "";
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/FileUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileUtils.java
@@ -80,7 +80,7 @@ public class FileUtils {
     }
 
     /**
-     * Get Geolocation of file from input stream
+     * Get Geolocation of file from input file path
      */
     static String getGeolocationOfFile(String filePath) {
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -65,6 +65,7 @@ import timber.log.Timber;
 import static fr.free.nrw.commons.utils.ImageUtils.Result;
 import static fr.free.nrw.commons.utils.ImageUtils.getErrorMessageForResult;
 import static fr.free.nrw.commons.wikidata.WikidataConstants.WIKIDATA_ENTITY_ID_PREF;
+import static fr.free.nrw.commons.wikidata.WikidataConstants.WIKIDATA_ITEM_LOCATION;
 
 public class UploadActivity extends AuthenticatedActivity implements UploadView, SimilarImageInterface {
     @Inject InputMethodManager inputMethodManager;
@@ -350,6 +351,9 @@ public class UploadActivity extends AuthenticatedActivity implements UploadView,
 
     @Override
     public void showBadPicturePopup(@Result int result) {
+        if (result >= 8 ) { // If location of image and nearby does not match, then set shared preferences to disable wikidata edits
+            directPrefs.edit().putBoolean("Picture_Has_Correct_Location",false);
+        }
         String errorMessageForResult = getErrorMessageForResult(this, result);
         if (StringUtils.isNullOrWhiteSpace(errorMessageForResult)) {
             return;
@@ -553,7 +557,8 @@ public class UploadActivity extends AuthenticatedActivity implements UploadView,
                 String imageDesc = directPrefs.getString("Desc", "");
                 Timber.i("Received direct upload with title %s and description %s", imageTitle, imageDesc);
                 String wikidataEntityIdPref = intent.getStringExtra(WIKIDATA_ENTITY_ID_PREF);
-                presenter.receiveDirect(mediaUri, mimeType, source, wikidataEntityIdPref, imageTitle, imageDesc);
+                String wikidataItemLocation = intent.getStringExtra(WIKIDATA_ITEM_LOCATION);
+                presenter.receiveDirect(mediaUri, mimeType, source, wikidataEntityIdPref, imageTitle, imageDesc, wikidataItemLocation);
             } else {
                 Timber.i("Received single upload");
                 presenter.receive(mediaUri, mimeType, source);

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
@@ -130,9 +130,9 @@ public class UploadModel {
                         .map(b -> b ? ImageUtils.IMAGE_DUPLICATE : ImageUtils.IMAGE_OK),
                 Single.fromCallable(() ->
                         filePath)
-                        .map(FileUtils::getGeolocation)
-                        .map(ImageUtils::checkImageGeolocationIsDifferent)
-                        .map(b -> b ? ImageUtils.IMAGE_GEOLOCATION_DIFFERENT : ImageUtils.IMAGE_OK),
+                        .map(FileUtils::getGeolocationOfFile)
+                        .map(geoLocation -> ImageUtils.checkImageGeolocationIsDifferent(geoLocation,wikidataItemLocation))
+                        .map(r -> r ? ImageUtils.IMAGE_GEOLOCATION_DIFFERENT : ImageUtils.IMAGE_OK),
                 Single.fromCallable(() ->
                         new FileInputStream(filePath))
                         .map(file -> BitmapRegionDecoder.newInstance(file, false))

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
@@ -117,7 +117,6 @@ public class UploadModel {
         FileProcessor fp = new FileProcessor(filePath, context.getContentResolver(), context);
         UploadItem item = new UploadItem(uri, mimeType, source, fp.processFileCoordinates(similarImageInterface),
                 FileUtils.getFileExt(filePath), wikidataEntityIdPref,fileCreatedDate);
-        Log.d("deneme","wikidate entity id preference"+wikidataEntityIdPref);
         item.title.setTitleText(title);
         item.descriptions.get(0).setDescriptionText(desc);
         //TODO figure out if default descriptions in other languages exist

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
@@ -109,7 +109,7 @@ public class UploadModel {
     }
 
     @SuppressLint("CheckResult")
-    void receiveDirect(Uri media, String mimeType, String source, String wikidataEntityIdPref, String title, String desc, SimilarImageInterface similarImageInterface) {
+    void receiveDirect(Uri media, String mimeType, String source, String wikidataEntityIdPref, String title, String desc, SimilarImageInterface similarImageInterface, String wikidataItemLocation) {
         initDefaultValues();
         long fileCreatedDate = getFileCreatedDate(media);
         String filePath = this.cacheFileUpload(media);

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
@@ -2,6 +2,7 @@ package fr.free.nrw.commons.upload;
 
 import android.annotation.SuppressLint;
 import android.net.Uri;
+import android.util.Log;
 
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
@@ -92,8 +93,8 @@ public class UploadPresenter {
      * @param source File source from {@link Contribution.FileSource}
      */
     @SuppressLint("CheckResult")
-    void receiveDirect(Uri media, String mimeType, @Contribution.FileSource String source, String wikidataEntityIdPref, String title, String desc) {
-        Completable.fromRunnable(() -> uploadModel.receiveDirect(media, mimeType, source, wikidataEntityIdPref, title, desc, similarImageInterface))
+    void receiveDirect(Uri media, String mimeType, @Contribution.FileSource String source, String wikidataEntityIdPref, String title, String desc, String wikidataItemLocation) {
+        Completable.fromRunnable(() -> uploadModel.receiveDirect(media, mimeType, source, wikidataEntityIdPref, title, desc, similarImageInterface, wikidataItemLocation))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(() -> {
@@ -249,6 +250,7 @@ public class UploadPresenter {
      * @param result the result returned by the image procesors.
      */
     private void handleBadPicture(@ImageUtils.Result int result) {
+        Log.d("deneme","result:"+result);
         view.showBadPicturePopup(result);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
@@ -250,7 +250,6 @@ public class UploadPresenter {
      * @param result the result returned by the image procesors.
      */
     private void handleBadPicture(@ImageUtils.Result int result) {
-        Log.d("deneme","result:"+result);
         view.showBadPicturePopup(result);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -199,7 +199,7 @@ public class UploadService extends HandlerService<Contribution> {
                 .setTicker(getString(R.string.upload_progress_notification_title_in_progress, contribution.getDisplayTitle()));
     }
 
-    private void uploadContribution(Contribution contribution) {
+    private void uploadContribution(Contribution contribution, boolean isIt) {
         InputStream fileInputStream = null;
         InputStream tempFileInputStream = null;
         ContentInfo contentInfo = null;

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -199,7 +199,7 @@ public class UploadService extends HandlerService<Contribution> {
                 .setTicker(getString(R.string.upload_progress_notification_title_in_progress, contribution.getDisplayTitle()));
     }
 
-    private void uploadContribution(Contribution contribution, boolean isIt) {
+    private void uploadContribution(Contribution contribution) {
         InputStream fileInputStream = null;
         InputStream tempFileInputStream = null;
         ContentInfo contentInfo = null;

--- a/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.location.LatLng;
 import timber.log.Timber;
 
 /**
@@ -96,13 +97,28 @@ public class ImageUtils {
     }
 
     /**
-     * @param geolocation Geolocation of image. If geotag doesn't exists, then this will be an empty string
+     * @param geolocationOfFileString Geolocation of image. If geotag doesn't exists, then this will be an empty string
      * @return IMAGE_OK if image is neither dark nor blurry or if the input bitmapRegionDecoder provided is null
      * IMAGE_GEOLOCATION_DIFFERENT if geolocation of the image and
      */
-    public static boolean checkImageGeolocationIsDifferent(String geolocation) {
-        Log.d("deneme","checkking for image location");
-        return true;
+    public static boolean checkImageGeolocationIsDifferent(String geolocationOfFileString, String wikidataItemLocationString) {
+        Log.d("deneme","checkking for image location:"+geolocationOfFileString+" ** wikidataItem location:"+wikidataItemLocationString);
+        if (geolocationOfFileString == null || geolocationOfFileString == "") { // Means that geolocation for this image is not given
+            return false; // Since we don't know geolocation of file, we choose letting upload
+        }
+
+        String[] geolocationOfFile = geolocationOfFileString.split("\\|");
+        String[] wikidataItemLocation = wikidataItemLocationString.split("/");
+        Log.d("deneme","geolocation:"+geolocationOfFile[0]+" 1:"+geolocationOfFile[1]);
+        Double distance = LengthUtils.computeDistanceBetween(
+                new LatLng(Double.parseDouble(geolocationOfFile[0]),Double.parseDouble(geolocationOfFile[1]),0)
+                , new LatLng(Double.parseDouble(wikidataItemLocation[0]), Double.parseDouble(wikidataItemLocation[1]),0));
+        Log.d("deneme","distance is:"+distance);
+        if ( distance >= 1000 ) {// Distance is more than 1 km, means that geolocation is wrong
+            return true;
+        } else {
+            return false;
+        }
     }
 
     private static boolean checkIfImageIsDark(Bitmap bitmap) {

--- a/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
@@ -98,22 +98,22 @@ public class ImageUtils {
 
     /**
      * @param geolocationOfFileString Geolocation of image. If geotag doesn't exists, then this will be an empty string
-     * @return IMAGE_OK if image is neither dark nor blurry or if the input bitmapRegionDecoder provided is null
-     * IMAGE_GEOLOCATION_DIFFERENT if geolocation of the image and
+     * @param wikidataItemLocationString Location of wikidata item will be edited after upload
+     * @return false if image is neither dark nor blurry or if the input bitmapRegionDecoder provided is null
+     * true if geolocation of the image and wikidata item are different
      */
     public static boolean checkImageGeolocationIsDifferent(String geolocationOfFileString, String wikidataItemLocationString) {
-        Log.d("deneme","checkking for image location:"+geolocationOfFileString+" ** wikidataItem location:"+wikidataItemLocationString);
+        Timber.d("Comparing geolocation of file with nearby place location");
         if (geolocationOfFileString == null || geolocationOfFileString == "") { // Means that geolocation for this image is not given
             return false; // Since we don't know geolocation of file, we choose letting upload
         }
 
         String[] geolocationOfFile = geolocationOfFileString.split("\\|");
         String[] wikidataItemLocation = wikidataItemLocationString.split("/");
-        Log.d("deneme","geolocation:"+geolocationOfFile[0]+" 1:"+geolocationOfFile[1]);
+
         Double distance = LengthUtils.computeDistanceBetween(
                 new LatLng(Double.parseDouble(geolocationOfFile[0]),Double.parseDouble(geolocationOfFile[1]),0)
                 , new LatLng(Double.parseDouble(wikidataItemLocation[0]), Double.parseDouble(wikidataItemLocation[1]),0));
-        Log.d("deneme","distance is:"+distance);
         if ( distance >= 1000 ) {// Distance is more than 1 km, means that geolocation is wrong
             return true;
         } else {

--- a/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
@@ -9,6 +9,7 @@ import android.graphics.Rect;
 import android.net.Uri;
 import android.support.annotation.IntDef;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import com.facebook.common.executors.CallerThreadExecutor;
 import com.facebook.common.references.CloseableReference;
@@ -36,13 +37,13 @@ public class ImageUtils {
     public static final int IMAGE_DARK = 1;
     public static final int IMAGE_BLURRY = 1 << 1;
     public static final int IMAGE_DUPLICATE = 1 << 2;
+    public static final int IMAGE_GEOLOCATION_DIFFERENT = 1 << 3;
     public static final int IMAGE_OK = 0;
     public static final int IMAGE_KEEP = -1;
     public static final int IMAGE_WAIT = -2;
     public static final int EMPTY_TITLE = -3;
     public static final int FILE_NAME_EXISTS = -4;
     public static final int NO_CATEGORY_SELECTED = -5;
-    public static final int IMAGE_GEOLOCATION_DIFFERENT = -6;
 
     @IntDef(
             flag = true,
@@ -97,9 +98,10 @@ public class ImageUtils {
     /**
      * @param geolocation Geolocation of image. If geotag doesn't exists, then this will be an empty string
      * @return IMAGE_OK if image is neither dark nor blurry or if the input bitmapRegionDecoder provided is null
-     * IMAGE_DARK if image is too dark
+     * IMAGE_GEOLOCATION_DIFFERENT if geolocation of the image and
      */
     public static boolean checkImageGeolocationIsDifferent(String geolocation) {
+        Log.d("deneme","checkking for image location");
         return true;
     }
 
@@ -212,14 +214,30 @@ public class ImageUtils {
             errorMessage = context.getString(R.string.upload_image_problem_blurry);
         else if (result == ImageUtils.IMAGE_DUPLICATE)
             errorMessage = context.getString(R.string.upload_image_problem_duplicate);
+        else if (result == ImageUtils.IMAGE_GEOLOCATION_DIFFERENT)
+            errorMessage = context.getString(R.string.upload_image_problem_wrong_location);
+        else if (result == (ImageUtils.IMAGE_DARK|ImageUtils.IMAGE_GEOLOCATION_DIFFERENT))
+            errorMessage = context.getString(R.string.upload_image_problem_wrong_location_dark);
+        else if (result == (ImageUtils.IMAGE_BLURRY|ImageUtils.IMAGE_GEOLOCATION_DIFFERENT))
+            errorMessage = context.getString(R.string.upload_image_problem_wrong_location_blurry);
+        else if (result == (ImageUtils.IMAGE_DUPLICATE|ImageUtils.IMAGE_GEOLOCATION_DIFFERENT))
+            errorMessage = context.getString(R.string.upload_image_problem_wrong_location_duplicate);
         else if (result == (ImageUtils.IMAGE_DARK|ImageUtils.IMAGE_BLURRY))
             errorMessage = context.getString(R.string.upload_image_problem_dark_blurry);
+        else if (result == (ImageUtils.IMAGE_DARK|ImageUtils.IMAGE_BLURRY|ImageUtils.IMAGE_GEOLOCATION_DIFFERENT))
+            errorMessage = context.getString(R.string.upload_image_problem_dark_blurry_wrong_location);
         else if (result == (ImageUtils.IMAGE_DARK|ImageUtils.IMAGE_DUPLICATE))
             errorMessage = context.getString(R.string.upload_image_problem_dark_duplicate);
+        else if (result == (ImageUtils.IMAGE_DARK|ImageUtils.IMAGE_DUPLICATE|IMAGE_GEOLOCATION_DIFFERENT))
+            errorMessage = context.getString(R.string.upload_image_problem_blurry_duplicate_wrong_location);
         else if (result == (ImageUtils.IMAGE_BLURRY|ImageUtils.IMAGE_DUPLICATE))
             errorMessage = context.getString(R.string.upload_image_problem_blurry_duplicate);
+        else if (result == (ImageUtils.IMAGE_BLURRY|ImageUtils.IMAGE_DUPLICATE|ImageUtils.IMAGE_GEOLOCATION_DIFFERENT))
+            errorMessage = context.getString(R.string.upload_image_problem_blurry_duplicate_wrong_location);
         else if (result == (ImageUtils.IMAGE_DARK|ImageUtils.IMAGE_BLURRY|ImageUtils.IMAGE_DUPLICATE))
             errorMessage = context.getString(R.string.upload_image_problem_dark_blurry_duplicate);
+        else if (result == (ImageUtils.IMAGE_DARK|ImageUtils.IMAGE_BLURRY|ImageUtils.IMAGE_DUPLICATE|ImageUtils.IMAGE_GEOLOCATION_DIFFERENT))
+            errorMessage = context.getString(R.string.upload_image_problem_dark_blurry_duplicate_wrong_location);
         else
             return "";
 

--- a/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
@@ -42,6 +42,7 @@ public class ImageUtils {
     public static final int EMPTY_TITLE = -3;
     public static final int FILE_NAME_EXISTS = -4;
     public static final int NO_CATEGORY_SELECTED = -5;
+    public static final int IMAGE_GEOLOCATION_DIFFERENT = -6;
 
     @IntDef(
             flag = true,
@@ -54,7 +55,8 @@ public class ImageUtils {
                     IMAGE_WAIT,
                     EMPTY_TITLE,
                     FILE_NAME_EXISTS,
-                    NO_CATEGORY_SELECTED
+                    NO_CATEGORY_SELECTED,
+                    IMAGE_GEOLOCATION_DIFFERENT
             }
     )
     @Retention(RetentionPolicy.SOURCE)
@@ -93,17 +95,14 @@ public class ImageUtils {
     }
 
     /**
-     * Pulls the pixels into an array and then runs through it while checking the brightness of each pixel.
-     * The calculation of brightness of each pixel is done by extracting the RGB constituents of the pixel
-     * and then applying the formula to calculate its "Luminance".
-     * Pixels with luminance greater than 40% are considered to be bright pixels while the ones with luminance
-     * greater than 26% but less than 40% are considered to be pixels with medium brightness. The rest are
-     * dark pixels.
-     * If the number of bright pixels is more than 2.5% or the number of pixels with medium brightness is
-     * more than 30% of the total number of pixels then the image is considered to be OK else dark.
-     * @param bitmap The bitmap that needs to be checked.
-     * @return true if bitmap is dark or null, false if bitmap is bright
+     * @param geolocation Geolocation of image. If geotag doesn't exists, then this will be an empty string
+     * @return IMAGE_OK if image is neither dark nor blurry or if the input bitmapRegionDecoder provided is null
+     * IMAGE_DARK if image is too dark
      */
+    public static boolean checkImageGeolocationIsDifferent(String geolocation) {
+        return true;
+    }
+
     private static boolean checkIfImageIsDark(Bitmap bitmap) {
         if (bitmap == null) {
             Timber.e("Expected bitmap was null");

--- a/app/src/main/java/fr/free/nrw/commons/utils/PlaceUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/PlaceUtils.java
@@ -1,0 +1,25 @@
+package fr.free.nrw.commons.utils;
+
+import fr.free.nrw.commons.location.LatLng;
+
+public class PlaceUtils {
+
+    /**
+     * Converts our defined LatLng to string, to put as String
+     * @param latLng latlang will be converted to string
+     * @return latitude + "/" + longitude
+     */
+    public static String latLangToString(LatLng latLng) {
+        return latLng.getLatitude()+"/"+latLng.getLongitude();
+    }
+
+    /**
+     * Converts latitude + "/" + longitude string to commons LatLng
+     * @param latLngString latitude + "/" + longitude string
+     * @return commons LatLng
+     */
+    public static LatLng stringToLatLng(String latLngString) {
+        String[] parts = latLngString.split("/");
+        return new LatLng(Double.parseDouble(parts[0]), Double.parseDouble(parts[1]), 0);
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataConstants.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataConstants.java
@@ -2,4 +2,5 @@ package fr.free.nrw.commons.wikidata;
 
 public class WikidataConstants {
     public static final String WIKIDATA_ENTITY_ID_PREF = "WikiDataEntityId";
+    public static final String WIKIDATA_ITEM_LOCATION = "WikiDataItemLocation";
 }

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
@@ -58,6 +58,11 @@ public class WikidataEditService {
             return;
         }
 
+        if (!(directPrefs.getBoolean("Picture_Has_Correct_Location",true))) {
+            Timber.d("Image location and nearby place location missmatched, so wikidata item won't be edited");
+            return;
+        }
+
         editWikidataProperty(wikidataEntityId, fileName);
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -239,10 +239,18 @@
   <string name="upload_image_problem_duplicate">This file already exists on Commons. Are you sure you want to proceed?</string>
   <string name="upload_image_problem_dark">This picture is too dark, are you sure you want to upload it? Wikimedia Commons is only for pictures with encyclopedic value.</string>
   <string name="upload_image_problem_blurry">This picture is blurry, are you sure you want to upload it? Wikimedia Commons is only for pictures with encyclopedic value.</string>
+  <string name="upload_image_problem_wrong_location">This picture is taken on another location, are you sure you want to upload for this place?</string>
+  <string name="upload_image_problem_wrong_location_dark">This picture is too dark and taken on another location, are you sure you want to upload for this place? Wikimedia Commons is only for pictures with encyclopedic value.</string>
+  <string name="upload_image_problem_wrong_location_duplicate">This picture is already exists on Commons and taken on another location, are you sure you want to upload for this place? Wikimedia Commons is only for pictures with encyclopedic value.</string>
+  <string name="upload_image_problem_wrong_location_blurry">This picture is blurry and taken on another location, are you sure you want to upload for this place? Wikimedia Commons is only for pictures with encyclopedic value.</string>
   <string name="upload_image_problem_dark_duplicate">This picture is too dark and already exists on Commons, are you sure you want to upload it? Please only upload pictures with encyclopedic value.</string>
+  <string name="upload_image_problem_dark_duplicate_wrong_location">This picture is too dark, duplicate and taken on another location, are you sure you want to upload it, for this place?</string>
   <string name="upload_image_problem_blurry_duplicate">This picture is blurry and already exists on Commons, are you sure you want to upload it? Please only upload pictures with encyclopedic value.</string>
+  <string name="upload_image_problem_blurry_duplicate_wrong_location">This picture is blurry, duplicate and taken on another location, are you sure you want to upload it, for this place?</string>
   <string name="upload_image_problem_dark_blurry">This picture is too dark and is blurry, are you sure you want to upload it? Please only upload pictures with encyclopedic value.</string>
+  <string name="upload_image_problem_dark_blurry_wrong_location">This picture is too dark, blurry and is taken on another location, are you sure you want to upload it, for this place?</string>
   <string name="upload_image_problem_dark_blurry_duplicate">This picture is too dark, is blurry and already exists on Commons, are you sure you want to upload it? Please only upload pictures with encyclopedic value.</string>
+  <string name="upload_image_problem_dark_blurry_duplicate_wrong_location">This picture is too dark, blurry, duplicate and is taken on another location, are you sure you want to upload it, for this place?</string>
 
   <string name="give_permission">Give permission</string>
   <string name="use_external_storage">Use external storage</string>


### PR DESCRIPTION
**Description (required)**

Fixes #945 Check image coordinates for direct Nearby uploads in locations that the user is not currently in. 

Compare Wikidata item location with photo location (if exists),
- If they missmatch, warns user and doesn't edits wikidata item if user still wants to continue
- If they match, does nothing special

If location information of file doesn't exists, doesn't prevent wikidata eidts for now. But we can discuss this decision, we can be more strict and block wikidata edits with no location information at all. 

**Tests performed (required)**

Tested prod debug, API 26 device

**Screenshots showing what changed (optional - for UI changes)**

![image](https://user-images.githubusercontent.com/3127881/49802172-39e69a00-fd5d-11e8-91af-be5f6523a72b.png)

