### PR TITLE
#2332 add param "uselang" in notifications API calls.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -566,6 +566,11 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
             }else {
                 notfilter = "!read";
             }
+            String language=Locale.getDefault().getLanguage();
+            if(StringUtils.isNullOrWhiteSpace(language)){
+                //if no language is set we use the default user language defined on wikipedia
+                language="user";
+            }
             notificationNode = api.action("query")
                     .param("notprop", "list")
                     .param("format", "xml")
@@ -573,6 +578,7 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
                     .param("notformat", "model")
                     .param("notwikis", "wikidatawiki|commonswiki|enwiki")
                     .param("notfilter", notfilter)
+                    .param("uselang", language)
                     .get()
                     .getNode("/api/query/notifications/list");
         } catch (IOException e) {


### PR DESCRIPTION
**Description (required)**

Fixes #2332 Notification activity: Dates not localized

What changes did you make and why?
add the param "uselang" in notifications API calls. The value used is the system user language or the value "user" if this value is empty.

**Tests performed (required)**

Tested betaDebug on Nexus 5X with API level 27.

