### PR TITLE
removed Search This Area button if network connection is lost

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFragment.java
@@ -729,6 +729,9 @@ public class NearbyFragment extends CommonsDaggerSupportFragment
                     } else {
                         if (snackbar == null) {
                             snackbar = Snackbar.make(view, R.string.no_internet, Snackbar.LENGTH_INDEFINITE);
+                            if (nearbyMapFragment != null && nearbyMapFragment.searchThisAreaButton != null) {
+                                nearbyMapFragment.searchThisAreaButton.setVisibility(View.GONE);
+                            }
                         }
 
                         isNetworkErrorOccured = true;

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -551,10 +551,8 @@ public class NearbyMapFragment extends DaggerFragment {
 
             if (NearbyController.currentLocation != null) { // If our nearby markers are calculated at least once
 
-                if (searchThisAreaButton.getVisibility() == View.GONE) {
-                    if (NetworkUtils.isInternetConnectionEstablished(getContext())) {
+                if (searchThisAreaButton.getVisibility() == View.GONE && NetworkUtils.isInternetConnectionEstablished(getContext())) {
                         searchThisAreaButton.setVisibility(View.VISIBLE);
-                    }
                 }
                 double distance = mapboxMap.getCameraPosition().target
                         .distanceTo(new LatLng(NearbyController.currentLocation.getLatitude()

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -552,7 +552,7 @@ public class NearbyMapFragment extends DaggerFragment {
             if (NearbyController.currentLocation != null) { // If our nearby markers are calculated at least once
 
                 if (searchThisAreaButton.getVisibility() == View.GONE && NetworkUtils.isInternetConnectionEstablished(getContext())) {
-                        searchThisAreaButton.setVisibility(View.VISIBLE);
+                    searchThisAreaButton.setVisibility(View.VISIBLE);
                 }
                 double distance = mapboxMap.getCameraPosition().target
                         .distanceTo(new LatLng(NearbyController.currentLocation.getLatitude()

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyMapFragment.java
@@ -62,6 +62,7 @@ import fr.free.nrw.commons.bookmarks.locations.BookmarkLocationsDao;
 import fr.free.nrw.commons.contributions.ContributionController;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.utils.LocationUtils;
+import fr.free.nrw.commons.utils.NetworkUtils;
 import fr.free.nrw.commons.utils.UiUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
 import timber.log.Timber;
@@ -551,7 +552,9 @@ public class NearbyMapFragment extends DaggerFragment {
             if (NearbyController.currentLocation != null) { // If our nearby markers are calculated at least once
 
                 if (searchThisAreaButton.getVisibility() == View.GONE) {
-                    searchThisAreaButton.setVisibility(View.VISIBLE);
+                    if (NetworkUtils.isInternetConnectionEstablished(getContext())) {
+                        searchThisAreaButton.setVisibility(View.VISIBLE);
+                    }
                 }
                 double distance = mapboxMap.getCameraPosition().target
                         .distanceTo(new LatLng(NearbyController.currentLocation.getLatitude()


### PR DESCRIPTION
**Description (required)**

Fixes #2773 

**What changes did you make and why?**

Removed Search This Area button from nearby if connection is lost as nearby gets stuck if button is clicked after connection gets lost.

**Tests performed (required)**

Tested ProdDebug on Motorola Moto G5 plus with API level 24.
