### PR TITLE
Use fitCenter instead of centerCrop where sensible

### DIFF
--- a/app/src/main/res/layout/activity_share.xml
+++ b/app/src/main/res/layout/activity_share.xml
@@ -26,7 +26,7 @@
                 android:id="@+id/backgroundImage"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                app:actualImageScaleType="centerCrop" />
+                app:actualImageScaleType="fitCenter" />
 
             <FrameLayout
                 android:id="@+id/single_upload_fragment_container"

--- a/app/src/main/res/layout/activity_upload.xml
+++ b/app/src/main/res/layout/activity_upload.xml
@@ -23,7 +23,7 @@
             android:layout_height="match_parent"
             android:layout_below="@id/toolbar"
             android:background="@color/commons_app_blue_dark"
-            app:actualImageScaleType="centerCrop" />
+            app:actualImageScaleType="fitCenter" />
 
         <android.support.constraint.ConstraintLayout
             android:id="@+id/activity_upload_cards"

--- a/app/src/main/res/layout/fragment_similar_image_dialog.xml
+++ b/app/src/main/res/layout/fragment_similar_image_dialog.xml
@@ -13,13 +13,13 @@
             android:layout_width="160dp"
             android:layout_height="240dp"
             android:layout_margin="3dp"
-            app:actualImageScaleType="centerCrop" />
+            app:actualImageScaleType="fitCenter" />
         <com.facebook.drawee.view.SimpleDraweeView
             android:id="@+id/possibleImage"
             android:layout_width="160dp"
             android:layout_height="240dp"
             android:layout_margin="3dp"
-            app:actualImageScaleType="centerCrop" />
+            app:actualImageScaleType="fitCenter" />
     </LinearLayout>
     <TextView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/layout_contribution.xml
+++ b/app/src/main/res/layout/layout_contribution.xml
@@ -22,7 +22,7 @@
         android:id="@+id/contributionImage"
         android:layout_width="match_parent"
         android:layout_height="240dp"
-        app:actualImageScaleType="centerCrop"
+        app:actualImageScaleType="fitCenter"
         />
 
     <LinearLayout


### PR DESCRIPTION
**Description (required)**

Fixes #804 Shrink images instead of cropping

What changes did you make and why?

Use `fitCenter` instead of `centerCrop` as the `android:scaleType` attribute. This means if the size of the image is larger than the ImageView containing it it is shrunk rather than cropped, allowing the user to see more of the image.

**Tests performed (required)**

Tested `2.9.0-debug-image-fitCenter~c85ac58c` on `Galaxy Nexus (emulator)` with API level `28`.
Tested `2.9.0-debug-image-fitCenter~c85ac58c` on `Galaxy Nexus (emulator)` with API level `23`.

**Screenshots showing what changed (optional - for UI changes)**

Before: left
After: right

![untitled](https://user-images.githubusercontent.com/10674/28487270-31ff81be-6ec8-11e7-9ee3-7832003dca18.png)