### PR TITLE
BugFix deprecated licenes #2720

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -103,12 +103,8 @@ public class Utils {
                 return R.string.license_name_cc_by_sa_four;
             case Prefs.Licenses.CC0:
                 return R.string.license_name_cc0;
-            case Prefs.Licenses.CC_BY:  // for backward compatibility to v2.1
-                return R.string.license_name_cc_by_3_0;
-            case Prefs.Licenses.CC_BY_SA:  // for backward compatibility to v2.1
-                return R.string.license_name_cc_by_sa_3_0;
         }
-        throw new RuntimeException("Unrecognized license value: " + license);
+        throw new IllegalStateException("Unrecognized license value: " + license);
     }
 
     /**
@@ -132,7 +128,7 @@ public class Utils {
             case Prefs.Licenses.CC0:
                 return "https://creativecommons.org/publicdomain/zero/1.0/";
             default:
-                throw new RuntimeException("Unrecognized license value: " + license);
+                throw new IllegalStateException("Unrecognized license value: " + license);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
@@ -258,10 +258,6 @@ public class  Contribution extends Media {
                 return "{{self|cc-by-sa-4.0}}";
             case Prefs.Licenses.CC0:
                 return "{{self|cc-zero}}";
-            case Prefs.Licenses.CC_BY:
-                return "{{self|cc-by-3.0}}";
-            case Prefs.Licenses.CC_BY_SA:
-                return "{{self|cc-by-sa-3.0}}";
         }
 
         throw new RuntimeException("Unrecognized license value: " + license);

--- a/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
@@ -14,9 +14,5 @@ public class Prefs {
         public static final String CC_BY_SA_4 = "CC BY-SA 4.0";
         public static final String CC_BY_4 = "CC BY 4.0";
         public static final String CC0 = "CC0";
-
-        // kept for backward compatibility to v2.1
-        @Deprecated public static final String CC_BY = "CC BY";
-        @Deprecated public static final String CC_BY_SA = "CC BY-SA";
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
@@ -2,16 +2,8 @@ package fr.free.nrw.commons.upload;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-
-import java.lang.reflect.Proxy;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.category.CategoriesModel;
 import fr.free.nrw.commons.contributions.Contribution;
 import fr.free.nrw.commons.filepicker.UploadableFile;
@@ -23,6 +15,12 @@ import fr.free.nrw.commons.utils.StringUtils;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
 import timber.log.Timber;
 
 import static fr.free.nrw.commons.upload.UploadModel.UploadItem;
@@ -330,7 +328,15 @@ public class UploadPresenter {
      * Sets the list of licences and the default license.
      */
     private void updateLicenses() {
-        String selectedLicense = defaultKvStore.getString(Prefs.DEFAULT_LICENSE, Prefs.Licenses.CC_BY_SA_3);
+        String selectedLicense = defaultKvStore.getString(Prefs.DEFAULT_LICENSE,
+            Prefs.Licenses.CC_BY_SA_4);//CC_BY_SA_4 is the default one used by the commons web app
+        try {//I have to make sure that the stored default license was not one of the deprecated one's
+            Utils.licenseNameFor(selectedLicense);
+        } catch (IllegalStateException exception) {
+            Timber.e(exception.getMessage());
+            selectedLicense = Prefs.Licenses.CC_BY_SA_4;
+            defaultKvStore.putString(Prefs.DEFAULT_LICENSE, Prefs.Licenses.CC_BY_SA_4);
+        }
         view.updateLicenses(uploadModel.getLicenses(), selectedLicense);
         view.updateLicenseSummary(selectedLicense, uploadModel.getCount());
     }


### PR DESCRIPTION
**Description (required)
For some of the users who have been using the app since a long time, the older licenses ("CC BY" & "CC BY-SA"), were most probably stored by the BasicKvStore which when being applied while upload used to throw a RuntimeException.
Fixes #2720 RuntimeException while uploading image if the license if invalid

What changes did you make and why?
* Removed deprecated licenses
* If the existing stored values of the licenses is one of the deprecated ones replace it with CC_BY_SA_4 (the one used by the commons web app)

**Tests performed (required)**
Tried uploading an image on betaDebug(One Plus 3T) and the upload worked fine.
