### PR TITLE
Fix typo in a string name in ImageUtil class

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
@@ -240,7 +240,7 @@ public class ImageUtils {
             }
 
             if ((IMAGE_BLURRY & result) != 0 ) {
-                errorMessage.append(context.getResources().getString(R.string.upload_image_problem_blurry));
+                errorMessage.append(context.getResources().getString(R.string.upload_problem_image_blurry));
             }
 
             if ((IMAGE_DUPLICATE & result) != 0 ) {


### PR DESCRIPTION
**Description (required)**

This should fix travis issue after translatewiki updates.

What changes did you make and why?

Fixed string variable name
