### PR TITLE
Bug fix issue #2476

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionDao.java
@@ -4,19 +4,18 @@ import android.content.ContentProviderClient;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteException;
 import android.net.Uri;
 import android.os.RemoteException;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
-
+import fr.free.nrw.commons.settings.Prefs;
+import fr.free.nrw.commons.utils.StringUtils;
 import java.util.Date;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
-
-import fr.free.nrw.commons.settings.Prefs;
-import fr.free.nrw.commons.utils.StringUtils;
+import timber.log.Timber;
 
 import static fr.free.nrw.commons.contributions.ContributionDao.Table.ALL_FIELDS;
 import static fr.free.nrw.commons.contributions.ContributionDao.Table.COLUMN_WIKI_DATA_ENTITY_ID;
@@ -262,16 +261,20 @@ public class ContributionDao {
             if (from == to) {
                 return;
             }
+
+            //Considering the crashes we have been facing recently, lets blindly add this column to any table which has ever existed
+            runQuery(db,ADD_WIKI_DATA_ENTITY_ID_FIELD);
+
             if (from == 1) {
-                db.execSQL(ADD_DESCRIPTION_FIELD);
-                db.execSQL(ADD_CREATOR_FIELD);
+                runQuery(db,ADD_DESCRIPTION_FIELD);
+                runQuery(db,ADD_CREATOR_FIELD);
                 from++;
                 onUpdate(db, from, to);
                 return;
             }
             if (from == 2) {
-                db.execSQL(ADD_MULTIPLE_FIELD);
-                db.execSQL(SET_DEFAULT_MULTIPLE);
+                runQuery(db, ADD_MULTIPLE_FIELD);
+                runQuery(db, SET_DEFAULT_MULTIPLE);
                 from++;
                 onUpdate(db, from, to);
                 return;
@@ -290,23 +293,34 @@ public class ContributionDao {
             }
             if (from == 5) {
                 // Added width and height fields
-                db.execSQL(ADD_WIDTH_FIELD);
-                db.execSQL(SET_DEFAULT_WIDTH);
-                db.execSQL(ADD_HEIGHT_FIELD);
-                db.execSQL(SET_DEFAULT_HEIGHT);
-                db.execSQL(ADD_LICENSE_FIELD);
-                db.execSQL(SET_DEFAULT_LICENSE);
+                runQuery(db, ADD_WIDTH_FIELD);
+                runQuery(db, SET_DEFAULT_WIDTH);
+                runQuery(db, ADD_HEIGHT_FIELD);
+                runQuery(db, SET_DEFAULT_HEIGHT);
+                runQuery(db, ADD_LICENSE_FIELD);
+                runQuery(db, SET_DEFAULT_LICENSE);
                 from++;
                 onUpdate(db, from, to);
                 return;
             }
             if (from > 5) {
                 // Added place field
-                db.execSQL(ADD_WIKI_DATA_ENTITY_ID_FIELD);
-                from++;
+                from=to;
                 onUpdate(db, from, to);
                 return;
             }
         }
+
+        /**
+         * perform the db.execSQl with handled exceptions
+         */
+        private static void runQuery(SQLiteDatabase db, String query) {
+            try {
+                db.execSQL(query);
+            } catch (SQLiteException e) {
+                Timber.e("Exception performing query: " + query + " message: " + e.getMessage());
+            }
+        }
+
     }
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionDaoTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionDaoTest.kt
@@ -78,17 +78,11 @@ class ContributionDaoTest {
     @Test
     fun upgradeDatabase_v3_to_v4() {
         Table.onUpdate(database, 3, 4)
-
-        // No changes
-        verifyZeroInteractions(database)
     }
 
     @Test
     fun upgradeDatabase_v4_to_v5() {
         Table.onUpdate(database, 4, 5)
-
-        // No changes
-        verifyZeroInteractions(database)
     }
 
     @Test


### PR DESCRIPTION

**Description (required)**
App used to crash while inserting values in column "wikidataEntityID" saying that the column does not exist

Fixes #2476  {Crash due to contribution dao in 2.10}

What changes did you make and why?
 * Added wikidataEntityID in all db versions, handled db.execSql via method runQuery

**Tests performed (required)**

Tested {build variant, ProdDebug} on {One Plus 3T} with API level {27}.
