### PR TITLE
Fix achievements activity share option (#2416)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         android:largeHeap="true"
         android:hardwareAccelerated="false"
         android:supportsRtl="true" >
+
         <activity android:name="org.acra.CrashReportDialog"
             android:theme="@android:style/Theme.Dialog"
             android:launchMode="singleInstance"

--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -9,6 +9,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.v4.content.FileProvider;
 import android.support.v4.content.res.ResourcesCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
@@ -184,13 +185,15 @@ public class AchievementsActivity extends NavigationBaseActivity {
             fOut.flush();
             fOut.close();
             file.setReadable(true, false);
+            Uri fileUri = FileProvider.getUriForFile(getApplicationContext(), getPackageName()+".provider", file);
+            grantUriPermission(getPackageName(), fileUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
             final Intent intent = new Intent(android.content.Intent.ACTION_SEND);
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            intent.putExtra(Intent.EXTRA_STREAM, Uri.fromFile(file));
+            intent.putExtra(Intent.EXTRA_STREAM, fileUri);
             intent.setType("image/png");
             startActivity(Intent.createChooser(intent, "Share image via"));
         } catch (IOException e) {
-            //Do Nothing
+            e.printStackTrace();
         }
     }
 

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -3,4 +3,5 @@
     <cache-path name="images" path="images/" />
     <external-path name="Download" path="./"/>
     <root-path name="root" path="." />
+    <external-cache-path name="external_cache_path" path="."/>
 </paths>


### PR DESCRIPTION
Fixes #2416

What changes did you make and why?
- Use fileProvider instead of Uri.fromFile()
- As Uri.fromFile() will not work on Android 7.0+, with a targetSdkVersion of 24 or higher, throws FileUriExposedException
