### PR TITLE
strings: fix typos on internet_downloaded

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -249,7 +249,7 @@
   <string name="upload_problem_different_geolocation">This picture was taken at a different location.</string>
   <string name="upload_problem_fbmd">Please only upload pictures that you have taken by yourself. Don\'t upload pictures that you have found on other people\'s Facebook accounts.</string>
   <string name="upload_problem_do_you_continue">Do you still want to upload this picture?</string>
-  <string name="internet_downloaded">Please only upload pictures that you have taken by yourself.Don\'t upload pictures that you have downloaded from internet</string>
+  <string name="internet_downloaded">Please only upload pictures that you have taken by yourself. Don\'t upload pictures that you have downloaded from the Internet.</string>
 
 
   <string name="give_permission">Give permission</string>


### PR DESCRIPTION
**Summary**
Fixes #2735 i18n: internet_downloaded: typos

**Changes made**
- Dot and space.
- 'internet' -> 'the Internet'.
- Final dot at the end of the string