### PR TITLE
Fix crash(es) upon upload failure.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -944,7 +944,7 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
             long dataLength,
             Uri fileUri,
             Uri contentProviderUri,
-            ProgressListener progressListener) throws IOException {
+            ProgressListener progressListener) {
         return Single.fromCallable(() -> {
             CustomApiResult result = api.uploadToStash(filename, file, dataLength, getEditToken(), progressListener::onProgress);
 

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
@@ -9,7 +9,6 @@ import java.io.InputStream;
 import java.util.List;
 
 import fr.free.nrw.commons.Media;
-import fr.free.nrw.commons.campaigns.CampaignResponseDTO;
 import fr.free.nrw.commons.notification.Notification;
 import io.reactivex.Observable;
 import io.reactivex.Single;
@@ -53,7 +52,7 @@ public interface MediaWikiApi {
     @NonNull
     Single<UploadStash> uploadFile(String filename, InputStream file,
                                    long dataLength, Uri fileUri, Uri contentProviderUri,
-                                   final ProgressListener progressListener) throws IOException;
+                                   final ProgressListener progressListener);
 
     @NonNull
     Single<UploadResult> uploadFileFinalize(String filename, String filekey,


### PR DESCRIPTION
There are a couple of incorrect assumptions and constructs in the Rx block that performs the upload:

- The Rx call is surrounded by a try-finally block, which is not really how it works. If you need to run some code at the end of an Rx sequence, you should put a doFinally() block in the sequence.
- The onError block of the Rx call simply rethrows the error as a RuntimeException (?) which will be unhandled and crash the app.

Fixes #2696.