### PR TITLE
fixing issue#2131: same description for all photos in multiple uploads 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
@@ -175,7 +175,7 @@ class DescriptionsAdapter extends RecyclerView.Adapter<DescriptionsAdapter.ViewH
                 }
 
                 descItemEditText.addTextChangedListener(new AbstractTextWatcher(descriptionText->{
-                    setNewDescription(description,descriptionText,position);
+                    descriptions.get(position - 1).setDescriptionText(descriptionText);
                 }));
 
                 descItemEditText.setOnFocusChangeListener((v, hasFocus) -> {
@@ -255,11 +255,6 @@ class DescriptionsAdapter extends RecyclerView.Adapter<DescriptionsAdapter.ViewH
         private Drawable getInfoIcon() {
             return context.getResources().getDrawable(R.drawable.mapbox_info_icon_default);
         }
-    }
-
-    private void setNewDescription(Description description, String descriptionText, int position) {
-        description=descriptions.get(position-1);
-        description.setDescriptionText(descriptionText);
     }
 
     public interface Callback {

--- a/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
@@ -174,7 +174,10 @@ class DescriptionsAdapter extends RecyclerView.Adapter<DescriptionsAdapter.ViewH
                     descItemEditText.setCompoundDrawablesWithIntrinsicBounds(null, null, null, null);
                 }
 
-                descItemEditText.addTextChangedListener(new AbstractTextWatcher(description::setDescriptionText));
+                descItemEditText.addTextChangedListener(new AbstractTextWatcher(descriptionText->{
+                    setNewDescription(description,descriptionText,position);
+                }));
+
                 descItemEditText.setOnFocusChangeListener((v, hasFocus) -> {
                     if (!hasFocus) {
                         ViewUtil.hideKeyboard(v);
@@ -238,8 +241,8 @@ class DescriptionsAdapter extends RecyclerView.Adapter<DescriptionsAdapter.ViewH
                     ((SpinnerLanguagesAdapter) adapterView.getAdapter()).selectedLangCode = languageCode;
                 }
 
-                    @Override
-                    public void onNothingSelected(AdapterView<?> adapterView) {
+                @Override
+                public void onNothingSelected(AdapterView<?> adapterView) {
 
                 }
             });
@@ -252,6 +255,11 @@ class DescriptionsAdapter extends RecyclerView.Adapter<DescriptionsAdapter.ViewH
         private Drawable getInfoIcon() {
             return context.getResources().getDrawable(R.drawable.mapbox_info_icon_default);
         }
+    }
+
+    private void setNewDescription(Description description, String descriptionText, int position) {
+        description=descriptions.get(position-1);
+        description.setDescriptionText(descriptionText);
     }
 
     public interface Callback {


### PR DESCRIPTION
**Fixes #2131 Multiple Uploads: All pictures are having same description** 

**What changes did you make and why?**
Added a new setNewDescription() method to set description of the photo. Earlier when we were writing any description it was calling setDescriptionText method for all the photos in multiple uploads and all photos were having same description. Now setDescriptionText method is only called for the desired image and all images are not having the same description.

Tested on Motorola Moto G5 plus with API level 24