### PR TITLE
Taping on notification takes to nomination page

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -463,7 +463,7 @@ public class MainActivity extends AuthenticatedActivity implements FragmentManag
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        Timber.d(data.toString());
+        //Timber.d(data.toString());
         super.onActivityResult(requestCode, resultCode, data);
         controller.handleActivityResult(this, requestCode, resultCode, data);
     }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -463,7 +463,7 @@ public class MainActivity extends AuthenticatedActivity implements FragmentManag
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        //Timber.d(data.toString());
+        Timber.d(data.toString());
         super.onActivityResult(requestCode, resultCode, data);
         controller.handleActivityResult(this, requestCode, resultCode, data);
     }

--- a/app/src/main/java/fr/free/nrw/commons/delete/DeleteTask.java
+++ b/app/src/main/java/fr/free/nrw/commons/delete/DeleteTask.java
@@ -1,7 +1,10 @@
 package fr.free.nrw.commons.delete;
 
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.AsyncTask;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationCompat.Builder;
@@ -31,6 +34,8 @@ public class DeleteTask extends AsyncTask<Void, Integer, Boolean> {
     @Inject SessionManager sessionManager;
 
     private static final int NOTIFICATION_DELETE = 1;
+    private static final String baseUrl="https://commons.wikimedia.org/wiki/Commons:Deletion_requests/File:";
+
 
     private NotificationManager notificationManager;
     private Builder notificationBuilder;
@@ -181,6 +186,10 @@ public class DeleteTask extends AsyncTask<Void, Integer, Boolean> {
                 .setProgress(0,0,false)
                 .setOngoing(false)
                 .setPriority(PRIORITY_HIGH);
+        String urlForDelete=baseUrl+media.getFilename();
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(urlForDelete));
+        PendingIntent pendingIntent = PendingIntent.getActivity(context , 1 , browserIntent , PendingIntent.FLAG_UPDATE_CURRENT);
+        notificationBuilder.setContentIntent(pendingIntent);
         notificationManager.notify(NOTIFICATION_DELETE, notificationBuilder.build());
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/delete/DeleteTask.java
+++ b/app/src/main/java/fr/free/nrw/commons/delete/DeleteTask.java
@@ -17,6 +17,7 @@ import java.util.Locale;
 
 import javax.inject.Inject;
 
+import fr.free.nrw.commons.BuildConfig;
 import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
@@ -34,8 +35,6 @@ public class DeleteTask extends AsyncTask<Void, Integer, Boolean> {
     @Inject SessionManager sessionManager;
 
     private static final int NOTIFICATION_DELETE = 1;
-    private static final String baseUrl="https://commons.wikimedia.org/wiki/Commons:Deletion_requests/File:";
-
 
     private NotificationManager notificationManager;
     private Builder notificationBuilder;
@@ -186,7 +185,7 @@ public class DeleteTask extends AsyncTask<Void, Integer, Boolean> {
                 .setProgress(0,0,false)
                 .setOngoing(false)
                 .setPriority(PRIORITY_HIGH);
-        String urlForDelete = baseUrl + media.getFilename();
+        String urlForDelete = BuildConfig.COMMONS_URL + "/wiki/Commons:Deletion_requests/File:" + media.getFilename();
         Intent browserIntent = new Intent(Intent.ACTION_VIEW , Uri.parse(urlForDelete));
         PendingIntent pendingIntent = PendingIntent.getActivity(context , 1 , browserIntent , PendingIntent.FLAG_UPDATE_CURRENT);
         notificationBuilder.setContentIntent(pendingIntent);

--- a/app/src/main/java/fr/free/nrw/commons/delete/DeleteTask.java
+++ b/app/src/main/java/fr/free/nrw/commons/delete/DeleteTask.java
@@ -186,8 +186,8 @@ public class DeleteTask extends AsyncTask<Void, Integer, Boolean> {
                 .setProgress(0,0,false)
                 .setOngoing(false)
                 .setPriority(PRIORITY_HIGH);
-        String urlForDelete=baseUrl+media.getFilename();
-        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(urlForDelete));
+        String urlForDelete = baseUrl + media.getFilename();
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW , Uri.parse(urlForDelete));
         PendingIntent pendingIntent = PendingIntent.getActivity(context , 1 , browserIntent , PendingIntent.FLAG_UPDATE_CURRENT);
         notificationBuilder.setContentIntent(pendingIntent);
         notificationManager.notify(NOTIFICATION_DELETE, notificationBuilder.build());


### PR DESCRIPTION
**Description (required)**

Fixes #2659 Tapping Android notification after deletion nomination does not do anything

### Changes made
- Recognised url for nomination page
- Added intent in the notification to start browser

### Preview

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/34261945/54604272-5edd5e00-4a6c-11e9-87ce-ce1ace56fb74.gif)

