### PR TITLE
Fix #2210: Fix inputs not being easily visible

### DIFF
--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -35,6 +35,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:focusable="true"
+                app:theme="@style/WhiteSearchBarTheme"
                 android:queryBackground="@android:color/transparent"
                 android:searchIcon="@null"
                 android:paddingLeft="-16dp"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -23,9 +23,6 @@
         <item name="textEnabled">@color/enabled_button_text_color_dark</item>
         <item name="mainCardBackground">@color/main_background_dark</item>
         <item name="mainScreenNearbyPermissionbutton">@style/DarkFlatNearbyPermissionButton</item>
-
-        <!-- SearchView cursor color -->
-        <item name="colorControlActivated">@android:color/white</item>
     </style>
 
     <style name="LightAppTheme" parent="Theme.AppCompat.Light.NoActionBar">
@@ -50,8 +47,9 @@
         <item name="textEnabled">@color/enabled_button_text_color_light</item>
         <item name="mainCardBackground">@color/primaryDarkColor</item>
         <item name="mainScreenNearbyPermissionbutton">@style/LightFlatNearbyPermissionButton</item>
+    </style>
 
-        <!-- SearchView cursor color -->
+    <style name="WhiteSearchBarTheme" parent="DarkAppTheme">
         <item name="colorControlActivated">@android:color/white</item>
     </style>
 


### PR DESCRIPTION
**Description**

Fixes #2189

What changes did you make and why?
- Moved the theme-ing for the search bar into its own theme so it does not affect inputs in `SettingsFragment`

**Tests performed**

Tested `2.9.0-debug-fix-2210~a220c58af` on `Galaxy Nexus (emulator)` with API level `28`

| Settings fixed | Search still looks right |
| - | - |
| ![screenshot_1545421344](https://user-images.githubusercontent.com/4953590/50360636-97969580-0558-11e9-9a43-29d1d6953e59.png) | ![screenshot_1545421357](https://user-images.githubusercontent.com/4953590/50360637-98c7c280-0558-11e9-9f2b-468cf758dfd0.png) |