### PR TITLE
Tidy up gradle.properties

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,15 +59,15 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:$DAGGER_VERSION"
     
     // Unit testing
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:$KOTLIN_VERSION"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.7.1'
     testImplementation 'com.nhaarman:mockito-kotlin:1.5.0'
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
 
     // Android testing
-    androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
@@ -78,9 +78,9 @@ dependencies {
     // Debugging
     implementation 'com.tspoon.traceur:traceur:1.0.1'
     implementation 'com.facebook.stetho:stetho:1.5.0'
-    debugImplementation "com.squareup.leakcanary:leakcanary-android:$LEAK_CANARY"
-    releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$LEAK_CANARY"
-    testImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$LEAK_CANARY"
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:$LEAK_CANARY_VERSION"
+    releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$LEAK_CANARY_VERSION"
+    testImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$LEAK_CANARY_VERSION"
 
     // Support libraries
     implementation "com.android.support:support-v4:$SUPPORT_LIB_VERSION"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.2.60'
     repositories {
         jcenter()
         mavenCentral()
@@ -10,7 +9,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.3'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
 
         classpath "com.github.triplet.gradle:play-publisher:2.0.0-rc1"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,15 +13,16 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Thu Mar 01 15:28:48 IST 2018
-systemProp.http.proxyPort=0
-compileSdkVersion=android-27
-BUTTERKNIFE_VERSION=8.8.1
 org.gradle.jvmargs=-Xmx1536M
+android.enableBuildCache=true
+compileSdkVersion=android-27
 buildToolsVersion=27.0.3
 
 SUPPORT_LIB_VERSION=27.1.1
-systemProp.http.proxyHost=
-LEAK_CANARY=1.5.4
+KOTLIN_VERSION=1.2.60
+BUTTERKNIFE_VERSION=8.8.1
+LEAK_CANARY_VERSION=1.5.4
 DAGGER_VERSION=2.15
-gradleVersion=3.0.0
-android.enableBuildCache=true
+
+systemProp.http.proxyPort=0
+systemProp.http.proxyHost=


### PR DESCRIPTION
**Description (required)**

Working towards fixing #1941, and generally improving code quality

Low priority, however I don't think these lines of these files will cause merge conflicts with any other PRs.

What changes did you make and why?

- Tidied up `gradle.properties` by grouping related properties
- Moved Kotlin version property from `build.gradle` to `gradle.properties` like all the other version properties
- Renamed some version properties so they are all consistently `PACKAGE_NAME_VERSION`

Did not change any versions in this PR so should be functionally identical

**Tests performed (required)**

All unit tests pass

Tested `2.9.0-debug-tidy-gradle-props~911bda1b4 (betaDebug)` on `Galaxy Nexus (emulator)` with API level `28`.