### PR TITLE
Fixed problem with crashing SearchActivity after orientation change

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -102,7 +102,7 @@
         <activity
             android:name=".explore.SearchActivity"
             android:label="@string/title_activity_search"
-            android:configChanges="orientation|keyboardHidden"
+            android:configChanges="orientation|keyboardHidden|screenSize"
             android:parentActivityName=".contributions.MainActivity"
             />
 


### PR DESCRIPTION
**Description (required)**

Resolves https://github.com/commons-app/apps-android-commons/issues/2125 

What changes did you make and why?

https://developer.android.com/guide/topics/manifest/activity-element#config 
"If your application targets Android 3.2 (API level 13) or higher, then you should also declare the "screenSize" configuration, because it also changes when a device switches between portrait and landscape orientations." - from docs.