### PR TITLE
resolved issue with German in case of empty notification activity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.constraint.ConstraintLayout;
 import android.support.design.widget.Snackbar;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
@@ -50,7 +51,7 @@ public class NotificationActivity extends NavigationBaseActivity {
     @BindView(R.id.container)
     RelativeLayout relativeLayout;
     @BindView(R.id.no_notification_background)
-    RelativeLayout no_notification;
+    ConstraintLayout no_notification;
     @BindView(R.id.no_notification_text)
     TextView noNotificationText;
 

--- a/app/src/main/res/layout/activity_notification.xml
+++ b/app/src/main/res/layout/activity_notification.xml
@@ -36,7 +36,7 @@
 
         </RelativeLayout>
 
-        <RelativeLayout
+        <android.support.constraint.ConstraintLayout
             android:id="@+id/no_notification_background"
             android:visibility="gone"
             android:layout_width="match_parent"
@@ -47,19 +47,23 @@
                 android:id="@+id/imageView"
                 android:layout_width="110dp"
                 android:layout_height="160dp"
-                android:layout_centerVertical="true"
-                android:layout_centerHorizontal="true"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:srcCompat="@drawable/ic_notifications_off_black_24dp" />
 
             <TextView
                 android:id="@+id/no_notification_text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_below="@+id/imageView"
-                android:layout_centerHorizontal="true"
+                app:layout_constraintTop_toBottomOf="@+id/imageView"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                android:gravity="center"
                 android:text="@string/no_notification"
                 android:textSize="20sp" />
-        </RelativeLayout>
+        </android.support.constraint.ConstraintLayout>
 
     </RelativeLayout>
 


### PR DESCRIPTION
**Fixed alignment issue with German in case of NO notification**

Fixes #2564 Notifications: message not centered in German

### Changes made
Modified layout for centre alignment 

**Screenshot showing what changed**
![WhatsApp Image 2019-03-10 at 2 33 01 AM](https://user-images.githubusercontent.com/34261945/54077422-ec3ae880-42dd-11e9-916b-64ee284228b9.jpeg)
