### PR TITLE
Fixed issue 2629 crash in upload activity due to migration to androidx

### DIFF
--- a/app/src/main/res/layout/activity_upload_bottom_card.xml
+++ b/app/src/main/res/layout/activity_upload_bottom_card.xml
@@ -67,7 +67,7 @@
     </androidx.cardview.widget.CardView>
 
 
-    <androidx.support.v7.widget.CardView
+    <androidx.cardview.widget.CardView
         android:id="@+id/bottom_card"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -177,8 +177,7 @@
                 app:layout_constraintStart_toStartOf="parent" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.support.v7.widget.CardView>
+    </androidx.cardview.widget.CardView>
 </androidx.constraintlayout.widget.ConstraintLayout>
 
 
-                


### PR DESCRIPTION
**Description (required)**

Fixes #2629 Crash in upload activity due to recent migrations to androidx

### Changes made
Changed the attribute `androidx.support.v7.widget.CardView` to `androidx.cardview.widget.CardView`
