### PR TITLE
Fixed #2825 where user was able to add one lang twice

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
@@ -229,7 +229,10 @@ class DescriptionsAdapter extends RecyclerView.Adapter<DescriptionsAdapter.ViewH
                     int defaultLocaleIndex = languagesAdapter.getIndexOfUserDefaultLocale(context);
                     spinnerDescriptionLanguages.setSelection(defaultLocaleIndex);
                 } else {
+                    // availableLangIndex gives the index of first non-selected language
                     int availableLangIndex = -1;
+
+                    // loops over the languagesAdapter and finds the index of first non-selected language
                     for (int i = 0; i < languagesAdapter.getCount(); i++) {
                         if (!selectedLanguages.containsKey(languagesAdapter.getLanguageCode(i))) {
                             availableLangIndex = i;
@@ -237,6 +240,7 @@ class DescriptionsAdapter extends RecyclerView.Adapter<DescriptionsAdapter.ViewH
                         }
                     }
                     if (availableLangIndex >= 0) {
+                        // sets the spinner value to the index of first non-selected language
                         spinnerDescriptionLanguages.setSelection(availableLangIndex);
                         selectedLanguages.put(spinnerDescriptionLanguages, languagesAdapter.getLanguageCode(position));
                     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
@@ -229,7 +229,17 @@ class DescriptionsAdapter extends RecyclerView.Adapter<DescriptionsAdapter.ViewH
                     int defaultLocaleIndex = languagesAdapter.getIndexOfUserDefaultLocale(context);
                     spinnerDescriptionLanguages.setSelection(defaultLocaleIndex);
                 } else {
-                    spinnerDescriptionLanguages.setSelection(0);
+                    int availableLangIndex = -1;
+                    for (int i = 0; i < languagesAdapter.getCount(); i++) {
+                        if (!selectedLanguages.containsKey(languagesAdapter.getLanguageCode(i))) {
+                            availableLangIndex = i;
+                            break;
+                        }
+                    }
+                    if (availableLangIndex >= 0) {
+                        spinnerDescriptionLanguages.setSelection(availableLangIndex);
+                        selectedLanguages.put(spinnerDescriptionLanguages, languagesAdapter.getLanguageCode(position));
+                    }
                 }
             } else {
                 spinnerDescriptionLanguages.setSelection(description.getSelectedLanguageIndex());


### PR DESCRIPTION
**Description**

Fixes #2825 The user should not be allowed to add the same language twice.

**What changes did you make and why?**

I added a check, where the first non selected language index will be picked instead of a static index.

**Tests performed**

Tested betaDebug on Xiaomi Mi A1 with API level 28.