### PR TITLE
Fix padding of FloatingActionButtons across all APIs.

### DIFF
--- a/app/src/main/res/layout/fragment_contributions_list.xml
+++ b/app/src/main/res/layout/fragment_contributions_list.xml
@@ -54,43 +54,35 @@
             android:id="@+id/fab_camera"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:scaleType="center"
             android:tint="@color/button_blue"
             android:visibility="gone"
             app:backgroundTint="@color/main_background_light"
-            app:elevation="6dp"
+            app:useCompatPadding="true"
+            app:elevation="4dp"
             app:fabSize="mini"
-            android:layout_margin="8dp"
-            app:pressedTranslationZ="12dp"
             app:srcCompat="@drawable/ic_photo_camera_white_24dp" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/fab_gallery"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:scaleType="center"
             android:tint="@color/button_blue"
             android:visibility="gone"
             app:backgroundTint="@color/main_background_light"
-            app:elevation="6dp"
+            app:useCompatPadding="true"
+            app:elevation="4dp"
             app:fabSize="mini"
-            android:layout_margin="8dp"
-            app:pressedTranslationZ="12dp"
             app:srcCompat="@drawable/ic_photo_white_24dp" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/fab_plus"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
             android:gravity="center_vertical"
-            android:clickable="true"
             android:visibility="visible"
             app:backgroundTint="@color/status_bar_blue"
-            app:elevation="12dp"
-            app:fabSize="normal"
-            android:layout_margin="8dp"
-            app:pressedTranslationZ="12dp"
+            app:useCompatPadding="true"
+            app:elevation="4dp"
             app:srcCompat="@drawable/ic_add_white_24dp" />
 
     </LinearLayout>


### PR DESCRIPTION
You might have noticed that the padding around your FloatingActionButtons is a little "off" in API 19. This is because shadows (elevations) are treated differently on pre-Lollipop devices.

Fortunately the `FloatingActionButton` has a convenient property called `useCompatPadding`, which automatically corrects the padding depending on what API level is being used.

This also removes a number of unnecessary or redundant attributes.