### PR TITLE
Add Device Support Information to Feedback Intent #2494

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -74,6 +74,8 @@ public class CommonsApplication extends Application {
 
     public static final String NOTIFICATION_CHANNEL_ID_ALL = "CommonsNotificationAll";
 
+    public static final String FEEDBACK_EMAIL_TEMPLATE_HEADER = "--Support-Info--";
+
     /**
      * Constants End
      */

--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -70,11 +70,11 @@ public class CommonsApplication extends Application {
 
     public static final String FEEDBACK_EMAIL = "commons-app-android@googlegroups.com";
 
-    public static final String FEEDBACK_EMAIL_SUBJECT = "Commons Android App (%s) Feedback";
+    public static final String FEEDBACK_EMAIL_SUBJECT = "Commons Android App Feedback";
 
     public static final String NOTIFICATION_CHANNEL_ID_ALL = "CommonsNotificationAll";
 
-    public static final String FEEDBACK_EMAIL_TEMPLATE_HEADER = "--Support-Info--";
+    public static final String FEEDBACK_EMAIL_TEMPLATE_HEADER = "--Technical-Info--";
 
     /**
      * Constants End

--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -74,7 +74,7 @@ public class CommonsApplication extends Application {
 
     public static final String NOTIFICATION_CHANNEL_ID_ALL = "CommonsNotificationAll";
 
-    public static final String FEEDBACK_EMAIL_TEMPLATE_HEADER = "--Technical-Info--";
+    public static final String FEEDBACK_EMAIL_TEMPLATE_HEADER = "-- Technical information --";
 
     /**
      * Constants End

--- a/app/src/main/java/fr/free/nrw/commons/logging/CommonsLogSender.java
+++ b/app/src/main/java/fr/free/nrw/commons/logging/CommonsLogSender.java
@@ -42,31 +42,49 @@ public class CommonsLogSender extends LogsSender {
      * @return String with extra meta information useful for debugging
      */
     @Override
-    protected String getExtraInfo() {
+    public String getExtraInfo() {
         StringBuilder builder = new StringBuilder();
-        builder.append("App Version Name: ")
-                .append(ConfigUtils.getVersionNameWithSha(context))
+
+        // Getting API Level
+        builder.append("API level: ")
+                .append(DeviceInfoUtil.getAPILevel())
                 .append("\n");
 
-        builder.append("User Name: ")
-                .append(sessionManager.getUserName())
+        // Getting Android Version
+        builder.append("Android version: ")
+                .append(DeviceInfoUtil.getAndroidVersion())
                 .append("\n");
 
-        builder.append("Network Type: ")
-                .append(DeviceInfoUtil.getConnectionType(context))
-                .append("\n");
-
+        // Getting Device Manufacturer
         builder.append("Device manufacturer: ")
                 .append(DeviceInfoUtil.getDeviceManufacturer())
                 .append("\n");
 
+        // Getting Device Model
         builder.append("Device model: ")
                 .append(DeviceInfoUtil.getDeviceModel())
                 .append("\n");
 
-        builder.append("Android Version: ")
-                .append(DeviceInfoUtil.getAndroidVersion())
+        // Getting Device Name
+        builder.append("Device: ")
+                .append(DeviceInfoUtil.getDevice())
                 .append("\n");
+
+        // Getting Network Type
+        builder.append("Network type: ")
+                .append(DeviceInfoUtil.getConnectionType(context))
+                .append("\n");
+
+        // Getting App Version
+        builder.append("App version name: ")
+                .append(ConfigUtils.getVersionNameWithSha(context))
+                .append("\n");
+
+        // Getting Username
+        builder.append("User name: ")
+                .append(sessionManager.getUserName())
+                .append("\n");
+
 
         return builder.toString();
     }

--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -34,13 +34,13 @@ import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.WelcomeActivity;
 import fr.free.nrw.commons.achievements.AchievementsActivity;
 import fr.free.nrw.commons.auth.LoginActivity;
+import fr.free.nrw.commons.auth.SessionManager;
 import fr.free.nrw.commons.bookmarks.BookmarksActivity;
 import fr.free.nrw.commons.category.CategoryImagesActivity;
 import fr.free.nrw.commons.contributions.MainActivity;
 import fr.free.nrw.commons.kvstore.BasicKvStore;
+import fr.free.nrw.commons.logging.CommonsLogSender;
 import fr.free.nrw.commons.settings.SettingsActivity;
-import fr.free.nrw.commons.utils.ConfigUtils;
-import fr.free.nrw.commons.utils.DeviceInfoUtil;
 import timber.log.Timber;
 
 public abstract class NavigationBaseActivity extends BaseActivity
@@ -56,6 +56,7 @@ public abstract class NavigationBaseActivity extends BaseActivity
     @BindView(R.id.drawer_layout)
     DrawerLayout drawerLayout;
     @Inject @Named("application_preferences") BasicKvStore applicationKvStore;
+    @Inject SessionManager sessionManager;
 
 
     private ActionBarDrawerToggle toggle;
@@ -189,7 +190,8 @@ public abstract class NavigationBaseActivity extends BaseActivity
             case R.id.action_feedback:
                 drawerLayout.closeDrawer(navigationView);
 
-                String technicalInfo = getTechnicalInfo();
+                String technicalInfo = new CommonsLogSender(sessionManager,
+                        getApplicationContext()).getExtraInfo();
 
                 Intent feedbackIntent = new Intent(Intent.ACTION_SENDTO);
                 feedbackIntent.setType("message/rfc822");
@@ -230,48 +232,6 @@ public abstract class NavigationBaseActivity extends BaseActivity
                 Timber.e("Unknown option [%s] selected from the navigation menu", itemId);
                 return false;
         }
-    }
-
-    private String getTechnicalInfo() {
-        StringBuilder builder = new StringBuilder();
-
-        // Getting API Level
-        builder.append("API Level: ")
-                .append(DeviceInfoUtil.getAPILevel())
-                .append("\n");
-
-        // Getting Android Version
-        builder.append("Android Version: ")
-                .append(DeviceInfoUtil.getAndroidVersion())
-                .append("\n");
-
-        // Getting Device Manufacturer
-        builder.append("Device Manufacturer: ")
-                .append(DeviceInfoUtil.getDeviceManufacturer())
-                .append("\n");
-
-        // Getting Device Model
-        builder.append("Device Model: ")
-                .append(DeviceInfoUtil.getDeviceModel())
-                .append("\n");
-
-        // Getting Device Name
-        builder.append("Device: ")
-                .append(DeviceInfoUtil.getDevice())
-                .append("\n");
-
-        // Getting Network Type
-        builder.append("Network Type: ")
-                .append(DeviceInfoUtil.getConnectionType(getApplicationContext()).toString())
-                .append("\n");
-
-        //Getting App Version
-        builder.append("Device model: ")
-                .append(ConfigUtils.getVersionNameWithSha(getApplicationContext()))
-                .append("\n");
-
-
-        return builder.toString();
     }
 
     private class BaseLogoutListener implements CommonsApplication.LogoutListener {

--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -56,7 +56,7 @@ public abstract class NavigationBaseActivity extends BaseActivity
     @BindView(R.id.drawer_layout)
     DrawerLayout drawerLayout;
     @Inject @Named("application_preferences") BasicKvStore applicationKvStore;
-    @Inject SessionManager sessionManager;
+    @Inject CommonsLogSender commonsLogSender;
 
 
     private ActionBarDrawerToggle toggle;
@@ -190,8 +190,7 @@ public abstract class NavigationBaseActivity extends BaseActivity
             case R.id.action_feedback:
                 drawerLayout.closeDrawer(navigationView);
 
-                String technicalInfo = new CommonsLogSender(sessionManager,
-                        getApplicationContext()).getExtraInfo();
+                String technicalInfo = commonsLogSender.getExtraInfo();
 
                 Intent feedbackIntent = new Intent(Intent.ACTION_SENDTO);
                 feedbackIntent.setType("message/rfc822");

--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -187,14 +187,28 @@ public abstract class NavigationBaseActivity extends BaseActivity
                 return true;
             case R.id.action_feedback:
                 drawerLayout.closeDrawer(navigationView);
+
+                String apiLevel = android.os.Build.VERSION.SDK; // Getting API Level
+                String manufacturer = Build.MANUFACTURER; // Getting Device Manufacturer
+                String model = android.os.Build.MODEL; // Getting Model
+                String device = android.os.Build.DEVICE; // Getting Device
+                String appVersion = ConfigUtils.getVersionNameWithSha(getApplicationContext()); //Getting App Version
+
+                String supportInfo = String.format("%s %s\n%s %s\n%s %s\n%s %s",
+                        getResources().getString(R.string.support_info_api_level), apiLevel,
+                        getResources().getString(R.string.support_info_manufacturer), manufacturer,
+                        getResources().getString(R.string.support_info_model), model,
+                        getResources().getString(R.string.support_info_device), device);
+
                 Intent feedbackIntent = new Intent(Intent.ACTION_SENDTO);
                 feedbackIntent.setType("message/rfc822");
                 feedbackIntent.setData(Uri.parse("mailto:"));
                 feedbackIntent.putExtra(Intent.EXTRA_EMAIL,
                         new String[]{CommonsApplication.FEEDBACK_EMAIL});
                 feedbackIntent.putExtra(Intent.EXTRA_SUBJECT,
-                        String.format(CommonsApplication.FEEDBACK_EMAIL_SUBJECT,
-                                ConfigUtils.getVersionNameWithSha(getApplicationContext())));
+                        String.format(CommonsApplication.FEEDBACK_EMAIL_SUBJECT, appVersion));
+                feedbackIntent.putExtra(Intent.EXTRA_TEXT, String.format(
+                        "\n\n%s\n%s", CommonsApplication.FEEDBACK_EMAIL_TEMPLATE_HEADER, supportInfo));
                 try {
                     startActivity(feedbackIntent);
                 } catch (ActivityNotFoundException e) {

--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -40,6 +40,7 @@ import fr.free.nrw.commons.contributions.MainActivity;
 import fr.free.nrw.commons.kvstore.BasicKvStore;
 import fr.free.nrw.commons.settings.SettingsActivity;
 import fr.free.nrw.commons.utils.ConfigUtils;
+import fr.free.nrw.commons.utils.DeviceInfoUtil;
 import timber.log.Timber;
 
 public abstract class NavigationBaseActivity extends BaseActivity
@@ -188,17 +189,7 @@ public abstract class NavigationBaseActivity extends BaseActivity
             case R.id.action_feedback:
                 drawerLayout.closeDrawer(navigationView);
 
-                String apiLevel = android.os.Build.VERSION.SDK; // Getting API Level
-                String manufacturer = Build.MANUFACTURER; // Getting Device Manufacturer
-                String model = android.os.Build.MODEL; // Getting Model
-                String device = android.os.Build.DEVICE; // Getting Device
-                String appVersion = ConfigUtils.getVersionNameWithSha(getApplicationContext()); //Getting App Version
-
-                String supportInfo = String.format("%s %s\n%s %s\n%s %s\n%s %s",
-                        getResources().getString(R.string.support_info_api_level), apiLevel,
-                        getResources().getString(R.string.support_info_manufacturer), manufacturer,
-                        getResources().getString(R.string.support_info_model), model,
-                        getResources().getString(R.string.support_info_device), device);
+                String technicalInfo = getTechnicalInfo();
 
                 Intent feedbackIntent = new Intent(Intent.ACTION_SENDTO);
                 feedbackIntent.setType("message/rfc822");
@@ -206,9 +197,9 @@ public abstract class NavigationBaseActivity extends BaseActivity
                 feedbackIntent.putExtra(Intent.EXTRA_EMAIL,
                         new String[]{CommonsApplication.FEEDBACK_EMAIL});
                 feedbackIntent.putExtra(Intent.EXTRA_SUBJECT,
-                        String.format(CommonsApplication.FEEDBACK_EMAIL_SUBJECT, appVersion));
+                        CommonsApplication.FEEDBACK_EMAIL_SUBJECT);
                 feedbackIntent.putExtra(Intent.EXTRA_TEXT, String.format(
-                        "\n\n%s\n%s", CommonsApplication.FEEDBACK_EMAIL_TEMPLATE_HEADER, supportInfo));
+                        "\n\n%s\n%s", CommonsApplication.FEEDBACK_EMAIL_TEMPLATE_HEADER, technicalInfo));
                 try {
                     startActivity(feedbackIntent);
                 } catch (ActivityNotFoundException e) {
@@ -239,6 +230,48 @@ public abstract class NavigationBaseActivity extends BaseActivity
                 Timber.e("Unknown option [%s] selected from the navigation menu", itemId);
                 return false;
         }
