### PR TITLE
BugFix issue #2711

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
@@ -242,6 +242,13 @@ public class OkHttpJsonApiClient {
                     return mediaList;
                 }
                 MwQueryResponse mwQueryResponse = gson.fromJson(json, MwQueryResponse.class);
+
+                if (null == mwQueryResponse
+                    || null == mwQueryResponse.query()
+                    || null == mwQueryResponse.query().pages()) {
+                    return mediaList;
+                }
+
                 List<MwQueryPage> pages = mwQueryResponse.query().pages();
                 for (MwQueryPage page : pages) {
                     mediaList.add(Media.from(page));


### PR DESCRIPTION
**Description (required)**
Because of null query(MwQueryResult) or null mwQueryResponse, the app crashes when accessing member variables of these references
Fixes  #2711 App crashes while searching images

What changes did you make and why?
* Added null checks in OkHttpJsonApiClient$searchImages MwQueryResponse

**Tests performed (required)**

Tested  ProdDebug on {Pixel2} with API level {27}.

