### PR TITLE
Fixes #2718 Crashes while setting null auth cookies

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/CustomMwApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/CustomMwApi.java
@@ -69,6 +69,10 @@ public class CustomMwApi {
     }
 
     public void setAuthCookie(String authCookie) {
+        if (authCookie == null) {//If the authCookie is null, no need to proceed
+            return;
+        }
+
         this.authCookie = authCookie;
         this.isLoggedIn = true;
         String[] cookies = authCookie.split(";");


### PR DESCRIPTION

**Description (required)**
Operating on null auth cookies used to throw a NullPointerException.
Fixes #2718 Crashes while setting null auth cookies

What changes did you make and why?
Handled null auth cookies