### PR TITLE
resolved issue 2563 with description text

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
@@ -165,7 +165,7 @@ class DescriptionsAdapter extends RecyclerView.Adapter<DescriptionsAdapter.ViewH
             } else {
                 Description description = descriptions.get(position - 1);
                 Timber.d("Description is " + description);
-                if (!TextUtils.isEmpty(description.getDescriptionText()) && !description.getDescriptionText().equals("?")) {
+                if (!TextUtils.isEmpty(description.getDescriptionText())) {
                     descItemEditText.setText(description.getDescriptionText());
                 } else {
                     descItemEditText.setText("");

--- a/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
@@ -165,7 +165,7 @@ class DescriptionsAdapter extends RecyclerView.Adapter<DescriptionsAdapter.ViewH
             } else {
                 Description description = descriptions.get(position - 1);
                 Timber.d("Description is " + description);
-                if (!TextUtils.isEmpty(description.getDescriptionText())) {
+                if (!TextUtils.isEmpty(description.getDescriptionText()) && !description.getDescriptionText().equals("?")) {
                     descItemEditText.setText(description.getDescriptionText());
                 } else {
                     descItemEditText.setText("");

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
@@ -126,7 +126,7 @@ public class UploadModel {
 
         if (place != null) {
             uploadItem.title.setTitleText(place.getName());
-            uploadItem.descriptions.get(0).setDescriptionText(place.getLongDescription());
+            uploadItem.descriptions.get(0).setDescriptionText(place.getLongDescription().equals("?")?"":place.getLongDescription());
             //TODO figure out if default descriptions in other languages exist
             uploadItem.descriptions.get(0).setLanguageCode("en");
         }


### PR DESCRIPTION
**Fixed issue 2563 with description text for those having empty nearby place information**

Fixes #2563 When type of nearby place is unknown, let description empty rather than just "?"

### Changes made
Added a condition to check if the description text is "?" then instead add blank space
