### PR TITLE
Fixes Lego Messages in strings.xml for "uploaded_by_myself"

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/delete/ReasonBuilder.java
+++ b/app/src/main/java/fr/free/nrw/commons/delete/ReasonBuilder.java
@@ -54,10 +54,8 @@ public class ReasonBuilder {
     }
 
     private String appendArticlesUsed(FeedbackResponse object, Media media, String reason) {
-        reason += context.getString(R.string.uploaded_by_myself) + prettyUploadedDate(media);
-        reason += context.getString(R.string.used_by)
-                + object.getArticlesUsingImages()
-                + context.getString(R.string.articles);
+        String reason1Template = context.getString(R.string.uploaded_by_myself);
+        reason += String.format(Locale.getDefault(), reason1Template, prettyUploadedDate(media), object.getArticlesUsingImages());
         Timber.i("New Reason %s", reason);
         return reason;
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -401,9 +401,7 @@
   <string name="deletion_reason_bad_for_my_privacy">Ich habe erkannt, dass es schlecht für meine Privatsphäre ist.</string>
   <string name="deletion_reason_no_longer_want_public">Ich habe meine Meinung geändert. Ich möchte nicht mehr, dass es öffentlich sichtbar ist.</string>
   <string name="deletion_reason_not_interesting">Entschuldigung, aber dieses Bild ist nicht für eine Enzyklopädie relevant.</string>
-  <string name="uploaded_by_myself">Von mir hochgeladen am</string>
-  <string name="used_by">, verwendet in</string>
-  <string name="articles">Artikel</string>
+  <string name="uploaded_by_myself">Von mir hochgeladen am %1$s, verwendet in %2$d Artikel(n).</string>
   <string name="no_uploads">Willkommen bei Commons!\n\nLade deine erste Datei hoch, indem du oben auf das Kamera- oder Galeriesymbol tippst.</string>
   <string name="desc_language_Worldwide">Weltweit</string>
   <string name="desc_language_America">Amerika</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -408,10 +408,8 @@
   <string name="deletion_reason_bad_for_my_privacy">Me di cuenta que es malo para mi privacidad</string>
   <string name="deletion_reason_no_longer_want_public">Cambié de opinión, no quiero que siga siendo visible públicamente</string>
   <string name="deletion_reason_not_interesting">Lo sentimos, esta imagen no es interesante para una enciclopedia</string>
-  <string name="uploaded_by_myself">Subida por mí mismo el</string>
-  <string name="used_by">, usado en</string>
-  <string name="articles">artículos</string>
-  <string name="no_uploads">¡Bienvenido a Commons!\n\nSube tu primer archivo tocando el icono de la cámara o galería arriba.</string>
+  <string name="uploaded_by_myself">Subida por mí mismo el %1$s, usado en %2$d artículo(s).</string>
+    <string name="no_uploads">¡Bienvenido a Commons!\n\nSube tu primer archivo tocando el icono de la cámara o galería arriba.</string>
   <string name="desc_language_Worldwide">Mundial</string>
   <string name="desc_language_America">América</string>
   <string name="desc_language_Europe">Europa</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -417,10 +417,8 @@
   <string name="deletion_reason_bad_for_my_privacy">J\'ai pensé que ce n\'était pas bon pour ma vie privée</string>
   <string name="deletion_reason_no_longer_want_public">J\'ai changé d\'avis, je ne désire plus qu\'il soit visible publiquement</string>
   <string name="deletion_reason_not_interesting">Désolé mais cette image n\'est pas intéressante pour une encyclopédie</string>
-  <string name="uploaded_by_myself">Téléversé par moi-même le</string>
-  <string name="used_by">,utilisé dans</string>
-  <string name="articles">articles</string>
-  <string name="no_uploads">Bienvenue sur Commons !\n\nTéléversez votre premier média en cliquant sur l’icône de l’appareil photo ou sur la galerie ci-dessus.</string>
+  <string name="uploaded_by_myself">Téléversé par moi-même le %1$s, utilisé dans %2$d article(s).</string>
+    <string name="no_uploads">Bienvenue sur Commons !\n\nTéléversez votre premier média en cliquant sur l’icône de l’appareil photo ou sur la galerie ci-dessus.</string>
   <string name="desc_language_Worldwide">Mondial</string>
   <string name="desc_language_America">Amérique</string>
   <string name="desc_language_Europe">Europe</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -244,4 +244,5 @@
   <string name="menu_option_unread">Ongelezen bekijken</string>
   <string name="image_chooser_title">Kies de afbeeldingen die u wilt plaatsen</string>
   <string name="please_wait">Een ogenblik geduld…</string>
+    <string name="uploaded_by_myself">Geüpload van mij op %1$s, gebruikt in %2$d artikel(s).</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -414,9 +414,7 @@
   <string name="deletion_reason_bad_for_my_privacy">I realized it is bad for my privacy</string>
   <string name="deletion_reason_no_longer_want_public">I changed my mind, I don\'t want it to be publicly visible anymore</string>
   <string name="deletion_reason_not_interesting">Sorry this picture is not interesting for an encyclopedia</string>
-  <string name="uploaded_by_myself">Uploaded by myself on</string>
-  <string name="used_by">,used in</string>
-  <string name="articles">articles</string>
+  <string name="uploaded_by_myself">Uploaded by myself on %1$s, used in %2$d article(s).</string>
 
   <string name="no_uploads">Welcome to Commons!\n
 Upload your first media by touching the camera or gallery icon above.</string>


### PR DESCRIPTION
**Description (required)**

Fixes Lego Messages in strings.xml for "uploaded_by_myself" 

Fixes #2498 "uploaded by myself", "used by", and several other lego messages

What changes did you make and why?

I corrected the strings for "uploaded_by_myself" in the strings.xml and changed the message generation in "ReasonBuilder.java". I also added translations for "uploaded_by_myself"-String in English, German, French, Spanish and Dutch.

**Tests performed (required)**
I was not able to perform tests.

Please let me know what you think of the changes and let me know if I should adjust something or change something.