### PR TITLE
Remove unused readmoretextview dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,6 @@ dependencies {
     implementation 'com.github.chrisbanes:PhotoView:2.0.0'
     implementation 'com.github.pedrovgs:renderers:3.3.3'
 
-    implementation 'com.borjabravo:readmoretextview:2.1.0'
     implementation 'com.mapzen.android:lost:3.0.4'
     implementation('com.mapbox.mapboxsdk:mapbox-android-sdk:5.5.0@aar') {
         transitive = true

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -64,7 +64,7 @@
     </style>
 
     <style name="LightFlatNearbyPermissionButton" parent="LightAppTheme">
-        <item name="colorControlHighlight">@color/colorPrimary</item>
+        <item name="colorControlHighlight">@color/primaryColor</item>
     </style>
 
     <style name="ProgressBar" parent="Widget.AppCompat.ProgressBar.Horizontal" />


### PR DESCRIPTION
**Description (required)**

Removed unused `readmoretextview` dependency. Needed to change `styles.xml` as was referencing a color from `readmoretextview`'s `values.xml` instead of our own `colors.xml`

See #1998 for more.

**Tests performed (required)**

Tested `2.9.0-debug-remove-dep-readmoretextview~6e7562b4` on `Galaxy Nexus (emulator)` with API level `28`.

**Screenshots**

Notifications page all working:

![screenshot_1545134652](https://user-images.githubusercontent.com/4953590/50153060-330bda00-02bd-11e9-964e-d8afce11cb33.png)