### PR TITLE
#2643: Standardize includes of toolbar layout

### DIFF
--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -9,11 +9,7 @@
         android:id="@+id/toolbarLayout"
         android:layout_width="wrap_content"
         android:layout_height="?attr/actionBarSize">
-        <include
-            android:id="@+id/toolbar"
-            layout="@layout/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize" />
+        <include layout="@layout/toolbar"/>
     </LinearLayout>
     <LinearLayout
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_achievements.xml
+++ b/app/src/main/res/layout/activity_achievements.xml
@@ -9,11 +9,7 @@
         android:id="@+id/toolbarLayout"
         android:layout_width="wrap_content"
         android:layout_height="?attr/actionBarSize">
-        <include
-            android:id="@+id/toolbar"
-            layout="@layout/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+        <include layout="@layout/toolbar"/>
     </LinearLayout>
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_bookmarks.xml
+++ b/app/src/main/res/layout/activity_bookmarks.xml
@@ -9,12 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <include
-            android:id="@+id/toolbar"
-            layout="@layout/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_scrollFlags="scroll" />
+        <include layout="@layout/toolbar"/>
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tab_layout"

--- a/app/src/main/res/layout/activity_category_details.xml
+++ b/app/src/main/res/layout/activity_category_details.xml
@@ -15,11 +15,7 @@
             android:layout_height="wrap_content"
             android:background="@color/primaryDarkColor">
 
-            <include
-                android:id="@+id/toolbar"
-                layout="@layout/toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+            <include layout="@layout/toolbar"/>
 
             <com.google.android.material.tabs.TabLayout
                 android:id="@+id/tab_layout"

--- a/app/src/main/res/layout/activity_category_images.xml
+++ b/app/src/main/res/layout/activity_category_images.xml
@@ -8,11 +8,7 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-        <include
-            android:id="@+id/toolbar"
-            layout="@layout/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+        <include layout="@layout/toolbar"/>
 
         <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_contributions.xml
+++ b/app/src/main/res/layout/activity_contributions.xml
@@ -12,11 +12,7 @@
         android:layout_height="match_parent"
         android:gravity="center_horizontal"
         >
-        <include
-            android:id="@+id/toolbar"
-            layout="@layout/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+        <include layout="@layout/toolbar"/>
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tab_layout"

--- a/app/src/main/res/layout/activity_explore.xml
+++ b/app/src/main/res/layout/activity_explore.xml
@@ -15,11 +15,7 @@
             android:layout_height="wrap_content"
             android:background="@color/primaryDarkColor">
 
-            <include
-                android:id="@+id/toolbar"
-                layout="@layout/toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+            <include layout="@layout/toolbar"/>
 
             <com.google.android.material.tabs.TabLayout
                 android:id="@+id/tab_layout"

--- a/app/src/main/res/layout/activity_notification.xml
+++ b/app/src/main/res/layout/activity_notification.xml
@@ -10,11 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <include
-            android:id="@+id/toolbar"
-            layout="@layout/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+        <include layout="@layout/toolbar"/>
 
         <RelativeLayout
             android:id="@+id/container"

--- a/app/src/main/res/layout/activity_quiz.xml
+++ b/app/src/main/res/layout/activity_quiz.xml
@@ -11,11 +11,7 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
-            <include
-                android:id="@+id/toolbar"
-                layout="@layout/toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+            <include layout="@layout/toolbar"/>
 
             <androidx.cardview.widget.CardView
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_quiz_result.xml
+++ b/app/src/main/res/layout/activity_quiz_result.xml
@@ -5,11 +5,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent">
 
-    <include
-        android:id="@+id/toolbar"
-        layout="@layout/toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+    <include layout="@layout/toolbar"/>
 
     <androidx.cardview.widget.CardView
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -15,12 +15,8 @@
             android:layout_height="wrap_content">
 
             <!-- Toolbar for viewing media -->
-        <include
-            android:visibility="gone"
-            android:id="@+id/toolbar"
-            layout="@layout/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            <include layout="@layout/toolbar"
+                android:visibility="gone" />
 
         <!--Toolbar containing search bar -->
         <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -10,11 +10,7 @@
         android:id="@+id/toolbarLayout"
         android:layout_width="wrap_content"
         android:layout_height="?attr/actionBarSize">
-        <include
-            android:id="@+id/toolbar"
-            layout="@layout/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize" />
+        <include layout="@layout/toolbar" />
     </LinearLayout>
 
     <RelativeLayout

--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.appcompat.widget.Toolbar
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/toolbar"
-    android:layout_height="wrap_content"
     android:layout_width="match_parent"
+    android:layout_height="?attr/actionBarSize"
+    android:background="?attr/colorPrimaryDark"
     android:fitsSystemWindows="true"
-    android:minHeight="?attr/actionBarSize"
-    app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-    android:background="?attr/colorPrimaryDark">
-
-</androidx.appcompat.widget.Toolbar>
+    app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />


### PR DESCRIPTION
**Description (required)**

Works on #2643

Include `toolbar.xml` in the same simple way everywhere - there is no need to add the id, width, height etc. in both the caller and the template - it should just be once in the template. There are a couple of unused files which I haven't updated but these should be deleted by #2641 and I don't want to create merge conflicts.

**Tests performed (required)**

Tested `2.10.1-debug-refactor-toolbar~9d15e177e`

[Beta Commons upload](https://commons.wikimedia.beta.wmflabs.org/wiki/File:MobileTest_2646.jpg)