### PR TITLE
fixing issue #2044

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -152,5 +152,7 @@ public class NotificationActivity extends NavigationBaseActivity {
     public void onBackPressed() {
         startActivityWithFlags(
                 this, MainActivity.class, Intent.FLAG_ACTIVITY_CLEAR_TOP,
-                Intent.FLAG_ACTIVITY_SINGLE_TOP);    }
+                Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        finish();
+    }
 }


### PR DESCRIPTION
Fixes #2044 2.9.0: Unable to exit app after going to notifications activity

What changes did you make and why?
Added finish() inside onBackPressed() method in app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java

Tested on Motorola Moto g(5) plus with API level 24