### PR TITLE
Adjusted the gravity of SKIP THIS IMAGE Fixed #2848

### DIFF
--- a/app/src/main/res/layout/activity_review.xml
+++ b/app/src/main/res/layout/activity_review.xml
@@ -30,7 +30,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="25dp"
                 android:layout_below="@+id/toolbar"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:gravity="center">
 
                 <Button
                     android:id="@+id/skip_image"
@@ -39,8 +40,7 @@
                     android:background="@android:color/transparent"
                     android:text="@string/skip_image"
                     android:textColor="@color/button_blue_dark"
-                    android:textStyle="bold"
-                    android:layout_marginLeft="120dp"/>
+                    android:textStyle="bold" />
 
                 <ImageView
                     android:layout_width="15dp"


### PR DESCRIPTION
**Description**
Adjusted the gravity of SKIP THIS IMAGE Fixed for both portrait mode and landscape mode.

Fixes #2848 Skip this image title should be in center in landscape mode

**Tests performed**
Tested betaDebug on Xiaomi Mi A1 with API level 28 stock android.

**Screenshots showing what changed**
**Before**
![Screenshot_20190404-072614](https://user-images.githubusercontent.com/30932899/55524979-cf12f300-56ac-11e9-84bc-8f8033dd8407.png)

**After**
![Screenshot_20190404-073601](https://user-images.githubusercontent.com/30932899/55524983-d20de380-56ac-11e9-832f-4f1f1c4d0571.png)
