### PR TITLE
Fixed “Dumping memory, app will freeze. Brrr.” message

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -23,6 +23,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -149,6 +150,10 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         } else {
             loginCredentials.setVisibility(View.GONE);
         }
+
+        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
+
+
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/delete/DeleteTask.java
+++ b/app/src/main/java/fr/free/nrw/commons/delete/DeleteTask.java
@@ -161,16 +161,25 @@ public class DeleteTask extends AsyncTask<Void, Integer, Boolean> {
 
     @Override
     protected void onPostExecute(Boolean result) {
+
+        //link to string resources
+        String title_resource = context.getResources().getString(R.string.nominating_for_Deletion);
+        String success_resource = context.getResources().getString(R.string.success);
+        String successfully_nominated_resource = context.getResources().getString(R.string.successfully_nominated);
+        String for_deletion_resource = context.getResources().getString(R.string.for_deletion);
+        String failed_resource = context.getResources().getString(R.string.failed);
+        String could_not_request_deletion_resource = context.getResources().getString(R.string.could_not_request_deletion);
+
         String message;
-        String title = "Nominating for Deletion";
+        String title = title_resource;
 
         if (result){
-            title += ": Success";
-            message = "Successfully nominated " + media.getDisplayTitle() + " deletion.";
+            title += ":"+success_resource;
+            message = successfully_nominated_resource + media.getDisplayTitle() + for_deletion_resource+".";
         }
         else {
-            title += ": Failed";
-            message = "Could not request deletion.";
+            title += ":"+failed_resource;
+            message = could_not_request_deletion_resource+".";
         }
 
         notificationBuilder.setDefaults(DEFAULT_ALL)

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -13,7 +13,9 @@ import android.support.v7.widget.CardView;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.text.Html;
+import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
+import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.text.style.ClickableSpan;
@@ -459,38 +461,34 @@ public class UploadActivity extends BaseActivity implements UploadView, SimilarI
     private void setTextViewHTML(TextView text, String html)
     {
         CharSequence sequence = Html.fromHtml(html);
-        SpannableStringBuilder strBuilder = new SpannableStringBuilder(sequence);
+        SpannableString strBuilder = new SpannableString(sequence);
         URLSpan[] urls = strBuilder.getSpans(0, sequence.length(), URLSpan.class);
         for (URLSpan span : urls) {
-            makeLinkClickable(strBuilder, span);
+            int start = strBuilder.getSpanStart(span);
+            int end = strBuilder.getSpanEnd(span);
+            String url = span.getURL();
+
+            makeLinkClickable(url,start,end,strBuilder);
         }
         text.setText(strBuilder);
         text.setMovementMethod(LinkMovementMethod.getInstance());
     }
 
     /**
-     * Sets onClick handler to launch browser for the specified URLSpan.
-     * @see <a href="https://stackoverflow.com/questions/12418279/android-textview-with-clickable-links-how-to-capture-clicks">Source</a>
+     * URLSpan class extends ClickableSpan implements ParcelableSpan hance avoiding the memeory leak
+     *URLSpan  open the {@param url}, by launching an an Activity with an Intent#ACTION_VIEW intent.
+     * @see <a https://developer.android.com/reference/android/text/style/URLSpan">Source</a>
+
+     * @param  url        span URL giving to be clicked on
+     * @param  start      spannable text  start index
+     * @param  end        spannable text end index
+     * @param  strBuilder spannable text string clickable variable
      */
-    private void makeLinkClickable(SpannableStringBuilder strBuilder, final URLSpan span)
-    {
-        int start = strBuilder.getSpanStart(span);
-        int end = strBuilder.getSpanEnd(span);
-        int flags = strBuilder.getSpanFlags(span);
-        ClickableSpan clickable = new ClickableSpan() {
-            public void onClick(View view) {
-                // Handle hyperlink click
-                String hyperLink = span.getURL();
-                launchBrowser(hyperLink);
-            }
-        };
-        strBuilder.setSpan(clickable, start, end, flags);
-        strBuilder.removeSpan(span);
+    private  final void makeLinkClickable(final String url, int start, int end, SpannableString  strBuilder) {
+
+        strBuilder.setSpan(new URLSpan(url),start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
     }
 
-    private void launchBrowser(String hyperLink) {
-        Utils.handleWebUrl(this, Uri.parse(hyperLink));
-    }
 
     private void configureLicenses() {
         licenseSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -489,7 +489,6 @@ public class UploadActivity extends BaseActivity implements UploadView, SimilarI
         strBuilder.setSpan(new URLSpan(url),start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
     }
 
-
     private void configureLicenses() {
         licenseSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -10,7 +10,7 @@
         android:orientation="vertical">
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="700dp"
         android:layout_centerInParent="true"
         android:layout_gravity="center_vertical"
         android:layout_marginTop="@dimen/small_gap">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -470,4 +470,12 @@ Upload your first media by tapping on the add button.</string>
   <string name="image_chooser_title">Choose Images to upload</string>
 
   <string name="please_wait">Please wait…</string>
+
+  <string name="nominating_for_Deletion">Nominating for Deletion</string>
+  <string name="success">Success</string>
+  <string name="successfully_nominated">Successfully nominated</string>
+  <string name="for_deletion">for deletion</string>
+  <string name="failed">Failed</string>
+  <string name="could_not_request_deletion">Could not request deletion</string>
+
 </resources>


### PR DESCRIPTION
Getting {“Dumping memory, app will freeze. Brrr.” message} error after uploading a picture.

Using ClickableSpan may still cause leaks even on versions higher than KitKat. If you look into implementation of the ClickableSpan you will notice that it doesn't extend NoCopySpan, so it leaks in onSaveInstanceState()

Fixes #2717 “Dumping memory, app will freeze. Brrr.” message

URLSpan class extends ClickableSpan implements ParcelableSpan hance avoiding the memeory leak
URLSpan open the url, by launching an an Activity with an Intent#ACTION_VIEW intent.
https://developer.android.com/reference/android/text/style/URLSpan

What changes did you make and why?

implementation{strBuilder.setSpan(new URLSpan(url),start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);}

instead of

ClickableSpan clickable = new ClickableSpan() {
public void onClick(View view) {
// Handle hyperlink click
String hyperLink = span.getURL();
launchBrowser(hyperLink);
}
};
strBuilder.setSpan(clickable, start, end, flags);
strBuilder.removeSpan(span);