### PR TITLE
update Notification count after notification is marked as read

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -492,6 +492,12 @@ public class MainActivity extends AuthenticatedActivity implements FragmentManag
     }
 
     @Override
+    protected void onResume() {
+        super.onResume();
+        setNotificationCount();
+    }
+
+    @Override
     protected void onDestroy() {
         locationManager.unregisterLocationManager();
         // Remove ourself from hashmap to prevent memory leaks


### PR DESCRIPTION
**Description (required)**

Fixes #2420 

**What changes did you make and why?**
Updated notification count when main activity is resumed so that app kill is not required to update the count

**Tests performed (required)**

Tested on Motorola Moto G5 plus with API level 24.