### PR TITLE
Added Quick Launch Icon to the Home Screen Widget #1296

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/widget/PicOfDayAppWidget.java
+++ b/app/src/main/java/fr/free/nrw/commons/widget/PicOfDayAppWidget.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 
 import androidx.annotation.Nullable;
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.contributions.MainActivity;
 import fr.free.nrw.commons.di.ApplicationlessInjection;
 import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -45,6 +46,13 @@ public class PicOfDayAppWidget extends AppWidgetProvider {
 
     void updateAppWidget(Context context, AppWidgetManager appWidgetManager, int appWidgetId) {
         RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.pic_of_day_app_widget);
+
+        // Launch App on Button Click
+        Intent viewIntent = new Intent(context, MainActivity.class);
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, viewIntent, 0);
+        views.setOnClickPendingIntent(R.id.camera_button, pendingIntent);
+        appWidgetManager.updateAppWidget(appWidgetId, views);
+
         loadPictureOfTheDay(context, views, appWidgetManager, appWidgetId);
     }
 

--- a/app/src/main/res/layout/pic_of_day_app_widget.xml
+++ b/app/src/main/res/layout/pic_of_day_app_widget.xml
@@ -1,19 +1,34 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/black"
     android:padding="@dimen/widget_margin"
     android:orientation="vertical">
 
-    <TextView
+    <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textColor="@color/white"
-        android:textSize="20sp"
-        android:gravity="center"
-        android:layout_marginTop="10dp"
-        android:text="@string/app_widget_heading"/>
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="@string/app_widget_heading"
+            android:textColor="@color/white"
+            android:layout_centerHorizontal="true"
+            android:textSize="20sp" />
+
+        <ImageView
+            android:id="@+id/camera_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="20dp"
+            android:layout_alignParentEnd="true"
+            android:src="@drawable/ic_photo_camera_white_24dp" />
+
+    </RelativeLayout>
 
     <TextView
         android:layout_width="match_parent"


### PR DESCRIPTION
**Description**
Added Quick Launch Icon to the Home Screen Widget #1296

By clicking on the camera icon the user will be taken to the MainActivity, the reason why it does not open the camera is that it is possible that the user is not logged in and it will result in a crash.

Fixes #1296 Widget

**Tests performed**
Tested betaDebug on Xiaomi Mi A1 with API level 28.

**Screenshots showing what changed**
![Screenshot_20190405-153929](https://user-images.githubusercontent.com/30932899/55620815-77ae7900-57b9-11e9-959c-716187c1adc9.png)
