### PR TITLE
Fab in landscape

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -91,7 +91,6 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
         }
     }
 
-
     private void initializeAnimations() {
         fab_open = AnimationUtils.loadAnimation(getActivity(), R.anim.fab_open);
         fab_close = AnimationUtils.loadAnimation(getActivity(), R.anim.fab_close);

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -13,6 +13,8 @@ import android.widget.GridView;
 import android.widget.ListAdapter;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import android.content.res.Configuration;
+import android.widget.LinearLayout;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -46,6 +48,8 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
     FloatingActionButton fabGallery;
     @BindView(R.id.noContributionsYet)
     TextView noContributionsYet;
+    @BindView(R.id.fab_layout)
+    LinearLayout fab_layout;
 
     @Inject @Named("default_preferences") BasicKvStore basicKvStore;
     @Inject @Named("direct_nearby_upload_prefs") JsonKvStore directKvStore;
@@ -75,6 +79,18 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
         initializeAnimations();
         setListeners();
     }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        // check orientation
+        if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            fab_layout.setOrientation(LinearLayout.HORIZONTAL);
+        } else if (newConfig.orientation == Configuration.ORIENTATION_PORTRAIT) {
+            fab_layout.setOrientation(LinearLayout.VERTICAL);
+        }
+    }
+
 
     private void initializeAnimations() {
         fab_open = AnimationUtils.loadAnimation(getActivity(), R.anim.fab_open);

--- a/app/src/main/res/layout/fragment_contributions_list.xml
+++ b/app/src/main/res/layout/fragment_contributions_list.xml
@@ -38,6 +38,7 @@
         />
 
     <LinearLayout
+        android:id="@+id/fab_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
@@ -55,7 +56,7 @@
             android:layout_height="wrap_content"
             android:scaleType="center"
             android:tint="@color/button_blue"
-            android:visibility="invisible"
+            android:visibility="gone"
             app:backgroundTint="@color/main_background_light"
             app:elevation="6dp"
             app:fabSize="mini"
@@ -69,7 +70,7 @@
             android:layout_height="wrap_content"
             android:scaleType="center"
             android:tint="@color/button_blue"
-            android:visibility="invisible"
+            android:visibility="gone"
             app:backgroundTint="@color/main_background_light"
             app:elevation="6dp"
             app:fabSize="mini"


### PR DESCRIPTION
Fix FAB of contribution list in landscape orientation 

Fixes #2461 Floating add button turns into a spot in landscape mode

What changes did you make and why?
Visibility of fab-camera and fab changed to 'gone' as it doesn't take any space in layout.
Orientation of fab_layout changed to horizontal in landscape mode in order to better fit the open FAB.

Tested betaDebug on Realme 2 pro (Android Version 8.1.0) with API level 27.

Screenshot of the result 

![close](https://user-images.githubusercontent.com/25826255/54050096-731c9200-4206-11e9-9c6f-b6b7c3818f22.png)

![open](https://user-images.githubusercontent.com/25826255/54050143-96474180-4206-11e9-9740-fe7dc15f2a38.png)
