### PR TITLE
issue(#2449) solved. Crashed when uploading an image to server which is in read-only mode

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/UploadResult.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/UploadResult.java
@@ -1,5 +1,7 @@
 package fr.free.nrw.commons.mwapi;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Date;
 
 public class UploadResult {
@@ -34,12 +36,13 @@ public class UploadResult {
         this.imageUrl = imageUrl;
     }
 
+    @NotNull
     @Override
     public String toString() {
         return "UploadResult{" +
                 "errorCode='" + errorCode + '\'' +
                 ", resultStatus='" + resultStatus + '\'' +
-                ", dateUploaded='" + dateUploaded.toString() + '\'' +
+                ", dateUploaded='" + (dateUploaded == null ? "" : dateUploaded.toString()) + '\'' +
                 ", imageUrl='" + imageUrl + '\'' +
                 ", canonicalFilename='" + canonicalFilename + '\'' +
                 '}';


### PR DESCRIPTION
Description :

Fixed #2449  Crashed when uploading an image to the server which is in read-only mode

What changes did you make and why?

The crash was getting due to null pointer exception on Date object at toString() method of UploadResult class. So, I have added checking for null at there.
