### PR TITLE
Remove unused code

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -537,7 +537,6 @@ public class NearbyMapFragment extends DaggerFragment {
                 addMapMovementListeners();
                 updateMapSignificantlyForCurrentLocation();
             });
-            mapView.setStyleUrl("asset://mapstyle.json");
         }
     }
 


### PR DESCRIPTION
**Description (required)**

Follow up of PR #2614 

We're using MapBox tiles at present. Code
mapView.setStyleUrl("asset://mapstyle.json"); tries to set nearby map
tiles to wikimedia. It should be removed as it has no actual effect
and is somewhat misleading.

**Tests performed (required)**

Tested current master ProdDebug on Nexus 6P with API level 27.