### PR TITLE
Fix #2090 and #2088: Night mode issues with search and categories

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -58,16 +58,9 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        boolean currentThemeIsDark = PreferenceManager.getDefaultSharedPreferences(this).getBoolean("theme", false);
         setContentView(R.layout.activity_search);
         ButterKnife.bind(this);
         initDrawer();
-        if (currentThemeIsDark) {
-            searchView.setBackgroundResource(R.color.vpi__bright_foreground_disabled_holo_dark);
-            tabLayout.setBackgroundResource(R.color.vpi__bright_foreground_disabled_holo_dark);
-            toolbar.setBackgroundResource(R.color.vpi__bright_foreground_disabled_holo_dark);
-            viewPager.setBackgroundResource(R.color.vpi__bright_foreground_disabled_holo_dark);
-        }
         setTitle(getString(R.string.title_activity_search));
         toolbar.setNavigationOnClickListener(v->onBackPressed());
         supportFragmentManager = getSupportFragmentManager();

--- a/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
@@ -1,8 +1,6 @@
 package fr.free.nrw.commons.explore.recentsearches;
 
-import android.content.Context;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.support.v7.app.AlertDialog;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -34,7 +32,6 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
     ArrayAdapter adapter;
     @BindView(R.id.recent_searches_delete_button)
     ImageView recent_searches_delete_button;
-    boolean currentThemeIsDark = false;
     @BindView(R.id.recent_searches_text_view)
     TextView recent_searches_text_view;
 
@@ -68,13 +65,12 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
                 .create()
                 .show();
         });
-        currentThemeIsDark = PreferenceManager.getDefaultSharedPreferences(getContext()).getBoolean("theme", false);
-        setAdapterForThemes(getContext(), currentThemeIsDark);
-        
+
+        adapter = new ArrayAdapter<>(requireContext(), R.layout.item_recent_searches, recentSearches);
         recentSearchesList.setAdapter(adapter);
         recentSearchesList.setOnItemClickListener((parent, view, position, id) -> (
                 (SearchActivity)getContext()).updateText(recentSearches.get(position)));
-        adapter.notifyDataSetChanged();
+        updateRecentSearches();
         return rootView;
     }
 
@@ -84,8 +80,7 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
      */
     @Override
     public void onResume() {
-        recentSearches = recentSearchesDao.recentSearches(10);
-        adapter.notifyDataSetChanged();
+        updateRecentSearches();
         super.onResume();
     }
 
@@ -94,21 +89,11 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
      */
     public void updateRecentSearches() {
         recentSearches = recentSearchesDao.recentSearches(10);
-        setAdapterForThemes(getContext(), currentThemeIsDark);
-        recentSearchesList.setAdapter(adapter);
         adapter.notifyDataSetChanged();
 
         if(!recentSearches.isEmpty()) {
             recent_searches_delete_button.setVisibility(View.VISIBLE);
             recent_searches_text_view.setText(R.string.search_recent_header);
-        }
-    }
-
-    private void setAdapterForThemes(Context context, boolean currentThemeIsDark) {
-        if (currentThemeIsDark) {
-            adapter = new ArrayAdapter<String>(context, R.layout.item_recent_searches_dark_theme, recentSearches);
-        } else {
-            adapter = new ArrayAdapter<String>(context, R.layout.item_recent_searches, recentSearches);
         }
     }
 }

--- a/app/src/main/res/layout/item_recent_searches.xml
+++ b/app/src/main/res/layout/item_recent_searches.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView android:id="@+id/textView1"
     android:layout_width="match_parent"
-    android:background="@color/item_white_background"
     android:layout_height="wrap_content"
     android:textAppearance="?android:attr/textAppearanceMedium"
     android:padding="@dimen/standard_gap"

--- a/app/src/main/res/layout/item_recent_searches_dark_theme.xml
+++ b/app/src/main/res/layout/item_recent_searches_dark_theme.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/textView2"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="@color/vpi__bright_foreground_disabled_holo_dark"
-    android:padding="@dimen/standard_gap"
-    android:text="@string/search_commons"
-    android:textAppearance="?android:attr/textAppearanceMedium" />


### PR DESCRIPTION
**Description**

Fixes #2090 and fixes #2088

What changes did you make and why?
- Removed theme dependent code from `RecentSearchesFragment.java` and `SearchActivity.java`. Wasn't necessary, and made it harder to track what was going on. Appearance related stuff should be kept in xml as much as possible.
- Updated `item_recent_searches.xml` to remove its white background
- Deleted now unused `item_recent_searches_dark_theme.xml`

