### PR TITLE
Use JSON version 2 API for MwQueryResponse responses

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
@@ -238,6 +238,7 @@ public class OkHttpJsonApiClient {
                 .newBuilder()
                 .addQueryParameter("action", "query")
                 .addQueryParameter("format", "json")
+                .addQueryParameter("formatversion", "2")
                 .addQueryParameter("titles", titles);
 
         if (useGenerator) {
@@ -293,7 +294,8 @@ public class OkHttpJsonApiClient {
                 .parse(commonsBaseUrl)
                 .newBuilder()
                 .addQueryParameter("action", "query")
-                .addQueryParameter("format", "json");
+                .addQueryParameter("format", "json")
+                .addQueryParameter("formatversion", "2");
 
 
         if (queryType.equals("search")) {
@@ -408,6 +410,7 @@ public class OkHttpJsonApiClient {
                 .newBuilder()
                 .addQueryParameter("action", "query")
                 .addQueryParameter("format", "json")
+                .addQueryParameter("formatversion", "2")
                 .addQueryParameter("list", "recentchanges")
                 .addQueryParameter("rcstart", DateUtils.formatMWDate(startDate))
                 .addQueryParameter("rcnamespace", FILE_NAMESPACE)
@@ -442,6 +445,7 @@ public class OkHttpJsonApiClient {
                 .newBuilder()
                 .addQueryParameter("action", "query")
                 .addQueryParameter("format", "json")
+                .addQueryParameter("formatversion", "2")
                 .addQueryParameter("prop", "revisions")
                 .addQueryParameter("rvprop", "timestamp|ids|user")
                 .addQueryParameter("titles", filename)

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/model/MwQueryResult.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/model/MwQueryResult.java
@@ -13,7 +13,7 @@ import fr.free.nrw.commons.media.model.MwQueryPage;
 public class MwQueryResult {
     @SuppressWarnings("unused")
     @Nullable
-    private HashMap<String, MwQueryPage> pages;
+    private List<MwQueryPage> pages;
     private List<RecentChange> recentchanges;
 
     @NonNull
@@ -21,7 +21,7 @@ public class MwQueryResult {
         if (pages == null) {
             return new ArrayList<>();
         }
-        return new ArrayList<>(pages.values());
+        return pages;
     }
 
     public List<RecentChange> getRecentchanges() {

--- a/app/src/test/kotlin/fr/free/nrw/commons/mwapi/OkHttpJsonApiClientTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/mwapi/OkHttpJsonApiClientTest.kt
@@ -22,7 +22,6 @@ import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import java.net.URLDecoder
 import kotlin.random.Random
 
 /**
@@ -97,6 +96,7 @@ class OkHttpJsonApiClientTest {
         assertBasicRequestParameters(server, "GET").let { request ->
             parseQueryParams(request).let { body ->
                 Assert.assertEquals("json", body["format"])
+                Assert.assertEquals("2", body["formatversion"])
                 Assert.assertEquals("query", body["action"])
                 Assert.assertEquals("categorymembers", body["generator"])
                 Assert.assertEquals("file", body["gcmtype"])
@@ -141,6 +141,7 @@ class OkHttpJsonApiClientTest {
         assertBasicRequestParameters(server, "GET").let { request ->
             parseQueryParams(request).let { body ->
                 Assert.assertEquals("json", body["format"])
+                Assert.assertEquals("2", body["formatversion"])
                 Assert.assertEquals("query", body["action"])
                 Assert.assertEquals("search", body["generator"])
                 Assert.assertEquals("text", body["gsrwhat"])
@@ -170,6 +171,7 @@ class OkHttpJsonApiClientTest {
         assertBasicRequestParameters(server, "GET").let { request ->
             parseQueryParams(request).let { body ->
                 Assert.assertEquals("json", body["format"])
+                Assert.assertEquals("2", body["formatversion"])
                 Assert.assertEquals("query", body["action"])
                 Assert.assertEquals("Test.jpg", body["titles"])
                 Assert.assertEquals("imageinfo", body["prop"])
@@ -195,6 +197,7 @@ class OkHttpJsonApiClientTest {
         assertBasicRequestParameters(server, "GET").let { request ->
             parseQueryParams(request).let { body ->
                 Assert.assertEquals("json", body["format"])
+                Assert.assertEquals("2", body["formatversion"])
                 Assert.assertEquals("query", body["action"])
                 Assert.assertEquals(template, body["titles"])
                 Assert.assertEquals("images", body["generator"])
@@ -220,6 +223,7 @@ class OkHttpJsonApiClientTest {
         assertBasicRequestParameters(server, "GET").let { request ->
             parseQueryParams(request).let { body ->
                 Assert.assertEquals("json", body["format"])
+                Assert.assertEquals("2", body["formatversion"])
                 Assert.assertEquals("query", body["action"])
                 Assert.assertEquals(template, body["titles"])
                 Assert.assertEquals("images", body["generator"])
@@ -238,6 +242,7 @@ class OkHttpJsonApiClientTest {
         assertBasicRequestParameters(server, "GET").let { request ->
             parseQueryParams(request).let { body ->
                 Assert.assertEquals("json", body["format"])
+                Assert.assertEquals("2", body["formatversion"])
                 Assert.assertEquals("query", body["action"])
                 Assert.assertEquals("search", body["generator"])
                 Assert.assertEquals("text", body["gsrwhat"])
@@ -258,6 +263,7 @@ class OkHttpJsonApiClientTest {
         assertBasicRequestParameters(server, "GET").let { request ->
             parseQueryParams(request).let { body ->
                 Assert.assertEquals("json", body["format"])
+                Assert.assertEquals("2", body["formatversion"])
                 Assert.assertEquals("query", body["action"])
                 Assert.assertEquals("categorymembers", body["generator"])
                 Assert.assertEquals("file", body["gcmtype"])
@@ -310,7 +316,7 @@ class OkHttpJsonApiClientTest {
         }
 
         val pagesString = mediaList.joinToString()
-        val responseBody = "{\"batchcomplete\":\"\"$continueJson,\"query\":{\"pages\":{$pagesString}}}"
+        val responseBody = "{\"batchcomplete\":\"\"$continueJson,\"query\":{\"pages\":[$pagesString]}}"
         mockResponse.setBody(responseBody)
         return mockResponse
     }
@@ -325,7 +331,7 @@ class OkHttpJsonApiClientTest {
         val id1 = random.nextInt()
         val id2 = random.nextInt()
         val categories = "cat$id1|cat$id2"
-        return "\"$pageID\":{\"pageid\":$pageID,\"ns\":6,\"title\":\"File:$fileName\",\"imagerepository\":\"local\",\"imageinfo\":[{\"url\":\"https://upload.wikimedia.org/$fileName\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:$fileName\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=4406048\",\"extmetadata\":{\"DateTime\":{\"value\":\"2013-04-13 15:12:11\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"Categories\":{\"value\":\"$categories\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<bdi><a href=\\\"https://en.wikipedia.org/wiki/en:Raphael\\\" class=\\\"extiw\\\" title=\\\"w:en:Raphael\\\">Raphael</a>\\n</bdi>\",\"source\":\"commons-desc-page\"},\"ImageDescription\":{\"value\":\"test desc\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"1511<div style=\\\"display: none;\\\">date QS:P571,+1511-00-00T00:00:00Z/9</div>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"Public domain\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}}}]}"
+        return "{\"pageid\":$pageID,\"ns\":6,\"title\":\"File:$fileName\",\"imagerepository\":\"local\",\"imageinfo\":[{\"url\":\"https://upload.wikimedia.org/$fileName\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:$fileName\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=4406048\",\"extmetadata\":{\"DateTime\":{\"value\":\"2013-04-13 15:12:11\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"Categories\":{\"value\":\"$categories\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<bdi><a href=\\\"https://en.wikipedia.org/wiki/en:Raphael\\\" class=\\\"extiw\\\" title=\\\"w:en:Raphael\\\">Raphael</a>\\n</bdi>\",\"source\":\"commons-desc-page\"},\"ImageDescription\":{\"value\":\"test desc\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"1511<div style=\\\"display: none;\\\">date QS:P571,+1511-00-00T00:00:00Z/9</div>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"Public domain\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}}}]}"
     }
 
     /**


### PR DESCRIPTION
**Description (required)**

Fixes #2802

What changes did you make and why?
- Use JSON format version 2 in `OkHttpJsonApiClient` requests to Commons
- Updated tests

**Tests performed (required)**

Tested `2.10.1-debug-json-2-api~f8425336a`

All unit and instrumentation tests pass

[Beta Commons Upload](https://commons.wikimedia.beta.wmflabs.org/wiki/File:MobileTest_190330-114958.jpg)