### PR TITLE
Added Click To View Photo on Home Screen Widget

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/widget/PicOfDayAppWidget.java
+++ b/app/src/main/java/fr/free/nrw/commons/widget/PicOfDayAppWidget.java
@@ -9,7 +9,6 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.net.Uri;
-import androidx.annotation.Nullable;
 import android.widget.RemoteViews;
 
 import com.facebook.common.executors.CallerThreadExecutor;
@@ -24,6 +23,7 @@ import com.facebook.imagepipeline.request.ImageRequestBuilder;
 
 import javax.inject.Inject;
 
+import androidx.annotation.Nullable;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.di.ApplicationlessInjection;
 import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient;
@@ -31,6 +31,8 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
 import timber.log.Timber;
+
+import static android.content.Intent.ACTION_VIEW;
 
 /**
  * Implementation of App Widget functionality.
@@ -64,9 +66,14 @@ public class PicOfDayAppWidget extends AppWidgetProvider {
                         response -> {
                             if (response != null) {
                                 views.setTextViewText(R.id.appwidget_title, response.getDisplayTitle());
-                                Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(response.getImageUrl()));
-                                PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, 0);
+
+                                // View in browser
+                                Intent viewIntent = new Intent();
+                                viewIntent.setAction(ACTION_VIEW);
+                                viewIntent.setData(response.getFilePageTitle().getMobileUri());
+                                PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, viewIntent, 0);
                                 views.setOnClickPendingIntent(R.id.appwidget_image, pendingIntent);
+
                                 loadImageFromUrl(response.getImageUrl(), context, views, appWidgetManager, appWidgetId);
                             }
                         },

--- a/app/src/main/java/fr/free/nrw/commons/widget/PicOfDayAppWidget.java
+++ b/app/src/main/java/fr/free/nrw/commons/widget/PicOfDayAppWidget.java
@@ -1,8 +1,10 @@
 package fr.free.nrw.commons.widget;
 
+import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
 import android.content.Context;
+import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Paint;
@@ -62,6 +64,9 @@ public class PicOfDayAppWidget extends AppWidgetProvider {
                         response -> {
                             if (response != null) {
                                 views.setTextViewText(R.id.appwidget_title, response.getDisplayTitle());
+                                Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(response.getImageUrl()));
+                                PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, 0);
+                                views.setOnClickPendingIntent(R.id.appwidget_image, pendingIntent);
                                 loadImageFromUrl(response.getImageUrl(), context, views, appWidgetManager, appWidgetId);
                             }
                         },


### PR DESCRIPTION
**Description**
Added Click To View Photo on Home Screen Widget

Fixes #2767 Add Click To View Photo on Home Screen Widget

**Tests performed**

Tested prodDebug on Xiaomi Mi A1 with API level 28 stock.

**Screenshots showing what changed**
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/30932899/55099931-aad07880-50e6-11e9-956e-7e545eda2c71.gif)
