### PR TITLE
Resolved progressbar overlapping issue while scrolling in explore activity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
@@ -52,6 +52,9 @@ public class CategoryImagesListFragment extends DaggerFragment {
     @BindView(R.id.loadingImagesProgressBar) ProgressBar progressBar;
     @BindView(R.id.categoryImagesList) GridView gridView;
     @BindView(R.id.parentLayout) RelativeLayout parentLayout;
+    @BindView(R.id.bottomProgressBar)
+    ProgressBar bottomProgressBar;
+
     private CompositeDisposable compositeDisposable = new CompositeDisposable();
     private boolean hasMoreImages = true;
     private boolean isLoading = true;
@@ -189,6 +192,8 @@ public class CategoryImagesListFragment extends DaggerFragment {
             public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
                 if (hasMoreImages && !isLoading && (firstVisibleItem + visibleItemCount + 1 >= totalItemCount)) {
                     isLoading = true;
+                    progressBar.setVisibility(GONE);
+                    bottomProgressBar.setVisibility(View.VISIBLE);
                     fetchMoreImages();
                 }
                 if (!hasMoreImages){
@@ -222,7 +227,6 @@ public class CategoryImagesListFragment extends DaggerFragment {
             return;
         }
 
-        progressBar.setVisibility(VISIBLE);
         compositeDisposable.add(Observable.fromCallable(() -> controller.getCategoryImages(categoryName))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
@@ -266,6 +270,7 @@ public class CategoryImagesListFragment extends DaggerFragment {
                 e.printStackTrace();
             }
         }
+        bottomProgressBar.setVisibility(GONE);
         progressBar.setVisibility(GONE);
         isLoading = false;
         statusTextView.setVisibility(GONE);

--- a/app/src/main/res/layout/fragment_category_images.xml
+++ b/app/src/main/res/layout/fragment_category_images.xml
@@ -20,10 +20,19 @@
         />
 
     <ProgressBar
+        android:id="@+id/bottomProgressBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_alignParentBottom="true"
+        android:paddingTop="5dp"
+        android:paddingBottom="5dp"
+        android:visibility="gone"/>
+
+    <ProgressBar
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
-        android:visibility="gone"
         android:id="@+id/loadingImagesProgressBar"
         />
 
@@ -36,6 +45,7 @@
         android:numColumns="auto_fit"
         android:listSelector="@null"
         android:fadingEdge="none"
+        android:layout_above="@+id/bottomProgressBar"
         android:fastScrollEnabled="true"
         />
 


### PR DESCRIPTION
**Description (required)**

Fixes #2740 Progressbar Overlaps images in Explore

### Changes made
- Modified fragment_category_images.xml
- Modified CategoryImagesListFragment.java

**Screenshots showing what changed (optional - for UI changes)**
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/34261945/54883020-b02f8800-4e86-11e9-9c05-73fa502f7dd4.gif)