### PR TITLE
Fix Lint Issues #171: Fix numerous errors/warnings

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/campaigns/CampaignsPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/campaigns/CampaignsPresenter.java
@@ -1,7 +1,6 @@
 package fr.free.nrw.commons.campaigns;
 
 import android.annotation.SuppressLint;
-import android.util.Log;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -20,6 +19,7 @@ import io.reactivex.SingleObserver;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
+import timber.log.Timber;
 
 /**
  * The presenter for the campaigns view, fetches the campaigns from the api and informs the view on
@@ -29,7 +29,6 @@ import io.reactivex.schedulers.Schedulers;
 public class CampaignsPresenter implements BasePresenter {
     private final OkHttpJsonApiClient okHttpJsonApiClient;
 
-    private final String TAG = "#CampaignsPresenter#";
     private ICampaignsView view;
     private Disposable disposable;
     private Campaign campaign;
@@ -74,7 +73,7 @@ public class CampaignsPresenter implements BasePresenter {
                         List<Campaign> campaigns = campaignResponseDTO.getCampaigns();
                         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
                         if (campaigns == null || campaigns.isEmpty()) {
-                            Log.e(TAG, "The campaigns list is empty");
+                            Timber.e("The campaigns list is empty");
                             view.showCampaigns(null);
                         }
                         Collections.sort(campaigns, (campaign, t1) -> {
@@ -108,7 +107,7 @@ public class CampaignsPresenter implements BasePresenter {
                     }
 
                     @Override public void onError(Throwable e) {
-                        Log.e(TAG, "could not fetch campaigns: " + e.getMessage());
+                        Timber.e(e.getMessage(), "could not fetch campaigns");
                     }
                 });
         }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesRenderer.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesRenderer.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.category;
 
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,6 +10,7 @@ import com.pedrogomez.renderers.Renderer;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import fr.free.nrw.commons.R;
+import timber.log.Timber;
 
 public class CategoriesRenderer extends Renderer<CategoryItem> {
     @BindView(R.id.tvName) CheckedTextView checkedView;
@@ -45,7 +45,7 @@ public class CategoriesRenderer extends Renderer<CategoryItem> {
     @Override
     public void render() {
         CategoryItem item = getContent();
-        Log.e("Commons", "Rendering: "+item);
+        Timber.e("Rendering: %s", item);
         checkedView.setChecked(item.isSelected());
         checkedView.setText(item.getName());
     }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -21,7 +21,6 @@ import android.support.v4.content.CursorLoader;
 import android.support.v4.content.Loader;
 import android.support.v4.widget.CursorAdapter;
 import android.support.v7.app.AlertDialog;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -178,7 +177,7 @@ public class ContributionsFragment
                 @Override public void onFragmentResumed(FragmentManager fm, Fragment f) {
                     super.onFragmentResumed(fm, f);
                     //If media detail pager fragment is visible, hide the campaigns view [might not be the best way to do, this but yeah, this proves to work for now]
-                    Log.e("#CF#", "onFragmentResumed" + f.getClass().getName());
+                    Timber.e("onFragmentResumed %s", f.getClass().getName());
                     if (f instanceof MediaDetailPagerFragment) {
                         campaignView.setVisibility(View.GONE);
                     }
@@ -186,7 +185,7 @@ public class ContributionsFragment
 
                 @Override public void onFragmentDetached(FragmentManager fm, Fragment f) {
                     super.onFragmentDetached(fm, f);
-                    Log.e("#CF#", "onFragmentDetached" + f.getClass().getName());
+                    Timber.e("onFragmentDetached %s", f.getClass().getName());
                     //If media detail pager fragment is detached, ContributionsList fragment is gonna be visible, [becomes tightly coupled though]
                     if (f instanceof MediaDetailPagerFragment) {
                         fetchCampaigns();

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.java
@@ -152,7 +152,7 @@ public class FilePicker implements Constants {
     }
 
     private static void storeType(@NonNull Context context, int type) {
-        PreferenceManager.getDefaultSharedPreferences(context).edit().putInt(KEY_TYPE, type).commit();
+        PreferenceManager.getDefaultSharedPreferences(context).edit().putInt(KEY_TYPE, type).apply();
     }
 
     private static int restoreType(@NonNull Context context) {

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/FilePickerConfiguration.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/FilePickerConfiguration.java
@@ -14,28 +14,28 @@ public class FilePickerConfiguration implements Constants {
     public FilePickerConfiguration setImagesFolderName(String folderName) {
         PreferenceManager.getDefaultSharedPreferences(context)
                 .edit().putString(BundleKeys.FOLDER_NAME, folderName)
-                .commit();
+                .apply();
         return this;
     }
 
     public FilePickerConfiguration setAllowMultiplePickInGallery(boolean allowMultiple) {
         PreferenceManager.getDefaultSharedPreferences(context).edit()
                 .putBoolean(BundleKeys.ALLOW_MULTIPLE, allowMultiple)
-                .commit();
+                .apply();
         return this;
     }
 
     public FilePickerConfiguration setCopyTakenPhotosToPublicGalleryAppFolder(boolean copy) {
         PreferenceManager.getDefaultSharedPreferences(context).edit()
                 .putBoolean(BundleKeys.COPY_TAKEN_PHOTOS, copy)
-                .commit();
+                .apply();
         return this;
     }
 
     public FilePickerConfiguration setCopyPickedImagesToPublicGalleryAppFolder(boolean copy) {
         PreferenceManager.getDefaultSharedPreferences(context).edit()
                 .putBoolean(BundleKeys.COPY_PICKED_IMAGES, copy)
-                .commit();
+                .apply();
         return this;
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/PickedFiles.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/PickedFiles.java
@@ -7,7 +7,6 @@ import android.net.Uri;
 import android.os.Environment;
 import android.support.annotation.NonNull;
 import android.support.v4.content.FileProvider;
-import android.util.Log;
 import android.webkit.MimeTypeMap;
 
 import java.io.File;
@@ -21,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.UUID;
+
+import timber.log.Timber;
 
 
 class PickedFiles implements Constants {
@@ -101,8 +102,8 @@ class PickedFiles implements Constants {
                 paths, null,
                 new MediaScannerConnection.OnScanCompletedListener() {
                     public void onScanCompleted(String path, Uri uri) {
-                        Log.d(getClass().getSimpleName(), "Scanned " + path + ":");
-                        Log.d(getClass().getSimpleName(), "-> uri=" + uri);
+                        Timber.d("Scanned " + path + ":");
+                        Timber.d("-> uri=%s", uri);
                     }
                 });
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/SimilarImageDialogFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/SimilarImageDialogFragment.java
@@ -47,9 +47,9 @@ public class SimilarImageDialogFragment extends DialogFragment {
     public SimilarImageDialogFragment() {
     }
     public interface onResponse{
-        public void onPositiveResponse();
+        void onPositiveResponse();
 
-        public void onNegativeResponse();
+        void onNegativeResponse();
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/utils/SwipableCardView.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/SwipableCardView.java
@@ -6,9 +6,10 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.CardView;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
+
+import timber.log.Timber;
 
 /**
  * A card view which informs onSwipe events to its child
@@ -37,7 +38,7 @@ public abstract class SwipableCardView extends CardView {
         this.setOnTouchListener((v, event) -> {
             boolean isSwipe = false;
             float deltaX = 0.0f;
-            Log.e("#SwipableCardView#", event.getAction() + "");
+            Timber.e(event.getAction() + "");
             switch (event.getAction()) {
                 case MotionEvent.ACTION_DOWN:
                     x1 = event.getX();

--- a/app/src/main/res/layout-land/activity_nearby.xml
+++ b/app/src/main/res/layout-land/activity_nearby.xml
@@ -37,7 +37,7 @@
                 <FrameLayout
                     android:id="@+id/container"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"></FrameLayout>
+                    android:layout_height="match_parent" />
 
             </LinearLayout>
             <View

--- a/app/src/main/res/layout/bottom_sheet_nearby.xml
+++ b/app/src/main/res/layout/bottom_sheet_nearby.xml
@@ -46,7 +46,6 @@
         android:layout_marginRight="16dp"
         android:layout_marginBottom="8dp"
         android:layout_marginTop="8dp"
-        android:visibility="gone"
-        ></FrameLayout>
+        android:visibility="gone" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_contributions.xml
+++ b/app/src/main/res/layout/fragment_contributions.xml
@@ -17,8 +17,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginTop="2dp"
-      app:cardBackgroundColor="?attr/mainCardBackground"
-      ></fr.free.nrw.commons.campaigns.CampaignView>
+      app:cardBackgroundColor="?attr/mainCardBackground" />
 
   <FrameLayout
       android:id="@+id/root_frame"

--- a/app/src/main/res/layout/row_item_languages_spinner.xml
+++ b/app/src/main/res/layout/row_item_languages_spinner.xml
@@ -23,8 +23,8 @@
     />
 
   <View
-    android:id="@+id/view"
-    android:layout_width="match_parent"
-    android:layout_height="1dp"
-    android:background="@color/item_white_background"></View>
+      android:id="@+id/view"
+      android:layout_width="match_parent"
+      android:layout_height="1dp"
+      android:background="@color/item_white_background" />
 </LinearLayout>

--- a/app/src/main/res/xml/pic_of_day_app_widget_info.xml
+++ b/app/src/main/res/xml/pic_of_day_app_widget_info.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<appwidget-provider
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:initialKeyguardLayout="@layout/pic_of_day_app_widget"
     android:initialLayout="@layout/pic_of_day_app_widget"
     android:minHeight="250dp"
@@ -8,4 +7,4 @@
     android:previewImage="@drawable/ic_launcher"
     android:resizeMode="horizontal|vertical"
     android:updatePeriodMillis="86400000"
-    android:widgetCategory="home_screen"></appwidget-provider>
+    android:widgetCategory="home_screen" />

--- a/app/src/test/kotlin/fr/free/nrw/commons/TestCommonsApplication.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/TestCommonsApplication.kt
@@ -16,7 +16,6 @@ import fr.free.nrw.commons.kvstore.BasicKvStore
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import fr.free.nrw.commons.location.LocationServiceManager
 import fr.free.nrw.commons.mwapi.MediaWikiApi
-import fr.free.nrw.commons.nearby.NearbyPlaces
 import fr.free.nrw.commons.upload.UploadController
 
 class TestCommonsApplication : CommonsApplication() {

--- a/app/src/test/kotlin/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApiTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApiTest.kt
@@ -246,7 +246,7 @@ class ApacheHttpClientMediaWikiApiTest {
     fun isUserBlockedFromCommonsForInfinitelyBlockedUser() {
         server.enqueue(MockResponse().setBody("<?xml version=\"1.0\"?><api><query><userinfo id=\"1000\" name=\"testusername\" blockid=\"3000\" blockedby=\"blockerusername\" blockedbyid=\"1001\" blockreason=\"testing\" blockedtimestamp=\"2018-05-24T15:32:09Z\" blockexpiry=\"infinite\"></userinfo></query></api>"))
 
-        val result = testObject.isUserBlockedFromCommons();
+        val result = testObject.isUserBlockedFromCommons()
 
         assertBasicRequestParameters(server, "GET").let { userBlockedRequest ->
             parseQueryParams(userBlockedRequest).let { body ->
@@ -268,7 +268,7 @@ class ApacheHttpClientMediaWikiApiTest {
         dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"))
         server.enqueue(MockResponse().setBody("<?xml version=\"1.0\"?><api><query><userinfo id=\"1000\" name=\"testusername\" blockid=\"3000\" blockedby=\"blockerusername\" blockedbyid=\"1001\" blockreason=\"testing\" blockedtimestamp=\"2018-05-24T15:32:09Z\" blockexpiry=\"" + dateFormat.format(expiredDate) + "\"></userinfo></query></api>"))
 
-        val result = testObject.isUserBlockedFromCommons();
+        val result = testObject.isUserBlockedFromCommons()
 
         assertBasicRequestParameters(server, "GET").let { userBlockedRequest ->
             parseQueryParams(userBlockedRequest).let { body ->
@@ -290,7 +290,7 @@ class ApacheHttpClientMediaWikiApiTest {
         dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"))
         server.enqueue(MockResponse().setBody("<?xml version=\"1.0\"?><api><query><userinfo id=\"1000\" name=\"testusername\" blockid=\"3000\" blockedby=\"blockerusername\" blockedbyid=\"1001\" blockreason=\"testing\" blockedtimestamp=\"2018-05-24T15:32:09Z\" blockexpiry=\"" + dateFormat.format(expiredDate) + "\"></userinfo></query></api>"))
 
-        val result = testObject.isUserBlockedFromCommons();
+        val result = testObject.isUserBlockedFromCommons()
 
         assertBasicRequestParameters(server, "GET").let { userBlockedRequest ->
             parseQueryParams(userBlockedRequest).let { body ->
@@ -308,7 +308,7 @@ class ApacheHttpClientMediaWikiApiTest {
     fun isUserBlockedFromCommonsForNotBlockedUser() {
         server.enqueue(MockResponse().setBody("<?xml version=\"1.0\"?><api><query><userinfo id=\"1000\" name=\"testusername\"></userinfo></query></api>"))
 
-        val result = testObject.isUserBlockedFromCommons();
+        val result = testObject.isUserBlockedFromCommons()
 
         assertBasicRequestParameters(server, "GET").let { userBlockedRequest ->
             parseQueryParams(userBlockedRequest).let { body ->

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/FileProcessorTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/FileProcessorTest.kt
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.upload
 
-import android.content.ContentResolver
 import android.content.SharedPreferences
 import fr.free.nrw.commons.caching.CacheController
 import fr.free.nrw.commons.mwapi.CategoryApi
@@ -8,8 +7,6 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.InjectMocks
 import org.mockito.Mock
-import org.mockito.Mockito.anyString
-import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
 import javax.inject.Inject
 import javax.inject.Named

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadControllerTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadControllerTest.kt
@@ -2,7 +2,6 @@ package fr.free.nrw.commons.upload
 
 import android.content.ComponentName
 import android.content.Context
-import android.content.SharedPreferences
 import fr.free.nrw.commons.HandlerService
 import fr.free.nrw.commons.auth.SessionManager
 import fr.free.nrw.commons.contributions.Contribution

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadModelTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadModelTest.kt
@@ -70,7 +70,7 @@ class UploadModelTest {
         `when`(fileUtilsWrapper!!.getGeolocationOfFile(anyString()))
                 .thenReturn("")
         `when`(imageProcessingService!!.validateImage(any(UploadModel.UploadItem::class.java), anyBoolean()))
-                .thenReturn(Single.just(IMAGE_OK));
+                .thenReturn(Single.just(IMAGE_OK))
 
     }
 


### PR DESCRIPTION
Fixes numerous Lint errors and warnings:
- Change Android Log to use Timber
- Use apply instead of commit for preference manager as this task runs asynchronously and the boolean returned by commit is not used
- Remove redundant semi colons from Kotlin classes
- Remove unused imports from Kotlin classes
- Clean up XML code in Layout files

Fixes #171 Fix Lint errors/warnings