### PR TITLE
Use viewholder for populating contributions list

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionViewHolder.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionViewHolder.java
@@ -1,35 +1,96 @@
 package fr.free.nrw.commons.contributions;
 
+import android.content.Context;
 import android.view.View;
-import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
 import fr.free.nrw.commons.MediaWikiImageView;
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.ViewHolder;
+import fr.free.nrw.commons.contributions.model.DisplayableContribution;
 
-class ContributionViewHolder {
-    final MediaWikiImageView imageView;
-    final TextView titleView;
-    final TextView stateView;
-    final TextView seqNumView;
-    final ProgressBar progressView;
-    final ImageButton retryButton;
-    final ImageButton cancelButton;
-    final LinearLayout failedImageOptions;
-    int position;
+class ContributionViewHolder implements ViewHolder<DisplayableContribution> {
+    @BindView(R.id.contributionImage) MediaWikiImageView imageView;
+    @BindView(R.id.contributionTitle) TextView titleView;
+    @BindView(R.id.contributionState) TextView stateView;
+    @BindView(R.id.contributionSequenceNumber) TextView seqNumView;
+    @BindView(R.id.contributionProgress) ProgressBar progressView;
+    @BindView(R.id.failed_image_options) LinearLayout failedImageOptions;
+
+    private DisplayableContribution contribution;
 
     ContributionViewHolder(View parent) {
-        imageView = parent.findViewById(R.id.contributionImage);
-        titleView = parent.findViewById(R.id.contributionTitle);
-        stateView = parent.findViewById(R.id.contributionState);
-        seqNumView = parent.findViewById(R.id.contributionSequenceNumber);
-        progressView = parent.findViewById(R.id.contributionProgress);
-        retryButton = parent.findViewById(R.id.retryButton);
-        cancelButton = parent.findViewById(R.id.cancelButton);
-        failedImageOptions=parent.findViewById(R.id.failed_image_options);
-        position = 0;
+        ButterKnife.bind(this, parent);
+    }
+
+    @Override
+    public void bindModel(Context context, DisplayableContribution contribution) {
+        this.contribution = contribution;
+        imageView.setMedia(contribution);
+        titleView.setText(contribution.getDisplayTitle());
+
+        seqNumView.setText(String.valueOf(contribution.getPosition() + 1));
+        seqNumView.setVisibility(View.VISIBLE);
+
+        switch (contribution.getState()) {
+            case Contribution.STATE_COMPLETED:
+                stateView.setVisibility(View.GONE);
+                progressView.setVisibility(View.GONE);
+                failedImageOptions.setVisibility(View.GONE);
+                stateView.setText("");
+                break;
+            case Contribution.STATE_QUEUED:
+                stateView.setVisibility(View.VISIBLE);
+                progressView.setVisibility(View.GONE);
+                stateView.setText(R.string.contribution_state_queued);
+                failedImageOptions.setVisibility(View.GONE);
+                break;
+            case Contribution.STATE_IN_PROGRESS:
+                stateView.setVisibility(View.GONE);
+                progressView.setVisibility(View.VISIBLE);
+                failedImageOptions.setVisibility(View.GONE);
+                long total = contribution.getDataLength();
+                long transferred = contribution.getTransferred();
+                if (transferred == 0 || transferred >= total) {
+                    progressView.setIndeterminate(true);
+                } else {
+                    progressView.setProgress((int)(((double)transferred / (double)total) * 100));
+                }
+                break;
+            case Contribution.STATE_FAILED:
+                stateView.setVisibility(View.VISIBLE);
+                stateView.setText(R.string.contribution_state_failed);
+                progressView.setVisibility(View.GONE);
+                failedImageOptions.setVisibility(View.VISIBLE);
+                break;
+        }
+    }
+
+    /**
+     * Retry upload when it is failed
+     */
+    @OnClick(R.id.retryButton)
+    public void retryUpload() {
+        DisplayableContribution.ContributionActions actions = contribution.getContributionActions();
+        if (actions != null) {
+            actions.retryUpload();
+        }
+    }
+
+    /**
+     * Delete a failed upload attempt
+     */
+    @OnClick(R.id.cancelButton)
+    public void deleteUpload() {
+        DisplayableContribution.ContributionActions actions = contribution.getContributionActions();
+        if (actions != null) {
+            actions.deleteUpload();
+        }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -84,31 +84,25 @@ public class ContributionsFragment
                     ContributionsListFragment.SourceRefresher,
                     LocationUpdateListener,ICampaignsView
                     {
-    @Inject
-    @Named("default_preferences")
-    BasicKvStore defaultKvStore;
-    @Inject
-    ContributionDao contributionDao;
-    @Inject
-    MediaWikiApi mediaWikiApi;
-    @Inject
-    NotificationController notificationController;
-    @Inject
-    NearbyController nearbyController;
+    @Inject @Named("default_preferences") BasicKvStore defaultKvStore;
+    @Inject ContributionDao contributionDao;
+    @Inject MediaWikiApi mediaWikiApi;
+    @Inject NotificationController notificationController;
+    @Inject NearbyController nearbyController;
 
     private ArrayList<DataSetObserver> observersWaitingForLoad = new ArrayList<>();
-    private Cursor allContributions;
     private UploadService uploadService;
     private boolean isUploadServiceConnected;
     private CompositeDisposable compositeDisposable = new CompositeDisposable();
-    CountDownLatch waitForContributionsListFragment = new CountDownLatch(1);
 
     private ContributionsListFragment contributionsListFragment;
     private MediaDetailPagerFragment mediaDetailPagerFragment;
     public static final String CONTRIBUTION_LIST_FRAGMENT_TAG = "ContributionListFragmentTag";
     public static final String MEDIA_DETAIL_PAGER_FRAGMENT_TAG = "MediaDetailFragmentTag";
 
-    public NearbyNotificationCardView nearbyNotificationCardView;
+    @BindView(R.id.card_view_nearby) public NearbyNotificationCardView nearbyNotificationCardView;
+    @BindView(R.id.campaigns_view) CampaignView campaignView;
+
     private Disposable placesDisposable;
     private LatLng curLatLng;
 
@@ -120,10 +114,7 @@ public class ContributionsFragment
     private CheckBox checkBox;
     private CampaignsPresenter presenter;
 
-
-    @BindView(R.id.campaigns_view) CampaignView campaignView;
-
-                        /**
+    /**
      * Since we will need to use parent activity on onAuthCookieAcquired, we have to wait
      * fragment to be attached. Latch will be responsible for this sync.
      */
@@ -159,7 +150,6 @@ public class ContributionsFragment
         presenter = new CampaignsPresenter();
         presenter.onAttachView(this);
         campaignView.setVisibility(View.GONE);
-        nearbyNotificationCardView = view.findViewById(R.id.card_view_nearby);
         checkBoxView = View.inflate(getActivity(), R.layout.nearby_permission_dialog, null);
         checkBox = (CheckBox) checkBoxView.findViewById(R.id.never_ask_again);
         checkBox.setOnCheckedChangeListener((buttonView, isChecked) -> {
@@ -359,7 +349,6 @@ public class ContributionsFragment
         if (getActivity() != null) { // If fragment is attached to parent activity
             getActivity().bindService(uploadServiceIntent, uploadServiceConnection, Context.BIND_AUTO_CREATE);
             isUploadServiceConnected = true;
-            allContributions = contributionDao.loadAllContributions();
             getActivity().getSupportLoaderManager().initLoader(0, null, ContributionsFragment.this);
         }
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListAdapter.java
@@ -2,13 +2,14 @@ package fr.free.nrw.commons.contributions;
 
 import android.content.Context;
 import android.database.Cursor;
+import android.support.annotation.Nullable;
 import android.support.v4.widget.CursorAdapter;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.contributions.model.DisplayableContribution;
 import fr.free.nrw.commons.upload.UploadService;
 import fr.free.nrw.commons.utils.NetworkUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
@@ -21,12 +22,15 @@ class ContributionsListAdapter extends CursorAdapter {
     private final ContributionDao contributionDao;
     private UploadService uploadService;
 
-    public ContributionsListAdapter(Context context, Cursor c, int flags, ContributionDao contributionDao) {
+    public ContributionsListAdapter(Context context,
+                                    Cursor c,
+                                    int flags,
+                                    ContributionDao contributionDao) {
         super(context, c, flags);
         this.contributionDao = contributionDao;
     }
 
-    public void setUploadService( UploadService uploadService) {
+    public void setUploadService(UploadService uploadService) {
         this.uploadService = uploadService;
     }
 
@@ -43,76 +47,34 @@ class ContributionsListAdapter extends CursorAdapter {
         final ContributionViewHolder views = (ContributionViewHolder)view.getTag();
         final Contribution contribution = contributionDao.fromCursor(cursor);
 
-        views.imageView.setMedia(contribution);
-        views.titleView.setText(contribution.getDisplayTitle());
-
-        views.seqNumView.setText(String.valueOf(cursor.getPosition() + 1));
-        views.seqNumView.setVisibility(View.VISIBLE);
-        views.position = cursor.getPosition();
-
-
-        switch (contribution.getState()) {
-            case Contribution.STATE_COMPLETED:
-                views.stateView.setVisibility(View.GONE);
-                views.progressView.setVisibility(View.GONE);
-                views.failedImageOptions.setVisibility(View.GONE);
-                views.stateView.setText("");
-                break;
-            case Contribution.STATE_QUEUED:
-                views.stateView.setVisibility(View.VISIBLE);
-                views.progressView.setVisibility(View.GONE);
-                views.stateView.setText(R.string.contribution_state_queued);
-                views.failedImageOptions.setVisibility(View.GONE);
-                break;
-            case Contribution.STATE_IN_PROGRESS:
-                views.stateView.setVisibility(View.GONE);
-                views.progressView.setVisibility(View.VISIBLE);
-                views.failedImageOptions.setVisibility(View.GONE);
-                long total = contribution.getDataLength();
-                long transferred = contribution.getTransferred();
-                if (transferred == 0 || transferred >= total) {
-                    views.progressView.setIndeterminate(true);
-                } else {
-                    views.progressView.setProgress((int)(((double)transferred / (double)total) * 100));
-                }
-                break;
-            case Contribution.STATE_FAILED:
-                views.stateView.setVisibility(View.VISIBLE);
-                views.stateView.setText(R.string.contribution_state_failed);
-                views.progressView.setVisibility(View.GONE);
-                views.failedImageOptions.setVisibility(View.VISIBLE);
-
-                views.retryButton.setOnClickListener(new View.OnClickListener() {
+        DisplayableContribution displayableContribution = new DisplayableContribution(contribution,
+                cursor.getPosition(),
+                new DisplayableContribution.ContributionActions() {
                     @Override
-                    public void onClick(View view) {
-                        retryUpload(cursor);
+                    public void retryUpload() {
+                        ContributionsListAdapter.this.retryUpload(contribution);
+                    }
+
+                    @Override
+                    public void deleteUpload() {
+                        ContributionsListAdapter.this.deleteUpload(contribution);
                     }
                 });
-
-                views.cancelButton.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View view) {
-                        deleteUpload(cursor);
-                    }
-                });
-
-
-                break;
-        }
+        views.bindModel(context, displayableContribution);
     }
 
     /**
      * Retry upload when it is failed
-     * @param cursor cursor will be retried
+     * @param contribution contribution to be retried
      */
-    public void retryUpload(Cursor cursor) {
+    private void retryUpload(Contribution contribution) {
         if (NetworkUtils.isInternetConnectionEstablished(mContext)) {
-            Contribution c = contributionDao.fromCursor(cursor);
-            if (c.getState() == STATE_FAILED) {
-                uploadService.queue(UploadService.ACTION_UPLOAD_FILE, c);
-                Timber.d("Restarting for %s", c.toString());
+            if (contribution.getState() == STATE_FAILED
+                    && uploadService!= null) {
+                uploadService.queue(UploadService.ACTION_UPLOAD_FILE, contribution);
+                Timber.d("Restarting for %s", contribution.toString());
             } else {
-                Timber.d("Skipping re-upload for non-failed %s", c.toString());
+                Timber.d("Skipping re-upload for non-failed %s", contribution.toString());
             }
         } else {
             ViewUtil.showLongToast(mContext,R.string.this_function_needs_network_connection);
@@ -122,16 +84,15 @@ class ContributionsListAdapter extends CursorAdapter {
 
     /**
      * Delete a failed upload attempt
-     * @param cursor cursor which will be deleted
+     * @param contribution contribution to be deleted
      */
-    public void deleteUpload(Cursor cursor) {
+    private void deleteUpload(Contribution contribution) {
         if (NetworkUtils.isInternetConnectionEstablished(mContext)) {
-            Contribution c = contributionDao.fromCursor(cursor);
-            if (c.getState() == STATE_FAILED) {
-                Timber.d("Deleting failed contrib %s", c.toString());
-                contributionDao.delete(c);
+            if (contribution.getState() == STATE_FAILED) {
+                Timber.d("Deleting failed contrib %s", contribution.toString());
+                contributionDao.delete(contribution);
             } else {
-                Timber.d("Skipping deletion for non-failed contrib %s", c.toString());
+                Timber.d("Skipping deletion for non-failed contrib %s", contribution.toString());
             }
         } else {
             ViewUtil.showLongToast(mContext,R.string.this_function_needs_network_connection);

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListAdapter.java
@@ -2,7 +2,6 @@ package fr.free.nrw.commons.contributions;
 
 import android.content.Context;
 import android.database.Cursor;
-import android.support.annotation.Nullable;
 import android.support.v4.widget.CursorAdapter;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -21,12 +20,14 @@ class ContributionsListAdapter extends CursorAdapter {
 
     private final ContributionDao contributionDao;
     private UploadService uploadService;
+    private Context context;
 
     public ContributionsListAdapter(Context context,
                                     Cursor c,
                                     int flags,
                                     ContributionDao contributionDao) {
         super(context, c, flags);
+        this.context = context;
         this.contributionDao = contributionDao;
     }
 
@@ -68,7 +69,7 @@ class ContributionsListAdapter extends CursorAdapter {
      * @param contribution contribution to be retried
      */
     private void retryUpload(Contribution contribution) {
-        if (NetworkUtils.isInternetConnectionEstablished(mContext)) {
+        if (NetworkUtils.isInternetConnectionEstablished(context)) {
             if (contribution.getState() == STATE_FAILED
                     && uploadService!= null) {
                 uploadService.queue(UploadService.ACTION_UPLOAD_FILE, contribution);
@@ -77,7 +78,7 @@ class ContributionsListAdapter extends CursorAdapter {
                 Timber.d("Skipping re-upload for non-failed %s", contribution.toString());
             }
         } else {
-            ViewUtil.showLongToast(mContext,R.string.this_function_needs_network_connection);
+            ViewUtil.showLongToast(context, R.string.this_function_needs_network_connection);
         }
 
     }
@@ -87,7 +88,7 @@ class ContributionsListAdapter extends CursorAdapter {
      * @param contribution contribution to be deleted
      */
     private void deleteUpload(Contribution contribution) {
-        if (NetworkUtils.isInternetConnectionEstablished(mContext)) {
+        if (NetworkUtils.isInternetConnectionEstablished(context)) {
             if (contribution.getState() == STATE_FAILED) {
                 Timber.d("Deleting failed contrib %s", contribution.toString());
                 contributionDao.delete(contribution);
@@ -95,7 +96,7 @@ class ContributionsListAdapter extends CursorAdapter {
                 Timber.d("Skipping deletion for non-failed contrib %s", contribution.toString());
             }
         } else {
-            ViewUtil.showLongToast(mContext,R.string.this_function_needs_network_connection);
+            ViewUtil.showLongToast(context, R.string.this_function_needs_network_connection);
         }
 
     }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.contributions;
 
-import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -16,6 +15,11 @@ import android.widget.ListAdapter;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import com.esafirm.imagepicker.features.ImagePicker;
+import com.esafirm.imagepicker.model.Image;
+
+import java.util.List;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -26,6 +30,8 @@ import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.kvstore.BasicKvStore;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.utils.ConfigUtils;
+import fr.free.nrw.commons.utils.ImageUtils;
+import fr.free.nrw.commons.utils.IntentUtils;
 
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
@@ -122,11 +128,16 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
     }
 
     @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-        ContributionsFragment parentFragment = (ContributionsFragment)getParentFragment();
-        parentFragment.waitForContributionsListFragment.countDown();
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (IntentUtils.shouldContributionsListHandle(requestCode, resultCode, data)) {
+            List<Image> images = ImagePicker.getImages(data);
+            Intent shareIntent = controller.handleImagesPicked(ImageUtils.getUriListFromImages(images), requestCode);
+            startActivity(shareIntent);
+        } else {
+            super.onActivityResult(requestCode, resultCode, data);
+        }
     }
+
 
     /**
      * Responsible to set progress bar invisible and visible

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.contributions;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.design.widget.FloatingActionButton;
@@ -15,11 +14,6 @@ import android.widget.ListAdapter;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import com.esafirm.imagepicker.features.ImagePicker;
-import com.esafirm.imagepicker.model.Image;
-
-import java.util.List;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -30,8 +24,6 @@ import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.kvstore.BasicKvStore;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.utils.ConfigUtils;
-import fr.free.nrw.commons.utils.ImageUtils;
-import fr.free.nrw.commons.utils.IntentUtils;
 
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
@@ -126,18 +118,6 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
             this.isFabOpen=!isFabOpen;
         }
     }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (IntentUtils.shouldContributionsListHandle(requestCode, resultCode, data)) {
-            List<Image> images = ImagePicker.getImages(data);
-            Intent shareIntent = controller.handleImagesPicked(ImageUtils.getUriListFromImages(images), requestCode);
-            startActivity(shareIntent);
-        } else {
-            super.onActivityResult(requestCode, resultCode, data);
-        }
-    }
-
 
     /**
      * Responsible to set progress bar invisible and visible

--- a/app/src/main/java/fr/free/nrw/commons/contributions/model/DisplayableContribution.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/model/DisplayableContribution.java
@@ -1,0 +1,58 @@
+package fr.free.nrw.commons.contributions.model;
+
+import fr.free.nrw.commons.contributions.Contribution;
+
+public class DisplayableContribution extends Contribution {
+    private int position;
+    private ContributionActions contributionActions;
+
+    public DisplayableContribution(Contribution contribution,
+                                   int position) {
+        super(contribution.getContentUri(),
+                contribution.getFilename(),
+                contribution.getLocalUri(),
+                contribution.getImageUrl(),
+                contribution.getDateCreated(),
+                contribution.getState(),
+                contribution.getDataLength(),
+                contribution.getDateUploaded(),
+                contribution.getTransferred(),
+                contribution.getSource(),
+                contribution.getDescription(),
+                contribution.getCreator(),
+                contribution.getMultiple(),
+                contribution.getWidth(),
+                contribution.getHeight(),
+                contribution.getLicense());
+        this.position = position;
+    }
+
+    public DisplayableContribution(Contribution contribution,
+                                   int position,
+                                   ContributionActions contributionActions) {
+        this(contribution, position);
+        this.contributionActions = contributionActions;
+    }
+
+    public void setContributionActions(ContributionActions contributionActions) {
+        this.contributionActions = contributionActions;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+
+    public ContributionActions getContributionActions() {
+        return contributionActions;
+    }
+
+    public interface ContributionActions {
+        void retryUpload();
+
+        void deleteUpload();
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/contributions/model/DisplayableContribution.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/model/DisplayableContribution.java
@@ -6,8 +6,8 @@ public class DisplayableContribution extends Contribution {
     private int position;
     private ContributionActions contributionActions;
 
-    public DisplayableContribution(Contribution contribution,
-                                   int position) {
+    private DisplayableContribution(Contribution contribution,
+                                    int position) {
         super(contribution.getContentUri(),
                 contribution.getFilename(),
                 contribution.getLocalUri(),
@@ -31,10 +31,6 @@ public class DisplayableContribution extends Contribution {
                                    int position,
                                    ContributionActions contributionActions) {
         this(contribution, position);
-        this.contributionActions = contributionActions;
-    }
-
-    public void setContributionActions(ContributionActions contributionActions) {
         this.contributionActions = contributionActions;
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/widget/ViewHolder.java
+++ b/app/src/main/java/fr/free/nrw/commons/widget/ViewHolder.java
@@ -1,0 +1,7 @@
+package fr.free.nrw.commons.widget;
+
+import android.content.Context;
+
+public interface ViewHolder<T> {
+    void bindModel(Context context, T model);
+}


### PR DESCRIPTION
**Description (required)**

@sp2710's PR should prevent the app from crashing but there are numerous places where the `contribution`/`activity`/`view` could be null. 

Have tried to address it by making the following changes: 
- start using butterknife for binding views
- implement an interface in the `ContributionListAdapter` to fire click listeners
- moved the logic of binding the view to `ContributionViewHolder`
- before retry and delete, am not fetching the contribution from the DB. As the adapter would always have the latest contributions items, there's no need to fetch again from the DB. 

 