### PR TITLE
Fix #2167 and #2168: Update mapbox sdk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,11 +32,7 @@ dependencies {
     implementation 'fr.avianey.com.viewpagerindicator:library:2.4.1.1@aar'
     implementation 'com.github.chrisbanes:PhotoView:2.0.0'
     implementation 'com.github.pedrovgs:renderers:3.3.3'
-
-    implementation 'com.mapzen.android:lost:3.0.4'
-    implementation('com.mapbox.mapboxsdk:mapbox-android-sdk:5.5.0@aar') {
-        transitive = true
-    }
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:6.8.0'
     implementation 'com.github.deano2390:MaterialShowcaseView:1.2.0'
     implementation 'com.dinuscxj:circleprogressbar:1.1.1'
     implementation 'com.karumi:dexter:5.0.0'

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -45,7 +45,6 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
-import com.mapbox.services.android.telemetry.MapboxTelemetry;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -61,7 +60,6 @@ import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.auth.LoginActivity;
 import fr.free.nrw.commons.bookmarks.locations.BookmarkLocationsDao;
 import fr.free.nrw.commons.contributions.ContributionController;
-
 import fr.free.nrw.commons.utils.LocationUtils;
 import fr.free.nrw.commons.utils.PlaceUtils;
 import fr.free.nrw.commons.utils.UriDeserializer;
@@ -180,7 +178,7 @@ public class NearbyMapFragment extends DaggerFragment {
         if (curLatLng != null) {
             Mapbox.getInstance(getActivity(),
                     getString(R.string.mapbox_commons_app_token));
-            MapboxTelemetry.getInstance().setTelemetryEnabled(false);
+            Mapbox.getTelemetry().setUserTelemetryRequestState(false);
         }
         setRetainInstance(true);
     }


### PR DESCRIPTION
**Description**

Fixes #2167 and fixes #2168, problems with the nearby map

**What changes did you make and why?**

- Updated mapbox to version `6.8.0`
- Removed unused lost dependency
- Removed unused transitive requirement of mapbox

This change updates mapbox (using new Telemetry method calls). This fixes #2168 and I can no longer reproduce #2167.

Also uses vector instead of bitmap map tiles which load faster and I think look better.

Given your expertise with the nearby stuff @neslihanturan can you review this.

**Tests performed**

All unit tests pass

Tested `2.9.0-debug-update-mapbox~06f189bf7` on `Samsung Galaxy S6` with API level `25`.
Tested `2.9.0-debug-update-mapbox~06f189bf7` on `Galaxy Nexus (emulator)` with API level `28`.
Tested `2.9.0-debug-update-mapbox~06f189bf7` on `Galaxy Nexus (emulator)` with API level `25`.
Tested `2.9.0-debug-update-mapbox~06f189bf7` on `Galaxy Nexus (emulator)` with API level `23`.

**Screenshots showing what changed**

| Before | After |
| - | - |
| ![screenshot_20181219-211713](https://user-images.githubusercontent.com/4953590/50248618-83755b80-03d3-11e9-93aa-23105c2760b9.png) | ![screenshot_1545250560](https://user-images.githubusercontent.com/4953590/50245720-24abe400-03cb-11e9-9fb4-4912644d5e0b.png) |