### PR TITLE
Bugfix/customproxy

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
@@ -2,15 +2,6 @@ package fr.free.nrw.commons.upload;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-
-import java.lang.reflect.Proxy;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.category.CategoriesModel;
 import fr.free.nrw.commons.contributions.Contribution;
@@ -18,11 +9,17 @@ import fr.free.nrw.commons.filepicker.UploadableFile;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.nearby.Place;
 import fr.free.nrw.commons.settings.Prefs;
+import fr.free.nrw.commons.utils.CustomProxy;
 import fr.free.nrw.commons.utils.StringUtils;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
 import timber.log.Timber;
 
 import static fr.free.nrw.commons.upload.UploadModel.UploadItem;
@@ -38,12 +35,16 @@ import static fr.free.nrw.commons.utils.ImageUtils.getErrorMessageForResult;
 @Singleton
 public class UploadPresenter {
 
-    private static final UploadView DUMMY = (UploadView) Proxy.newProxyInstance(UploadView.class.getClassLoader(),
-            new Class[]{UploadView.class}, (proxy, method, methodArgs) -> null);
+    private static final UploadView DUMMY =
+        (UploadView) CustomProxy.newInstance(UploadView.class.getClassLoader(),
+            new Class[] { UploadView.class });
+
     private UploadView view = DUMMY;
 
-    private static final SimilarImageInterface SIMILAR_IMAGE = (SimilarImageInterface) Proxy.newProxyInstance(SimilarImageInterface.class.getClassLoader(),
-            new Class[]{SimilarImageInterface.class}, (proxy, method, methodArgs) -> null);
+    private static final SimilarImageInterface SIMILAR_IMAGE =
+        (SimilarImageInterface) CustomProxy.newInstance(
+            SimilarImageInterface.class.getClassLoader(),
+            new Class[] { SimilarImageInterface.class });
     private SimilarImageInterface similarImageInterface = SIMILAR_IMAGE;
 
     @UploadView.UploadPage

--- a/app/src/main/java/fr/free/nrw/commons/utils/CustomProxy.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/CustomProxy.java
@@ -3,6 +3,11 @@ package fr.free.nrw.commons.utils;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 
+/**
+ * Returns a new instance of proxy with overriden invocationhanlder() returning appropriate values
+ * for different datatypes
+ * See https://stackoverflow.com/questions/52083338/expected-to-unbox-a-string-primitive-type-but-was-returned-null
+ */
 public class CustomProxy extends Proxy {
     protected CustomProxy(InvocationHandler h) {
         super(h);

--- a/app/src/main/java/fr/free/nrw/commons/utils/CustomProxy.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/CustomProxy.java
@@ -1,0 +1,28 @@
+package fr.free.nrw.commons.utils;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+
+public class CustomProxy extends Proxy {
+    protected CustomProxy(InvocationHandler h) {
+        super(h);
+    }
+
+    public static Object newInstance(ClassLoader loader, Class<?>[] interfaces) {
+        return Proxy.newProxyInstance(loader, interfaces, (o, method, objects) -> {
+            if (String.class == method.getReturnType()) {
+                return "";
+            } else if (Integer.class == method.getReturnType()) {
+                return Integer.valueOf(0);
+            } else if (int.class == method.getReturnType()) {
+                return 0;
+            } else if (Boolean.class == method.getReturnType()) {
+                return Boolean.FALSE;
+            } else if (boolean.class == method.getReturnType()) {
+                return false;
+            } else {
+                return null;
+            }
+        });
+    }
+}


### PR DESCRIPTION
**Description (required)**
Added a CustomProxy class, the instance of which overrides the invocationHandler() method which returns appropriate values for different datatypes instead of null for all of them. See https://stackoverflow.com/questions/52083338/expected-to-unbox-a-string-primitive-type-but-was-returned-null
Fixes #2737 App crashed with NPE in UploadPresenter due to null object returned by Proxy InvocationHandler

**Tests performed (required)**

Tested {ProdDebug} on {Pixel} with API level {27}.
