### PR TITLE
Show captions of image in media details

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Media.java
+++ b/app/src/main/java/fr/free/nrw/commons/Media.java
@@ -40,6 +40,7 @@ public class Media implements Parcelable {
     protected String filename;
     protected String description; // monolingual description on input...
     protected String discussion;
+    protected String captions;
     protected long dataLength;
     protected Date dateCreated;
     protected @Nullable Date dateUploaded;
@@ -178,6 +179,22 @@ public class Media implements Parcelable {
             imageUrl = Utils.makeThumbBaseUrl(this.getFilename());
         }
         return imageUrl;
+    }
+
+    /**
+     * Sets the Captions of the file.
+     * @param captions
+     */
+    public void setCaptions(String captions) {
+        this.captions = captions;
+    }
+
+    /**
+     * Gets the file Captions as a string.
+     * @return file Captions as a string
+     */
+    public String getCaptions() {
+        return captions;
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/Media.java
+++ b/app/src/main/java/fr/free/nrw/commons/Media.java
@@ -182,7 +182,7 @@ public class Media implements Parcelable {
     }
 
     /**
-     * Sets the Captions of the file.
+     * Sets the Caption of the file.
      * @param caption
      */
     public void setCaption(String caption) {
@@ -190,8 +190,8 @@ public class Media implements Parcelable {
     }
 
     /**
-     * Gets the file Captions as a string.
-     * @return file Captions as a string
+     * Gets the file Caption as a string.
+     * @return file Caption as a string
      */
     public String getCaption() {
         return caption;

--- a/app/src/main/java/fr/free/nrw/commons/Media.java
+++ b/app/src/main/java/fr/free/nrw/commons/Media.java
@@ -40,7 +40,7 @@ public class Media implements Parcelable {
     protected String filename;
     protected String description; // monolingual description on input...
     protected String discussion;
-    protected String captions;
+    protected String caption;
     protected long dataLength;
     protected Date dateCreated;
     protected @Nullable Date dateUploaded;
@@ -183,18 +183,18 @@ public class Media implements Parcelable {
 
     /**
      * Sets the Captions of the file.
-     * @param captions
+     * @param caption
      */
-    public void setCaptions(String captions) {
-        this.captions = captions;
+    public void setCaption(String caption) {
+        this.caption = caption;
     }
 
     /**
      * Gets the file Captions as a string.
      * @return file Captions as a string
      */
-    public String getCaptions() {
-        return captions;
+    public String getCaption() {
+        return caption;
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
@@ -40,7 +40,7 @@ public class MediaDataExtractor {
     private boolean deletionStatus;
     private ArrayList<String> categories;
     private Map<String, String> descriptions;
-    private String captions;
+    private String caption;
     private String discussion;
     private String license;
     private @Nullable LatLng coordinates;
@@ -52,7 +52,7 @@ public class MediaDataExtractor {
         this.fetched = false;
         this.mediaWikiApi = mwApi;
         this.discussion = new String();
-        this.captions = new String();
+        this.caption = new String();
     }
 
     /*
@@ -77,7 +77,7 @@ public class MediaDataExtractor {
         MediaResult result = mediaWikiApi.fetchMediaByFilename(filename);
         MediaResult discussion = mediaWikiApi.fetchMediaByFilename(filename.replace("File", "File talk"));
         setDiscussion(discussion.getWikiSource());
-        captions = mediaWikiApi.fetchCaptionsByFilename(filename);
+        caption = mediaWikiApi.fetchCaptionByFilename(filename);
 
         // In-page category links are extracted from source, as XML doesn't cover [[links]]
         extractCategories(result.getWikiSource());
@@ -324,7 +324,7 @@ public class MediaDataExtractor {
         media.setDescriptions(descriptions);
         media.setCoordinates(coordinates);
         media.setDiscussion(discussion);
-        media.setCaptions(captions);
+        media.setCaption(caption);
         if (license != null) {
             media.setLicense(license);
         }

--- a/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
@@ -40,6 +40,7 @@ public class MediaDataExtractor {
     private boolean deletionStatus;
     private ArrayList<String> categories;
     private Map<String, String> descriptions;
+    private String captions;
     private String discussion;
     private String license;
     private @Nullable LatLng coordinates;
@@ -51,6 +52,7 @@ public class MediaDataExtractor {
         this.fetched = false;
         this.mediaWikiApi = mwApi;
         this.discussion = new String();
+        this.captions = new String();
     }
 
     /*
@@ -75,7 +77,7 @@ public class MediaDataExtractor {
         MediaResult result = mediaWikiApi.fetchMediaByFilename(filename);
         MediaResult discussion = mediaWikiApi.fetchMediaByFilename(filename.replace("File", "File talk"));
         setDiscussion(discussion.getWikiSource());
-
+        captions = mediaWikiApi.fetchCaptionsByFilename(filename);
 
         // In-page category links are extracted from source, as XML doesn't cover [[links]]
         extractCategories(result.getWikiSource());
@@ -322,6 +324,7 @@ public class MediaDataExtractor {
         media.setDescriptions(descriptions);
         media.setCoordinates(coordinates);
         media.setDiscussion(discussion);
+        media.setCaptions(captions);
         if (license != null) {
             media.setLicense(license);
         }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -512,7 +512,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
     private String prettyCaptions(Media media) {
         String captions = media.getCaptions().trim();
         if (captions.equals("")) {
-            return getString(R.string.detail_captions_empty);
+            return getString(R.string.detail_caption_empty);
         } else {
             return captions;
         }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -100,8 +100,8 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
     MediaWikiImageView image;
     @BindView(R.id.mediaDetailSpacer)
     MediaDetailSpacer spacer;
-    @BindView(R.id.mediaDetailCaptions)
-    TextView mediaCaptions;
+    @BindView(R.id.mediaDetailCaption)
+    TextView mediaCaption;
     @BindView(R.id.mediaDetailTitle)
     TextView title;
     @BindView(R.id.mediaDetailDesc)
@@ -346,7 +346,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         coordinates.setText(prettyCoordinates(media));
         uploadedDate.setText(prettyUploadedDate(media));
         mediaDiscussion.setText(prettyDiscussion(media));
-        mediaCaptions.setText(prettyCaptions(media));
+        mediaCaption.setText(prettyCaption(media));
 
         categoryNames.clear();
         categoryNames.addAll(media.getCategories());
@@ -509,12 +509,12 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         }
     }
 
-    private String prettyCaptions(Media media) {
-        String captions = media.getCaption().trim();
-        if (captions.equals("")) {
+    private String prettyCaption(Media media) {
+        String caption = media.getCaption().trim();
+        if (caption.equals("")) {
             return getString(R.string.detail_caption_empty);
         } else {
-            return captions;
+            return caption;
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -100,6 +100,8 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
     MediaWikiImageView image;
     @BindView(R.id.mediaDetailSpacer)
     MediaDetailSpacer spacer;
+    @BindView(R.id.mediaDetailCaptions)
+    TextView mediaCaptions;
     @BindView(R.id.mediaDetailTitle)
     TextView title;
     @BindView(R.id.mediaDetailDesc)
@@ -344,6 +346,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         coordinates.setText(prettyCoordinates(media));
         uploadedDate.setText(prettyUploadedDate(media));
         mediaDiscussion.setText(prettyDiscussion(media));
+        mediaCaptions.setText(prettyCaptions(media));
 
         categoryNames.clear();
         categoryNames.addAll(media.getCategories());
@@ -505,6 +508,16 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
             return desc;
         }
     }
+
+    private String prettyCaptions(Media media) {
+        String captions = media.getCaptions().trim();
+        if (captions.equals("")) {
+            return getString(R.string.detail_captions_empty);
+        } else {
+            return captions;
+        }
+    }
+
     private String prettyDiscussion(Media media) {
         String disc = media.getDiscussion().trim();
         if (disc.equals("")) {

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -510,7 +510,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
     }
 
     private String prettyCaptions(Media media) {
-        String captions = media.getCaptions().trim();
+        String captions = media.getCaption().trim();
         if (captions.equals("")) {
             return getString(R.string.detail_caption_empty);
         } else {

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -324,7 +324,7 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
                 .param("titles", filename)
                 .param("props", "labels")
                 .param("format", "xml")
-                .param("languages", "en")
+                .param("languages", Locale.getDefault().getLanguage())
                 .param("languagefallback", "1")
                 .get()
                 .getString("/api/entities/entity/labels/label/@value");

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -318,7 +318,7 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
     }
 
     @Override
-    public String getCaptionsByFilename(String filename) throws IOException {
+    public String fetchCaptionsByFilename(String filename) throws IOException {
         return api.action("wbgetentities")
                 .param("sites", "commonswiki")
                 .param("titles", filename)

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -317,8 +317,12 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
                 .getString("/api/flow-parsoid-utils/@content");
     }
 
+    /**
+     * fetches the Caption of the file with a given name.
+     * @param filename title of the file
+     */
     @Override
-    public String fetchCaptionsByFilename(String filename) throws IOException {
+    public String fetchCaptionByFilename(String filename) throws IOException {
         return api.action("wbgetentities")
                 .param("sites", "commonswiki")
                 .param("titles", filename)

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -318,6 +318,19 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
     }
 
     @Override
+    public String getCaptionsByFilename(String filename) throws IOException {
+        return api.action("wbgetentities")
+                .param("sites", "commonswiki")
+                .param("titles", filename)
+                .param("props", "labels")
+                .param("format", "xml")
+                .param("languages", "en")
+                .param("languagefallback", "1")
+                .get()
+                .getString("/api/entities/entity/labels/label/@value");
+    }
+
+    @Override
     @NonNull
     public MediaResult fetchMediaByFilename(String filename) throws IOException {
         CustomApiResult apiResult = api.action("query")

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
@@ -74,7 +74,7 @@ public interface MediaWikiApi {
 
     String parseWikicode(String source) throws IOException;
 
-    String getCaptionsByFilename(String filename) throws IOException;
+    String fetchCaptionsByFilename(String filename) throws IOException;
 
     @NonNull
     MediaResult fetchMediaByFilename(String filename) throws IOException;

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
@@ -74,6 +74,8 @@ public interface MediaWikiApi {
 
     String parseWikicode(String source) throws IOException;
 
+    String getCaptionsByFilename(String filename) throws IOException;
+
     @NonNull
     MediaResult fetchMediaByFilename(String filename) throws IOException;
 

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
@@ -74,7 +74,7 @@ public interface MediaWikiApi {
 
     String parseWikicode(String source) throws IOException;
 
-    String fetchCaptionsByFilename(String filename) throws IOException;
+    String fetchCaptionByFilename(String filename) throws IOException;
 
     @NonNull
     MediaResult fetchMediaByFilename(String filename) throws IOException;

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -69,7 +69,7 @@
                         android:textStyle="bold" />
 
                     <TextView
-                        android:id="@+id/mediaDetailCaptions"
+                        android:id="@+id/mediaDetailCaption"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_gravity="start"

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -63,6 +63,34 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:paddingBottom="@dimen/tiny_gap"
+                        android:text="@string/media_detail_captions"
+                        android:textColor="@android:color/white"
+                        android:textSize="@dimen/normal_text"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/mediaDetailCaptions"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="start"
+                        android:background="?attr/subBackground"
+                        android:padding="@dimen/small_gap"
+                        android:textColor="@android:color/white"
+                        android:textSize="@dimen/description_text_size"
+                        tools:text="Captions of the media" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/subBackground"
+                    android:orientation="vertical"
+                    android:padding="@dimen/standard_gap">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingBottom="@dimen/tiny_gap"
                         android:text="@string/media_detail_title"
                         android:textColor="@android:color/white"
                         android:textSize="@dimen/normal_text"

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -63,7 +63,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:paddingBottom="@dimen/tiny_gap"
-                        android:text="@string/media_detail_captions"
+                        android:text="@string/media_detail_caption"
                         android:textColor="@android:color/white"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,7 +159,7 @@
   <string name="detail_panel_cats_none">None selected</string>
   <string name="detail_description_empty">No description</string>
   <string name="detail_discussion_empty">No discussion</string>
-  <string name="detail_captions_empty">No captions</string>
+  <string name="detail_caption_empty">No caption</string>
   <string name="detail_license_empty">Unknown license</string>
   <string name="menu_refresh">Refresh</string>
   <string name="storage_permission_title">Requesting Storage Permission</string>
@@ -173,7 +173,7 @@
   <string name="upload_image_duplicate">This file already exists on Commons. Are you sure you want to proceed?</string>
   <string name="yes">Yes</string>
   <string name="no">No</string>
-  <string name="media_detail_captions">Captions</string>
+  <string name="media_detail_caption">Caption</string>
   <string name="media_detail_title">Title</string>
   <string name="media_detail_description">Description</string>
   <string name="media_detail_discussion">Discussion</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,6 +159,7 @@
   <string name="detail_panel_cats_none">None selected</string>
   <string name="detail_description_empty">No description</string>
   <string name="detail_discussion_empty">No discussion</string>
+  <string name="detail_captions_empty">No captions</string>
   <string name="detail_license_empty">Unknown license</string>
   <string name="menu_refresh">Refresh</string>
   <string name="storage_permission_title">Requesting Storage Permission</string>
@@ -172,6 +173,7 @@
   <string name="upload_image_duplicate">This file already exists on Commons. Are you sure you want to proceed?</string>
   <string name="yes">Yes</string>
   <string name="no">No</string>
+  <string name="media_detail_captions">Captions</string>
   <string name="media_detail_title">Title</string>
   <string name="media_detail_description">Description</string>
   <string name="media_detail_discussion">Discussion</string>

--- a/app/src/test/kotlin/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApiTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApiTest.kt
@@ -241,6 +241,27 @@ class ApacheHttpClientMediaWikiApiTest {
     }
 
     @Test
+    fun fetchCaptionByFilename() {
+        server.enqueue(MockResponse().setBody("<?xml version=\"1.0\"?><api success=\"1\"><entities><entity type=\"mediainfo\" id=\"M77157483\"><labels><label language=\"it\" value=\"Test\" /></labels><statements /></entity></entities></api>"))
+
+        val result = testObject.fetchCaptionByFilename("File:foo")
+
+        assertBasicRequestParameters(server, "GET").let { request ->
+            parseQueryParams(request).let { params ->
+                assertEquals("xml", params["format"])
+                assertEquals("wbgetentities", params["action"])
+                assertEquals("commonswiki", params["sites"])
+                assertEquals("File:foo", params["titles"])
+                assertEquals("labels", params["props"])
+                assertEquals(Locale.getDefault().getLanguage(), params["languages"])
+                assertEquals("1", params["languagefallback"])
+            }
+        }
+
+        assertEquals("Test", result)
+    }
+
+    @Test
     fun isUserBlockedFromCommonsForInfinitelyBlockedUser() {
         server.enqueue(MockResponse().setBody("<?xml version=\"1.0\"?><api><query><userinfo id=\"1000\" name=\"testusername\" blockid=\"3000\" blockedby=\"blockerusername\" blockedbyid=\"1001\" blockreason=\"testing\" blockedtimestamp=\"2018-05-24T15:32:09Z\" blockexpiry=\"infinite\"></userinfo></query></api>"))
 


### PR DESCRIPTION
**Description (required)**

Fixes #2337

**What changes did you make and why?**

- fetched captions of media by using mediawiki api
- Added captions section in media details
- Added unit test cases

**Tests performed (required)**

Tested ProdDebug on Motorola Moto G5 plus with API level 24.

**Screenshots showing what changed (optional - for UI changes)**

![device-2019-03-19-130232](https://user-images.githubusercontent.com/39745544/54587852-5292da00-4a47-11e9-9e69-aa313d75a051.png)

