### PR TITLE
strings: add spacing after "Uploaded by:" in French

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -314,7 +314,7 @@
   <string name="showcase_view_plus_fab">Vous pouvez téléverser une photo de n\'importe quel endroit de votre gallerie ou de votre appareil photo</string>
   <string name="no_images_found">Aucune images trouvée.</string>
   <string name="error_loading_images">Une erreur s\'est produite pendant le chargement des images.</string>
-  <string name="image_uploaded_by">Importé par:%1$s</string>
+  <string name="image_uploaded_by">Importé par: %1$s</string>
   <string name="block_notification">Vous avez été bloqué et ne pouvez plus modifier sur  Commons</string>
   <string name="appwidget_img">Image du jour</string>
   <string name="app_widget_heading">Image du jour</string>


### PR DESCRIPTION
**Description (required)**

Fixes #2558

What changes did you make and why?

Added spacing between "Uploaded by:" and the name of the user

**Tests performed (required)**

Tested prodDebug on Samsung S6 with API level 23.

**Screenshots showing what changed (optional - for UI changes)**

![Screenshot_20190309-211941](https://user-images.githubusercontent.com/24768306/54077059-9cdfc280-42b3-11e9-8acc-739d2904ce47.png)


---
