### PR TITLE
BugFix issue #2652

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/pictures/BookmarkPicturesDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/pictures/BookmarkPicturesDao.java
@@ -6,16 +6,13 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.RemoteException;
 import android.support.annotation.NonNull;
-
+import fr.free.nrw.commons.bookmarks.Bookmark;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
-
-import fr.free.nrw.commons.bookmarks.Bookmark;
 
 import static fr.free.nrw.commons.bookmarks.pictures.BookmarkPicturesContentProvider.BASE_URI;
 
@@ -121,6 +118,10 @@ public class BookmarkPicturesDao {
      * @return boolean : is bookmark in database ?
      */
     public boolean findBookmark(Bookmark bookmark) {
+        if (bookmark == null) {//Avoiding NPE's
+            return false;
+        }
+
         Cursor cursor = null;
         ContentProviderClient db = clientProvider.get();
         try {


### PR DESCRIPTION
**Description (required)**
Querying on ContrubutionsDao with null bookmarks used to crash the app. Added a fix for the same

Fixes #2652 NPE on bookmark while pic from explore still loading (slow internet)

What changes did you make and why?
* Added null check on bookmark before operating on it

**Tests performed (required)**

Tested { ProdDebug} on {Pixel 2} with API level 27.
