### PR TITLE
Update to Gradle 5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'com.facebook.fresco:fresco:1.13.0'
     implementation 'com.drewnoakes:metadata-extractor:2.11.0'
     implementation 'com.dmitrybrant:wikimedia-android-data-client:0.0.18'
+    implementation 'org.apache.commons:commons-lang3:3.8.1'
 
     // UI
     implementation 'fr.avianey.com.viewpagerindicator:library:2.4.1.1@aar'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,4 @@ systemProp.http.proxyPort=0
 systemProp.http.proxyHost=
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableR8=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
**Description (required)**
Fixes #2824 Update to Gradle 5

What changes did you make and why?
Updated Gradle from version 4.10 to 5.3.1 to
get faster builds and help towards fixing #1941.
Added 'org.apache.commons:commons-lang3:3.8.1' 
to fix import errors. 

Tested {betaDebug} on Nexus 5X Emulator with API level {24}.

**Screenshots showing what changed (optional - for UI changes)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
