### PR TITLE
Bug Fix #2845

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
@@ -146,7 +146,7 @@ public class ReviewActivity extends AuthenticatedActivity {
                 .subscribe(revision -> {
                     reviewController.firstRevision = revision;
                     reviewPagerAdapter.updateFileInformation(fileName);
-                    ((TextView) imageCaption).setText(fileName + " is uploaded by: " + revision.content());
+                    ((TextView) imageCaption).setText(fileName + " is uploaded by: " + revision.getUser());
                     progressBar.setVisibility(View.GONE);
                 }));
         reviewPager.setCurrentItem(0);


### PR DESCRIPTION
**Description (required)**
* Show username instead of revision.content in image caption

Fixes #2845 Null username in ReviewActivity for review image

What changes did you make and why?
use review.getUser() instead of review.content for image caption
**Tests performed (required)**

Tested betaDebug on One Plus 6T Android 7

**Screenshots showing what changed (optional - for UI changes)**
![device-2019-04-03-225110](https://user-images.githubusercontent.com/17375274/55499582-f5f90700-5663-11e9-8772-1c0d9ea1f97d.png)

---

