### PR TITLE
Use central auth token only for cross wiki calls

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -230,7 +230,6 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
     @Override
     public String getEditToken() throws IOException {
         String editToken = api.action("query")
-                .param("centralauthtoken", getCentralAuthToken())
                 .param("meta", "tokens")
                 .post()
                 .getString("/api/query/tokens/@csrftoken");
@@ -288,7 +287,6 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
         return api.action("edit")
                 .param("title", filename)
                 .param("token", getEditToken())
-                .param("centralauthtoken", getCentralAuthToken())
                 .param("text", processedPageContent)
                 .param("summary", summary)
                 .post()
@@ -302,7 +300,6 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
         return api.action("edit")
                 .param("title", filename)
                 .param("token", getEditToken())
-                .param("centralauthtoken", getCentralAuthToken())
                 .param("appendtext", processedPageContent)
                 .param("summary", summary)
                 .post()
@@ -315,7 +312,6 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
         return api.action("edit")
                 .param("title", filename)
                 .param("token", getEditToken())
-                .param("centralauthtoken", getCentralAuthToken())
                 .param("prependtext", processedPageContent)
                 .param("summary", summary)
                 .post()
@@ -895,7 +891,7 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
                                    Uri contentProviderUri,
                                    final ProgressListener progressListener) throws IOException {
 
-        CustomApiResult result = api.upload(filename, file, dataLength, pageContents, editSummary, getCentralAuthToken(), getEditToken(), progressListener::onProgress);
+        CustomApiResult result = api.upload(filename, file, dataLength, pageContents, editSummary, getEditToken(), progressListener::onProgress);
 
         Timber.d("Result: %s", result.toString());
 

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/CustomMwApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/CustomMwApi.java
@@ -131,20 +131,19 @@ public class CustomMwApi {
         }
     }
 
-    public CustomApiResult upload(String filename, InputStream file, long length, String text, String comment, String centralAuthToken, String token) throws IOException {
-        return this.upload(filename, file, length, text, comment,centralAuthToken, token, null);
+    public CustomApiResult upload(String filename, InputStream file, long length, String text, String comment, String token) throws IOException {
+        return this.upload(filename, file, length, text, comment, token, null);
     }
 
-    public CustomApiResult upload(String filename, InputStream file, String text, String comment, String centralAuthToken, String token) throws IOException {
-        return this.upload(filename, file, -1, text, comment,centralAuthToken, token, null);
+    public CustomApiResult upload(String filename, InputStream file, String text, String comment, String token) throws IOException {
+        return this.upload(filename, file, -1, text, comment, token, null);
     }
 
-    public CustomApiResult upload(String filename, InputStream file, long length, String text, String comment, String centralAuthToken, String token, ProgressListener uploadProgressListener) throws IOException {
+    public CustomApiResult upload(String filename, InputStream file, long length, String text, String comment, String token, ProgressListener uploadProgressListener) throws IOException {
         Timber.d("Initiating upload for file %s", filename);
         Http.HttpRequestBuilder builder = Http.multipart(apiURL)
                 .data("action", "upload")
                 .data("token", token)
-                .data("centralauthtoken", centralAuthToken)
                 .data("text", text)
                 .data("ignorewarnings", "1")
                 .data("comment", comment)

--- a/app/src/test/kotlin/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApiTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApiTest.kt
@@ -186,22 +186,13 @@ class ApacheHttpClientMediaWikiApiTest {
 
     @Test
     fun editToken() {
-        server.enqueue(MockResponse().setBody("<?xml version=\"1.0\"?><api><centralauthtoken centralauthtoken=\"abc\" /></api>"))
         server.enqueue(MockResponse().setBody("<?xml version=\"1.0\"?><api><query><tokens csrftoken=\"baz\" /></query></api>"))
 
         val result = testObject.editToken
 
-        assertBasicRequestParameters(server, "GET").let { centralAuthTokenRequest ->
-            parseQueryParams(centralAuthTokenRequest).let { params ->
-                assertEquals("xml", params["format"])
-                assertEquals("centralauthtoken", params["action"])
-            }
-        }
-
         assertBasicRequestParameters(server, "POST").let { editTokenRequest ->
             parseBody(editTokenRequest.body.readUtf8()).let { body ->
                 assertEquals("query", body["action"])
-                assertEquals("abc", body["centralauthtoken"])
                 assertEquals("tokens", body["meta"])
             }
         }


### PR DESCRIPTION
**Description (required)**

Fixes #2013 

What changes did you make and why?

This would remove the dependency on `centralAuthToken` and should reduce the possibility of failure. 

**Tests performed (required)**

Uploaded an image without using `centralAuthToken`