### PR TITLE
Fixed Night Mode Problem in Spinner #2809

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/SpinnerLanguagesAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/SpinnerLanguagesAdapter.java
@@ -2,9 +2,6 @@ package fr.free.nrw.commons.upload;
 
 import android.content.Context;
 import android.graphics.Color;
-import android.os.Build;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -18,6 +15,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import fr.free.nrw.commons.R;
@@ -126,16 +125,14 @@ public class SpinnerLanguagesAdapter extends ArrayAdapter {
                 view.setVisibility(View.VISIBLE);
                 if (languageCodesList.get(position).isEmpty()) {
                     tvLanguage.setText(languageNamesList.get(position));
-                    tvLanguage.setTextColor(Color.GRAY);
                     tvLanguage.setTextAlignment(View.TEXT_ALIGNMENT_CENTER);
                 } else {
                     tvLanguage.setText(
                             String.format("%s [%s]", languageNamesList.get(position), languageCodesList.get(position)));
                     if(selectedLanguages.containsKey(languageCodesList.get(position))&&
-                            !languageCodesList.get(position).equals(selectedLangCode))
+                            !languageCodesList.get(position).equals(selectedLangCode)) {
                         tvLanguage.setTextColor(Color.GRAY);
-                    else
-                        tvLanguage.setTextColor(Color.BLACK);
+                    }
                 }
             }
         }

--- a/app/src/main/res/layout/activity_upload_bottom_card.xml
+++ b/app/src/main/res/layout/activity_upload_bottom_card.xml
@@ -91,9 +91,8 @@
                 android:gravity="center_vertical"
                 android:textSize="@dimen/normal_text"
                 android:textStyle="bold"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
+                tools:layout_editor_absoluteX="8dp"
+                tools:layout_editor_absoluteY="8dp"
                 tools:text="Step 1 of 15" />
 
             <TextView

--- a/app/src/main/res/layout/activity_upload_bottom_card.xml
+++ b/app/src/main/res/layout/activity_upload_bottom_card.xml
@@ -91,8 +91,9 @@
                 android:gravity="center_vertical"
                 android:textSize="@dimen/normal_text"
                 android:textStyle="bold"
-                tools:layout_editor_absoluteX="8dp"
-                tools:layout_editor_absoluteY="8dp"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
                 tools:text="Step 1 of 15" />
 
             <TextView


### PR DESCRIPTION
**Description**

Fixes #2809 Night Mode: Language Selection dialog is not readable 

**Tests performed**

Tested betaDebug on Xiaomi Mi A1 with API level 28 stock.

**Screenshots showing what changed**

![Screenshot_20190331-015907](https://user-images.githubusercontent.com/30932899/55281353-410bd500-5359-11e9-8618-6e991d35feca.png)

