### PR TITLE
Use channel ID while showing failed upload notification

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -319,7 +319,7 @@ public class UploadService extends HandlerService<Contribution> {
     @SuppressLint("StringFormatInvalid")
     @SuppressWarnings("deprecation")
     private void showFailedNotification(Contribution contribution) {
-        Notification failureNotification = new NotificationCompat.Builder(this).setAutoCancel(true)
+        Notification failureNotification = new NotificationCompat.Builder(this, CommonsApplication.NOTIFICATION_CHANNEL_ID_ALL).setAutoCancel(true)
                 .setSmallIcon(R.drawable.ic_launcher)
                 .setAutoCancel(true)
                 .setContentIntent(PendingIntent.getActivity(this, 0, new Intent(this, MainActivity.class), 0))


### PR DESCRIPTION
**Description (required)**

Fixes #2321 

What changes did you make and why?

Started using `channelID` for failed notifications. 