### PR TITLE
[WIP] Extend WelcomeActivityTest

### DIFF
--- a/app/src/androidTest/java/fr/free/nrw/commons/WelcomeActivityTest.kt
+++ b/app/src/androidTest/java/fr/free/nrw/commons/WelcomeActivityTest.kt
@@ -37,7 +37,7 @@ class WelcomeActivityTest {
     }
 
     @Test
-    fun ifSkipButtonClicked() {
+    fun testBetaSkipButton() {
         if (ConfigUtils.isBetaFlavour()) {
             onView(withId(R.id.finishTutorialButton))
                     .perform(ViewActions.click())
@@ -47,29 +47,27 @@ class WelcomeActivityTest {
 
     @Test
     fun testSwipingOnce() {
-            onView(withId(R.id.welcomePager))
-                    .perform(ViewActions.swipeLeft())
-            assert(true)
-            onView(withId(R.id.welcomePager))
-                    .perform(ViewActions.swipeRight())
-            assert(true)
+        onView(withId(R.id.welcomePager))
+                .perform(ViewActions.swipeLeft())
+        assert(true)
+        onView(withId(R.id.welcomePager))
+                .perform(ViewActions.swipeRight())
+        assert(true)
     }
 
     @Test
     fun testSwipingWholeTutorial() {
-        if (!ConfigUtils.isBetaFlavour()) {
-            onView(withId(R.id.welcomePager))
-                    .perform(ViewActions.swipeLeft())
-                    .perform(ViewActions.swipeLeft())
-                    .perform(ViewActions.swipeLeft())
-                    .perform(ViewActions.swipeLeft())
-            assert(true)
-            onView(withId(R.id.welcomePager))
-                    .perform(ViewActions.swipeRight())
-                    .perform(ViewActions.swipeRight())
-                    .perform(ViewActions.swipeRight())
-                    .perform(ViewActions.swipeRight())
-            assert(true)
-        }
+        onView(withId(R.id.welcomePager))
+                .perform(ViewActions.swipeLeft())
+                .perform(ViewActions.swipeLeft())
+                .perform(ViewActions.swipeLeft())
+                .perform(ViewActions.swipeLeft())
+        assert(true)
+        onView(withId(R.id.welcomePager))
+                .perform(ViewActions.swipeRight())
+                .perform(ViewActions.swipeRight())
+                .perform(ViewActions.swipeRight())
+                .perform(ViewActions.swipeRight())
+        assert(true)
     }
 }

--- a/app/src/androidTest/java/fr/free/nrw/commons/WelcomeActivityTest.kt
+++ b/app/src/androidTest/java/fr/free/nrw/commons/WelcomeActivityTest.kt
@@ -38,7 +38,7 @@ class WelcomeActivityTest {
 
     @Test
     fun ifSkipButtonClicked() {
-        if (!ConfigUtils.isBetaFlavour()) {
+        if (ConfigUtils.isBetaFlavour()) {
             onView(withId(R.id.finishTutorialButton))
                     .perform(ViewActions.click())
             assert(activityRule.activity.isDestroyed)
@@ -46,19 +46,17 @@ class WelcomeActivityTest {
     }
 
     @Test
-    fun ifSwiped() {
-        if (!ConfigUtils.isBetaFlavour()) {
+    fun testSwipingOnce() {
             onView(withId(R.id.welcomePager))
                     .perform(ViewActions.swipeLeft())
             assert(true)
             onView(withId(R.id.welcomePager))
                     .perform(ViewActions.swipeRight())
             assert(true)
-        }
     }
 
     @Test
-    fun ifEndedTutorial() {
+    fun testSwipingWholeTutorial() {
         if (!ConfigUtils.isBetaFlavour()) {
             onView(withId(R.id.welcomePager))
                     .perform(ViewActions.swipeLeft())

--- a/app/src/androidTest/java/fr/free/nrw/commons/WelcomeActivityTest.kt
+++ b/app/src/androidTest/java/fr/free/nrw/commons/WelcomeActivityTest.kt
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons
 
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -32,6 +33,44 @@ class WelcomeActivityTest {
         if (!ConfigUtils.isBetaFlavour()) {
             onView(withId(R.id.finishTutorialButton))
                     .check(matches(not(isDisplayed())))
+        }
+    }
+    @Test
+    fun ifSkipButtonClicked(){
+        if(!ConfigUtils.isBetaFlavour()){
+            onView(withId(R.id.finishTutorialButton))
+                    .perform(ViewActions.click())
+            assert(activityRule.activity.isDestroyed)
+        }
+    }
+
+    @Test
+    fun ifSwiped(){
+        if (!ConfigUtils.isBetaFlavour()){
+            onView(withId(R.id.welcomePager))
+                    .perform(ViewActions.swipeLeft())
+            assert(true)
+            onView(withId(R.id.welcomePager))
+                    .perform(ViewActions.swipeRight())
+            assert(true)
+        }
+    }
+
+    @Test
+    fun ifEndedTutorial(){
+        if(!ConfigUtils.isBetaFlavour()){
+            onView(withId(R.id.welcomePager))
+                    .perform(ViewActions.swipeLeft())
+                    .perform(ViewActions.swipeLeft())
+                    .perform(ViewActions.swipeLeft())
+                    .perform(ViewActions.swipeLeft())
+            assert(true)
+            onView(withId(R.id.welcomePager))
+                    .perform(ViewActions.swipeRight())
+                    .perform(ViewActions.swipeRight())
+                    .perform(ViewActions.swipeRight())
+                    .perform(ViewActions.swipeRight())
+            assert(true)
         }
     }
 }

--- a/app/src/androidTest/java/fr/free/nrw/commons/WelcomeActivityTest.kt
+++ b/app/src/androidTest/java/fr/free/nrw/commons/WelcomeActivityTest.kt
@@ -1,13 +1,17 @@
 package fr.free.nrw.commons
 
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.ViewAssertion
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.ViewPagerActions
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.filters.LargeTest
 import androidx.test.rule.ActivityTestRule
 import androidx.test.runner.AndroidJUnit4
+import androidx.viewpager.widget.ViewPager
+import fr.free.nrw.commons.explore.ViewPagerAdapter
 import fr.free.nrw.commons.utils.ConfigUtils
 import org.hamcrest.core.IsNot.not
 import org.junit.Rule

--- a/app/src/androidTest/java/fr/free/nrw/commons/WelcomeActivityTest.kt
+++ b/app/src/androidTest/java/fr/free/nrw/commons/WelcomeActivityTest.kt
@@ -1,17 +1,13 @@
 package fr.free.nrw.commons
 
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.ViewAssertion
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.contrib.ViewPagerActions
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.filters.LargeTest
 import androidx.test.rule.ActivityTestRule
 import androidx.test.runner.AndroidJUnit4
-import androidx.viewpager.widget.ViewPager
-import fr.free.nrw.commons.explore.ViewPagerAdapter
 import fr.free.nrw.commons.utils.ConfigUtils
 import org.hamcrest.core.IsNot.not
 import org.junit.Rule
@@ -39,9 +35,10 @@ class WelcomeActivityTest {
                     .check(matches(not(isDisplayed())))
         }
     }
+
     @Test
-    fun ifSkipButtonClicked(){
-        if(!ConfigUtils.isBetaFlavour()){
+    fun ifSkipButtonClicked() {
+        if (!ConfigUtils.isBetaFlavour()) {
             onView(withId(R.id.finishTutorialButton))
                     .perform(ViewActions.click())
             assert(activityRule.activity.isDestroyed)
@@ -49,8 +46,8 @@ class WelcomeActivityTest {
     }
 
     @Test
-    fun ifSwiped(){
-        if (!ConfigUtils.isBetaFlavour()){
+    fun ifSwiped() {
+        if (!ConfigUtils.isBetaFlavour()) {
             onView(withId(R.id.welcomePager))
                     .perform(ViewActions.swipeLeft())
             assert(true)
@@ -61,8 +58,8 @@ class WelcomeActivityTest {
     }
 
     @Test
-    fun ifEndedTutorial(){
-        if(!ConfigUtils.isBetaFlavour()){
+    fun ifEndedTutorial() {
+        if (!ConfigUtils.isBetaFlavour()) {
             onView(withId(R.id.welcomePager))
                     .perform(ViewActions.swipeLeft())
                     .perform(ViewActions.swipeLeft())


### PR DESCRIPTION
**Description (required)**

Fixes #2644 Extend WelcomeActivityTest

### Changes Made
>Test swiping the correct number of times and then clicking 'yes' exits WelcomeActivity
Test that on beta clicking the 'skip tutorial' button exits WelcomeActivity
Test we can swipe both ways (i.e. backwards and forwards)

Added the above three tests

**Tests performed (required)**

Tested betaDebug on vivo 1713 with API level 24.
