### PR TITLE
Fixed Search activity launching twice if button pressed quickly

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -106,6 +106,7 @@
         <activity
             android:name=".explore.SearchActivity"
             android:label="@string/title_activity_search"
+            android:launchMode="singleTop"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:parentActivityName=".contributions.MainActivity"
             />


### PR DESCRIPTION
Fixed Search activity launching twice if button pressed quickly

Fixes #2466 

changed  searchActivity's launch mode to "singleTop
