### PR TITLE
Fixed bug #2324 - Number of Contributions not updating unless app is restarted

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -332,6 +332,12 @@ public class ContributionsFragment
         for (DataSetObserver observer : observersWaitingForLoad) {
             observer.onChanged();
         }
+
+        if (!ConfigUtils.isBetaFlavour()) {
+            setUploadCount();
+        } else {
+            betaSetUploadCount(getTotalMediaCount());
+        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -333,10 +333,10 @@ public class ContributionsFragment
             observer.onChanged();
         }
 
-        if (!ConfigUtils.isBetaFlavour()) {
-            setUploadCount();
-        } else {
+        if (ConfigUtils.isBetaFlavour()) {
             betaSetUploadCount(getTotalMediaCount());
+        } else {
+            setUploadCount();
         }
     }
 


### PR DESCRIPTION
**Description**
The number of contributions was not updating until we restart the app. The bug was caused because when the loader is reset the function which updates the contributions was not called.

**Fixes #2324 Number of contributions does not update until the app is restarted**

**Tests performed**
Tested betaDebug on Xiaomi Mi A1 with API level 28 stock android.
