### PR TITLE
made Version number selectable in About menu(#2342)

### DIFF
--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -55,7 +55,8 @@
                     <TextView
                         android:id="@+id/about_version"
                         android:layout_width="wrap_content"
-                        android:layout_height="wrap_content" />
+                        android:layout_height="wrap_content"
+                        android:textIsSelectable="true" />
 
                     <fr.free.nrw.commons.ui.widget.HtmlTextView
                         android:id="@+id/about_license"


### PR DESCRIPTION
Fixes #2342 Version number not selectable in About menu

What changes did you make and why?
Made the version no. selectable

Tested on motorola moto g5 plus with API level 24.