### PR TITLE
fixing issue #2072

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
@@ -65,7 +65,7 @@ public class UploadModel {
                 MediaWikiApi mwApi) {
         this.licenses = licenses;
         this.prefs = prefs;
-        this.license = Prefs.Licenses.CC_BY_SA_3;
+        this.license = prefs.getString(Prefs.DEFAULT_LICENSE, Prefs.Licenses.CC_BY_SA_3);
         this.licensesByName = licensesByName;
         this.context = context;
         this.mwApi = mwApi;
@@ -300,7 +300,7 @@ public class UploadModel {
     }
 
     String getSelectedLicense() {
-        return license;
+        return prefs.getString(Prefs.DEFAULT_LICENSE, Prefs.Licenses.CC_BY_SA_3);
     }
 
     void setSelectedLicense(String licenseName) {


### PR DESCRIPTION

Fixes #2072 Fix default license selector in Settings

What changes did you make and why?
Changed return statement of getSelectedLicense() method in app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java as it was always returning the default license

Tested on Motorola Moto G(5) plus with API level 24