### PR TITLE
Nearby map not loading on changing orientation issue solved(#2368)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFragment.java
@@ -451,7 +451,7 @@ public class NearbyFragment extends CommonsDaggerSupportFragment
          */
         NearbyMapFragment nearbyMapFragment = getMapFragment();
 
-        if (nearbyMapFragment != null && !nearbyMapFragment.isCurrentLocationMarkerVisible()) {
+        if (nearbyMapFragment != null && !nearbyMapFragment.isCurrentLocationMarkerVisible() && !onOrientationChanged) {
             Timber.d("Do not update the map, user is not seeing current location marker" +
                     " means they are checking around and moving on map");
             return;


### PR DESCRIPTION
**Description (required)**

Fixes #2368 

**What changes did you make and why?**

Now After Orientation is changed nearby map is visible after some loading.

**Tests performed (required)**

Tested on Motorola Moto G5 plus with API level 24
