### PR TITLE
Fixed looping bad image Warning #2191

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
@@ -228,7 +228,7 @@ public class ImageUtils {
          * is 0001 means IMAGE_DARK, if result is 1100 IMAGE_DUPLICATE and IMAGE_GEOLOCATION_DIFFERENT
          */
         StringBuilder errorMessage = new StringBuilder();
-        if (((IMAGE_DARK | IMAGE_GEOLOCATION_DIFFERENT | IMAGE_BLURRY | IMAGE_DUPLICATE) & result) == 0 ) {
+        if (result <= 0 ) {
             Timber.d("No issues to warn user is found");
         } else {
             Timber.d("Issues found to warn user");


### PR DESCRIPTION
**Description (required)**

Fixes Bad Image Warning caught in loop #2191

Changed the if condition within ImageUtils.getErrorMessageForResult(), which is based on the value of the variable 'result'. If result >0 then it generates a error message string, (eg result = 4 if it is a duplicate picture). The previous condition was allowing a string to be generated when result < 0, which is used for results that the user does not need to be warned about (eg.  result = -1 if user chooses to proceed with uploading image even if it is a duplicate). The updated condition only generates messages for when result > 0 .

**Tests performed (required)**

Enter the upload wizard
Select a photograph that you have already uploaded
Dialogue box warns: "image already is commons" click yes
Check that wizard Progresses as normal

Tested master branch on Nexus 7 API 27, emulator