+    }
+
+    private String getTechnicalInfo() {
+        StringBuilder builder = new StringBuilder();
+
+        // Getting API Level
+        builder.append("API Level: ")
+                .append(DeviceInfoUtil.getAPILevel())
+                .append("\n");
+
+        // Getting Android Version
+        builder.append("Android Version: ")
+                .append(DeviceInfoUtil.getAndroidVersion())
+                .append("\n");
+
+        // Getting Device Manufacturer
+        builder.append("Device Manufacturer: ")
+                .append(DeviceInfoUtil.getDeviceManufacturer())
+                .append("\n");
+
+        // Getting Device Model
+        builder.append("Device Model: ")
+                .append(DeviceInfoUtil.getDeviceModel())
+                .append("\n");
+
+        // Getting Device Name
+        builder.append("Device: ")
+                .append(DeviceInfoUtil.getDevice())
+                .append("\n");
+
+        // Getting Network Type
+        builder.append("Network Type: ")
+                .append(DeviceInfoUtil.getConnectionType(getApplicationContext()).toString())
+                .append("\n");
+
+        //Getting App Version
+        builder.append("Device model: ")
+                .append(ConfigUtils.getVersionNameWithSha(getApplicationContext()))
+                .append("\n");
+
+
+        return builder.toString();
     }
 
     private class BaseLogoutListener implements CommonsApplication.LogoutListener {

--- a/app/src/main/java/fr/free/nrw/commons/utils/DeviceInfoUtil.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/DeviceInfoUtil.java
@@ -62,7 +62,7 @@ public class DeviceInfoUtil {
      * @return
      */
     public static String getDeviceModel() {
-        return Build.DEVICE;
+        return Build.MODEL;
     }
 
     /**
@@ -82,7 +82,7 @@ public class DeviceInfoUtil {
     }
 
     /**
-     * Get Device Name.
+     * Get Device.
      * @return
      */
     public static String getDevice() {

--- a/app/src/main/java/fr/free/nrw/commons/utils/DeviceInfoUtil.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/DeviceInfoUtil.java
@@ -72,4 +72,20 @@ public class DeviceInfoUtil {
     public static String getAndroidVersion() {
         return Build.VERSION.RELEASE;
     }
+
+    /**
+     * Get API Level. Eg. 26
+     * @return
+     */
+    public static String getAPILevel() {
+        return Build.VERSION.SDK;
+    }
+
+    /**
+     * Get Device Name.
+     * @return
+     */
+    public static String getDevice() {
+        return Build.DEVICE;
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -477,4 +477,9 @@ Upload your first media by touching the camera or gallery icon above.</string>
   <string name="image_chooser_title">Choose Images to upload</string>
 
   <string name="please_wait">Please wait…</string>
+  <string name="support_info_api_level">API Level:</string>
+  <string name="support_info_manufacturer">Manufacturer:</string>
+  <string name="support_info_model">Model:</string>
+  <string name="support_info_device">Device:</string>
+  <string name="support_info_app_version">App Version:</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -477,9 +477,4 @@ Upload your first media by touching the camera or gallery icon above.</string>
   <string name="image_chooser_title">Choose Images to upload</string>
 
   <string name="please_wait">Please wait…</string>
-  <string name="support_info_api_level">API Level:</string>
-  <string name="support_info_manufacturer">Manufacturer:</string>
-  <string name="support_info_model">Model:</string>
-  <string name="support_info_device">Device:</string>
-  <string name="support_info_app_version">App Version:</string>
 </resources>


### PR DESCRIPTION
**Description**
Added Support Info to email when the user wants to share feedback.

**Fixes #2494 Collection of device's essential information when user want to share feedback** 

What changes did you make and why?
When a user wants to share some feedback, the current scenario does not include the device name, model number, etc. so I added it the email template.

**Tests performed**
Tested betaDebug on Xiamo Mi A1 with API level 28.

**Screenshots showing what changed**
![screenshot_20190221-152328](https://user-images.githubusercontent.com/30932899/53159898-d1355c80-35ec-11e9-83b6-f090256cd6ab.png)
