### PR TITLE
hide the notification card if there's no nearby location

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -628,9 +628,10 @@ public class ContributionsFragment
             String distance = formatDistanceBetween(curLatLng, closestNearbyPlace.location);
             closestNearbyPlace.setDistance(distance);
             nearbyNotificationCardView.updateContent (true, closestNearbyPlace);
+            nearbyNotificationCardView.setVisibility(View.VISIBLE);
         } else {
             // Means that no close nearby place is found
-            nearbyNotificationCardView.updateContent (false, null);
+            nearbyNotificationCardView.setVisibility(View.GONE);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -627,7 +627,7 @@ public class ContributionsFragment
             Place closestNearbyPlace = nearbyPlacesInfo.placeList.get(0);
             String distance = formatDistanceBetween(curLatLng, closestNearbyPlace.location);
             closestNearbyPlace.setDistance(distance);
-            nearbyNotificationCardView.updateContent (true, closestNearbyPlace);
+            nearbyNotificationCardView.updateContent(closestNearbyPlace);
             nearbyNotificationCardView.setVisibility(View.VISIBLE);
         } else {
             // Means that no close nearby place is found

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyNotificationCardView.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyNotificationCardView.java
@@ -116,10 +116,9 @@ public class NearbyNotificationCardView extends SwipableCardView {
 
     /**
      * Pass place information to views.
-     * @param isClosestNearbyPlaceFound false if there are no close place
      * @param place Closes place where we will get information from
      */
-    public void updateContent(boolean isClosestNearbyPlaceFound, Place place) {
+    public void updateContent(Place place) {
         Timber.d("Update nearby card notification content");
         this.setVisibility(VISIBLE);
         cardViewVisibilityState = CardViewVisibilityState.READY;
@@ -131,14 +130,9 @@ public class NearbyNotificationCardView extends SwipableCardView {
         notificationTitle.setVisibility(VISIBLE);
         notificationDistance.setVisibility(VISIBLE);
         notificationIcon.setVisibility(VISIBLE);
+        notificationTitle.setText(place.name);
+        notificationDistance.setText(place.distance);
 
-        if (isClosestNearbyPlaceFound) {
-            notificationTitle.setText(place.name);
-            notificationDistance.setText(place.distance);
-        } else {
-            notificationDistance.setText("");
-            notificationTitle.setText(R.string.no_close_nearby);
-        }
     }
 
     @Override


### PR DESCRIPTION
**Description (required)**

Fixes #2381 

**What changes did you make and why?**
made  notification card visibility gone if no nearby location is found

**Tests performed (required)**

Tested on Motorola Moto G5 plus with API level 24