### PR TITLE
Use Timber.e(Throwable t, String message, Object... args)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
@@ -66,7 +66,7 @@ public class MediaDataExtractor {
             Timber.d("Nominated for deletion: " + deletionStatus);
         }
         catch (Exception e){
-            Timber.d(e.getMessage());
+            Timber.d(e, "Exception during fetching");
         }
 
         MediaResult result = mediaWikiApi.fetchMediaByFilename(filename);

--- a/app/src/main/java/fr/free/nrw/commons/campaigns/CampaignsPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/campaigns/CampaignsPresenter.java
@@ -107,7 +107,7 @@ public class CampaignsPresenter implements BasePresenter {
                     }
 
                     @Override public void onError(Throwable e) {
-                        Timber.e(e.getMessage(), "could not fetch campaigns");
+                        Timber.e(e, "could not fetch campaigns");
                     }
                 });
         }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionDao.java
@@ -318,7 +318,7 @@ public class ContributionDao {
             try {
                 db.execSQL(query);
             } catch (SQLiteException e) {
-                Timber.e("Exception performing query: " + query + " message: " + e.getMessage());
+                Timber.e(e, "Exception performing query: " + query);
             }
         }
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
@@ -66,7 +66,7 @@ public class NearbyPlaces {
                 try {
                     places = getFromWikidataQuery(curLatLng, lang, radius);
                 } catch (InterruptedIOException e) {
-                    Timber.e(e,"exception in fetching nearby places");
+                    Timber.e(e, "exception in fetching nearby places");
                     return places;
                 }
                 Timber.d("%d results at radius: %f", places.size(), radius);


### PR DESCRIPTION
**Description (required)**

Use the appropriate variation of ``Timber.e`` for exceptions. 

Some logging code use the wrong variation of Timber methods resulting in unexpected error messages. This commit fixes that.

**Tests performed (required)**

Tested upload function using betaDebug on emulator with API level 24, but the test didn't allow me to see error messages. The messages are kind of hard to encounter. I merely trusted [the documentation](https://jakewharton.github.io/timber/timber/log/Timber.html#e-java.lang.Throwable-java.lang.String-java.lang.Object...-).
