### PR TITLE
Fixed issue #1507

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFragment.java
@@ -10,6 +10,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.constraint.ConstraintLayout;
 import android.support.design.widget.BottomSheetBehavior;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.FragmentTransaction;
@@ -19,6 +20,7 @@ import android.view.LayoutInflater;
 
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 
@@ -65,6 +67,10 @@ public class NearbyFragment extends CommonsDaggerSupportFragment
     LinearLayout bottomSheetDetails;
     @BindView(R.id.transparentView)
     View transparentView;
+    @BindView(R.id.container_sheet)
+    FrameLayout frameLayout;
+    @BindView(R.id.loading_nearby_list)
+    ConstraintLayout loading_nearby_layout;
 
     @Inject
     LocationServiceManager locationManager;
@@ -529,6 +535,8 @@ public class NearbyFragment extends CommonsDaggerSupportFragment
      * Calls fragment for list view.
      */
     private void setListFragment() {
+        loading_nearby_layout.setVisibility(View.GONE);
+        frameLayout.setVisibility(View.VISIBLE);
         FragmentTransaction fragmentTransaction = getChildFragmentManager().beginTransaction();
         nearbyListFragment = new NearbyListFragment();
         nearbyListFragment.setArguments(bundle);

--- a/app/src/main/res/layout/bottom_sheet_nearby.xml
+++ b/app/src/main/res/layout/bottom_sheet_nearby.xml
@@ -10,6 +10,32 @@
     app:behavior_peekHeight="0dp"
     app:behavior_hideable="true"
     >
+    <android.support.constraint.ConstraintLayout
+        android:id="@+id/loading_nearby_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="visible">
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        />
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        android:layout_marginTop="10dp"
+        android:textSize="20sp"
+        app:layout_constraintTop_toBottomOf="@+id/progress_bar"
+        android:text="Loading..."
+        />
+    </android.support.constraint.ConstraintLayout>
 
     <FrameLayout
         android:id="@+id/container_sheet"
@@ -20,6 +46,7 @@
         android:layout_marginRight="16dp"
         android:layout_marginBottom="8dp"
         android:layout_marginTop="8dp"
+        android:visibility="gone"
         ></FrameLayout>
 
 </LinearLayout>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
**Added a progressbar and a textview to the nearbyListFragment till it fetches the nearby list **

Fixes #1507  Disable list option in Nearby until nearby places are loaded

What changes did you make and why?

- Added a Layout to bottom_sheet_nearby.xml for showing progressbar
- When the nearbyList is loaded set visibility of progressbar layout to gone and set the recycler view as visible

**Screenshots showing what changed (optional - for UI changes)**

Loading Screen:

![whatsapp image 2019-01-25 at 11 00 44 pm](https://user-images.githubusercontent.com/34261945/51763096-a3491f00-20f7-11e9-93eb-e35c420e2b73.jpeg)

NearbyList:

![whatsapp image 2019-01-25 at 11 06 04 pm](https://user-images.githubusercontent.com/34261945/51763103-a5ab7900-20f7-11e9-8c7b-c81c6d9f4dbe.jpeg)







