### PR TITLE
Enable hardware acceleration, and make the whole interface 100% snappier.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,6 @@
         android:label="@string/app_name"
         android:theme="@style/LightAppTheme"
         android:largeHeap="true"
-        android:hardwareAccelerated="false"
         android:supportsRtl="true"
         tools:replace="android:appComponentFactory"
         android:appComponentFactory="commons"


### PR DESCRIPTION
So... I don't know if you've noticed this, but I have noticed that the whole interface of the Commons app is generally kind of sluggish:

- When scrolling the "explore" list, it's sluggish
- When pulling out the navigation menu, it's sluggish
- When looking at an image and scrolling the overlaid attribute list, it's sluggish.

So I looked into it briefly, and I found that you have the `hardwareAccelerated` flag set to `false` in your manifest!!!  This means that none of your views are taking advantage of GPU acceleration, so _of course_ they'll render like a sloth.

After my eyebrows returned from the back of my head, I made this PR for you.
Check it out, and see how much snappier everything is!

(Setting the `hardwareAccelerated` flag to `false` may have been useful in the ancient days of API ~10, when devices literally didn't have the memory to render what's on the screen, but not any more. This is like booting into "safe mode"... it might be good for emergency debugging, but is _not_ for production.)