### PR TITLE
Added Forgot Password Unit Test

### DIFF
--- a/app/src/androidTest/java/fr/free/nrw/commons/LoginActivityTest.kt
+++ b/app/src/androidTest/java/fr/free/nrw/commons/LoginActivityTest.kt
@@ -1,10 +1,12 @@
 package fr.free.nrw.commons
 
+import android.content.Intent
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -31,6 +33,17 @@ class LoginActivityTest {
                 .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
                 .perform(click())
         intended(hasComponent(SignupActivity::class.java.name))
+        Intents.release()
+    }
+
+    @Test
+    fun isForgotPasswordWorks() {
+        // Clicks the forgot password
+        Intents.init()
+        Espresso.onView(withId(R.id.forgotPassword))
+                .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+                .perform(click())
+        intended(hasAction(Intent.ACTION_VIEW))
         Intents.release()
     }
 }


### PR DESCRIPTION
**Description**
Added Forgot Password Unit Test for Login Activity in Kotlin

**Fixes #2686 Write Unit Test for Login Activity**

**What changes did you make and why?**
Added Unit Test for Forgot Password URL

**Tests performed**
Tested betaDebug on Xiaomi Mi A1 with API level 28.

**Logs**
Testing started at 06:36 PM ...

03/23 18:36:24: Launching isForgotPasswordWo...()
No apk changes detected since last installation, skipping installation of C:\Users\madhu\Desktop\apps-android-commons\app\build\outputs\apk\beta\debug\app-commons-v2.10.1-master-beta-debug.apk
No apk changes detected since last installation, skipping installation of C:\Users\madhu\Desktop\apps-android-commons\app\build\outputs\apk\androidTest\beta\debug\app-commons-v2.10.1-master-beta-debug-androidTest.apk
Running tests

$ adb shell am instrument -w -r   -e debug false -e class 'fr.free.nrw.commons.LoginActivityTest#isForgotPasswordWorks' fr.free.nrw.commons.beta.test/androidx.test.runner.AndroidJUnitRunner
Connected to process 21700 on device xiaomi-mi_a1-7af99b9c0404

Started running tests
Tests ran to completion.

Test Passed