### PR TITLE
Close FAB automatically

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -85,8 +85,14 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
 
     private void setListeners() {
         fabPlus.setOnClickListener(view -> animateFAB(isFabOpen));
-        fabCamera.setOnClickListener(view -> controller.initiateCameraPick(getActivity()));
-        fabGallery.setOnClickListener(view -> controller.initiateGalleryPick(getActivity(), true));
+        fabCamera.setOnClickListener(view -> {
+            controller.initiateCameraPick(getActivity());
+            animateFAB(isFabOpen);
+        });
+        fabGallery.setOnClickListener(view -> {
+            controller.initiateGalleryPick(getActivity(), true);
+            animateFAB(isFabOpen);
+        });
     }
 
     private void animateFAB(boolean isFabOpen) {


### PR DESCRIPTION
**Description (required)**
Close FAB  in Contributions when gallery or camera mini-fab is clicked.

Fixes #2552

What changes did you make and why?
Called 'animateFab' in OnClickListener of 'fabCamera' and 'fabGallery' in order to collapse the FAB

**Tests performed (required)**
Tested betaDebug and prodDebug on Samsung Galaxy Note 3, API level 21