### PR TITLE
UploadActivity - Used if statement to chose licence summary based on number of images

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -256,9 +256,14 @@ public class UploadActivity extends AuthenticatedActivity implements UploadView,
         String licenseHyperLink = "<a href='" + Utils.licenseUrlFor(selectedLicense)+"'>" +
                 getString(Utils.licenseNameFor(selectedLicense)) + "</a><br>";
         licenseSummary.setMovementMethod(LinkMovementMethod.getInstance());
-        licenseSummary.setText(
-                Html.fromHtml(
-                        getString(R.string.share_license_summary, licenseHyperLink)));
+        if(getIntent().getAction() == Intent.ACTION_SEND) {
+            licenseSummary.setText(
+                    Html.fromHtml(
+                            getString(R.string.share_license_summary, licenseHyperLink)));
+        } else {
+            licenseSummary.setText(Html.fromHtml(
+                    getString(R.string.share_licenses_summary, licenseHyperLink)));
+        }
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@
   <string name="menu_retry_upload">Retry</string>
   <string name="menu_cancel_upload">Cancel</string>
   <string name="share_license_summary">This image will be licensed under %1$s</string>
+    <string name="share_licenses_summary">These images will be licensed under %1$s</string>
   <string name="media_upload_policy">By submitting this picture, I declare that this is my own work, that it does not contain copyrighted material or selfies, and otherwise adheres to &lt;a href=\"https://commons.wikimedia.org/wiki/Commons:Policies_and_guidelines\"&gt;Wikimedia Commons policies&lt;/a&gt;.</string>
   <string name="menu_download">Download</string>
   <string name="preference_license">Default License</string>


### PR DESCRIPTION

Fixes #2156 When uploading multiple images the image license selector implies singular

What changes did you make and why?

string.xml - Added a string for multiple images license
UploadActivity - Used if statement to check the number of images and use appropriate license summary string.


Tested on Motorola Moto G(4) with API level 24.

