### PR TITLE
Diasbled buttons in peer activity until view is loaded

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
@@ -59,6 +59,7 @@ public class ReviewActivity extends AuthenticatedActivity {
     TextView imageCaption;
     @Inject
     MediaWikiApi mwApi;
+    Button yesButton, noButton;
 
     /**
      * Consumers should be simply using this method to use this activity.
@@ -91,6 +92,9 @@ public class ReviewActivity extends AuthenticatedActivity {
         ButterKnife.bind(this);
         initDrawer();
 
+        yesButton=findViewById(R.id.yesButton);
+        noButton=findViewById(R.id.noButton);
+
         reviewController = new ReviewController();
 
         reviewPagerAdapter = new ReviewPagerAdapter(getSupportFragmentManager());
@@ -118,6 +122,7 @@ public class ReviewActivity extends AuthenticatedActivity {
 
     @SuppressLint("CheckResult")
     private void updateImage(String fileName) {
+        reviewPagerAdapter.disableButtons();
         if (fileName.length() == 0) {
             ViewUtil.showShortSnackbar(drawerLayout, R.string.error_review);
             return;
@@ -151,6 +156,7 @@ public class ReviewActivity extends AuthenticatedActivity {
     }
 
     private void updateCategories(ArrayList<String> categories) {
+        reviewPagerAdapter.enableButtons();
         reviewController.onCategoriesRefreshed(categories);
         reviewPagerAdapter.updateCategories();
     }

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
@@ -118,7 +118,6 @@ public class ReviewActivity extends AuthenticatedActivity {
 
     @SuppressLint("CheckResult")
     private void updateImage(String fileName) {
-        reviewPagerAdapter.disableButtons();
         if (fileName.length() == 0) {
             ViewUtil.showShortSnackbar(drawerLayout, R.string.error_review);
             return;

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
@@ -59,7 +59,6 @@ public class ReviewActivity extends AuthenticatedActivity {
     TextView imageCaption;
     @Inject
     MediaWikiApi mwApi;
-    Button yesButton, noButton;
 
     /**
      * Consumers should be simply using this method to use this activity.
@@ -91,9 +90,6 @@ public class ReviewActivity extends AuthenticatedActivity {
         setContentView(R.layout.activity_review);
         ButterKnife.bind(this);
         initDrawer();
-
-        yesButton=findViewById(R.id.yesButton);
-        noButton=findViewById(R.id.noButton);
 
         reviewController = new ReviewController();
 

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
@@ -71,10 +71,10 @@ public class ReviewImageFragment extends CommonsDaggerSupportFragment {
         textViewQuestionContext = layoutView.findViewById(R.id.reviewQuestionContext);
         yesButton = layoutView.findViewById(R.id.yesButton);
         noButton = layoutView.findViewById(R.id.noButton);
-
         String question, explanation, yesButtonText, noButtonText;
         switch (position) {
             case COPYRIGHT:
+                enableButtons();
                 question = getString(R.string.review_copyright);
                 explanation = getString(R.string.review_copyright_explanation);
                 yesButtonText = getString(R.string.review_copyright_yes_button_text);
@@ -82,6 +82,7 @@ public class ReviewImageFragment extends CommonsDaggerSupportFragment {
                 yesButton.setOnClickListener(view -> getReviewActivity().reviewController.reportPossibleCopyRightViolation(requireActivity()));
                 break;
             case CATEGORY:
+                enableButtons();
                 question = getString(R.string.review_category);
                 explanation = getString(R.string.review_no_category);
                 yesButtonText = getString(R.string.review_category_yes_button_text);
@@ -92,6 +93,7 @@ public class ReviewImageFragment extends CommonsDaggerSupportFragment {
                 });
                 break;
             case SPAM:
+                disableButtons();
                 question = getString(R.string.review_spam);
                 explanation = getString(R.string.review_spam_explanation);
                 yesButtonText = getString(R.string.review_spam_yes_button_text);
@@ -99,6 +101,7 @@ public class ReviewImageFragment extends CommonsDaggerSupportFragment {
                 yesButton.setOnClickListener(view -> getReviewActivity().reviewController.reportSpam(requireActivity()));
                 break;
             case THANKS:
+                enableButtons();
                 question = getString(R.string.review_thanks);
                 explanation = getString(R.string.review_thanks_explanation, getReviewActivity().reviewController.firstRevision.getUser());
                 yesButtonText = getString(R.string.review_thanks_yes_button_text);

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
@@ -133,4 +133,17 @@ public class ReviewImageFragment extends CommonsDaggerSupportFragment {
     private ReviewActivity getReviewActivity() {
         return (ReviewActivity) requireActivity();
     }
+
+    public void enableButtons(){
+        yesButton.setEnabled(true);
+        yesButton.setAlpha(1);
+        noButton.setEnabled(true);
+        noButton.setAlpha(1);
+    }
+    public void disableButtons(){
+        yesButton.setEnabled(false);
+        yesButton.setAlpha(0.5f);
+        noButton.setEnabled(false);
+        noButton.setAlpha(0.5f);
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewPagerAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewPagerAdapter.java
@@ -46,4 +46,10 @@ public class ReviewPagerAdapter extends FragmentStatePagerAdapter {
         return reviewImageFragments[position];
     }
 
+    public void enableButtons(){
+        reviewImageFragments[0].enableButtons();
+    }
+    public void disableButtons(){
+        reviewImageFragments[0].disableButtons();
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewPagerAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewPagerAdapter.java
@@ -50,8 +50,4 @@ public class ReviewPagerAdapter extends FragmentStatePagerAdapter {
         if (reviewImageFragments != null)
         reviewImageFragments[0].enableButtons();
     }
-    public void disableButtons(){
-        if (reviewImageFragments != null)
-        reviewImageFragments[0].disableButtons();
-    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewPagerAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewPagerAdapter.java
@@ -47,9 +47,11 @@ public class ReviewPagerAdapter extends FragmentStatePagerAdapter {
     }
 
     public void enableButtons(){
+        if (reviewImageFragments != null)
         reviewImageFragments[0].enableButtons();
     }
     public void disableButtons(){
+        if (reviewImageFragments != null)
         reviewImageFragments[0].disableButtons();
     }
 }

--- a/app/src/main/res/layout/fragment_review_image.xml
+++ b/app/src/main/res/layout/fragment_review_image.xml
@@ -47,6 +47,8 @@
                     android:layout_weight="1"
                     android:background="@android:color/transparent"
                     android:text="@string/yes"
+                    android:enabled="false"
+                    android:alpha="0.5"
                     android:textAlignment="center"
                     android:textColor="@color/yes_button_color"
                     android:textSize="18sp" />
@@ -59,6 +61,8 @@
                     android:layout_weight="1"
                     android:background="@android:color/transparent"
                     android:text="@string/no"
+                    android:enabled="false"
+                    android:alpha="0.5"
                     android:textAlignment="center"
                     android:textColor="@color/no_button_color"
                     android:textSize="18sp" />

--- a/app/src/main/res/layout/fragment_review_image.xml
+++ b/app/src/main/res/layout/fragment_review_image.xml
@@ -47,8 +47,6 @@
                     android:layout_weight="1"
                     android:background="@android:color/transparent"
                     android:text="@string/yes"
-                    android:enabled="false"
-                    android:alpha="0.5"
                     android:textAlignment="center"
                     android:textColor="@color/yes_button_color"
                     android:textSize="18sp" />
@@ -61,8 +59,6 @@
                     android:layout_weight="1"
                     android:background="@android:color/transparent"
                     android:text="@string/no"
-                    android:enabled="false"
-                    android:alpha="0.5"
                     android:textAlignment="center"
                     android:textColor="@color/no_button_color"
                     android:textSize="18sp" />


### PR DESCRIPTION
**Description (required)**
In peer activity until image is loaded user shouldn't be taken to next view pager. We can disable the buttons until the view is loaded

Fixes #2753 Disable the answering buttons in Review Activity until image is loaded

### Changes made
Disable the buttons until view is loaded 

**Screenshots showing what changed (optional - for UI changes)**
![WhatsApp Image 2019-03-26 at 5 01 29 PM](https://user-images.githubusercontent.com/34261945/54994654-c35b6880-4fea-11e9-8985-6496d2de7ae7.jpeg)
