### PR TITLE
Fix #2214: Use Utils.isDarkTheme consistently through app

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsActivity.java
@@ -1,7 +1,6 @@
 package fr.free.nrw.commons.settings;
 
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.support.v7.app.AppCompatDelegate;
 import android.view.MenuItem;
 
@@ -21,13 +20,6 @@ public class SettingsActivity extends NavigationBaseActivity {
      */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        // Check prefs on every activity starts
-        if (PreferenceManager.getDefaultSharedPreferences(this).getBoolean("theme",false)) {
-            setTheme(R.style.DarkAppTheme);
-        } else {
-            setTheme(R.style.LightAppTheme);
-        }
-
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_settings);
 

--- a/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
@@ -1,37 +1,28 @@
 package fr.free.nrw.commons.theme;
 
-import android.content.Intent;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.di.CommonsDaggerAppCompatActivity;
 
 public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
-    protected boolean currentTheme;
+    protected boolean wasPreviouslyDarkTheme;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        boolean currentThemeIsDark = PreferenceManager.getDefaultSharedPreferences(this).getBoolean("theme", false);
-        if (currentThemeIsDark){
-            currentTheme = true;
-            setTheme(R.style.DarkAppTheme);
-        } else {
-            currentTheme = false;
-            setTheme(R.style.LightAppTheme); // default
-        }
+        wasPreviouslyDarkTheme = Utils.isDarkTheme(this);
+        setTheme(wasPreviouslyDarkTheme ? R.style.DarkAppTheme : R.style.LightAppTheme);
         super.onCreate(savedInstanceState);
     }
 
     @Override
     protected void onResume() {
         // Restart activity if theme is changed
-        boolean newTheme = PreferenceManager.getDefaultSharedPreferences(this).getBoolean("theme", false);
-        if (currentTheme != newTheme) { //is activity theme changed
-            Intent intent = getIntent();
-            finish();
-            startActivity(intent);
+        if (wasPreviouslyDarkTheme != Utils.isDarkTheme(this)) {
+            recreate();
         }
+
         super.onResume();
     }
 }


### PR DESCRIPTION
**Description (required)**

Fixes #2214 Inconsistent usage of Utils.isDarkTheme

**Tests performed (required)**

Tested `2.9.0-debug-fix-2214~03c36bb11` on `Galaxy Nexus (emulator)` with API level `28`.