### PR TITLE
Fix loading of images in contributions list

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/di/CommonsApplicationModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/CommonsApplicationModule.java
@@ -150,6 +150,7 @@ public class CommonsApplicationModule {
 
     @Provides
     @Singleton
+    @Named("thumbnail-cache")
     public LruCache<String, String> provideLruCache() {
         return new LruCache<>(1024);
     }


### PR DESCRIPTION
**Description (required)**

Fixes #2892 

What changes did you make and why?

Earlier, `ContributionViewHolder` was trying to set the image url on `Schedulers.io()` thread. The fix was to use `AndroidSchedulers.mainThread()` instead. 

Also, I have re-added `LruCache` which was removed in #2906. So now, in an app session, a thumbnail would be fetched only once for a filename. 

**Tests performed (required)**

Tested on prod debug API 27. 

**Screenshots showing what changed (optional - for UI changes)**

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/3069373/56860759-b77f0f80-69b7-11e9-8d39-f2e45c9ba6cc.gif)
