### PR TITLE
Exclude nominated media

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
@@ -74,14 +74,14 @@ public class NetworkingModule {
     public OkHttpJsonApiClient provideOkHttpJsonApiClient(OkHttpClient okHttpClient,
                                                           @Named("tools_force") HttpUrl toolsForgeUrl,
                                                           @Named("default_preferences") JsonKvStore defaultKvStore,
-                                                          Gson gson) {
+                                                          Gson gson,MediaWikiApi mediaWikiApi) {
         return new OkHttpJsonApiClient(okHttpClient,
                 toolsForgeUrl,
                 WIKIDATA_SPARQL_QUERY_URL,
                 BuildConfig.WIKIMEDIA_CAMPAIGNS_URL,
                 BuildConfig.WIKIMEDIA_API_HOST,
                 defaultKvStore,
-                gson);
+                gson,mediaWikiApi);
     }
 
     @Provides

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -20,6 +20,7 @@ import org.apache.http.params.CoreProtocolPNames;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.wikipedia.page.PageTitle;
 import org.wikipedia.util.DateUtil;
 
 import java.io.IOException;
@@ -314,6 +315,17 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
                 .param("title", "Main_page")
                 .get()
                 .getString("/api/flow-parsoid-utils/@content"));
+    }
+
+    @Override
+    @NonNull
+    public String getWikiText(PageTitle title) throws IOException {
+         return api.action("parse")
+                .param("page", title)
+                .param("prop", "wikitext")
+                .param("format", "json")
+                .get()
+                .getString("/api/parse/wikitext");
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
@@ -2,6 +2,8 @@ package fr.free.nrw.commons.mwapi;
 
 import android.net.Uri;
 
+import org.wikipedia.page.PageTitle;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -105,4 +107,8 @@ public interface MediaWikiApi {
     interface ProgressListener {
         void onProgress(long transferred, long total);
     }
+
+    @NonNull
+    String getWikiText(PageTitle title) throws IOException;
+
 }

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
@@ -1,5 +1,6 @@
 package fr.free.nrw.commons.mwapi;
 
+
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
@@ -58,6 +59,7 @@ public class OkHttpJsonApiClient {
     private final String commonsBaseUrl;
     private final JsonKvStore defaultKvStore;
     private Gson gson;
+    private MediaWikiApi mediaWikiApi;
 
 
     @Inject
@@ -67,7 +69,7 @@ public class OkHttpJsonApiClient {
                                String campaignsUrl,
                                String commonsBaseUrl,
                                JsonKvStore defaultKvStore,
-                               Gson gson) {
+                               Gson gson,MediaWikiApi mediaWikiApi) {
         this.okHttpClient = okHttpClient;
         this.wikiMediaToolforgeUrl = wikiMediaToolforgeUrl;
         this.sparqlQueryUrl = sparqlQueryUrl;
@@ -75,6 +77,7 @@ public class OkHttpJsonApiClient {
         this.commonsBaseUrl = commonsBaseUrl;
         this.defaultKvStore = defaultKvStore;
         this.gson = gson;
+        this.mediaWikiApi = mediaWikiApi;
     }
 
     @NonNull
@@ -330,7 +333,19 @@ public class OkHttpJsonApiClient {
                 for (MwQueryPage page : pages) {
                     Media media = Media.from(page);
                     if (media != null) {
-                        mediaList.add(media);
+                        if(keyword.equals("Category:Uploaded_with_Mobile/Android")){
+
+                            String wikiText = "";
+                            try {
+                                wikiText = mediaWikiApi.getWikiText(media.getPageTitle());
+                            } catch (Exception e){
+                                e.printStackTrace();
+                            }
+
+                            if(!wikiText.contains("{{delete")){
+                                mediaList.add(media);
+                            }
+                        } else mediaList.add(media);
                     }
                 }
             }


### PR DESCRIPTION
**Description**
Not showing media that have been nominated for deletion in Explore's Uploaded via mobile tab.

**Fixes** #2658 In "Uploaded via mobile", hide media nominated for deletion

**What changes did you make and why?**
Getting wikitext of media using API:Parse and filtering that have been nominated for deletion.

**Tests performed**
Tested betaDebug on Realme 2 pro (Android Version 8.1.0) with API level 27.