### PR TITLE
Fix upload card view arrow direction error (#2205)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -667,8 +667,18 @@ public class UploadActivity extends BaseActivity implements UploadView, SimilarI
         finish();
     }
 
+    /**
+     * Rotates the button and shows or hides the content based on the given state. Typically used
+     * for collapsing or expanding {@link CardView} animation.
+     *
+     * @param state the expanded state of the View whose elements are to be updated. True if
+     *              expanded.
+     * @param button the image to rotate. Typically an arrow points up when the CardView is
+     *               collapsed and down when it is expanded.
+     * @param content the Views that should be shown or hidden based on the state.
+     */
     private void updateCardState(boolean state, ImageView button, View... content) {
-        button.animate().rotation(button.getRotation() + (state ? 180 : -180)).start();
+        button.animate().rotation(state ? 180 : 0).start();
         if (content != null) {
             for (View view : content) {
                 view.setVisibility(state ? View.VISIBLE : View.GONE);


### PR DESCRIPTION
**Description**

Fixes #2205 Upload card view arrow points in random direction

This is an intermittent bug, hard to reproduce but when it occurs then the bug hides in the Android native libraries where the [ViewPropertyAnimator](https://developer.android.com/reference/android/view/ViewPropertyAnimator) sets the rotation member variable on the arrow ImageView. Therefore I eliminated the reading of this field and set the rotation property explicitly. The rotation of the arrow is also set explicitly in the activity_upload_bottom_card.xml layout file.

**Tests performed**

Tested on betaDebug build variant on Galaxy_Nexus_API_28 with API level 28 with the same settings as described in the conversation below the Issue.

**Screenshots showing what changed (optional - for UI changes)**

![Screenshot_1552935907](https://user-images.githubusercontent.com/4821857/54557106-b1f6d880-49ba-11e9-9b03-21f5ef1b7d4b.png)
![Screenshot_1552935915](https://user-images.githubusercontent.com/4821857/54557119-b8855000-49ba-11e9-832d-4d1accb2271a.png)
