### PR TITLE
Fix #2107 by changing notification text colour to white in night mode

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationRenderer.java
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.notification;
 
 import android.graphics.Color;
+import android.preference.PreferenceManager;
 import android.text.Html;
 import android.text.SpannableString;
 import android.text.Spanned;
@@ -77,7 +78,13 @@ public class NotificationRenderer extends Renderer<Notification> {
             public void updateDrawState(TextPaint ds) {
                 super.updateDrawState(ds);
                 ds.setUnderlineText(false);
-                ds.setColor(Color.BLACK);
+
+                if(PreferenceManager.getDefaultSharedPreferences(getContext()).getBoolean("theme", false)) {
+                    ds.setColor(Color.WHITE);
+                }
+                else {
+                    ds.setColor(Color.BLACK);
+                }
             }
         };
 


### PR DESCRIPTION
**Description (required)**

Fixes #2107  Notification text should be white in night mode

Now, notification text in NotificationActivity will be white in colour when the app is in night mode.

**Tests performed (required)**

Tested betaDebug on API level 25.

**Screenshot showing what has changed**

![img_20181213_211747](https://user-images.githubusercontent.com/35566748/49949969-e58a1880-ff1c-11e8-9482-95c95a4dd62f.png)
