### PR TITLE
Avoid "form movements" in the login screen

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -23,6 +23,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -149,6 +150,10 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         } else {
             loginCredentials.setVisibility(View.GONE);
         }
+
+        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
+
+
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/delete/DeleteTask.java
+++ b/app/src/main/java/fr/free/nrw/commons/delete/DeleteTask.java
@@ -161,16 +161,25 @@ public class DeleteTask extends AsyncTask<Void, Integer, Boolean> {
 
     @Override
     protected void onPostExecute(Boolean result) {
+
+        //link to string resources
+        String title_resource = context.getResources().getString(R.string.nominating_for_Deletion);
+        String success_resource = context.getResources().getString(R.string.success);
+        String successfully_nominated_resource = context.getResources().getString(R.string.successfully_nominated);
+        String for_deletion_resource = context.getResources().getString(R.string.for_deletion);
+        String failed_resource = context.getResources().getString(R.string.failed);
+        String could_not_request_deletion_resource = context.getResources().getString(R.string.could_not_request_deletion);
+
         String message;
-        String title = "Nominating for Deletion";
+        String title = title_resource;
 
         if (result){
-            title += ": Success";
-            message = "Successfully nominated " + media.getDisplayTitle() + " deletion.";
+            title += ":"+success_resource;
+            message = successfully_nominated_resource + media.getDisplayTitle() + for_deletion_resource+".";
         }
         else {
-            title += ": Failed";
-            message = "Could not request deletion.";
+            title += ":"+failed_resource;
+            message = could_not_request_deletion_resource+".";
         }
 
         notificationBuilder.setDefaults(DEFAULT_ALL)

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -10,7 +10,7 @@
         android:orientation="vertical">
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="700dp"
         android:layout_centerInParent="true"
         android:layout_gravity="center_vertical"
         android:layout_marginTop="@dimen/small_gap">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -470,4 +470,12 @@ Upload your first media by tapping on the add button.</string>
   <string name="image_chooser_title">Choose Images to upload</string>
 
   <string name="please_wait">Please wait…</string>
+
+  <string name="nominating_for_Deletion">Nominating for Deletion</string>
+  <string name="success">Success</string>
+  <string name="successfully_nominated">Successfully nominated</string>
+  <string name="for_deletion">for deletion</string>
+  <string name="failed">Failed</string>
+  <string name="could_not_request_deletion">Could not request deletion</string>
+
 </resources>


### PR DESCRIPTION
I have Avoided "dynamism/movements" of username and password fields in the login screen by stopping the soft keyboard from pushing my view up.

Fixes #1107