### PR TITLE
Changed from harcoded text to string resource. Fix  #2331

### DIFF
--- a/app/src/main/res/layout/custom_nearby_tab_layout.xml
+++ b/app/src/main/res/layout/custom_nearby_tab_layout.xml
@@ -11,7 +11,8 @@
         android:layout_height="wrap_content"
         android:textAlignment="center"
         android:textColor="@android:color/white"
-        android:text="NEARBY"
+        android:text="@string/nearby_fragment"
+        android:textAllCaps="true"
         android:gravity="center"/>
     <ImageView
         android:layout_width="18dp"


### PR DESCRIPTION
**Description (required)** 
Changed from harcoded text to string resource.

Fixes #2331 "Nearby" tab name not localised

What changes did you make and why?
I changed hardcoded "NEARBY" to string resource and added attribute to make it capital.

**Tests performed (required)**
Tested  on Motorola Moto G4 with API level 27.


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
