### PR TITLE
Fix #2231: Recent searches list updation issues while exploring

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -121,11 +121,11 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
                                 searchImageFragment.updateImageList(query.toString());
                                 searchCategoryFragment.updateCategoryList(query.toString());
                             }else {
+                                //Open RecentSearchesFragment
+                                recentSearchesFragment.updateRecentSearches();
                                 viewPager.setVisibility(View.GONE);
                                 tabLayout.setVisibility(View.GONE);
                                 searchHistoryContainer.setVisibility(View.VISIBLE);
-                                recentSearchesFragment.updateRecentSearches();
-                                // open search history fragment
                             }
                         }
                 );

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -125,6 +125,7 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
                                 recentSearchesFragment.updateRecentSearches();
                                 viewPager.setVisibility(View.GONE);
                                 tabLayout.setVisibility(View.GONE);
+                                setSearchHistoryFragment();
                                 searchHistoryContainer.setVisibility(View.VISIBLE);
                             }
                         }

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -135,6 +135,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .doOnSubscribe(disposable -> saveQuery(query))
                 .subscribe(this::handleSuccess, this::handleError);
     }
 
@@ -181,10 +182,6 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
             progressBar.setVisibility(View.GONE);
             categoriesAdapter.addAll(mediaList);
             categoriesAdapter.notifyDataSetChanged();
-
-            // check if user is waiting for 5 seconds if yes then save search query to history.
-            Handler handler = new Handler();
-            handler.postDelayed(() -> saveQuery(query), 5000);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
@@ -141,6 +141,7 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .doOnSubscribe(disposable -> saveQuery(query))
                 .subscribe(this::handleSuccess, this::handleError);
     }
 
@@ -192,10 +193,6 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
             imagesAdapter.addAll(mediaList);
             imagesAdapter.notifyDataSetChanged();
             ((SearchActivity)getContext()).viewPagerNotifyDataSetChanged();
-
-            // check if user is waiting for 5 seconds if yes then save search query to history.
-            Handler handler = new Handler();
-            handler.postDelayed(() -> saveQuery(query), 5000);
         }
     }
 


### PR DESCRIPTION
**Description (required)**

Fixes #2231 

Now, the list of recent searches will update before the RecentSearchesFragment is shown.

**Tests performed (required)**

Tested betaDebug on API 25.

**GIF showing the change:**

![ezgif com-video-to-gif 37](https://user-images.githubusercontent.com/35566748/52168978-39fc8800-2757-11e9-8e2d-20443af2d0dd.gif)