### PR TITLE
Bug Fix issue #2789

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/utils/ViewUtil.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ViewUtil.java
@@ -8,6 +8,7 @@ import android.view.Display;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Toast;
+import timber.log.Timber;
 
 public class ViewUtil {
 
@@ -25,7 +26,13 @@ public class ViewUtil {
             return;
         }
 
-        ExecutorUtils.uiExecutor().execute(() -> Snackbar.make(view, messageResourceId, Snackbar.LENGTH_SHORT).show());
+        ExecutorUtils.uiExecutor().execute(() -> {
+            try {
+                Snackbar.make(view, messageResourceId, Snackbar.LENGTH_SHORT).show();
+            }catch (IllegalStateException e){
+                Timber.e(e.getMessage());
+            }
+        });
     }
 
     public static void showLongToast(Context context, String text) {


### PR DESCRIPTION
**Description (required)**
Fixes #2789 App Crashes with Illegal State Exception in ViewUtils
SnackBar make method takes a view and from that view it trails up the hierarchy until it finds a suitable layout to show and throws an exception if it cannot find one, as the logs donot lead to any specific place, I have added a temporary fix to handle the crash
What changes did you make and why?
* Handled Illegal State Exception for non existent appropriate view parents in ViewUtils$showShortSnackbar
**Tests performed (required)**
Tested {ProdDebug} on {Pixel 2} with API level {29l}.

