### PR TITLE
Bug Fix #2585

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -23,6 +23,7 @@ import fr.free.nrw.commons.explore.images.SearchImageFragment;
 import fr.free.nrw.commons.explore.recentsearches.RecentSearchesFragment;
 import fr.free.nrw.commons.media.MediaDetailPagerFragment;
 import fr.free.nrw.commons.theme.NavigationBaseActivity;
+import fr.free.nrw.commons.utils.FragmentUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
@@ -108,17 +109,14 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
                     viewPager.setVisibility(View.VISIBLE);
                     tabLayout.setVisibility(View.VISIBLE);
                     searchHistoryContainer.setVisibility(View.GONE);
-                    if (searchImageFragment != null
-                        && searchImageFragment.isAdded()
-                        && !searchImageFragment.isDetached()) {
+                    if (FragmentUtils.isFragmentUIActive(searchImageFragment)) {
                         searchImageFragment.updateImageList(query.toString());
                     }
 
-                    if (searchCategoryFragment != null
-                        && searchCategoryFragment.isAdded()
-                        && !searchCategoryFragment.isDetached()) {
+                    if (FragmentUtils.isFragmentUIActive(searchCategoryFragment)) {
                         searchCategoryFragment.updateCategoryList(query.toString());
                     }
+
                 } else {
                     viewPager.setVisibility(View.GONE);
                     tabLayout.setVisibility(View.GONE);

--- a/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
@@ -62,8 +62,6 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
     OkHttpJsonApiClient okHttpJsonApiClient;
     @Inject @Named("default_preferences") BasicKvStore defaultKvStore;
 
-    private final String TAG="#SearchImageFragment#";
-
     private RVRendererAdapter<Media> imagesAdapter;
     private List<Media> queryList = new ArrayList<>();
 
@@ -236,7 +234,7 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
             }
             ViewUtil.showShortSnackbar(imagesRecyclerView, R.string.no_internet);
         } else {
-            Timber.d(TAG + ": attempt to update fragment ui after its view was destroyed");
+            Timber.d("Attempt to update fragment ui after its view was destroyed");
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/utils/FragmentUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/FragmentUtils.java
@@ -15,6 +15,6 @@ public class FragmentUtils {
      * @return
      */
     public static boolean isFragmentUIActive(Fragment fragment) {
-        return fragment.getActivity() != null && fragment.isAdded() && !fragment.isDetached() && !fragment.isRemoving();
+        return fragment!=null && fragment.getActivity() != null && fragment.isAdded() && !fragment.isDetached() && !fragment.isRemoving();
     }
 }


### PR DESCRIPTION

**Description (required)**
Public methods are exposed to update ui of fragment from activity, and the methods are not lifecycle aware, added associated checks for ui in active state and null checks on views

Fixes  #2585 Crash in SearchImageFragment 

What changes did you make and why?
* Added null checks on view in SearchImageFragment when updating views from external sources
* Disposed the disposables in SearchActivity and SearchImageFragment when no longer in active lifecycle

**Tests performed (required)**

Tested { ProdDebug} on {Pixel 2} with API level {28}.
