### PR TITLE
Feat: Align 'Achievements' image to the right of drawer

### DIFF
--- a/app/src/main/res/layout/drawer_header.xml
+++ b/app/src/main/res/layout/drawer_header.xml
@@ -36,7 +36,7 @@
         android:textColor="@color/item_white_background"
         android:textSize="@dimen/subheading_text_size"
         android:layout_below="@+id/pictureOfTheDay"
-        android:layout_marginLeft="8dp"
-        android:layout_toRightOf="@+id/username" />
+        android:layout_marginRight="8dp"
+        android:layout_alignParentRight="true" />
 
 </RelativeLayout>


### PR DESCRIPTION
**Description** : Align achievement icon to the right for clear visibility and enhancement. 

**Changes:**
           -> align icon to the right of drawer for clarity and provide more space for username. 

Tested on Xiaomi Redmi 4A with API level 25.

**Screenshots :**
![b](https://user-images.githubusercontent.com/33434495/51754243-d5e81d00-20e1-11e9-8971-3372fe8d34be.png)                         ![a_apps](https://user-images.githubusercontent.com/33434495/51754321-0039da80-20e2-11e9-89bb-6811cdc29f4d.png)

