### PR TITLE
Bottom card retains all data on rotation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,7 +48,8 @@
 
         <activity android:name=".upload.UploadActivity"
             android:icon="@mipmap/ic_launcher"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:configChanges="orientation|screenSize|keyboard">
             <intent-filter android:label="@string/intent_share_upload_label">
                 <action android:name="android.intent.action.SEND" />
 


### PR DESCRIPTION
**Retain data on rotation of upload activity**

Fixes #2369 Rotating screen erases title

### Changes Made
Configuration changes in manifest
