### PR TITLE
Fix #2208 Proper back stack management for NotificationActivity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -147,10 +147,4 @@ public class NotificationActivity extends NavigationBaseActivity {
                 .commit();
         mNotificationWorkerFragment.setNotificationList(notificationList);
     }
-
-    @Override
-    public void onBackPressed() {
-        startActivityWithFlags(
-                this, MainActivity.class, Intent.FLAG_ACTIVITY_CLEAR_TOP,
-                Intent.FLAG_ACTIVITY_SINGLE_TOP);    }
 }


### PR DESCRIPTION
**Description (required)**

Fixes #2208 

Now, pressing back on Notifications will take to the previous activity and not always Home which was the behaviour earlier.

**Tests performed (required)**

Tested betaDebug on API 25.

**GIF**

![ezgif com-video-to-gif 15](https://user-images.githubusercontent.com/35566748/50351562-98372800-0568-11e9-8878-823f4ef9b56c.gif)
