### PR TITLE
Fix #2163: Hide subtitle message when uploading a single image

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -93,6 +93,8 @@ public class UploadActivity extends AuthenticatedActivity implements UploadView,
     @BindView(R.id.bottom_card_next) Button next;
     @BindView(R.id.bottom_card_previous) Button previous;
     @BindView(R.id.bottom_card_add_desc) Button bottomCardAddDescription;
+    @BindView(R.id.categories_subtitle) TextView categoriesSubtitle;
+    @BindView(R.id.license_subtitle) TextView licenseSubtitle;
 
     //Right Card
     @BindView(R.id.right_card) CardView rightCard;
@@ -328,12 +330,10 @@ public class UploadActivity extends AuthenticatedActivity implements UploadView,
      */
     @Override
     public void updateSubtitleVisibility(int imageCount) {
-        TextView categoriesSubtitle = viewFlipper.findViewById(R.id.categories_subtitle);
         if (categoriesSubtitle != null) {
             categoriesSubtitle.setVisibility(imageCount > 1 ? View.VISIBLE : View.GONE);
         }
 
-        TextView licenseSubtitle = viewFlipper.findViewById(R.id.license_subtitle);
         if (licenseSubtitle != null) {
             licenseSubtitle.setVisibility(imageCount > 1 ? View.VISIBLE : View.GONE);
         }

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -330,13 +330,8 @@ public class UploadActivity extends AuthenticatedActivity implements UploadView,
      */
     @Override
     public void updateSubtitleVisibility(int imageCount) {
-        if (categoriesSubtitle != null) {
-            categoriesSubtitle.setVisibility(imageCount > 1 ? View.VISIBLE : View.GONE);
-        }
-
-        if (licenseSubtitle != null) {
-            licenseSubtitle.setVisibility(imageCount > 1 ? View.VISIBLE : View.GONE);
-        }
+        categoriesSubtitle.setVisibility(imageCount > 1 ? View.VISIBLE : View.GONE);
+        licenseSubtitle.setVisibility(imageCount > 1 ? View.VISIBLE : View.GONE);
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -323,6 +323,27 @@ public class UploadActivity extends AuthenticatedActivity implements UploadView,
     }
 
     @Override
+    public void updateSubtitleVisibility(int imageCount) {
+        TextView categoriesSubtitle = viewFlipper.findViewById(R.id.categories_subtitle);
+        if (categoriesSubtitle != null) {
+            if (imageCount > 1) {
+                categoriesSubtitle.setVisibility(View.VISIBLE);
+            } else {
+                categoriesSubtitle.setVisibility(View.GONE);
+            }
+        }
+
+        TextView licenseSubtitle = viewFlipper.findViewById(R.id.license_subtitle);
+        if (licenseSubtitle != null) {
+            if (imageCount > 1) {
+                licenseSubtitle.setVisibility(View.VISIBLE);
+            } else {
+                licenseSubtitle.setVisibility(View.GONE);
+            }
+        }
+    }
+
+    @Override
     public void setBottomCardState(boolean state) {
         updateCardState(state, bottomCardExpandButton, rvDescriptions, previous, next, bottomCardAddDescription);
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -322,24 +322,20 @@ public class UploadActivity extends AuthenticatedActivity implements UploadView,
         }
     }
 
+    /**
+     * Only show the subtitle ("For all images in set") if multiple images being uploaded
+     * @param imageCount Number of images being uploaded
+     */
     @Override
     public void updateSubtitleVisibility(int imageCount) {
         TextView categoriesSubtitle = viewFlipper.findViewById(R.id.categories_subtitle);
         if (categoriesSubtitle != null) {
-            if (imageCount > 1) {
-                categoriesSubtitle.setVisibility(View.VISIBLE);
-            } else {
-                categoriesSubtitle.setVisibility(View.GONE);
-            }
+            categoriesSubtitle.setVisibility(imageCount > 1 ? View.VISIBLE : View.GONE);
         }
 
         TextView licenseSubtitle = viewFlipper.findViewById(R.id.license_subtitle);
         if (licenseSubtitle != null) {
-            if (imageCount > 1) {
-                licenseSubtitle.setVisibility(View.VISIBLE);
-            } else {
-                licenseSubtitle.setVisibility(View.GONE);
-            }
+            licenseSubtitle.setVisibility(imageCount > 1 ? View.VISIBLE : View.GONE);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
@@ -381,6 +381,8 @@ public class UploadPresenter {
         GPSExtractor gpsObj = uploadModel.getCurrentItem().gpsCoords;
         view.updateRightCardContent(gpsObj != null && gpsObj.imageCoordsExists);
 
+        view.updateSubtitleVisibility(uploadModel.getCount());
+
         showCorrectCards(uploadModel.getCurrentStep(), uploadModel.getCount());
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadView.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadView.java
@@ -64,6 +64,8 @@ public interface UploadView {
 
     void updateTopCardContent();
 
+    void updateSubtitleVisibility(int imageCount);
+
     void dismissKeyboard();
 
     void showBadPicturePopup(@ImageUtils.Result int errorMessage);

--- a/app/src/main/res/layout/activity_upload_categories.xml
+++ b/app/src/main/res/layout/activity_upload_categories.xml
@@ -38,7 +38,7 @@
         android:textSize="@dimen/subtitle_text"
         android:text="@string/upload_flow_all_images_in_set"
         android:layout_below="@+id/categories_title"
-        tools:text="(For all images in set)" />
+        android:visibility="gone" />
 
     <FrameLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_upload_license.xml
+++ b/app/src/main/res/layout/activity_upload_license.xml
@@ -38,7 +38,7 @@
         android:textSize="@dimen/subtitle_text"
         android:text="@string/upload_flow_all_images_in_set"
         android:layout_below="@+id/license_title"
-        tools:text="(For all images in set)" />
+        android:visibility="gone" />
 
     <Spinner
         android:id="@+id/license_list"


### PR DESCRIPTION
**Description (required)**

Fixes #2163

Let TextView categories_subtitle and license_subtitle gone by default. Only show them if uploading more than one image.

**Tests performed (required)**

Tested BetaDebug on Nexus 6P with API level 27.

**Screenshots showing what changed (optional - for UI changes)**

![screenshot_20181219-103526](https://user-images.githubusercontent.com/692944/50196046-9c9eed80-037c-11e9-8433-40b7def273eb.png)
![screenshot_20181219-103533](https://user-images.githubusercontent.com/692944/50196048-9d378400-037c-11e9-8074-3e21966e0db1.png)
![screenshot_20181219-103558](https://user-images.githubusercontent.com/692944/50196049-9d378400-037c-11e9-859d-ac8a57ba78dc.png)
![screenshot_20181219-103460](https://user-images.githubusercontent.com/692944/50196045-9c9eed80-037c-11e9-9404-a154d7059fd0.png)
