### PR TITLE
Remove unused string values(Fixed #2448)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,17 +136,14 @@
   <string name="tutorial_1_text">Wikimedia Commons hosts most of the images that are used in Wikipedia.</string>
   <string name="tutorial_1_subtext">Your images help educate people around the world!</string>
   <string name="tutorial_2_text">Please upload pictures that are taken or created entirely by yourself:</string>
-  <string name="tutorial_2_subtext">Natural objects (flowers, animals, mountains)\n&#8226; Useful objects (bicycles, train stations)\n&#8226; Famous people (your mayor, Olympic athletes you met)</string>
   <string name="tutorial_2_subtext_1">Natural objects (flowers, animals, mountains)</string>
   <string name="tutorial_2_subtext_2">Useful objects (bicycles, train stations)</string>
   <string name="tutorial_2_subtext_3">Famous people (your mayor, Olympic athletes you met)</string>
   <string name="tutorial_3_text">Please do NOT upload:</string>
-  <string name="tutorial_3_subtext">- Selfies or pictures of your friends\n- Pictures you downloaded from the Internet\n- Screenshots of proprietary apps</string>
   <string name="tutorial_3_subtext_1">Selfies or pictures of your friends</string>
   <string name="tutorial_3_subtext_2">Pictures you downloaded from the Internet</string>
   <string name="tutorial_3_subtext_3">Screenshots of proprietary apps</string>
   <string name="tutorial_4_text">Example upload:</string>
-  <string name="tutorial_4_subtext">- Title: Sydney Opera House\n- Description: Sydney Opera House as viewed from across the bay\n- Categories: Sydney Opera House from the west, Sydney Opera House remote views</string>
   <string name="tutorial_4_subtext_1">Title: Sydney Opera House</string>
   <string name="tutorial_4_subtext_2">Description: Sydney Opera House as viewed from across the bay</string>
   <string name="tutorial_4_subtext_3">Categories: Sydney Opera House from the west, Sydney Opera House remote views</string>


### PR DESCRIPTION
**Description (required)**

Fixes #2448 

What changes did you make and why?

These string values are not used in layouts and java files. So just
remove them.

**Tests performed (required)**

Tested master betaDebug on Nexus 6P with API level 27.

**Screenshots showing what changed (optional - for UI changes)**

No screenshots but I tested the tutorial pages show correctly without these string values.