### PR TITLE
Fix #2177: Move "OK" button to bottom right of various dialogs

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -379,7 +379,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
                 .setTitle(title)
                 .setMessage(message)
                 .setCancelable(true)
-                .setNeutralButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
+                .setPositiveButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
                 .create()
                 .show();
     }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -128,7 +128,7 @@ public class MainActivity extends AuthenticatedActivity implements FragmentManag
                     .setTitle(R.string.title_activity_nearby)
                     .setMessage(R.string.showcase_view_whole_nearby_activity)
                     .setCancelable(true)
-                    .setNeutralButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
+                    .setPositiveButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
                     .create()
                     .show()
         );

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -599,7 +599,7 @@ public class UploadActivity extends AuthenticatedActivity implements UploadView,
                 .setTitle(titleStringID)
                 .setMessage(getString(messageStringId, (Object[]) formatArgs))
                 .setCancelable(true)
-                .setNeutralButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
+                .setPositiveButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
                 .create()
                 .show();
     }


### PR DESCRIPTION
**Description**

Fixes #2177

What changes did you make and why?

Changed "OK" button to the "positive" button so it is on the bottom right hand of the AlertDialog.

**Tests performed**

Tested `2.9.0-debug-pr-2206~fbbd025b0` on `Galaxy Nexus (emulator)` with API level `28`.

**Screenshots showing what changed**

| Nearby | Achievements | Upload title | Upload description |
| - | - | - | - |
| ![screenshot_1545398897](https://user-images.githubusercontent.com/4953590/50344891-f04c3b00-0524-11e9-984d-043c36327908.png) | ![screenshot_1545398903](https://user-images.githubusercontent.com/4953590/50344894-f3dfc200-0524-11e9-850e-eb00cb15784a.png) | ![screenshot_1545398989](https://user-images.githubusercontent.com/4953590/50344895-f6dab280-0524-11e9-9c2b-52604877d049.png) | ![screenshot_1545398992](https://user-images.githubusercontent.com/4953590/50344897-f93d0c80-0524-11e9-85f2-816e7ab82a61.png) |