### PR TITLE
Clean up placeholders in media detail fragment fields(Fixed #2471)

### DIFF
--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -75,9 +75,9 @@
                         android:layout_gravity="start"
                         android:background="?attr/subBackground"
                         android:padding="@dimen/small_gap"
-                        android:text="@string/media_detail_media_title"
                         android:textColor="@android:color/white"
-                        android:textSize="@dimen/description_text_size" />
+                        android:textSize="@dimen/description_text_size"
+                        tools:text="Title of the media" />
                 </LinearLayout>
 
                 <fr.free.nrw.commons.media.MediaDetailSpacer
@@ -108,9 +108,9 @@
                         android:layout_gravity="start"
                         android:background="?attr/subBackground"
                         android:padding="@dimen/small_gap"
-                        android:text="@string/media_detail_author_explanation"
                         android:textColor="@android:color/white"
-                        android:textSize="@dimen/description_text_size" />
+                        android:textSize="@dimen/description_text_size"
+                        tools:text="Media author user name goes here." />
                 </LinearLayout>
 
                 <fr.free.nrw.commons.media.MediaDetailSpacer
@@ -140,9 +140,9 @@
                         android:layout_gravity="start"
                         android:background="?attr/subBackground"
                         android:padding="@dimen/small_gap"
-                        android:text="@string/media_detail_description_explanation"
                         android:textColor="@android:color/white"
-                        android:textSize="@dimen/description_text_size" />
+                        android:textSize="@dimen/description_text_size"
+                        tools:text="Description of the media goes here. This can potentially be fairly long, and will need to wrap across multiple lines. We hope it looks nice though." />
                 </LinearLayout>
 
                 <fr.free.nrw.commons.media.MediaDetailSpacer
@@ -174,7 +174,6 @@
                         android:foreground="?attr/selectableItemBackground"
                         android:gravity="center_vertical"
                         android:padding="@dimen/small_gap"
-                        android:text="@string/media_detail_license"
                         android:textColor="@android:color/white"
                         android:textSize="@dimen/description_text_size"
                         app:drawablePadding="@dimen/tiny_gap"
@@ -211,7 +210,6 @@
                         android:foreground="?attr/selectableItemBackground"
                         android:gravity="center_vertical"
                         android:padding="@dimen/small_gap"
-                        android:text="@string/media_detail_coordinates"
                         android:textColor="@android:color/white"
                         android:textSize="@dimen/description_text_size"
                         app:drawablePadding="@dimen/tiny_gap"
@@ -275,9 +273,9 @@
                         android:layout_gravity="start"
                         android:background="?attr/subBackground"
                         android:padding="@dimen/small_gap"
-                        android:text="@string/media_detail_uploaded_date"
                         android:textColor="@android:color/white"
-                        android:textSize="@dimen/description_text_size" />
+                        android:textSize="@dimen/description_text_size"
+                        tools:text="Uploaded date" />
                 </LinearLayout>
 
                 <fr.free.nrw.commons.media.MediaDetailSpacer

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,11 +175,8 @@
   <string name="yes">Yes</string>
   <string name="no">No</string>
   <string name="media_detail_title">Title</string>
-  <string name="media_detail_media_title">Title of the media</string>
   <string name="media_detail_description">Description</string>
-  <string name="media_detail_description_explanation">Description of the media goes here. This can potentially be fairly long, and will need to wrap across multiple lines. We hope it looks nice though.</string>
   <string name="media_detail_author">Author</string>
-  <string name="media_detail_author_explanation">Featured image author user name goes here.</string>
   <string name="media_detail_uploaded_date">Uploaded date</string>
   <string name="media_detail_license">License</string>
   <string name="media_detail_coordinates">Coordinates</string>


### PR DESCRIPTION
**Description (required)**

Fixes #2471 

What changes did you make and why?

Remove placeholders and let these descriptions only shown in Android
Studio layout preview. Use plain text in tools:text attributes so
relative string values can also be removed and ease the translation work.

**Tests performed (required)**

Tested master ProdDebug on Nexus 6P with API level 27.

**Screenshots showing what changed (optional - for UI changes)**

| with data | without data |
| ---  | --- |
| ![screenshot_20190221-174652](https://user-images.githubusercontent.com/692944/53160185-668f1b80-3602-11e9-9273-c651a060dfa4.png) | ![screenshot_20190221-174716](https://user-images.githubusercontent.com/692944/53160186-668f1b80-3602-11e9-806c-df40b892ddd5.png) |

