### PR TITLE
Fix #2200: Prevent app from closing while navigating to Home

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarksActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarksActivity.java
@@ -54,7 +54,7 @@ public class BookmarksActivity extends NavigationBaseActivity
      */
     public static void startYourself(Context context) {
         Intent intent = new Intent(context, BookmarksActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         context.startActivity(intent);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -140,7 +140,7 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
      */
     public static void startYourself(Context context, String categoryName) {
         Intent intent = new Intent(context, CategoryDetailsActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.putExtra("categoryName", categoryName);
         context.startActivity(intent);
     }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
@@ -148,7 +148,7 @@ public class CategoryImagesActivity
      */
     public static void startYourself(Context context, String title, String categoryName) {
         Intent intent = new Intent(context, CategoryImagesActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.putExtra("title", title);
         intent.putExtra("categoryName", categoryName);
         context.startActivity(intent);

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -136,7 +136,7 @@ public class NotificationActivity extends NavigationBaseActivity {
 
     public static void startYourself(Context context) {
         Intent intent = new Intent(context, NotificationActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         context.startActivity(intent);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -177,11 +177,11 @@ public abstract class NavigationBaseActivity extends BaseActivity
                 return true;
             case R.id.action_about:
                 drawerLayout.closeDrawer(navigationView);
-                startActivityWithFlags(this, AboutActivity.class, Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+                startActivityWithFlags(this, AboutActivity.class, Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 return true;
             case R.id.action_settings:
                 drawerLayout.closeDrawer(navigationView);
-                startActivityWithFlags(this, SettingsActivity.class, Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+                startActivityWithFlags(this, SettingsActivity.class, Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 return true;
             case R.id.action_introduction:
                 drawerLayout.closeDrawer(navigationView);


### PR DESCRIPTION
**Description (required)**

Fixes #2200 App closes unexpectedly when navigating to Home

Now, the app will not close and Home activity will open as expected.

**Tests performed (required)**

Tested betaDebug on API 25.

**GIF**

![ezgif com-video-to-gif 13](https://user-images.githubusercontent.com/35566748/50341867-9f4d3e80-0546-11e9-8ec3-f6a7f3cc4508.gif)
