### PR TITLE
Adjusted position of level number in achievements activity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -7,6 +7,8 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
+
+import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.core.content.FileProvider;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
@@ -127,7 +129,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
         int width = displayMetrics.widthPixels;
 
         // Used for the setting the size of imageView at runtime
-        RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams)
+        ConstraintLayout.LayoutParams params = (ConstraintLayout.LayoutParams)
                 imageView.getLayoutParams();
         params.height = (int) (height * BADGE_IMAGE_HEIGHT_RATIO);
         params.width = (int) (width * BADGE_IMAGE_WIDTH_RATIO);

--- a/app/src/main/res/layout/activity_achievements.xml
+++ b/app/src/main/res/layout/activity_achievements.xml
@@ -59,32 +59,45 @@
                         android:tint="?attr/icon"
                         android:layout_marginVertical="@dimen/activity_margin_vertical" />
 
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/badge_layout"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@id/achievement_info"
+                        android:layout_alignParentRight="true"
+                        android:layout_alignParentLeft="true"
+                        >
+
                     <ImageView
                         android:id="@+id/achievement_badge_image"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_below="@id/achievement_info"
-                        android:layout_alignParentLeft="true"
-                        android:layout_alignParentRight="true"
+                        app:layout_constraintLeft_toLeftOf="parent"
+                        app:layout_constraintRight_toRightOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:srcCompat="@drawable/badge"
                         android:layout_marginVertical="@dimen/activity_margin_vertical" />
 
-                    <TextView
-                        android:id="@+id/achievement_badge_text"
-                        android:textColor="@color/achievement_badge_text"
-                        android:textSize="90dp"
-                        android:textAlignment="center"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="50dp"
-                        android:layout_alignTop="@+id/achievement_badge_image"
-                        android:layout_alignParentLeft="true"
-                        android:layout_alignParentRight="true" />
+                        <TextView
+                            android:id="@+id/achievement_badge_text"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textAlignment="center"
+                            android:textColor="@color/achievement_badge_text"
+                            android:textSize="90sp"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintHorizontal_bias="0.498"
+                            app:layout_constraintLeft_toLeftOf="parent"
+                            app:layout_constraintRight_toRightOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintVertical_bias="0.65" />
+                    </androidx.constraintlayout.widget.ConstraintLayout>
 
                     <RelativeLayout
                         android:id="@+id/layout_image_uploaded"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_below="@+id/achievement_badge_image"
+                        android:layout_below="@+id/badge_layout"
                         android:layout_marginEnd="@dimen/activity_margin_horizontal"
                         android:layout_marginLeft="@dimen/activity_margin_horizontal"
                         android:layout_marginRight="@dimen/activity_margin_horizontal"

--- a/app/src/main/res/layout/activity_achievements.xml
+++ b/app/src/main/res/layout/activity_achievements.xml
@@ -28,7 +28,6 @@
                 android:orientation="vertical">
 
 
-
                 <RelativeLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -64,19 +63,16 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_below="@id/achievement_info"
-                        android:layout_alignParentRight="true"
-                        android:layout_alignParentLeft="true"
-                        >
+                        android:layout_centerHorizontal="true">
 
-                    <ImageView
-                        android:id="@+id/achievement_badge_image"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        app:layout_constraintLeft_toLeftOf="parent"
-                        app:layout_constraintRight_toRightOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:srcCompat="@drawable/badge"
-                        android:layout_marginVertical="@dimen/activity_margin_vertical" />
+                        <ImageView
+                            android:id="@+id/achievement_badge_image"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:layout_constraintLeft_toLeftOf="parent"
+                            app:layout_constraintRight_toRightOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:srcCompat="@drawable/badge" />
 
                         <TextView
                             android:id="@+id/achievement_badge_text"
@@ -84,13 +80,12 @@
                             android:layout_height="wrap_content"
                             android:textAlignment="center"
                             android:textColor="@color/achievement_badge_text"
-                            android:textSize="90sp"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintHorizontal_bias="0.498"
-                            app:layout_constraintLeft_toLeftOf="parent"
-                            app:layout_constraintRight_toRightOf="parent"
-                            app:layout_constraintTop_toTopOf="parent"
-                            app:layout_constraintVertical_bias="0.65" />
+                            android:textSize="75sp"
+                            app:layout_constraintBottom_toBottomOf="@+id/achievement_badge_image"
+                            app:layout_constraintEnd_toEndOf="@+id/achievement_badge_image"
+                            app:layout_constraintStart_toStartOf="@+id/achievement_badge_image"
+                            app:layout_constraintTop_toTopOf="@+id/achievement_badge_image"
+                            app:layout_constraintVertical_bias="0.58" />
                     </androidx.constraintlayout.widget.ConstraintLayout>
 
                     <RelativeLayout


### PR DESCRIPTION
**Description**
Adjusted layout of achievements activity to adjust vertical position of level number on all screen sizes 

Fixes #2677 Level number in achievements position is a bit odd with 2 digits

**Screenshot for 1 digit level number**
![WhatsApp Image 2019-03-21 at 2 59 11 PM](https://user-images.githubusercontent.com/34261945/54743658-c4efef80-4bea-11e9-9317-ef869f9fc639.jpeg)

**Screenshot for 2-digit level number**
![WhatsApp Image 2019-03-21 at 3 02 59 PM](https://user-images.githubusercontent.com/34261945/54743661-c6b9b300-4bea-11e9-8798-6329fac6e645.jpeg)

