### PR TITLE
Prevent additional possible crash(es) from improperly disposed observables.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/ImageProcessingService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ImageProcessingService.java
@@ -33,16 +33,19 @@ public class ImageProcessingService {
     private final MediaWikiApi mwApi;
     private final ReadFBMD readFBMD;
     private final EXIFReader EXIFReader;
+    private final Context context;
 
     @Inject
     public ImageProcessingService(FileUtilsWrapper fileUtilsWrapper,
                                   ImageUtilsWrapper imageUtilsWrapper,
-                                  MediaWikiApi mwApi, ReadFBMD readFBMD, EXIFReader EXIFReader) {
+                                  MediaWikiApi mwApi, ReadFBMD readFBMD, EXIFReader EXIFReader,
+                                  Context context) {
         this.fileUtilsWrapper = fileUtilsWrapper;
         this.imageUtilsWrapper = imageUtilsWrapper;
         this.mwApi = mwApi;
         this.readFBMD = readFBMD;
         this.EXIFReader = EXIFReader;
+        this.context = context;
     }
 
     /**
@@ -61,13 +64,13 @@ public class ImageProcessingService {
         Timber.d("Checking the validity of image");
         String filePath = uploadItem.getMediaUri().getPath();
         Uri contentUri=uploadItem.getContentUri();
-        Context context=uploadItem.getContext();
         Single<Integer> duplicateImage = checkDuplicateImage(filePath);
         Single<Integer> wrongGeoLocation = checkImageGeoLocation(uploadItem.getPlace(), filePath);
         Single<Integer> darkImage = checkDarkImage(filePath);
         Single<Integer> itemTitle = checkTitle ? validateItemTitle(uploadItem) : Single.just(ImageUtils.IMAGE_OK);
         Single<Integer> checkFBMD = checkFBMD(context,contentUri);
         Single<Integer> checkEXIF = checkEXIF(filePath);
+
         Single<Integer> zipResult = Single.zip(duplicateImage, wrongGeoLocation, darkImage, itemTitle,
                 (duplicate, wrongGeo, dark, title) -> {
                     Timber.d("Result for duplicate: %d, geo: %d, dark: %d, title: %d", duplicate, wrongGeo, dark, title);

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
@@ -21,6 +21,7 @@ import fr.free.nrw.commons.settings.Prefs;
 import fr.free.nrw.commons.utils.StringUtils;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
 import timber.log.Timber;
 
@@ -52,6 +53,7 @@ public class UploadPresenter {
     private final UploadController uploadController;
     private final Context context;
     private final JsonKvStore directKvStore;
+    private CompositeDisposable compositeDisposable = new CompositeDisposable();
 
     @Inject
     UploadPresenter(UploadModel uploadModel,
@@ -77,12 +79,12 @@ public class UploadPresenter {
         Observable<UploadItem> uploadItemObservable = uploadModel
                 .preProcessImages(media, place, source, similarImageInterface);
 
-        uploadItemObservable
+        compositeDisposable.add(uploadItemObservable
                 .toList()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(uploadItems -> onImagesProcessed(uploadItems, place),
-                        throwable -> Timber.e(throwable, "Error occurred in processing images"));
+                        throwable -> Timber.e(throwable, "Error occurred in processing images")));
     }
 
     private void onImagesProcessed(List<UploadItem> uploadItems, Place place) {
@@ -211,9 +213,9 @@ public class UploadPresenter {
     @SuppressLint("CheckResult")
     void handleSubmit(CategoriesModel categoriesModel) {
         if (view.checkIfLoggedIn())
-            uploadModel.buildContributions(categoriesModel.getCategoryStringList())
+            compositeDisposable.add(uploadModel.buildContributions(categoriesModel.getCategoryStringList())
                     .observeOn(Schedulers.io())
-                    .subscribe(uploadController::startUpload);
+                    .subscribe(uploadController::startUpload));
     }
 
     /**
@@ -286,6 +288,8 @@ public class UploadPresenter {
     }
 
     void cleanup() {
+        compositeDisposable.clear();
+        uploadModel.cleanup();
         uploadController.cleanup();
     }
 


### PR DESCRIPTION
You've got some additional helper classes that perform Rx operations internally on their own. These, too, need to be contained and disposed when they are no longer needed (i.e. no longer associated with an activity or fragment).