### PR TITLE
Add setting Picture_Has_Correct_Location prefs(Fixed #2530)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
@@ -129,6 +129,7 @@ public class UploadPresenter {
         if (imageResult == IMAGE_KEEP || imageResult == IMAGE_OK) {
             Timber.d("Set title and desc; Show next uploaded item");
             setTitleAndDescription(title, descriptions);
+            directKvStore.putBoolean("Picture_Has_Correct_Location", true);
             nextUploadedItem();
         } else {
             handleBadImage(imageResult);


### PR DESCRIPTION
**Description (required)**

Fixes #2530

What changes did you make and why?

Update Picture_Has_Correct_Location prefs in method handleImage. This
fixed an issue that this prefs is not set and related wikidata
can't be updated.

**Tests performed (required)**

Tested master ProdDebug on Nexus 6P with API level 27.
