### PR TITLE
Fixes #2922 Beta account alert is missing

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -131,6 +131,12 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         usernameEdit.addTextChangedListener(textWatcher);
         passwordEdit.addTextChangedListener(textWatcher);
         twoFactorEdit.addTextChangedListener(textWatcher);
+        
+        if (ConfigUtils.isBetaFlavour()) {
+            loginCredentials.setText(getString(R.string.login_credential));
+        } else {
+            loginCredentials.setVisibility(View.GONE);
+        }
     }
 
     @OnFocusChange(R.id.login_username)
@@ -173,12 +179,6 @@ public class LoginActivity extends AccountAuthenticatorActivity {
                 })
                 .setNegativeButton(R.string.no, (dialog, which) -> dialog.cancel())
                 .show();
-
-        if (ConfigUtils.isBetaFlavour()) {
-            loginCredentials.setText(getString(R.string.login_credential));
-        } else {
-            loginCredentials.setVisibility(View.GONE);
-        }
     }
 
     @OnClick(R.id.forgot_password)


### PR DESCRIPTION
**Description (required)**

Fixes #2922 We used to see a beta login alert text when we login to beta account previously. Somehow it has gone, this PR puts it back.

**Tests performed (required)**

Tested with betaDebug and prodDebug on API 26 emulator 

**Screenshots showing what changed (optional - for UI changes)**
![Screenshot from 2019-04-25 14-04-46](https://user-images.githubusercontent.com/3127881/56732176-2c0e4000-6765-11e9-9f45-d31222ab95b5.png)
