### PR TITLE
wording fix for issue#2441

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -458,7 +458,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="achievements_fetch_failed">Something went wrong, We could not fetch your achievements</string>
   <string name="ends_on">Ends on:</string>
   <string name="display_campaigns">Display campaigns</string>
-  <string name="display_campaigns_explanation">Tap here to see the ongoing campaigns</string>
+  <string name="display_campaigns_explanation">See the ongoing campaigns</string>
   <string name="nearby_campaign_dismiss_message">You won\'t see the campaigns anymore. However, you can re-enable this notification in Settings if you wish.</string>
 
   <string name="this_function_needs_network_connection">This function requires network connection, please check your connection settings.</string>


### PR DESCRIPTION
**Description (required)**

Fixes #2441 Tap here to see the ongoing campaigns: Wrong wording

Corrected wrong wording in the settings preference Display campaigns. 
Changes affecting strings.xml

Tested betaDebug on Samsung with API level 22.

![WhatsApp Image 2019-03-25 at 12 14 15 PM](https://user-images.githubusercontent.com/22516895/54907931-c9245180-4ef7-11e9-8e0b-6697584d025a.jpeg)


