### PR TITLE
Fix #2139: Now showing "Upload your media" text properly

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -309,7 +309,7 @@ public class ContributionsFragment
                 ((CursorAdapter) contributionsListFragment.getAdapter()).swapCursor(cursor);
             }
 
-            contributionsListFragment.clearSyncMessage();
+            contributionsListFragment.showWelcomeTip(cursor.getCount() == 0);
             notifyAndMigrateDataSetObservers();
             ((ContributionsListAdapter)contributionsListFragment.getAdapter()).setUploadService(uploadService);
         }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -36,8 +36,6 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
 
     @BindView(R.id.contributionsList)
     GridView contributionsList;
-    @BindView(R.id.waitingMessage)
-    TextView waitingMessage;
     @BindView(R.id.loadingContributionsProgressBar)
     ProgressBar progressBar;
     @BindView(R.id.fab_plus)
@@ -46,8 +44,8 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
     FloatingActionButton fabCamera;
     @BindView(R.id.fab_gallery)
     FloatingActionButton fabGallery;
-    @BindView(R.id.noDataYet)
-    TextView noDataYet;
+    @BindView(R.id.noContributionsYet)
+    TextView noContributionsYet;
 
     @Inject @Named("default_preferences") BasicKvStore basicKvStore;
     @Inject @Named("direct_nearby_upload_prefs") JsonKvStore directKvStore;
@@ -67,7 +65,6 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
 
         contributionsList.setOnItemClickListener((AdapterView.OnItemClickListener) getParentFragment());
 
-        changeEmptyScreen(true);
         changeProgressBarVisibility(true);
         return view;
     }
@@ -77,10 +74,6 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
         super.onViewCreated(view, savedInstanceState);
         initializeAnimations();
         setListeners();
-    }
-
-    public void changeEmptyScreen(boolean isEmpty){
-        this.noDataYet.setVisibility(isEmpty ? VISIBLE : GONE);
     }
 
     private void initializeAnimations() {
@@ -125,11 +118,10 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
     }
 
     /**
-     * Clears sync message displayed with progress bar before contributions list became visible
+     * Shows welcome message if user has no contributions yet i.e. new user.
      */
-    protected void clearSyncMessage() {
-        waitingMessage.setVisibility(GONE);
-        noDataYet.setVisibility(GONE);
+    protected void showWelcomeTip(boolean noContributions) {
+        noContributionsYet.setVisibility(noContributions ? VISIBLE : GONE);
     }
 
     public ListAdapter getAdapter() {

--- a/app/src/main/res/layout/fragment_contributions_list.xml
+++ b/app/src/main/res/layout/fragment_contributions_list.xml
@@ -8,7 +8,7 @@
     >
 
     <TextView
-        android:id="@+id/noDataYet"
+        android:id="@+id/noContributionsYet"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/no_uploads"
@@ -19,15 +19,6 @@
         android:layout_marginEnd="@dimen/tiny_gap"
         />
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/waiting_first_sync"
-        android:id="@+id/waitingMessage"
-        android:layout_gravity="center"
-        android:visibility="gone"
-        android:layout_centerHorizontal="true"
-        />
     <ProgressBar
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -419,7 +419,7 @@
   <string name="articles">articles</string>
 
   <string name="no_uploads">Welcome to Commons!\n
-Upload your first media by touching the camera or gallery icon above.</string>
+Upload your first media by tapping on the add button.</string>
 
   <string name="desc_language_Worldwide">Worldwide</string>
   <string name="desc_language_America">America</string>


### PR DESCRIPTION
* "Upload your media..." text was being shown while contributions were
  still being loaded. Fixed things to show after load is finished and no
  contributions are present. Also updated text string since UI now uses
  FAB button for uploads (no camera/gallery) icons any more.
* Removed waitingMessage in ContributionsListFragment and from layout
  since it's never VISIBLE, only GONE.

Tested BetaDebug on Nexus 5X with API level 27.