### PR TITLE
Fix #2147: Remove strings from notification and place layouts

### DIFF
--- a/app/src/main/res/layout/item_notification.xml
+++ b/app/src/main/res/layout/item_notification.xml
@@ -14,7 +14,6 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
         android:background="@android:color/white"
-        android:contentDescription="@string/no_image_found"
         android:scaleType="centerCrop"
         app:srcCompat="@drawable/ic_message_black_24dp"
         app:tint="@color/primaryDarkColor"
@@ -30,7 +29,6 @@
         android:layout_marginRight="16dp"
         android:layout_marginTop="16dp"
         android:textAppearance="@style/TextAppearance.AppCompat.Caption"
-        tools:text="@string/placeholder_place_distance"
         />
 
     <com.borjabravo.readmoretextview.ReadMoreTextView
@@ -50,7 +48,6 @@
         android:layout_alignParentTop="true"
         app:colorClickableText="#969494"
         android:textAppearance="@style/TextAppearance.AppCompat.Body2"
-        tools:text="@string/placeholder_place_name"
         android:padding="12dp"
         />
 </RelativeLayout>

--- a/app/src/main/res/layout/item_place.xml
+++ b/app/src/main/res/layout/item_place.xml
@@ -14,7 +14,6 @@
         android:layout_marginStart="@dimen/standard_gap"
         android:layout_marginTop="@dimen/standard_gap"
         android:background="@android:color/white"
-        android:contentDescription="@string/no_image_found"
         android:scaleType="centerCrop"
         android:src="@drawable/empty_photo"
         />
@@ -29,7 +28,6 @@
         android:layout_marginRight="@dimen/standard_gap"
         android:layout_marginTop="@dimen/standard_gap"
         android:textAppearance="@style/TextAppearance.AppCompat.Caption"
-        tools:text="@string/placeholder_place_distance"
         />
 
     <ImageView
@@ -57,7 +55,6 @@
         android:ellipsize="end"
         android:maxLines="2"
         android:textAppearance="@style/TextAppearance.AppCompat.Body2"
-        tools:text="@string/placeholder_place_name"
         />
 
     <TextView
@@ -73,7 +70,6 @@
         android:ellipsize="end"
         android:maxLines="4"
         android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-        tools:text="@string/placeholder_place_description"
         />
 
     <include layout="@layout/nearby_row_button" />


### PR DESCRIPTION
**Description (required)**

Fixes #2147 Incorrect contentDescription on ImageViews: no_image_found

What changes did you make and why?

Removed unhelpful and unused strings from notification and place layouts

**Tests performed (required)**

Tested `2.9.0-debug-fix-2147~12174b67` on `Galaxy Nexus (emulator)` with API level `28`.