### PR TITLE
Fixes #2337 - Show captions of image in media details (conflicts fixed)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Media.java
+++ b/app/src/main/java/fr/free/nrw/commons/Media.java
@@ -47,6 +47,7 @@ public class Media implements Parcelable {
     protected String filename;
     protected String description; // monolingual description on input...
     protected String discussion;
+    protected String caption;
     protected long dataLength;
     protected Date dateCreated;
     protected @Nullable Date dateUploaded;
@@ -238,6 +239,22 @@ public class Media implements Parcelable {
     @Nullable
     public String getImageUrl() {
         return imageUrl;
+    }
+
+    /**
+     * Sets the Caption of the file.
+     * @param caption
+     */
+    public void setCaption(String caption) {
+        this.caption = caption;
+    }
+
+    /**
+     * Gets the file Caption as a string.
+     * @return file Caption as a string
+     */
+    public String getCaption() {
+        return caption;
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.java
@@ -1,5 +1,9 @@
 package fr.free.nrw.commons;
 
+import android.util.Log;
+
+import java.io.IOException;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -20,16 +24,18 @@ public class MediaDataExtractor {
     private final MediaWikiApi mediaWikiApi;
     private final OkHttpJsonApiClient okHttpJsonApiClient;
 
+
     @Inject
     public MediaDataExtractor(MediaWikiApi mwApi,
                               OkHttpJsonApiClient okHttpJsonApiClient) {
         this.okHttpJsonApiClient = okHttpJsonApiClient;
         this.mediaWikiApi = mwApi;
+
     }
 
     /**
      * Simplified method to extract all details required to show media details.
-     * It fetches media object, deletion status and talk page for the filename
+     * It fetches media object, deletion status, talk page and caption for the filename
      * @param filename for which the details are to be fetched
      * @return full Media object with all details including deletion status and talk page
      */
@@ -37,8 +43,11 @@ public class MediaDataExtractor {
         Single<Media> mediaSingle = getMediaFromFileName(filename);
         Single<Boolean> pageExistsSingle = mediaWikiApi.pageExists("Commons:Deletion_requests/" + filename);
         Single<String> discussionSingle = getDiscussion(filename);
-        return Single.zip(mediaSingle, pageExistsSingle, discussionSingle, (media, deletionStatus, discussion) -> {
+        Single<String> captionSingle = getCaption(filename);
+
+        return Single.zip(mediaSingle, pageExistsSingle, discussionSingle, captionSingle, (media, deletionStatus, discussion, caption) -> {
             media.setDiscussion(discussion);
+            media.setCaption(caption);
             if (deletionStatus) {
                 media.setRequestedDeletion();
             }
@@ -66,6 +75,20 @@ public class MediaDataExtractor {
                 .map(discussion -> HtmlCompat.fromHtml(discussion, HtmlCompat.FROM_HTML_MODE_LEGACY).toString())
                 .onErrorReturn(throwable -> {
                     Timber.e(throwable, "Error occurred while fetching discussion");
+                    return "";
+                });
+
+    }
+
+    /**
+     * Fetch caption from the MediaWiki API
+     * @param filename the filename we will return the caption for
+     * @return a single with caption string (an empty string if no caption)
+     */
+    private Single<String> getCaption(String filename)  {
+        return mediaWikiApi.fetchCaptionByFilename(filename)
+                .onErrorReturn(throwable -> {
+                    Timber.e(throwable, "Error occurred while fetching caption");
                     return "";
                 });
     }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -101,6 +101,8 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
     SimpleDraweeView image;
     @BindView(R.id.mediaDetailSpacer)
     MediaDetailSpacer spacer;
+    @BindView(R.id.mediaDetailCaption)
+    TextView mediaCaption;
     @BindView(R.id.mediaDetailTitle)
     TextView title;
     @BindView(R.id.mediaDetailDesc)
@@ -315,6 +317,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         coordinates.setText(prettyCoordinates(media));
         uploadedDate.setText(prettyUploadedDate(media));
         mediaDiscussion.setText(prettyDiscussion(media));
+        mediaCaption.setText(prettyCaption(media));
 
         categoryNames.clear();
         categoryNames.addAll(media.getCategories());
@@ -516,6 +519,16 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
             return desc;
         }
     }
+
+    private String prettyCaption(Media media) {
+        String caption = media.getCaption().trim();
+        if (caption.equals("")) {
+            return getString(R.string.detail_caption_empty);
+        } else {
+            return caption;
+        }
+    }
+
     private String prettyDiscussion(Media media) {
         String disc = media.getDiscussion().trim();
         if (disc.equals("")) {

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.mwapi;
 import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.google.gson.Gson;
 
@@ -301,6 +302,26 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
                 .param("title", "Main_page")
                 .get()
                 .getString("/api/flow-parsoid-utils/@content"));
+    }
+
+    /**
+     * fetches the Caption of the file with a given name.
+     * @param filename title of the file
+     * @return a single with media caption
+     */
+    @Override
+    public Single<String> fetchCaptionByFilename(String filename) {
+        return Single.fromCallable(() -> {
+            CustomApiResult apiResult = api.action("wbgetentities")
+                    .param("sites", "commonswiki")
+                    .param("titles", filename)
+                    .param("props", "labels")
+                    .param("format", "xml")
+                    .param("languages", Locale.getDefault().getLanguage())
+                    .param("languagefallback", "1")
+                    .get();
+            return apiResult.getString("/api/entities/entity/labels/label/@value");
+        });
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
@@ -66,6 +66,8 @@ public interface MediaWikiApi {
 
     Single<String> parseWikicode(String source);
 
+    Single<String> fetchCaptionByFilename(String filename);
+
     @NonNull
     Single<MediaResult> fetchMediaByFilename(String filename);
 

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -63,6 +63,34 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:paddingBottom="@dimen/tiny_gap"
+                        android:text="@string/media_detail_caption"
+                        android:textColor="@android:color/white"
+                        android:textSize="@dimen/normal_text"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/mediaDetailCaption"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="start"
+                        android:background="?attr/subBackground"
+                        android:padding="@dimen/small_gap"
+                        android:textColor="@android:color/white"
+                        android:textSize="@dimen/description_text_size"
+                        tools:text="Captions of the media" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/subBackground"
+                    android:orientation="vertical"
+                    android:padding="@dimen/standard_gap">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingBottom="@dimen/tiny_gap"
                         android:text="@string/media_detail_title"
                         android:textColor="@android:color/white"
                         android:textSize="@dimen/normal_text"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,7 @@
   <string name="detail_panel_cats_none">None selected</string>
   <string name="detail_description_empty">No description</string>
   <string name="detail_discussion_empty">No discussion</string>
+  <string name="detail_caption_empty">No caption</string>
   <string name="detail_license_empty">Unknown license</string>
   <string name="menu_refresh">Refresh</string>
   <string name="storage_permission_title">Requesting Storage Permission</string>
@@ -173,6 +174,7 @@
   <string name="upload_image_duplicate">This file already exists on Commons. Are you sure you want to proceed?</string>
   <string name="yes">Yes</string>
   <string name="no">No</string>
+  <string name="media_detail_caption">Caption</string>
   <string name="media_detail_title">Title</string>
   <string name="media_detail_description">Description</string>
   <string name="media_detail_discussion">Discussion</string>

--- a/app/src/test/kotlin/fr/free/nrw/commons/MediaDataExtractorTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/MediaDataExtractorTest.kt
@@ -7,12 +7,9 @@ import io.reactivex.Single
 import junit.framework.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatchers
-import org.mockito.InjectMocks
-import org.mockito.Mock
+import org.mockito.*
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
-import org.mockito.MockitoAnnotations
 
 /**
  * Test methods in media data extractor
@@ -44,6 +41,8 @@ class MediaDataExtractorTest {
     fun fetchMediaDetails() {
         `when`(okHttpJsonApiClient?.getMedia(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean()))
                 .thenReturn(Single.just(mock(Media::class.java)))
+
+        Mockito.`when`(mwApi!!.fetchCaptionByFilename(ArgumentMatchers.anyString())).thenReturn(Single.just("test caption"))
 
         `when`(mwApi?.pageExists(ArgumentMatchers.anyString()))
                 .thenReturn(Single.just(true))

--- a/app/src/test/kotlin/fr/free/nrw/commons/MediaDataExtractorTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/MediaDataExtractorTest.kt
@@ -42,7 +42,7 @@ class MediaDataExtractorTest {
         `when`(okHttpJsonApiClient?.getMedia(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean()))
                 .thenReturn(Single.just(mock(Media::class.java)))
 
-        Mockito.`when`(mwApi!!.fetchCaptionByFilename(ArgumentMatchers.anyString())).thenReturn(Single.just("test caption"))
+        Mockito.`when`(mwApi?.fetchCaptionByFilename(ArgumentMatchers.anyString())).thenReturn(Single.just("test caption"))
 
         `when`(mwApi?.pageExists(ArgumentMatchers.anyString()))
                 .thenReturn(Single.just(true))

--- a/app/src/test/kotlin/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApiTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApiTest.kt
@@ -6,6 +6,7 @@ import fr.free.nrw.commons.BuildConfig
 import fr.free.nrw.commons.TestCommonsApplication
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import fr.free.nrw.commons.utils.ConfigUtils
+import io.reactivex.observers.TestObserver
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -22,6 +23,7 @@ import org.robolectric.annotation.Config
 import org.wikipedia.util.DateUtil
 import java.net.URLDecoder
 import java.util.*
+
 
 @RunWith(RobolectricTestRunner::class)
 @Config(constants = BuildConfig::class, sdk = intArrayOf(21), application = TestCommonsApplication::class)
@@ -245,7 +247,8 @@ class ApacheHttpClientMediaWikiApiTest {
         server.enqueue(MockResponse().setBody("<?xml version=\"1.0\"?><api success=\"1\"><entities><entity type=\"mediainfo\" id=\"M77157483\"><labels><label language=\"it\" value=\"Test\" /></labels><statements /></entity></entities></api>"))
 
         val result = testObject.fetchCaptionByFilename("File:foo")
-
+        val testObserver = TestObserver<String>()
+        result.subscribe(testObserver)
         assertBasicRequestParameters(server, "GET").let { request ->
             parseQueryParams(request).let { params ->
                 assertEquals("xml", params["format"])
@@ -258,7 +261,9 @@ class ApacheHttpClientMediaWikiApiTest {
             }
         }
 
-        assertEquals("Test", result)
+        testObserver.assertResult("Test")
+        testObserver.assertNoErrors()
+
     }
 
     @Test

--- a/app/src/test/kotlin/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApiTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApiTest.kt
@@ -241,6 +241,27 @@ class ApacheHttpClientMediaWikiApiTest {
     }
 
     @Test
+    fun fetchCaptionByFilename() {
+        server.enqueue(MockResponse().setBody("<?xml version=\"1.0\"?><api success=\"1\"><entities><entity type=\"mediainfo\" id=\"M77157483\"><labels><label language=\"it\" value=\"Test\" /></labels><statements /></entity></entities></api>"))
+
+        val result = testObject.fetchCaptionByFilename("File:foo")
+
+        assertBasicRequestParameters(server, "GET").let { request ->
+            parseQueryParams(request).let { params ->
+                assertEquals("xml", params["format"])
+                assertEquals("wbgetentities", params["action"])
+                assertEquals("commonswiki", params["sites"])
+                assertEquals("File:foo", params["titles"])
+                assertEquals("labels", params["props"])
+                assertEquals(Locale.getDefault().getLanguage(), params["languages"])
+                assertEquals("1", params["languagefallback"])
+            }
+        }
+
+        assertEquals("Test", result)
+    }
+
+    @Test
     fun isUserBlockedFromCommonsForInfinitelyBlockedUser() {
         server.enqueue(MockResponse().setBody("<?xml version=\"1.0\"?><api><query><userinfo id=\"1000\" name=\"testusername\" blockid=\"3000\" blockedby=\"blockerusername\" blockedbyid=\"1001\" blockreason=\"testing\" blockedtimestamp=\"2018-05-24T15:32:09Z\" blockexpiry=\"infinite\"></userinfo></query></api>"))
 


### PR DESCRIPTION
**Description (required)**
Fixes the conflicts from #2662 which solves #2337 to be able to merge changes, the code of @sp2710 was already working perfectly.

![image](https://user-images.githubusercontent.com/3127881/56884117-75b29f80-6a71-11e9-8293-8f8661b754a8.png)
