### PR TITLE
Use get content intent instead of pick

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.java
@@ -368,7 +368,9 @@ public class FilePicker implements Constants {
     }
 
     private static Intent plainGalleryPickerIntent() {
-        return new Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+        intent.setType("image/*");
+        return intent;
     }
 
     public static boolean canDeviceHandleGallery(@NonNull Context context) {


### PR DESCRIPTION
**Description (required)**

Fixes #2406 

What changes did you make and why?

Till v2.8.5 the app used `ACTION_GET_CONTENT` intent for picking image. In the last PR ie #2375 I made some changes after which the app started using `ACTION_PICK` intent. 

According to this thread, `ACTION_GET_CONTENT` should be preferred. 

https://stackoverflow.com/questions/17765265/difference-between-intent-action-get-content-and-intent-action-pick

So am changing the back the intent to the one we originally used  ie `ACTION_GET_CONTENT`

**Tests performed (required)**

Tested by uploading an image using `betaDebug`. 

**Screenshots showing what changed (optional - for UI changes)**

The familiar screen will start showing again. No more gallery chooser dialogs. :)

![device-2019-02-04-105827](https://user-images.githubusercontent.com/3069373/52191655-d31cc300-286b-11e9-9c74-d83421176639.png)
