### PR TITLE
Travis should only sign and build APK on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
 - android-wait-for-emulator
 script:
 - "./gradlew clean check connectedCheck jacocoTestReport"
-- if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+- if [ "$TRAVIS_PULL_REQUEST" == "false" ] && ["$TRAVIS_BRANCH" == "master" ]; then
   ./gradlew publishProdReleaseApk;
   fi
 after_success:
@@ -47,9 +47,9 @@ cache:
   - "$HOME/.gradle/caches/"
   - "$HOME/.gradle/wrapper/"
 before_install:
-- if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+- if [ "$TRAVIS_PULL_REQUEST" == "false" ] && ["$TRAVIS_BRANCH" == "master" ]; then
   openssl aes-256-cbc -K $encrypted_7b5c925cc32c_key -iv $encrypted_7b5c925cc32c_iv -in nr-commons.keystore.enc -out nr-commons.keystore -d;
   fi
-- if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+- if [ "$TRAVIS_PULL_REQUEST" == "false" ] && ["$TRAVIS_BRANCH" == "master" ]; then
   openssl aes-256-cbc -K $encrypted_38ac1a5053f6_key -iv $encrypted_38ac1a5053f6_iv -in play.p12.enc -out play.p12 -d;
   fi


### PR DESCRIPTION
**Description (required)**

Fixes #1056

What changes did you make and why?

Travis now checks we're on the master branch before pushing a release to Google Play. Otherwise, things like this will create an alpha build for Google Play:

https://travis-ci.org/commons-app/apps-android-commons/builds/468986786

(Worked on a non-master branch of commons-app, which resulted in Travis running a `continuous-integration/travis-ci/push` build - see #2148)

**Tests performed (required)**

Not really able to test, so need someone to look at carefully.