### PR TITLE
resolved progressbar overlap text issue

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint;
 import android.app.ProgressDialog;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.design.widget.TextInputLayout;
 import android.support.v7.app.AlertDialog;
@@ -23,6 +24,7 @@ import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
@@ -120,6 +122,8 @@ public class UploadActivity extends BaseActivity implements UploadView, SimilarI
     @BindView(R.id.category_search) EditText categoriesSearch;
     @BindView(R.id.category_search_container) TextInputLayout categoriesSearchContainer;
     @BindView(R.id.categories) RecyclerView categoriesList;
+    @BindView(R.id.category_search_layout)
+    FrameLayout categoryFrameLayout;
 
     // Final Submission
     @BindView(R.id.license_title) TextView licenseTitle;
@@ -563,6 +567,9 @@ public class UploadActivity extends BaseActivity implements UploadView, SimilarI
     }
 
     private void configureCategories() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            categoryFrameLayout.setLayoutDirection(View.LAYOUT_DIRECTION_LTR);
+        }
         categoriesAdapter = new UploadCategoriesAdapterFactory(categoriesModel).create(new ArrayList<>());
         categoriesList.setLayoutManager(new LinearLayoutManager(this));
         categoriesList.setAdapter(categoriesAdapter);


### PR DESCRIPTION
**Fixed the Error of Spinner overlapping text in case of right to left languages**

Fixes #2565 Upload category search in RTL: Spinner overlaps text

### Changes made
Set Layout direction for LTL irrespective of the current locale

**Screenshot**

![WhatsApp Image 2019-03-11 at 6 45 58 PM](https://user-images.githubusercontent.com/34261945/54126599-f53acf80-442d-11e9-91bd-e9d6ce064487.jpeg)
