### PR TITLE
Fix searching in Explore screen.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Media.java
+++ b/app/src/main/java/fr/free/nrw/commons/Media.java
@@ -460,12 +460,12 @@ public class Media implements Parcelable {
                 page.title(),
                 imageInfo.getMetadata().imageDescription().value(),
                 0,
-                DateUtils.getDateFromString(imageInfo.getMetadata().getDateTimeOriginal().value()),
-                DateUtils.getDateFromString(imageInfo.getMetadata().getDateTime().value()),
-                StringUtils.getParsedStringFromHtml(imageInfo.getMetadata().getArtist().value())
+                DateUtils.getDateFromString(imageInfo.getMetadata().dateTimeOriginal().value()),
+                DateUtils.getDateFromString(imageInfo.getMetadata().dateTime().value()),
+                StringUtils.getParsedStringFromHtml(imageInfo.getMetadata().artist().value())
         );
 
-        media.setLicense(imageInfo.getMetadata().getLicenseShortName().value());
+        media.setLicense(imageInfo.getMetadata().licenseShortName().value());
 
         return media;
     }

--- a/app/src/main/java/fr/free/nrw/commons/media/model/ExtMetadata.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/model/ExtMetadata.java
@@ -1,9 +1,10 @@
 package fr.free.nrw.commons.media.model;
 
+import com.google.gson.annotations.SerializedName;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
-import com.google.gson.annotations.SerializedName;
+import fr.free.nrw.commons.utils.StringUtils;
 
 public class ExtMetadata {
     @SuppressWarnings("unused") @SerializedName("DateTime") @Nullable
@@ -26,136 +27,53 @@ public class ExtMetadata {
     @SuppressWarnings("unused") @SerializedName("Restrictions") @Nullable private Values restrictions;
     @SuppressWarnings("unused") @SerializedName("License") @Nullable private Values license;
 
-    @Nullable public Values licenseShortName() {
-        return licenseShortName;
+    @NonNull public Values dateTime() {
+        return dateTime != null ? dateTime : new Values();
     }
 
-    @Nullable public Values licenseUrl() {
-        return licenseUrl;
+    @NonNull public Values dateTimeOriginal() {
+        return dateTimeOriginal != null ? dateTimeOriginal : new Values();
     }
 
-    @Nullable public Values license() {
-        return license;
+    @NonNull public Values licenseShortName() {
+        return licenseShortName != null ? licenseShortName : new Values();
     }
 
-    @Nullable public Values imageDescription() {
-        return imageDescription;
+    @NonNull public Values licenseUrl() {
+        return licenseUrl != null ? licenseUrl : new Values();
     }
 
-    @Nullable
-    public Values getDateTime() {
-        return dateTime;
+    @NonNull public Values license() {
+        return license != null ? license : new Values();
     }
 
-    @Nullable
-    public Values getObjectName() {
-        return objectName;
+    @NonNull public Values imageDescription() {
+        return imageDescription != null ? imageDescription : new Values();
     }
 
-    @Nullable
-    public Values getCommonsMetadataExtension() {
-        return commonsMetadataExtension;
+    @NonNull public Values objectName() {
+        return objectName != null ? objectName : new Values();
     }
 
-    @Nullable
-    public Values getCategories() {
-        return categories;
+    @NonNull public Values usageTerms() {
+        return usageTerms != null ? usageTerms : new Values();
     }
 
-    @Nullable
-    public Values getAssessments() {
-        return assessments;
-    }
-
-    @Nullable
-    public Values getImageDescription() {
-        return imageDescription;
-    }
-
-    @Nullable
-    public Values getDateTimeOriginal() {
-        return dateTimeOriginal;
-    }
-
-    @Nullable
-    public Values getArtist() {
-        return artist;
-    }
-
-    @Nullable
-    public Values getCredit() {
-        return credit;
-    }
-
-    @Nullable
-    public Values getPermission() {
-        return permission;
-    }
-
-    @Nullable
-    public Values getAuthorCount() {
-        return authorCount;
-    }
-
-    @Nullable
-    public Values getLicenseShortName() {
-        return licenseShortName;
-    }
-
-    @Nullable
-    public Values getUsageTerms() {
-        return usageTerms;
-    }
-
-    @Nullable
-    public Values getLicenseUrl() {
-        return licenseUrl;
-    }
-
-    @Nullable
-    public Values getAttributionRequired() {
-        return attributionRequired;
-    }
-
-    @Nullable
-    public Values getCopyrighted() {
-        return copyrighted;
-    }
-
-    @Nullable
-    public Values getRestrictions() {
-        return restrictions;
-    }
-
-    @Nullable
-    public Values getLicense() {
-        return license;
-    }
-
-    @Nullable public Values objectName() {
-        return objectName;
-    }
-
-    @Nullable public Values usageTerms() {
-        return usageTerms;
-    }
-
-    @Nullable public Values artist() {
-        return artist;
+    @NonNull public Values artist() {
+        return artist != null ? artist : new Values();
     }
 
     public class Values {
-        @SuppressWarnings("unused,NullableProblems") @NonNull
-        private String value;
-        @SuppressWarnings("unused,NullableProblems") @NonNull private String source;
-        @SuppressWarnings("unused,NullableProblems") @NonNull private String hidden;
+        @SuppressWarnings("unused,NullableProblems") @Nullable private String value;
+        @SuppressWarnings("unused,NullableProblems") @Nullable private String source;
+        @SuppressWarnings("unused,NullableProblems") @Nullable private String hidden;
 
         @NonNull public String value() {
-            return value;
+            return StringUtils.defaultString(value);
         }
 
         @NonNull public String source() {
-            return source;
+            return StringUtils.defaultString(source);
         }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/media/model/ExtMetadata.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/model/ExtMetadata.java
@@ -66,7 +66,6 @@ public class ExtMetadata {
     public class Values {
         @SuppressWarnings("unused,NullableProblems") @Nullable private String value;
         @SuppressWarnings("unused,NullableProblems") @Nullable private String source;
-        @SuppressWarnings("unused,NullableProblems") @Nullable private String hidden;
 
         @NonNull public String value() {
             return StringUtils.defaultString(value);


### PR DESCRIPTION
You may have noticed that searching is broken (in the "explore" screen). This is because the `Media` object was trying to initialize itself from fields that might be null. This PR updates the `ExtMetadata` object to be more robust and resilient against empty fields. (In fact this is a copy of `ExtMetadata` from the new Library, and will be absorbed once that is complete.)