### PR TITLE
Fix crash(es) caused by disposed Rx observables.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -44,6 +44,8 @@ import fr.free.nrw.commons.modifications.ModifierSequenceDao;
 import fr.free.nrw.commons.upload.FileUtils;
 import fr.free.nrw.commons.utils.ConfigUtils;
 import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 import timber.log.Timber;
 
@@ -128,6 +130,9 @@ public class CommonsApplication extends Application {
 
         createNotificationChannel(this);
 
+        // This handler will catch exceptions thrown from Observables after they are disposed,
+        // or from Observables that are (deliberately or not) missing an onError handler.
+        RxJavaPlugins.setErrorHandler(Functions.emptyConsumer());
 
         if (setupLeakCanary() == RefWatcher.DISABLED) {
             return;


### PR DESCRIPTION
After Rx Observables are disposed, they can still produce errors, and if they are detached from an Observer when an error happens, the error goes to a "global" error handler defined in Rx.  By default, this error handler does nothing, and allows the error to be unhandled, thereby causing a crash.

(I'm guessing you've seen these kinds of crashes -- it might happen right after you back out of an Activity, or anytime you dispose an observable that is still performing a network call.)

This fixes these crashes by providing an "empty" global Rx error handler.  This means that any time you subscribe to an Observable, you should provide an `onError` handler (assuming you want to handle errors from it). And for Observables where you don't care about errors, they will simply fall through without crashing.