### PR TITLE
#2643: Create drawer_view.xml

### DIFF
--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -169,12 +169,6 @@
         </ScrollView>
     </LinearLayout>
 
-    <com.google.android.material.navigation.NavigationView
-        android:id="@+id/navigation_view"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        app:headerLayout="@layout/drawer_header"
-        app:menu="@menu/drawer" />
+    <include layout="@layout/drawer_view" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_achievements.xml
+++ b/app/src/main/res/layout/activity_achievements.xml
@@ -438,12 +438,6 @@
         </ScrollView>
     </LinearLayout>
 
-    <com.google.android.material.navigation.NavigationView
-        android:id="@+id/navigation_view"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        app:headerLayout="@layout/drawer_header"
-        app:menu="@menu/drawer" />
+    <include layout="@layout/drawer_view" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_bookmarks.xml
+++ b/app/src/main/res/layout/activity_bookmarks.xml
@@ -50,12 +50,6 @@
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 
-    <com.google.android.material.navigation.NavigationView
-        android:id="@+id/navigation_view"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        app:headerLayout="@layout/drawer_header"
-        app:menu="@menu/drawer" />
+    <include layout="@layout/drawer_view" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_category_details.xml
+++ b/app/src/main/res/layout/activity_category_details.xml
@@ -48,12 +48,6 @@
             android:layout_below="@id/toolbar_layout" />
     </RelativeLayout>
 
-    <com.google.android.material.navigation.NavigationView
-        android:id="@+id/navigation_view"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        app:headerLayout="@layout/drawer_header"
-        app:menu="@menu/drawer" />
+    <include layout="@layout/drawer_view" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_category_images.xml
+++ b/app/src/main/res/layout/activity_category_images.xml
@@ -24,12 +24,6 @@
         </FrameLayout>
     </RelativeLayout>
 
-    <com.google.android.material.navigation.NavigationView
-        android:id="@+id/navigation_view"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        app:headerLayout="@layout/drawer_header"
-        app:menu="@menu/drawer"/>
+    <include layout="@layout/drawer_view" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_contributions.xml
+++ b/app/src/main/res/layout/activity_contributions.xml
@@ -45,12 +45,6 @@
 
     </RelativeLayout>
 
-    <com.google.android.material.navigation.NavigationView
-        android:id="@+id/navigation_view"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        app:headerLayout="@layout/drawer_header"
-        app:menu="@menu/drawer"/>
+    <include layout="@layout/drawer_view" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_explore.xml
+++ b/app/src/main/res/layout/activity_explore.xml
@@ -48,12 +48,6 @@
             android:layout_below="@id/toolbar_layout" />
     </RelativeLayout>
 
-    <com.google.android.material.navigation.NavigationView
-        android:id="@+id/navigation_view"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        app:headerLayout="@layout/drawer_header"
-        app:menu="@menu/drawer" />
+    <include layout="@layout/drawer_view" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_notification.xml
+++ b/app/src/main/res/layout/activity_notification.xml
@@ -67,12 +67,6 @@
 
     </RelativeLayout>
 
-    <com.google.android.material.navigation.NavigationView
-        android:id="@+id/navigation_view"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        app:headerLayout="@layout/drawer_header"
-        app:menu="@menu/drawer"/>
+    <include layout="@layout/drawer_view" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -89,12 +89,6 @@
             />
     </RelativeLayout>
 
-    <com.google.android.material.navigation.NavigationView
-        android:id="@+id/navigation_view"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        app:headerLayout="@layout/drawer_header"
-        app:menu="@menu/drawer"/>
+    <include layout="@layout/drawer_view" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -32,12 +32,6 @@
             />
     </RelativeLayout>
 
-    <com.google.android.material.navigation.NavigationView
-        android:id="@+id/navigation_view"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        app:headerLayout="@layout/drawer_header"
-        app:menu="@menu/drawer"/>
+    <include layout="@layout/drawer_view" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/drawer_view.xml
+++ b/app/src/main/res/layout/drawer_view.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.navigation.NavigationView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/navigation_view"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:layout_gravity="start"
+    app:headerLayout="@layout/drawer_header"
+    app:menu="@menu/drawer" />


### PR DESCRIPTION
**Description (required)**

Works on #2643

Extract the `NavigationView` for the drawer into `drawer_view.xml` so it's not duplicated everywhere. There are a couple of unused files which still refer to `NavigationView` but these should be deleted by #2641 and I don't want to create merge conflicts.

**Tests performed (required)**

Tested `2.10.1-debug-refactor-drawer~0b5af825a` at API levels `28` and `19`