### PR TITLE
Use unsecure HTTP clients for debug builds

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
@@ -47,15 +47,19 @@ public class NetworkingModule {
                                             HttpLoggingInterceptor httpLoggingInterceptor,
                                             SSLSocketFactory sslSocketFactory) {
         File dir = new File(context.getCacheDir(), "okHttpCache");
-        return new OkHttpClient.Builder()
-                .sslSocketFactory(sslSocketFactory)
-                .hostnameVerifier((hostname, session) -> true)
+        OkHttpClient.Builder builder = new OkHttpClient.Builder()
                 .connectTimeout(60, TimeUnit.SECONDS)
                 .writeTimeout(60, TimeUnit.SECONDS)
                 .addInterceptor(httpLoggingInterceptor)
                 .readTimeout(60, TimeUnit.SECONDS)
-                .cache(new Cache(dir, OK_HTTP_CACHE_SIZE))
-                .build();
+                .cache(new Cache(dir, OK_HTTP_CACHE_SIZE));
+
+        if (BuildConfig.DEBUG) {
+            builder.sslSocketFactory(sslSocketFactory)
+                    .hostnameVerifier((hostname, session) -> true);
+        }
+
+        return builder.build();
     }
 
     @Provides

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -88,6 +88,10 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
         this.gson = gson;
     }
 
+    /**
+     * Get socket factory for SSL connections
+     * @return Returns unsecure SSL socket factory for debug builds and returns existing SSL socket for release builds
+     */
     private SSLSocketFactory getSocketFactory() {
         if (BuildConfig.DEBUG) {
             try {

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/UnsecureApacheSSLSocketFactory.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/UnsecureApacheSSLSocketFactory.java
@@ -14,6 +14,9 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 
 
+/**
+ * Extends SSLSocketFactory to return an unsecure instance
+ */
 public class UnsecureApacheSSLSocketFactory extends SSLSocketFactory {
     SSLContext sslContext = SSLContext.getInstance("TLS");
 

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/UnsecureApacheSSLSocketFactory.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/UnsecureApacheSSLSocketFactory.java
@@ -1,0 +1,34 @@
+package fr.free.nrw.commons.mwapi;
+
+import org.apache.http.conn.ssl.SSLSocketFactory;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+
+
+public class UnsecureApacheSSLSocketFactory extends SSLSocketFactory {
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+
+    public UnsecureApacheSSLSocketFactory(KeyStore keyStore) throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException, UnrecoverableKeyException {
+        super(keyStore);
+        sslContext.init(null, new TrustManager[]{new UnsecureKeyStoresTrustManager(keyStore)}, null);
+    }
+
+    @Override
+    public Socket createSocket(Socket socket, String host, int port, boolean autoClose) throws IOException {
+        return sslContext.getSocketFactory().createSocket(socket, host, port, autoClose);
+    }
+
+    @Override
+    public Socket createSocket() throws IOException {
+        return sslContext.getSocketFactory().createSocket();
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/UnsecureKeyStoresTrustManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/UnsecureKeyStoresTrustManager.java
@@ -10,12 +10,14 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
+/**
+ * Class to get an instance of unsecure key store trust manager
+ */
 public class UnsecureKeyStoresTrustManager implements X509TrustManager {
 
-    protected ArrayList<X509TrustManager> x509TrustManagers = new ArrayList<X509TrustManager>();
+    private ArrayList<X509TrustManager> x509TrustManagers = new ArrayList<X509TrustManager>();
 
-
-    public UnsecureKeyStoresTrustManager(KeyStore... additionalkeyStores) {
+    UnsecureKeyStoresTrustManager(KeyStore... additionalkeyStores) {
         final ArrayList<TrustManagerFactory> factories = new ArrayList<TrustManagerFactory>();
 
         try {
@@ -51,7 +53,7 @@ public class UnsecureKeyStoresTrustManager implements X509TrustManager {
 
     }
 
-    /*
+    /**
      * Delegate to the default trust manager.
      */
     public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
@@ -59,7 +61,7 @@ public class UnsecureKeyStoresTrustManager implements X509TrustManager {
         defaultX509TrustManager.checkClientTrusted(chain, authType);
     }
 
-    /*
+    /**
      * Loop over the trustmanagers until we find one that accepts our server
      */
     public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/UnsecureKeyStoresTrustManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/UnsecureKeyStoresTrustManager.java
@@ -1,0 +1,83 @@
+package fr.free.nrw.commons.mwapi;
+
+import java.security.KeyStore;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+public class UnsecureKeyStoresTrustManager implements X509TrustManager {
+
+    protected ArrayList<X509TrustManager> x509TrustManagers = new ArrayList<X509TrustManager>();
+
+
+    public UnsecureKeyStoresTrustManager(KeyStore... additionalkeyStores) {
+        final ArrayList<TrustManagerFactory> factories = new ArrayList<TrustManagerFactory>();
+
+        try {
+            // The default Trustmanager with default keystore
+            final TrustManagerFactory original = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            original.init((KeyStore) null);
+            factories.add(original);
+
+            for (KeyStore keyStore : additionalkeyStores) {
+                final TrustManagerFactory additionalCerts = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                additionalCerts.init(keyStore);
+                factories.add(additionalCerts);
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+
+
+        /*
+         * Iterate over the returned trustmanagers, and hold on
+         * to any that are X509TrustManagers
+         */
+        for (TrustManagerFactory tmf : factories)
+            for (TrustManager tm : tmf.getTrustManagers())
+                if (tm instanceof X509TrustManager)
+                    x509TrustManagers.add((X509TrustManager) tm);
+
+
+        if (x509TrustManagers.size() == 0)
+            throw new RuntimeException("Couldn't find any X509TrustManagers");
+
+    }
+
+    /*
+     * Delegate to the default trust manager.
+     */
+    public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        final X509TrustManager defaultX509TrustManager = x509TrustManagers.get(0);
+        defaultX509TrustManager.checkClientTrusted(chain, authType);
+    }
+
+    /*
+     * Loop over the trustmanagers until we find one that accepts our server
+     */
+    public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        for (X509TrustManager tm : x509TrustManagers) {
+            try {
+                tm.checkServerTrusted(chain, authType);
+                return;
+            } catch (CertificateException e) {
+                // ignore
+            }
+        }
+        throw new CertificateException();
+    }
+
+    public X509Certificate[] getAcceptedIssuers() {
+        final ArrayList<X509Certificate> list = new ArrayList<X509Certificate>();
+        for (X509TrustManager tm : x509TrustManagers)
+            list.addAll(Arrays.asList(tm.getAcceptedIssuers()));
+        return list.toArray(new X509Certificate[list.size()]);
+    }
+}


### PR DESCRIPTION
**Description (required)**

Fixes #2875 

Beta build was working fine for me on API 24 but wasn't working on API 28. 

What changes did you make and why?

The issue was related to SSL certificates of beta server not being recognized by Android. To fix it I have used unsecure HTTP clients for `debug` builds. Release builds will continue to work as it is. Just for debug builds, all certificates would be trusted and all hosts would be marked as verified. 

Read up more here: 

https://developer.android.com/training/articles/security-ssl#java

@dbrant It would be great if you could take a quick look and suggest if there's a cleaner way to do it? 

**Tests performed (required)**

Tested `betaDebug` on API 28. Earlier none of the API calls were working but now everything works fine. 