### PR TITLE
Fix crash on API 19 in Achievements screen.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -5,11 +5,9 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
-import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.core.content.FileProvider;
-import androidx.core.content.res.ResourcesCompat;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 import android.util.DisplayMetrics;
@@ -33,6 +31,7 @@ import java.util.Objects;
 
 import javax.inject.Inject;
 
+import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
@@ -132,7 +131,6 @@ public class AchievementsActivity extends NavigationBaseActivity {
                 imageView.getLayoutParams();
         params.height = (int) (height * BADGE_IMAGE_HEIGHT_RATIO);
         params.width = (int) (width * BADGE_IMAGE_WIDTH_RATIO);
-        imageView.setImageResource(R.drawable.badge);
         imageView.requestLayout();
 
         setSupportActionBar(toolbar);
@@ -351,9 +349,8 @@ public class AchievementsActivity extends NavigationBaseActivity {
         String levelUpInfoString = getString(R.string.level);
         levelUpInfoString += " " + Integer.toString(levelInfo.getLevelNumber());
         levelNumber.setText(levelUpInfoString);
-        final ContextThemeWrapper wrapper = new ContextThemeWrapper(this, levelInfo.getLevelStyle());
-        Drawable drawable = ResourcesCompat.getDrawable(getResources(), R.drawable.badge, wrapper.getTheme());
-        imageView.setImageDrawable(drawable);
+        imageView.setImageDrawable(VectorDrawableCompat.create(getResources(), R.drawable.badge,
+                new ContextThemeWrapper(this, levelInfo.getLevelStyle()).getTheme()));
         badgeText.setText(Integer.toString(levelInfo.getLevelNumber()));
     }
 


### PR DESCRIPTION
If you go to the Achievements screen in API 19, it crashes.
This is because the "badge" icon is a vector drawable that needs to be loaded using VectorDrawableCompat (for cases when you need to load the drawable dynamically in code.)