### PR TITLE
Toggle state of bottom card on click

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -519,6 +519,7 @@ public class UploadActivity extends AuthenticatedActivity implements UploadView,
 
     private void configureBottomCard() {
         bottomCardExpandButton.setOnClickListener(v -> presenter.toggleBottomCardState());
+        bottomCard.setOnClickListener(v -> presenter.toggleBottomCardState());
         bottomCardAddDescription.setOnClickListener(v -> addNewDescription());
     }
 


### PR DESCRIPTION
**Description (required)**

Fixes #2390 

What changes did you make and why?

Added same functionality as the arrow-shaped button to the Step 1 bottom card as a whole.

**Tests performed (required)**

Tested betaDebug on Android 7.1.2 (API 25)

**GIF showing what changed (optional - for UI changes)**

![ezgif com-video-to-gif 34](https://user-images.githubusercontent.com/35566748/52149200-0572c880-2692-11e9-86b8-f9e2a571acf4.gif)
