### PR TITLE
Rephrase misleading statement shown when skipping login

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -261,7 +261,7 @@
   <string name="skip_login">Skip</string>
   <string name="navigation_item_login">Log in</string>
   <string name="skip_login_title">Do you really want to skip login?</string>
-  <string name="skip_login_message">You will not be able to upload pictures.</string>
+  <string name="skip_login_message">You would have to login in future to upload picutres.</string>
   <string name="login_alert_message">Please log in to use this feature</string>
   <string name="copy_wikicode">Copy the wikitext to the clipboard</string>
   <string name="wikicode_copied">The wikitext was copied to the clipboard</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -261,7 +261,7 @@
   <string name="skip_login">Skip</string>
   <string name="navigation_item_login">Log in</string>
   <string name="skip_login_title">Do you really want to skip login?</string>
-  <string name="skip_login_message">You would have to login in future to upload picutres.</string>
+  <string name="skip_login_message">You would have to log in to upload pictures in the future.</string>
   <string name="login_alert_message">Please log in to use this feature</string>
   <string name="copy_wikicode">Copy the wikitext to the clipboard</string>
   <string name="wikicode_copied">The wikitext was copied to the clipboard</string>


### PR DESCRIPTION
**Description (required)**

Fixes #2248.

The previous statement was misleading as it could also
mean that the user could never upload pictures if he
skips login. This not the case because after skipping
the login he could login again if he wants to upload
pictures.

Clarify it by using a statement which states that he
would have to login in future in case he wants to
upload pictures.


**Tests performed (required)**
Haven't tested this as this is just a change in the string being shown.
