### PR TITLE
Make nearby query faster

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
@@ -151,13 +151,10 @@ public class BookmarkLocationsDao {
         builder.setWikidataLink(cursor.getString(cursor.getColumnIndex(Table.COLUMN_WIKIDATA_LINK)));
         builder.setCommonsLink(cursor.getString(cursor.getColumnIndex(Table.COLUMN_COMMONS_LINK)));
 
-        Uri uri = Uri.parse(cursor.getString(cursor.getColumnIndex(Table.COLUMN_IMAGE_URL)));
-
         return new Place(
                 cursor.getString(cursor.getColumnIndex(Table.COLUMN_NAME)),
                 Label.fromText((cursor.getString(cursor.getColumnIndex(Table.COLUMN_LABEL_TEXT)))),
                 cursor.getString(cursor.getColumnIndex(Table.COLUMN_DESCRIPTION)),
-                uri,
                 location,
                 cursor.getString(cursor.getColumnIndex(Table.COLUMN_CATEGORY)),
                 builder.build()
@@ -171,7 +168,6 @@ public class BookmarkLocationsDao {
         cv.put(BookmarkLocationsDao.Table.COLUMN_CATEGORY, bookmarkLocation.getCategory());
         cv.put(BookmarkLocationsDao.Table.COLUMN_LABEL_TEXT, bookmarkLocation.getLabel().getText());
         cv.put(BookmarkLocationsDao.Table.COLUMN_LABEL_ICON, bookmarkLocation.getLabel().getIcon());
-        cv.put(BookmarkLocationsDao.Table.COLUMN_IMAGE_URL, bookmarkLocation.getSecondaryImageUrl().toString());
         cv.put(BookmarkLocationsDao.Table.COLUMN_WIKIPEDIA_LINK, bookmarkLocation.siteLinks.getWikipediaLink().toString());
         cv.put(BookmarkLocationsDao.Table.COLUMN_WIKIDATA_LINK, bookmarkLocation.siteLinks.getWikidataLink().toString());
         cv.put(BookmarkLocationsDao.Table.COLUMN_COMMONS_LINK, bookmarkLocation.siteLinks.getCommonsLink().toString());

--- a/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.nearby;
 
-import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -20,22 +19,17 @@ public class Place implements Parcelable {
     public final String name;
     private final Label label;
     private final String longDescription;
-    private final Uri secondaryImageUrl;
     public final LatLng location;
     private final String category;
 
-    public Bitmap image;
-    private Bitmap secondaryImage;
     public String distance;
     public final Sitelinks siteLinks;
 
 
-    public Place(String name, Label label, String longDescription,
-                 Uri secondaryImageUrl, LatLng location, String category, Sitelinks siteLinks) {
+    public Place(String name, Label label, String longDescription, LatLng location, String category, Sitelinks siteLinks) {
         this.name = name;
         this.label = label;
         this.longDescription = longDescription;
-        this.secondaryImageUrl = secondaryImageUrl;
         this.location = location;
         this.category = category;
         this.siteLinks = siteLinks;
@@ -45,7 +39,6 @@ public class Place implements Parcelable {
         this.name = in.readString();
         this.label = (Label) in.readSerializable();
         this.longDescription = in.readString();
-        this.secondaryImageUrl = in.readParcelable(Uri.class.getClassLoader());
         this.location = in.readParcelable(LatLng.class.getClassLoader());
         this.category = in.readString();
         this.siteLinks = in.readParcelable(Sitelinks.class.getClassLoader());
@@ -61,7 +54,6 @@ public class Place implements Parcelable {
                 item.getLabel().getValue(),
                 Label.fromText(classEntityId), // list
                 item.getClassLabel().getValue(), // details
-                Uri.parse(item.getIcon().getValue()),
                 PlaceUtils.latLngFromPointString(item.getLocation().getValue()),
                 item.getCommonsCategory().getValue(),
                 new Sitelinks.Builder()
@@ -108,12 +100,6 @@ public class Place implements Parcelable {
     public void setDistance(String distance) {
         this.distance = distance;
     }
-
-    /**
-     * Gets the secondary image url for bookmarks
-     * @return secondary image url
-     */
-    public Uri getSecondaryImageUrl() { return this.secondaryImageUrl; }
 
     /**
      * Extracts the entity id from the wikidata link
@@ -181,11 +167,8 @@ public class Place implements Parcelable {
                 "name='" + name + '\'' +
                 ", label='" + label + '\'' +
                 ", longDescription='" + longDescription + '\'' +
-                ", secondaryImageUrl='" + secondaryImageUrl + '\'' +
                 ", location='" + location + '\'' +
                 ", category='" + category + '\'' +
-                ", image='" + image + '\'' +
-                ", secondaryImage=" + secondaryImage +
                 ", distance='" + distance + '\'' +
                 ", siteLinks='" + siteLinks.toString() + '\'' +
                 '}';
@@ -201,7 +184,6 @@ public class Place implements Parcelable {
         dest.writeString(name);
         dest.writeSerializable(label);
         dest.writeString(longDescription);
-        dest.writeParcelable(secondaryImageUrl, 0);
         dest.writeParcelable(location, 0);
         dest.writeString(category);
         dest.writeParcelable(siteLinks, 0);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceRenderer.java
@@ -218,7 +218,7 @@ public class PlaceRenderer extends Renderer<Place> {
         distance.setText(place.distance);
 
 
-        icon.setImageURI(place.getSecondaryImageUrl());
+        icon.setImageResource(place.getLabel().getIcon());
 
         directionsButton.setOnClickListener(view -> {
             //Open map app at given position

--- a/app/src/main/resources/queries/nearby_query.rq
+++ b/app/src/main/resources/queries/nearby_query.rq
@@ -32,10 +32,6 @@ SELECT
        OPTIONAL {?classId rdfs:label ?class_label_preferred_language. FILTER (lang(?class_label_preferred_language) = "${LANG}")}
        OPTIONAL {?classId rdfs:label ?class_label_any_language}
 
-       # Get icon
-       OPTIONAL { ?classId wdt:P2910 ?icon0. }
-       OPTIONAL { ?classId wdt:P279*/wdt:P2910 ?icon1. }
-
        OPTIONAL {
            ?wikipediaArticle   schema:about ?item ;
                                schema:isPartOf <https://${LANG}.wikipedia.org/> .

--- a/app/src/main/resources/queries/nearby_query.rq
+++ b/app/src/main/resources/queries/nearby_query.rq
@@ -5,7 +5,6 @@ SELECT
      (SAMPLE(?classId) as ?class)
      (SAMPLE(COALESCE(?class_label_preferred_language, ?class_label_any_language, "?")) as ?class_label)
      (SAMPLE(COALESCE(?icon0, ?icon1)) as ?icon)
-     (SAMPLE(COALESCE(?emoji0, ?emoji1)) as ?emoji)
      ?wikipediaArticle
      ?commonsArticle
      (SAMPLE(?Commons_category) as ?Commons_category)
@@ -36,9 +35,6 @@ SELECT
        # Get icon
        OPTIONAL { ?classId wdt:P2910 ?icon0. }
        OPTIONAL { ?classId wdt:P279*/wdt:P2910 ?icon1. }
-       # Get emoji
-       OPTIONAL { ?classId wdt:P487 ?emoji0. }
-       OPTIONAL { ?classId wdt:P279*/wdt:P487 ?emoji1. }
 
        OPTIONAL {
            ?wikipediaArticle   schema:about ?item ;

--- a/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/locations/BookMarkLocationDaoTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/locations/BookMarkLocationDaoTest.kt
@@ -60,8 +60,8 @@ class BookMarkLocationDaoTest {
         builder.setCommonsLink("commonsLink")
 
 
-        examplePlaceBookmark = Place("placeName", exampleLabel, "placeDescription",
-                exampleUri, exampleLocation, "placeCategory", builder.build())
+        examplePlaceBookmark = Place("placeName", exampleLabel, "placeDescription"
+                , exampleLocation, "placeCategory", builder.build())
         testObject = BookmarkLocationsDao { client }
     }
 
@@ -88,7 +88,6 @@ class BookMarkLocationDaoTest {
                 assertEquals("placeName", it.name)
                 assertEquals(Label.FOREST, it.label)
                 assertEquals("placeDescription", it.longDescription)
-                assertEquals(exampleUri, it.secondaryImageUrl)
                 assertEquals(40.0, it.location.latitude)
                 assertEquals(51.4, it.location.longitude)
                 assertEquals("placeCategory", it.category)
@@ -147,7 +146,7 @@ class BookMarkLocationDaoTest {
         assertTrue(testObject.updateBookmarkLocation(examplePlaceBookmark))
         verify(client).insert(eq(BASE_URI), captor.capture())
         captor.firstValue.let { cv ->
-            assertEquals(11, cv.size())
+            assertEquals(10, cv.size())
             assertEquals(examplePlaceBookmark.name, cv.getAsString(COLUMN_NAME))
             assertEquals(examplePlaceBookmark.longDescription, cv.getAsString(COLUMN_DESCRIPTION))
             assertEquals(examplePlaceBookmark.label.text, cv.getAsString(COLUMN_LABEL_TEXT))


### PR DESCRIPTION
**Description (required)**

Fixes part of #2358 

What changes did you make and why?

Removed, `icon` and and `emoji`

- The app wasn't using `icon` as the API returns `.svg` icons. We are instead using hardcoded image resources. We can reintroduce this later if needed. 
- `emoji` was not used anywhere. 