### PR TITLE
Fix #2610: Use dark map theme in night mode

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -511,10 +511,11 @@ public class NearbyMapFragment extends DaggerFragment {
      */
     private void setupMapView(Bundle savedInstanceState) {
         Timber.d("setupMapView called");
+        boolean isDarkTheme = defaultKvStore.getBoolean("theme", false);
         MapboxMapOptions options = new MapboxMapOptions()
                 .compassGravity(Gravity.BOTTOM | Gravity.LEFT)
                 .compassMargins(new int[]{12, 0, 0, 24})
-                .styleUrl(Style.OUTDOORS)
+                .styleUrl(isDarkTheme ? Style.DARK : Style.OUTDOORS)
                 .logoEnabled(false)
                 .attributionEnabled(false)
                 .camera(new CameraPosition.Builder()


### PR DESCRIPTION
**Description (required)**

Fixes #2610 and #2180

What changes did you make and why?
- Use the dark mapbox theme in night mode

**Tests performed (required)**

Tested `2.10.1-debug-night-nearby-map~86fb780c4` on `Galaxy Nexus` with API level `28`.

Tested both night mode and non-night mode (see screenshots)

**Screenshots showing what changed (optional - for UI changes)**

| Before | After |
| - | - |
| ![Screenshot_1552737459](https://user-images.githubusercontent.com/4953590/54474913-def09300-47e2-11e9-8b30-cdf065056234.png) | ![Screenshot_1552737525](https://user-images.githubusercontent.com/4953590/54474910-def09300-47e2-11e9-918e-cf5330670d3f.png) |
| ![Screenshot_1552737481](https://user-images.githubusercontent.com/4953590/54474912-def09300-47e2-11e9-8e51-5ba04caca524.png) | ![Screenshot_1552737517](https://user-images.githubusercontent.com/4953590/54474911-def09300-47e2-11e9-810c-eea6b03b9864.png) |
