### PR TITLE
Wrap and enlarge title edit text

### DIFF
--- a/app/src/main/res/layout/row_item_title.xml
+++ b/app/src/main/res/layout/row_item_title.xml
@@ -13,7 +13,6 @@
         android:layout_height="wrap_content"
         android:hint="@string/share_title_hint"
         android:imeOptions="actionNext"
-        android:inputType="text"
-        android:maxLines="1"
+        android:inputType="textMultiLine"
         android:nextFocusForward="@+id/image_description" />
 </android.support.design.widget.TextInputLayout>


### PR DESCRIPTION
**Description (required)**

Fixes #2561 

What changes did you make and why?

Changed the inputType of title edit text so that long text input gets wrapped.

**Tests performed (required)**

Tested prodDebug on Samsung S6 with API level 23.

**Screenshots showing what changed (optional - for UI changes)**

![fix_2561](https://user-images.githubusercontent.com/24768306/54088762-8ee87b00-4361-11e9-9ef9-293f3be11a59.png)

