### PR TITLE
Fix #2394: Prevent app from closing while navigating between Explore and Achievements

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -344,8 +344,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
      */
     public static void startYourself(Context context) {
         Intent intent = new Intent(context, AchievementsActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         context.startActivity(intent);
     }
 


### PR DESCRIPTION
**Description (required)**

Fixes #2394 App closes unexpectedly while navigating between Explore and Achievements

**Tests performed (required)**

Tested prodDebug on Android 7.1.2 (API 25)

**GIF showing changes:**

![ezgif com-video-to-gif 36](https://user-images.githubusercontent.com/35566748/52164573-9b056b00-2719-11e9-824b-dff96d3b9da0.gif)