### PR TITLE
Fixed Bug Erroneous string shown in tutorial #2447

### DIFF
--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -167,7 +167,7 @@
   <string name="welcome_copyright_subtext">避免使用受版權保護的材料，例如從網際網路找來的圖片、海報、書籍封面等</string>
   <string name="welcome_final_text">以上您明白了嗎？</string>
   <string name="welcome_final_button_text">是的！</string>
-  <string name="welcome_help_button_text">此提示為空，可能無效。請見錯誤報告： https://github.com/commons-app/apps-android-commons/issues/1333 。</string>
+  <string name="welcome_help_button_text"><![CDATA[<u>更多信息</u>]]></string>
   <string name="detail_panel_cats_label">分類</string>
   <string name="detail_panel_cats_loading">載入中…</string>
   <string name="detail_panel_cats_none">未選擇</string>


### PR DESCRIPTION
**Description (required)**

Fixes #2447 Erroneous string shown in the tutorial

**What changes did you make and why?**
Fixed the string which was not updated in Chinese Traditional resulting in confusing user experience.

**Tests performed (required)**

Tested betaDebug on Google Pixel 3 with API level 28.

**Screenshots showing what changed**
![screenshot-2019-02-17_07 26 45 412](https://user-images.githubusercontent.com/30932899/52907365-74514380-3286-11e9-8ce0-9bfae3b4e2d4.png)