### PR TITLE
Fix #2123: Remove unnecessary calls to getParentFragment() to avoid NPE

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -343,7 +343,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
 
     @Override
     public void onPageScrolled(int i, float v, int i2) {
-        if(getParentFragment().getActivity() == null) {
+        if(getActivity() == null) {
             Timber.d("Returning as activity is destroyed!");
             return;
         }
@@ -398,7 +398,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
         public Fragment getItem(int i) {
             if (i == 0) {
                 // See bug https://code.google.com/p/android/issues/detail?id=27526
-                if(getParentFragment().getActivity() == null) {
+                if(getActivity() == null) {
                     Timber.d("Skipping getItem. Returning as activity is destroyed!");
                     return null;
                 }


### PR DESCRIPTION
**Description (required)**

Fixes #2123 Crashes viewing media in explore mode

What changes did you make and why?

Removed unnecessary `getParentFragment()` calls. I'm not sure why it is used here given `getActivity()` should already go up the chain until it reaches the calling activity or returns null.

**Tests performed (required)**

All automated tests pass.

Tested `2.9.0-debug-hotfix-explore-media-detail~7b5e1068` on `Galaxy Nexus (emulator)` with API level `28`.
Tested `2.9.0-debug-hotfix-explore-media-detail~7b5e1068` on `Samsung Galax S6` with API level `25`.