### PR TITLE
Prevent crashing of Peer activity on orientation change

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -133,7 +133,8 @@
 
         <activity
             android:name=".review.ReviewActivity"
-            android:label="@string/title_activity_review" />
+            android:label="@string/title_activity_review"
+            android:configChanges="orientation|screenSize|keyboard"/>
 
         <service android:name=".upload.UploadService" />
         <service


### PR DESCRIPTION
**Description (required)**
On orientation change Peer review activity crashes due to a null pointer exception due to reloading of the activity. Prevented reloading to tackle the Null pointer exception

Fixes #2786 Peer review bug on orientation change

### Changes made
Prevented reloading of the activity on screen rotation to avoid Null pointer Exception