### PR TITLE
Bring back the label for multiple upload intent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,7 +55,7 @@
                 <data android:mimeType="image/*" />
                 <data android:mimeType="audio/ogg" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter android:label="@string/intent_share_upload_label">
                 <action android:name="android.intent.action.SEND_MULTIPLE" />
 
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
**Description (required)**
Fixes #2229

In the upload revamp, commit f607c1c1 (Multiple uploads with over haul (#1968), 19 Nov 2018),
kept back the label for the single upload intent but removed the label for the multiple upload
intent.

Correct it and bring back the label for the multiple upload intent thus giving a more useful
label for the intent, again.

**Tests performed (required)**
Not tested but shouldn't have any issues as this was based on my previous commit 783b6955aba93c8a75eb4feed7a06c5998410a4f (which was in PR #1680).

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
