### PR TITLE
fixed #2781 : Multiple instances of Peer Review

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
@@ -68,6 +68,8 @@ public class ReviewActivity extends AuthenticatedActivity {
      */
     public static void startYourself(Context context, String title) {
         Intent reviewActivity = new Intent(context, ReviewActivity.class);
+        reviewActivity.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        reviewActivity.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         context.startActivity(reviewActivity);
     }
     @Inject


### PR DESCRIPTION
**Description (required)**

Fixes #2781 

**What changes did you make and why?**
Added Flags to prevent app from creating multiple instances of Peer Review activity

**Tests performed (required)**

Tested ProdDebug on Motorola Moto G5 plus with API level 24

