### PR TITLE
Add mapzen lost to build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'com.github.pedrovgs:renderers:3.3.3'
 
     implementation 'com.borjabravo:readmoretextview:2.1.0'
+    implementation 'com.mapzen.android:lost:3.0.4'
     implementation('com.mapbox.mapboxsdk:mapbox-android-sdk:5.5.0@aar') {
         transitive = true
     }


### PR DESCRIPTION
**Description (required)**

Reduces the number of javac warnings, and pushes us a step closer to it working with Instant Run.

Also see #2028 and #1941

What changes did you make and why?

Added `com.mapzen.android:lost:3.0.4` to `build.gradle`