### PR TITLE
Fix tests in SettingsActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,11 +66,11 @@ dependencies {
 
     // Android testing
     androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    androidTestImplementation 'androidx.test:runner:1.1.1'
+    androidTestImplementation 'androidx.test:rules:1.1.1'
+    androidTestImplementation 'androidx.annotation:annotation:1.0.2'
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
-    androidTestImplementation 'androidx.test:rules:1.1.2-alpha02'
-    androidTestImplementation 'androidx.test:runner:1.1.2-alpha02'
-    androidTestImplementation "androidx.annotation:annotation:1.0.2"
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0-alpha02'
     androidTestImplementation 'org.mockito:mockito-core:2.10.0'
 
     // Debugging

--- a/app/src/androidTest/java/fr/free/nrw/commons/SettingsActivityTest.java
+++ b/app/src/androidTest/java/fr/free/nrw/commons/SettingsActivityTest.java
@@ -22,9 +22,11 @@ import fr.free.nrw.commons.settings.SettingsActivity;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
 
 @LargeTest
@@ -50,7 +52,7 @@ public class SettingsActivityTest {
                 .inAdapterView(withId(android.R.id.list))
                 .perform(click());
 
-        // Try setting it to 100
+        // Try setting it to 123
         Espresso.onView(withId(android.R.id.edit))
                 .perform(replaceText("123"));
 
@@ -78,7 +80,7 @@ public class SettingsActivityTest {
                 .inAdapterView(withId(android.R.id.list))
                 .perform(click());
 
-        // Try setting it to 100
+        // Try setting it to 0
         Espresso.onView(withId(android.R.id.edit))
                 .perform(replaceText("0"));
 
@@ -97,5 +99,63 @@ public class SettingsActivityTest {
                 .inAdapterView(withId(android.R.id.list))
                 .onChildView(withId(android.R.id.summary))
                 .check(matches(withText("100")));
+    }
+
+    @Test
+    public void setRecentUploadLimitTo700() {
+        // Open "Use external storage" preference
+        Espresso.onData(PreferenceMatchers.withKey("uploads"))
+                .inAdapterView(withId(android.R.id.list))
+                .perform(click());
+
+        // Try setting it to 700
+        Espresso.onView(withId(android.R.id.edit))
+                .perform(replaceText("700"));
+
+        // Click "OK"
+        Espresso.onView(allOf(withId(android.R.id.button1), withText("OK")))
+                .perform(click());
+
+        // Check setting set to 500 in SharedPreferences
+        assertEquals(
+                500,
+                defaultKvStore.getInt(Prefs.UPLOADS_SHOWING, 0)
+        );
+
+        // Check displaying 100 in summary text
+        Espresso.onData(PreferenceMatchers.withKey("uploads"))
+                .inAdapterView(withId(android.R.id.list))
+                .onChildView(withId(android.R.id.summary))
+                .check(matches(withText("500")));
+    }
+
+    @Test
+    public void useAuthorNameTogglesOn() {
+        // Turn on "Use external storage" preference if currently off
+        if (!defaultKvStore.getBoolean("useAuthorName", true)) {
+            Espresso.onData(PreferenceMatchers.withKey("useAuthorName"))
+                    .inAdapterView(withId(android.R.id.list))
+                    .perform(click());
+        }
+
+        // Check authorName preference is enabled
+        Espresso.onData(PreferenceMatchers.withKey("authorName"))
+                .inAdapterView(withId(android.R.id.list))
+                .check(matches(isEnabled()));
+    }
+
+    @Test
+    public void useAuthorNameTogglesOff() {
+        // Turn off "Use external storage" preference if currently on
+        if (defaultKvStore.getBoolean("useAuthorName", false)) {
+            Espresso.onData(PreferenceMatchers.withKey("useAuthorName"))
+                    .inAdapterView(withId(android.R.id.list))
+                    .perform(click());
+        }
+
+        // Check authorName preference is enabled
+        Espresso.onData(PreferenceMatchers.withKey("authorName"))
+                .inAdapterView(withId(android.R.id.list))
+                .check(matches(not(isEnabled())));
     }
 }

--- a/app/src/androidTest/java/fr/free/nrw/commons/SettingsActivityTest.java
+++ b/app/src/androidTest/java/fr/free/nrw/commons/SettingsActivityTest.java
@@ -70,4 +70,32 @@ public class SettingsActivityTest {
                 .onChildView(withId(android.R.id.summary))
                 .check(matches(withText("123")));
     }
+
+    @Test
+    public void setRecentUploadLimitTo0() {
+        // Open "Use external storage" preference
+        Espresso.onData(PreferenceMatchers.withKey("uploads"))
+                .inAdapterView(withId(android.R.id.list))
+                .perform(click());
+
+        // Try setting it to 100
+        Espresso.onView(withId(android.R.id.edit))
+                .perform(replaceText("0"));
+
+        // Click "OK"
+        Espresso.onView(allOf(withId(android.R.id.button1), withText("OK")))
+                .perform(click());
+
+        // Check setting set to 100 in SharedPreferences
+        assertEquals(
+                100,
+                defaultKvStore.getInt(Prefs.UPLOADS_SHOWING, 0)
+        );
+
+        // Check displaying 100 in summary text
+        Espresso.onData(PreferenceMatchers.withKey("uploads"))
+                .inAdapterView(withId(android.R.id.list))
+                .onChildView(withId(android.R.id.summary))
+                .check(matches(withText("100")));
+    }
 }

--- a/app/src/androidTest/java/fr/free/nrw/commons/SettingsActivityTest.java
+++ b/app/src/androidTest/java/fr/free/nrw/commons/SettingsActivityTest.java
@@ -35,8 +35,7 @@ public class SettingsActivityTest {
     JsonKvStore defaultKvStore;
 
     @Rule
-    public ActivityTestRule<SettingsActivity> activityRule =
-            new ActivityTestRule<>(SettingsActivity.class, false, true);
+    public ActivityTestRule activityRule = new ActivityTestRule<>(SettingsActivity.class);
 
     @Before
     public void setup() {

--- a/app/src/androidTest/java/fr/free/nrw/commons/SettingsActivityTest.java
+++ b/app/src/androidTest/java/fr/free/nrw/commons/SettingsActivityTest.java
@@ -1,18 +1,20 @@
 package fr.free.nrw.commons;
 
 import android.content.Context;
-import androidx.test.InstrumentationRegistry;
-import androidx.test.espresso.Espresso;
-import androidx.test.espresso.matcher.PreferenceMatchers;
-import androidx.test.filters.LargeTest;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
+
+import com.google.gson.Gson;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import androidx.test.InstrumentationRegistry;
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.matcher.PreferenceMatchers;
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.AndroidJUnit4;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.settings.Prefs;
 import fr.free.nrw.commons.settings.SettingsActivity;
@@ -28,7 +30,7 @@ import static org.junit.Assert.assertEquals;
 @LargeTest
 @RunWith(AndroidJUnit4.class)
 public class SettingsActivityTest {
-    BasicKvStore prefs;
+    JsonKvStore defaultKvStore;
 
     @Rule
     public ActivityTestRule<SettingsActivity> activityRule =
@@ -38,11 +40,11 @@ public class SettingsActivityTest {
     public void setup() {
         Context context = InstrumentationRegistry.getTargetContext();
         String storeName = context.getPackageName() + "_preferences";
-        prefs = new BasicKvStore(context, storeName);
+        defaultKvStore = new JsonKvStore(context, storeName, new Gson());
     }
 
     @Test
-    public void setRecentUploadLimitTo100() {
+    public void setRecentUploadLimitTo123() {
         // Open "Use external storage" preference
         Espresso.onData(PreferenceMatchers.withKey("uploads"))
                 .inAdapterView(withId(android.R.id.list))
@@ -50,22 +52,22 @@ public class SettingsActivityTest {
 
         // Try setting it to 100
         Espresso.onView(withId(android.R.id.edit))
-                .perform(replaceText("100"));
+                .perform(replaceText("123"));
 
         // Click "OK"
         Espresso.onView(allOf(withId(android.R.id.button1), withText("OK")))
                 .perform(click());
 
-        // Check setting set to 100 in SharedPreferences
+        // Check setting set to 123 in SharedPreferences
         assertEquals(
-                100,
-                prefs.getInt(Prefs.UPLOADS_SHOWING, 0)
+                123,
+                defaultKvStore.getInt(Prefs.UPLOADS_SHOWING, 0)
         );
 
-        // Check displaying 100 in summary text
+        // Check displaying 123 in summary text
         Espresso.onData(PreferenceMatchers.withKey("uploads"))
                 .inAdapterView(withId(android.R.id.list))
                 .onChildView(withId(android.R.id.summary))
-                .check(matches(withText("100")));
+                .check(matches(withText("123")));
     }
 }


### PR DESCRIPTION
**Description (required)**

I think SettingsActivityTest got broken either in #2594 and #2613

I've fixed the androidx dependencies and updated SettingsActivityTest to use JsonKvStore, and now the tests work again.

What's kinda worrying is that Travis didn't seem to throw an error in `:app:compileBetaDebugAndroidTestJavaWithJavac`. Update: #2595 disabled running android tests as there was only one minor one. This makes sense for now - once we have some more android tests we'll enable it again.