### PR TITLE
Fixed the issue #2770 where incomplete list was shown in landscape mode

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFragment.java
@@ -180,15 +180,13 @@ public class NearbyFragment extends CommonsDaggerSupportFragment
     }
 
     /**
-     * Initialize bottom sheet behaviour (sheet for map list.) Set height 9/16 of all window.
+     * Initialize bottom sheet behaviour (sheet for map list.)
      * Add callback for bottom sheet changes, so that we can sync it with bottom sheet for details
      * (sheet for nearby details)
      */
     private void initBottomSheetBehaviour() {
 
         transparentView.setAlpha(0);
-        bottomSheet.getLayoutParams().height = getActivity().getWindowManager()
-                .getDefaultDisplay().getHeight() / 16 * 9;
         bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet);
         bottomSheetBehavior.setBottomSheetCallback(new BottomSheetBehavior.BottomSheetCallback() {
 

--- a/app/src/main/res/layout/bottom_sheet_nearby.xml
+++ b/app/src/main/res/layout/bottom_sheet_nearby.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="480dp"
+    android:layout_height="wrap_content"
     android:id="@+id/bottom_sheet"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
@@ -40,7 +40,7 @@
     <FrameLayout
         android:id="@+id/container_sheet"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:focusableInTouchMode="true"
         android:layout_marginLeft="16dp"
         android:layout_marginRight="16dp"

--- a/app/src/main/res/layout/fragment_nearby_list.xml
+++ b/app/src/main/res/layout/fragment_nearby_list.xml
@@ -1,13 +1,5 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.recyclerview.widget.RecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/listView"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    >
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/listView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        />
-
-</RelativeLayout>
+    android:layout_height="match_parent" />


### PR DESCRIPTION
**Description**
Fixed the issue where incomplete list was shown in landscape mode

Fixes #2770 Incomplete Nearby List shown in Landscape mode

What changes did you make and why?
The problem we had earlier was, when the view is generated in portrait mode the height was set according to the portrait mode, when we rotate the height of the container remained same as of portrait, due to which we were not able to see the rest of the list which was already generated but was hidden.

**Tests performed**

Tested betaDebug on Xiaomi Mi A1 with API level 28.

**Screenshots showing what changed**
![Screenshot_20190403-142646](https://user-images.githubusercontent.com/30932899/55482596-8161a080-5642-11e9-927b-fb9016a600b2.png)
![Screenshot_20190403-142704](https://user-images.githubusercontent.com/30932899/55482597-81fa3700-5642-11e9-980e-971d644b249f.png)