Was trying to fix #2095, ended up with something completely different. Fixes #2088 by accident, as `SearchCategoriesRenderer.java` also uses `R.layout.item_recent_searches` which was the root cause for both issues. Sorry for taking over these issues.

Note that this does not deal with the tabs issue, that is separate in #2186.

**Tests performed**

Tested `2.9.0-debug-master~493fa6b72` on `Galaxy Nexus (emulator)` with API level `28`
Tested `2.9.0-debug-master~493fa6b72` on `Galaxy Nexus (emulator)` with API level `25`

See screenshots for results below

**Search - no recent searches**

| Light | Dark |
| - | - |
| ![screenshot_1545434280](https://user-images.githubusercontent.com/4953590/50367369-b9534500-0577-11e9-985b-f27a530decc7.png) | ![screenshot_1545434272](https://user-images.githubusercontent.com/4953590/50367372-ba847200-0577-11e9-9d9e-a36cc324046e.png) |

**Search - recent searches**

| Light | Dark |
| - | - |
| ![screenshot_1545434403](https://user-images.githubusercontent.com/4953590/50367407-e869b680-0577-11e9-8fd9-3c61148ef691.png) | ![screenshot_1545434390](https://user-images.githubusercontent.com/4953590/50367409-eacc1080-0577-11e9-861a-d43bbcce949e.png) |

**Search - media results**

| Light | Dark |
| - | - |
| ![screenshot_1545434421](https://user-images.githubusercontent.com/4953590/50367415-f4557880-0577-11e9-95c4-ce86c8617ee3.png) | ![screenshot_1545434451](https://user-images.githubusercontent.com/4953590/50367418-fae3f000-0577-11e9-8bd8-eb28afe0ec60.png) |

**Search - no media results**

| Light | Dark |
| - | - |
| ![screenshot_1545434530](https://user-images.githubusercontent.com/4953590/50367444-2666da80-0578-11e9-9e52-ecfe4a027541.png) | ![screenshot_1545434518](https://user-images.githubusercontent.com/4953590/50367442-223abd00-0578-11e9-838d-39c3ea40cacd.png) |

**Search - category results**

| Light | Dark |
| - | - |
| ![screenshot_1545434535](https://user-images.githubusercontent.com/4953590/50367456-4dbda780-0578-11e9-9f36-73ca8e72ecc5.png) | ![screenshot_1545434547](https://user-images.githubusercontent.com/4953590/50367459-50b89800-0578-11e9-8b0d-946dcf7ef400.png) |

**Search - no category results**

| Light | Dark |
| - | - |
| ![screenshot_1545434531](https://user-images.githubusercontent.com/4953590/50367463-59a96980-0578-11e9-83a7-489985808b66.png) | ![screenshot_1545434520](https://user-images.githubusercontent.com/4953590/50367465-5dd58700-0578-11e9-959c-198fb2acec6d.png) |

**Category - media**

| Light | Dark |
| - | - |
| ![screenshot_1545434694](https://user-images.githubusercontent.com/4953590/50367484-75ad0b00-0578-11e9-91cf-81589ac7bc38.png) | ![screenshot_1545434671](https://user-images.githubusercontent.com/4953590/50367485-79409200-0578-11e9-8346-78cb347c057d.png) |

**Category - subcategories**

| Light | Dark |
| - | - |
| ![screenshot_1545434695](https://user-images.githubusercontent.com/4953590/50367494-88bfdb00-0578-11e9-847e-a9bde0011b5f.png) | ![screenshot_1545434673](https://user-images.githubusercontent.com/4953590/50367487-81003680-0578-11e9-87f4-3f8ffca9429d.png) |

**Category - no subcategories**

| Light | Dark |
| - | - |
| ![screenshot_1545435134](https://user-images.githubusercontent.com/4953590/50367515-a9883080-0578-11e9-8dbc-f9a5968b5f38.png) | ![screenshot_1545434679](https://user-images.githubusercontent.com/4953590/50367500-92e1d980-0578-11e9-952e-c0f0e70a193c.png) |

**Category - parent categories**

| Light | Dark |
| - | - |
| ![screenshot_1545434696](https://user-images.githubusercontent.com/4953590/50367522-c1f84b00-0578-11e9-9eeb-1019cdf79643.png) | ![screenshot_1545434674](https://user-images.githubusercontent.com/4953590/50367526-c7ee2c00-0578-11e9-945a-cf8c1fdfae46.png) |