### PR TITLE
Removed default license settings, and implemented selecting last selected license as default licence(#2170)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -47,16 +47,6 @@ public class SettingsFragment extends PreferenceFragment {
         // Load the preferences from an XML resource
         addPreferencesFromResource(R.xml.preferences);
 
-        // Update spinner to show selected value as summary
-        ListPreference licensePreference = (ListPreference) findPreference(Prefs.DEFAULT_LICENSE);
-        licensePreference.setSummary(getString(Utils.licenseNameFor(licensePreference.getValue())));
-
-        // Keep summary updated when changing value
-        licensePreference.setOnPreferenceChangeListener((preference, newValue) -> {
-            preference.setSummary(getString(Utils.licenseNameFor((String) newValue)));
-            return true;
-        });
-
         SwitchPreference themePreference = (SwitchPreference) findPreference("theme");
         themePreference.setOnPreferenceChangeListener((preference, newValue) -> {
             getActivity().recreate();

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
@@ -330,6 +330,7 @@ public class UploadModel {
 
     void setSelectedLicense(String licenseName) {
         this.license = licensesByName.get(licenseName);
+        prefs.edit().putString(Prefs.DEFAULT_LICENSE, license).commit();
     }
 
     Observable<Contribution> buildContributions(List<String> categoryStringList) {

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -16,13 +16,6 @@
     <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreferenceCategory
         android:title="@string/preference_category_general">
 
-        <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleListPreference
-            android:key="defaultLicense"
-            android:title="@string/preference_license"
-            android:entries="@array/pref_defaultLicense_entries"
-            android:entryValues="@array/pref_defaultLicense_values"
-            android:defaultValue="@string/license_pref_cc_by_sa_4_0" />
-
         <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleSwitchPreference
             android:key="useExternalStorage"
             android:title="@string/use_external_storage"


### PR DESCRIPTION
**Fixes #2170  Remove license setting, and just use last selected license?**

**What changes did you make and why?**
Removed Default License settings and used last selected license as default license. DEFAULT_LICENSE is now updated whenever user selects a license during upload.

Tested on Motorola Moto G5 plus with API level 24.