### PR TITLE
Fix Bug #2489

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceRenderer.java
@@ -9,7 +9,6 @@ import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.PopupMenu;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceRenderer.java
@@ -6,7 +6,10 @@ import android.support.transition.TransitionManager;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AlertDialog;
+import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.PopupMenu;
+import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -112,6 +115,11 @@ public class PlaceRenderer extends Renderer<Place> {
                 closeLayout(buttonLayout);
             } else {
                 openLayout(buttonLayout);
+                RecyclerView recyclerView = (RecyclerView) view.getParent();
+                int lastPosition = recyclerView.getAdapter().getItemCount() - 1;
+                if (recyclerView.getChildLayoutPosition(view) == lastPosition) {
+                    ((LinearLayoutManager) recyclerView.getLayoutManager()).scrollToPositionWithOffset(lastPosition, buttonLayout.getHeight());
+                }
             }
 
         };


### PR DESCRIPTION
**Description**
The button Layout was not showing on clicking the last item, the user needs to scroll in order to see it.
Fixes #2489

What changes did you make and why?
I added automatic scrolling when the last item is clicked so that the user can easily see button layout without scrolling.

**Tests performed**
Tested betaDebug on Xiaomi Mi A1 with API level 28.

**Screenshots showing what changed**
![ezgif-2-d0907bf97e62](https://user-images.githubusercontent.com/30932899/53099251-64b65100-354b-11e9-8e42-a8c6ecab478b.gif)

