### PR TITLE
Fix #2104 by removing delete recent searches button when list is empty

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
@@ -38,10 +38,16 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
         View rootView = inflater.inflate(R.layout.fragment_search_history, container, false);
         ButterKnife.bind(this, rootView);
         recentSearches = recentSearchesDao.recentSearches(10);
+
+        if(recentSearches.isEmpty()) {
+            recent_searches_delete_button.setVisibility(View.GONE);
+        }
+
         recent_searches_delete_button.setOnClickListener(v -> new AlertDialog.Builder(getContext())
             .setMessage(getString(R.string.delete_recent_searches_dialog))
             .setPositiveButton(android.R.string.yes, (dialog, which) -> {
                 recentSearchesDao.deleteAll(recentSearches);
+                recent_searches_delete_button.setVisibility(View.GONE);
                 Toast.makeText(getContext(),getString(R.string.search_history_deleted),Toast.LENGTH_SHORT).show();
                 recentSearches = recentSearchesDao.recentSearches(10);
                 adapter = new ArrayAdapter<String>(getContext(),R.layout.item_recent_searches, recentSearches);

--- a/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
@@ -85,5 +85,9 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
         adapter = new ArrayAdapter<String>(getContext(),R.layout.item_recent_searches, recentSearches);
         recentSearchesList.setAdapter(adapter);
         adapter.notifyDataSetChanged();
+
+        if(!recentSearches.isEmpty()) {
+            recent_searches_delete_button.setVisibility(View.VISIBLE);
+        }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.ListView;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import java.util.List;
@@ -31,6 +32,8 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
     ArrayAdapter adapter;
     @BindView(R.id.recent_searches_delete_button)
     ImageView recent_searches_delete_button;
+    @BindView(R.id.recent_searches_text_view)
+    TextView recent_searches_text_view;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
@@ -41,6 +44,7 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
 
         if(recentSearches.isEmpty()) {
             recent_searches_delete_button.setVisibility(View.GONE);
+            recent_searches_text_view.setText(R.string.no_recent_searches);
         }
 
         recent_searches_delete_button.setOnClickListener(v -> new AlertDialog.Builder(getContext())
@@ -48,6 +52,7 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
             .setPositiveButton(android.R.string.yes, (dialog, which) -> {
                 recentSearchesDao.deleteAll(recentSearches);
                 recent_searches_delete_button.setVisibility(View.GONE);
+                recent_searches_text_view.setText(R.string.no_recent_searches);
                 Toast.makeText(getContext(),getString(R.string.search_history_deleted),Toast.LENGTH_SHORT).show();
                 recentSearches = recentSearchesDao.recentSearches(10);
                 adapter = new ArrayAdapter<String>(getContext(),R.layout.item_recent_searches, recentSearches);
@@ -88,6 +93,7 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
 
         if(!recentSearches.isEmpty()) {
             recent_searches_delete_button.setVisibility(View.VISIBLE);
+            recent_searches_text_view.setText(R.string.search_recent_header);
         }
     }
 }

--- a/app/src/main/res/layout/fragment_search_history.xml
+++ b/app/src/main/res/layout/fragment_search_history.xml
@@ -17,6 +17,7 @@
             android:layout_height="wrap_content">
 
             <TextView
+                android:id="@+id/recent_searches_text_view"
                 android:layout_width="wrap_content"
                 android:layout_height="48dp"
                 android:layout_gravity="start"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -343,6 +343,7 @@
   <string name="error_fetching_nearby_places">Error fetching nearby places.</string>
   <string name="add_description">+ Add description</string>
 
+  <string name="no_recent_searches">No recent searches</string>
   <string name="delete_recent_searches_dialog">Are you sure you want to clear your search history?</string>
   <string name="search_history_deleted">Search history deleted</string>
   <string name="nominate_delete">Nominate For Deletion</string>


### PR DESCRIPTION
**Description (required)**

Fixes #2104  Delete recent searches button remains there even when the list of recent searches is empty

Now, the delete recent searches button will only show when there is at least one recent search in the list.

**Tests performed (required)**

Tested betaDebug on API level 25.

**GIF**

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/35566748/49869709-332c5580-fe37-11e8-9445-299645c25a30.gif)

