### PR TITLE
Fix #2153: Fix explore category lists

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
@@ -26,9 +26,11 @@ public class CategoryImageUtils {
      */
     public static List<Media> getMediaList(NodeList childNodes) {
         List<Media> categoryImages = new ArrayList<>();
+
         for (int i = 0; i < childNodes.getLength(); i++) {
             Node node = childNodes.item(i);
-            if (getMediaFromPage(node).getFilename().substring(0,5).equals("File:")){
+
+            if (getFileName(node).substring(0, 5).equals("File:")) {
                 categoryImages.add(getMediaFromPage(node));
             }
         }
@@ -46,7 +48,7 @@ public class CategoryImageUtils {
         List<String> subCategories = new ArrayList<>();
         for (int i = 0; i < childNodes.getLength(); i++) {
             Node node = childNodes.item(i);
-            subCategories.add(getMediaFromPage(node).getFilename());
+            subCategories.add(getFileName(node));
         }
         Collections.sort(subCategories);
         return subCategories;


### PR DESCRIPTION
**Description (required)**

Fixes #2153 Subcategories / parent categories not loading

What changes did you make and why?

Used `getFileName(node)` instead of `getMediaFromPage(node).getFilename()`

This is because it is used as part of the check as to whether a node is a category or media file (L33), and when handling category nodes (L51).

When `getMediaFromPage` is called on a category node, it throws a NPE as it tries to find a media 'creator'.

It also doesn't make that much sense to have a category as a `Media` object, so this fixes that.
It also has the added benefit of being faster as not parsing all properties and generating a `Media` object.

I believe the issue was introduced in https://github.com/commons-app/apps-android-commons/commit/86e849683aeade551af1e71846d704b0955aebbc as the creator parsing was no longer null-safe.

**Tests performed (required)**

Tested `2.9.0-debug-fix-2153~4acf7501 (prod)` on `Galaxy Nexus (emulator)` with API level `28`.