### PR TITLE
Fix #2197: Links on about page in night mode are correct color

### DIFF
--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -110,7 +110,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/standard_gap"
                 android:gravity="center"
-                android:textColor="@color/primaryColor"
+                android:textColor="?attr/colorAccent"
                 />
           
             <TextView
@@ -119,7 +119,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/standard_gap"
-                android:textColor="@color/primaryColor"
+                android:textColor="?attr/colorAccent"
                 android:gravity="center"
                 />
 
@@ -128,7 +128,7 @@
                 style="?android:textAppearanceSmall"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="@color/primaryColor"
+                android:textColor="?attr/colorAccent"
                 android:layout_marginTop="@dimen/standard_gap"
                 android:gravity="center"
                 />
@@ -138,7 +138,7 @@
                 style="?android:textAppearanceSmall"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="@color/primaryColor"
+                android:textColor="?attr/colorAccent"
                 android:layout_marginTop="@dimen/standard_gap"
                 android:gravity="center"
                 />
@@ -148,8 +148,9 @@
                 style="?android:textAppearanceSmall"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="@color/primaryColor"
+                android:textColor="?attr/colorAccent"
                 android:layout_marginTop="@dimen/standard_gap"
+                android:layout_marginBottom="@dimen/standard_gap"
                 android:gravity="center"
                 />
 


### PR DESCRIPTION
**Description**

Fixes #2197

**Tests performed**

Tested `2.9.0-debug-master~b1056572` on `Galaxy Nexus (emulator)` with API level `28`.

Checked did not break non-night mode version:

![screenshot_1545330763](https://user-images.githubusercontent.com/4953590/50303651-a6604800-0485-11e9-9472-26bee4565a00.png)

**Screenshots showing what changed**

| Before | After |
| - | - |
| ![screenshot_1545330616](https://user-images.githubusercontent.com/4953590/50303549-4f5a7300-0485-11e9-8b6f-ade36a75d249.png) | ![screenshot_1545330684](https://user-images.githubusercontent.com/4953590/50303593-77e26d00-0485-11e9-86c2-8640f8ca7ac5.png) |