### PR TITLE
Fixed Search activity launching twice if button pressed quickly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Wikimedia Commons for Android
 
+## v2.10.0
+- Added option to search for places that need pictures in any location
+- Added coordinate check for images submitted via Nearby
+- Added news about ongoing campaigns
+- Easy retry for failed uploads
+- Javadocs for Nearby package
+- Optimized Nearby query for faster loading
+- Allow users to dismiss notifications
+- Various bugfixes for Explore, Notifications and Nearby
+- Fixed uploads getting stuck in "receiving shared content" phase
+- Fixed empty notifications bell icon in main screen
+
 ## v2.9.0
 - New main screen UI with Nearby tab
 - New upload UI and flow

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,8 +96,8 @@ android {
 
     defaultConfig {
         applicationId 'fr.free.nrw.commons'
-        versionCode 94
-        versionName '2.9.0'
+        versionCode 212
+        versionName '2.10.0'
         setProperty("archivesBaseName", "app-commons-v$versionName-" + getBranchName())
 
         minSdkVersion 15

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,6 +108,7 @@
             android:label="@string/title_activity_search"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:parentActivityName=".contributions.MainActivity"
+            android:launchMode="singleTop"
             />
 
         <activity


### PR DESCRIPTION
fixed the search activity launching twice when icon pressed twice 

Fixes #2466 

changed SearchActivity's launch mode to "singleTop"
