### PR TITLE
Fixed 2857 where achievements activity was getting recreated on rotation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -125,6 +125,7 @@
 
         <activity
             android:name=".achievements.AchievementsActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/Achievements" />
 
         <activity


### PR DESCRIPTION
**Description**
 Achievements activity was getting recreated on rotation

Fixes #2857 Achievements Activity getting recreated on rotation

**Tests performed**
Tested betaDebug on Xiaomi Mi A1 with API level 28 stock android.