### PR TITLE
Fix #2203: Require number of uploads not to have decimal

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsSyncAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsSyncAdapter.java
@@ -41,6 +41,10 @@ public class ContributionsSyncAdapter extends AbstractThreadedSyncAdapter {
     private static final ContentValues[] EMPTY = {};
     private static int COMMIT_THRESHOLD = 10;
 
+    // Arbitrary limit to cap the number of contributions to ever load. This is a maximum built
+    // into the app, rather than the user's setting. Also see Github issue #52.
+    public static final int ABSOLUTE_CONTRIBUTIONS_LOAD_LIMIT = 500;
+
     @SuppressWarnings("WeakerAccess")
     @Inject MediaWikiApi mwApi;
     @Inject
@@ -49,13 +53,6 @@ public class ContributionsSyncAdapter extends AbstractThreadedSyncAdapter {
 
     public ContributionsSyncAdapter(Context context, boolean autoInitialize) {
         super(context, autoInitialize);
-    }
-
-    private int getLimit() {
-
-        int limit = 500;
-        Timber.d("Max number of uploads set to %d", limit);
-        return limit; // FIXME: Parameterize!
     }
 
     private boolean fileExists(ContentProviderClient client, String filename) {
@@ -99,7 +96,7 @@ public class ContributionsSyncAdapter extends AbstractThreadedSyncAdapter {
         while (!done) {
 
             try {
-                result = mwApi.logEvents(user, lastModified, queryContinue, getLimit());
+                result = mwApi.logEvents(user, lastModified, queryContinue, ABSOLUTE_CONTRIBUTIONS_LOAD_LIMIT);
             } catch (IOException e) {
                 // There isn't really much we can do, eh?
                 // FIXME: Perhaps add EventLogging?

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -60,9 +60,9 @@ public class SettingsFragment extends PreferenceFragment {
         });
 
         final EditTextPreference uploadLimit = (EditTextPreference) findPreference("uploads");
-        int uploads = defaultKvStore.getInt(Prefs.UPLOADS_SHOWING, 100);
-        uploadLimit.setText(uploads + "");
-        uploadLimit.setSummary(uploads + "");
+        int currentUploadLimit = defaultKvStore.getInt(Prefs.UPLOADS_SHOWING, 100);
+        uploadLimit.setText(Integer.toString(currentUploadLimit));
+        uploadLimit.setSummary(Integer.toString(currentUploadLimit));
         uploadLimit.getEditText().addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {
@@ -75,36 +75,25 @@ public class SettingsFragment extends PreferenceFragment {
 
             @Override
             public void afterTextChanged(Editable s) {
-                int value;
-                if (s.length()>0)
-                try {
-                    value = Integer.parseInt(s.toString());
-                    if (value > 500) {
-                        uploadLimit.getEditText().setError(getString((R.string.maximum_limit_alert)));
-                        defaultKvStore.putInt(Prefs.UPLOADS_SHOWING, 500);
-                        defaultKvStore.putBoolean(Prefs.IS_CONTRIBUTION_COUNT_CHANGED, true);
-                        uploadLimit.setSummary(500 + "");
-                        uploadLimit.setText(500 + "");
-                    } else if (value == 0) {
-                        uploadLimit.getEditText().setError(getString(R.string.cannot_be_zero));
-                        defaultKvStore.putInt(Prefs.UPLOADS_SHOWING, 100);
-                        defaultKvStore.putBoolean(Prefs.IS_CONTRIBUTION_COUNT_CHANGED, true);
-                        uploadLimit.setSummary(100 + "");
-                        uploadLimit.setText(100 + "");
-                    } else {
-                        defaultKvStore.putInt(Prefs.UPLOADS_SHOWING, value);
-                        defaultKvStore.putBoolean(Prefs.IS_CONTRIBUTION_COUNT_CHANGED, true);
-                        uploadLimit.setSummary(String.valueOf(value));
-                    }
-                } catch (Exception e) {
-                    uploadLimit.getEditText().setError(getString(R.string.enter_valid));
-                    defaultKvStore.putInt(Prefs.UPLOADS_SHOWING, 100);
-                    defaultKvStore.putBoolean(Prefs.IS_CONTRIBUTION_COUNT_CHANGED, true);
-                    uploadLimit.setSummary(100 + "");
-                    uploadLimit.setText(100 + "");
+                if (s.length() == 0) return;
+
+                int value = Integer.parseInt(s.toString());
+
+                if (value > 500) {
+                    uploadLimit.getEditText().setError(getString(R.string.maximum_limit_alert));
+                    value = 500;
+                } else if (value == 0) {
+                    uploadLimit.getEditText().setError(getString(R.string.cannot_be_zero));
+                    value = 100;
                 }
+
+                defaultKvStore.putInt(Prefs.UPLOADS_SHOWING, value);
+                defaultKvStore.putBoolean(Prefs.IS_CONTRIBUTION_COUNT_CHANGED, true);
+                uploadLimit.setText(Integer.toString(value));
+                uploadLimit.setSummary(Integer.toString(value));
             }
         });
+
         Preference betaTesterPreference = findPreference("becomeBetaTester");
         betaTesterPreference.setOnPreferenceClickListener(preference -> {
             Utils.handleWebUrl(getActivity(), Uri.parse(getResources().getString(R.string.beta_opt_in_link)));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,7 +192,7 @@
   <string name="maximum_limit_alert">Unable to display more than 500</string>
   <string name="enter_valid">Enter a valid number</string>
   <string name="cannot_be_zero">Upload limit cannot be 0</string>
-  <string name="set_limit">Set Recent Upload Limit</string>
+  <string name="set_limit">Recent upload limit</string>
   <string name="login_failed_2fa_not_supported">Two factor authentication is currently not supported.</string>
   <string name="logout_verification">Do you really want to logout?</string>
   <string name="commons_logo">Commons Logo</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -26,7 +26,7 @@
             android:key="uploads"
             android:defaultValue="100"
             android:title= "@string/set_limit"
-            android:inputType="numberDecimal"
+            android:inputType="number"
             android:maxLength="3" />
 
         <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleSwitchPreference


### PR DESCRIPTION
**Description (required)**

Fixes #2203

What changes did you make and why?

This is a semi re-merge of #2207 after #2292

- In `preferences.xml` set `android:inputType` of the pref to be `number`, stopping users from entering decimal points (which could cause `NumberFormatException`s when parsed as an integer)
- Removed duplicated code
- In `strings.xml` changed preference title from "Set Recent Upload Limit" to just "Recent upload limit" to standardise capitalisation among settings and remove redundant "Set"

**Tests performed (required)**

Tested `2.10.1-debug-fix-2203-2~95de319b4` on `Galaxy Nexus` with API level `28`