### PR TITLE
Make DeleteTask notification quieter on some devices(Fixed #2528)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/delete/DeleteTask.java
+++ b/app/src/main/java/fr/free/nrw/commons/delete/DeleteTask.java
@@ -55,7 +55,8 @@ public class DeleteTask extends AsyncTask<Void, Integer, Boolean> {
                 (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         notificationBuilder = new NotificationCompat.Builder(
                 context,
-                CommonsApplication.NOTIFICATION_CHANNEL_ID_ALL);
+                CommonsApplication.NOTIFICATION_CHANNEL_ID_ALL)
+                .setOnlyAlertOnce(true);
         Toast toast = new Toast(context);
         toast.setGravity(Gravity.CENTER,0,0);
         toast = Toast.makeText(context,"Trying to nominate "+media.getDisplayTitle()+ " for deletion",Toast.LENGTH_SHORT);


### PR DESCRIPTION
**Description (required)**

This is a followup fix of issue #2528 

What changes did you make and why?

As commit ab4fca5e does, this commit fixed the repeated notification
alarms in DeleteTask.class.

Since progress indication in notification can be cleared by calling
.setProgress(0,0,false) on notificationBuilder(As shown in DeleteTask.class).
This commit also refactored notification related code in UploadService.class.
Make progress and failed notification uses the same notificationBuilder.

**Tests performed (required)**

Tested master betaDebug on Nexus 6P with API level 27.