### PR TITLE
Show settings when not logged in

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -104,12 +104,18 @@ public class SettingsFragment extends PreferenceFragment {
             checkPermissionsAndSendLogs();
             return true;
         });
-        // Disable "useExternalStorage", "Recent upload limit" and "Use custom author name" when not logged in.
+        // Disable some settings when not logged in.
         if (defaultKvStore.getBoolean("login_skipped", false)){
             SwitchPreference useExternalStorage = (SwitchPreference) findPreference("useExternalStorage");
+            SwitchPreference displayNearbyCardView = (SwitchPreference) findPreference("displayNearbyCardView");
+            SwitchPreference displayLocationPermissionForCardView = (SwitchPreference) findPreference("displayLocationPermissionForCardView");
+            SwitchPreference displayCampaignsCardView = (SwitchPreference) findPreference("displayCampaignsCardView");
             useExternalStorage.setEnabled(false);
             uploadLimit.setEnabled(false);
             useAuthorName.setEnabled(false);
+            displayNearbyCardView.setEnabled(false);
+            displayLocationPermissionForCardView.setEnabled(false);
+            displayCampaignsCardView.setEnabled(false);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -104,7 +104,7 @@ public class SettingsFragment extends PreferenceFragment {
             checkPermissionsAndSendLogs();
             return true;
         });
-        // Disable "Recent upload limit" and "Use custom author name" when not logged in.
+        // Disable "useExternalStorage", "Recent upload limit" and "Use custom author name" when not logged in.
         if (defaultKvStore.getBoolean("login_skipped", false)){
             SwitchPreference useExternalStorage = (SwitchPreference) findPreference("useExternalStorage");
             useExternalStorage.setEnabled(false);

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -106,6 +106,8 @@ public class SettingsFragment extends PreferenceFragment {
         });
         // Disable "Recent upload limit" and "Use custom author name" when not logged in.
         if (defaultKvStore.getBoolean("login_skipped", false)){
+            SwitchPreference useExternalStorage = (SwitchPreference) findPreference("useExternalStorage");
+            useExternalStorage.setEnabled(false);
             uploadLimit.setEnabled(false);
             useAuthorName.setEnabled(false);
         }

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -104,6 +104,11 @@ public class SettingsFragment extends PreferenceFragment {
             checkPermissionsAndSendLogs();
             return true;
         });
+        // Disable "Recent upload limit" and "Use custom author name" when not logged in.
+        if (defaultKvStore.getBoolean("login_skipped", false)){
+            uploadLimit.setEnabled(false);
+            useAuthorName.setEnabled(false);
+        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -82,7 +82,7 @@ public abstract class NavigationBaseActivity extends BaseActivity
             userIcon.setVisibility(View.GONE);
             nav_Menu.findItem(R.id.action_login).setVisible(true);
             nav_Menu.findItem(R.id.action_home).setVisible(false);
-            nav_Menu.findItem(R.id.action_settings).setVisible(false);
+            nav_Menu.findItem(R.id.action_settings).setVisible(true);
             nav_Menu.findItem(R.id.action_logout).setVisible(false);
             nav_Menu.findItem(R.id.action_bookmarks).setVisible(true);
         }else {


### PR DESCRIPTION
**Description**
Show settings when not logged in.
Disable "Recent upload limit" and "Use custom author name" when not logged in.

**Fixes** #2853 Show settings even when not logged in

**Tests performed**
Tested betaDebug on Realme 2 pro (Android Version 8.1.0) with API level 27.

**Screenshot**

Navigation drawer         |  Settings
:-------------------------:|:-------------------------:
![1](https://user-images.githubusercontent.com/25826255/55666281-738f6380-586c-11e9-8b08-cf8219fc106d.png) | ![2](https://user-images.githubusercontent.com/25826255/55666284-7db16200-586c-11e9-9454-2414377fb802.png)



