### PR TITLE
Fixed Width of Navigation Drawer for Tablets

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -73,7 +73,6 @@ public abstract class NavigationBaseActivity extends BaseActivity
         drawerLayout.addDrawerListener(toggle);
         toggle.setDrawerIndicatorEnabled(true);
         toggle.syncState();
-        setDrawerPaneWidth();
         setUserName();
         Menu nav_Menu = navigationView.getMenu();
         View headerLayout = navigationView.getHeaderView(0);
@@ -145,16 +144,6 @@ public abstract class NavigationBaseActivity extends BaseActivity
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setDisplayShowHomeEnabled(true);
-    }
-
-    private void setDrawerPaneWidth() {
-        ViewGroup.LayoutParams params = navigationView.getLayoutParams();
-        // set width to lowerBound of 70% of the screen size in portrait mode
-        // set width to lowerBound of 50% of the screen size in landscape mode
-        int percentageWidth = getResources().getInteger(R.integer.drawer_width);
-
-        params.width = (getResources().getDisplayMetrics().widthPixels * percentageWidth) / 100;
-        navigationView.setLayoutParams(params);
     }
 
     @Override


### PR DESCRIPTION
**Description**
Fixed Width of Navigation Drawer for Tablets.

Fixes #2854 Navigation Drawer is huge in Tablets

**Tests performed**
Tested betaDebug on Custom Tablet 9inch with API level 28 stock android.

**Screenshots showing what changed**
![screenshot-2019-04-04_15 27 43 758](https://user-images.githubusercontent.com/30932899/55547360-c5aa7a80-56ee-11e9-97a6-3d15c5b8c17e.png)
![screenshot-2019-04-04_15 28 00 006](https://user-images.githubusercontent.com/30932899/55547361-c5aa7a80-56ee-11e9-8310-d929ea5c22e1.png)
