### PR TITLE
Fix #2177: Move "OK" button to bottom right of nearby places info dialog

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -123,18 +123,15 @@ public class MainActivity extends AuthenticatedActivity implements FragmentManag
         ImageView nearbyInfo = nearbyTabLinearLayout.findViewById(R.id.nearby_info_image);
         tabLayout.getTabAt(1).setCustomView(nearbyTabLinearLayout);
 
-        nearbyInfo.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
+        nearbyInfo.setOnClickListener(view ->
                 new AlertDialog.Builder(MainActivity.this)
                         .setTitle(R.string.title_activity_nearby)
                         .setMessage(R.string.showcase_view_whole_nearby_activity)
                         .setCancelable(true)
-                        .setNeutralButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
+                        .setPositiveButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
                         .create()
-                        .show();
-            }
-        });
+                        .show()
+        );
 
         if (uploadServiceIntent != null) {
             // If auth cookie already acquired notify contrib fragmnet so that it san operate auth required actions


### PR DESCRIPTION
**Description**

Fixes #2177 Nearby places information dialog okay button

- Used `setPositiveButton` instead of `setNeutralButton`
- Changed function to use lambda

**Tests performed**

Automated tests

Tested `2.9.0-debug-nearby-info-button~1e8a940cc` on `Galaxy Nexus (emulator)` with API level `28`.

**Screenshots showing what changed**

| Before | After |
| - | - |
| ![screenshot_1545255229](https://user-images.githubusercontent.com/4953590/50249501-2038f880-03d6-11e9-9ead-4acf19405a8b.png) | ![screenshot_1545255392](https://user-images.githubusercontent.com/4953590/50249520-28913380-03d6-11e9-8989-f6d76dcc0ed9.png) |