### PR TITLE
Use data client for peer review calls

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/di/CommonsApplicationModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/CommonsApplicationModule.java
@@ -3,10 +3,11 @@ package fr.free.nrw.commons.di;
 import android.app.Activity;
 import android.content.ContentProviderClient;
 import android.content.Context;
-import androidx.collection.LruCache;
 import android.view.inputmethod.InputMethodManager;
 
 import com.google.gson.Gson;
+
+import org.wikipedia.dataclient.WikiSite;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -16,6 +17,7 @@ import java.util.Map;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import androidx.collection.LruCache;
 import dagger.Module;
 import dagger.Provides;
 import fr.free.nrw.commons.BuildConfig;
@@ -23,7 +25,6 @@ import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.auth.AccountUtil;
 import fr.free.nrw.commons.auth.SessionManager;
 import fr.free.nrw.commons.data.DBOpenHelper;
-import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.location.LocationServiceManager;
 import fr.free.nrw.commons.settings.Prefs;

--- a/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
@@ -4,6 +4,8 @@ import android.content.Context;
 
 import com.google.gson.Gson;
 
+import org.wikipedia.dataclient.ServiceFactory;
+import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.json.GsonUtil;
 
 import java.io.File;
@@ -20,6 +22,7 @@ import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.mwapi.ApacheHttpClientMediaWikiApi;
 import fr.free.nrw.commons.mwapi.MediaWikiApi;
 import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient;
+import fr.free.nrw.commons.review.ReviewInterface;
 import okhttp3.Cache;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -108,4 +111,16 @@ public class NetworkingModule {
         return GsonUtil.getDefaultGson();
     }
 
+    @Provides
+    @Singleton
+    @Named("commons-wikisite")
+    public WikiSite provideCommonsWikiSite() {
+        return new WikiSite(BuildConfig.COMMONS_URL);
+    }
+
+    @Provides
+    @Singleton
+    public ReviewInterface provideReviewInterface(@Named("commons-wikisite") WikiSite commonsWikiSite) {
+        return ServiceFactory.get(commonsWikiSite, BuildConfig.COMMONS_URL, ReviewInterface.class);
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
@@ -1,10 +1,28 @@
 package fr.free.nrw.commons.mwapi;
 
 import android.text.TextUtils;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+
+import org.apache.commons.lang3.StringUtils;
+import org.wikipedia.dataclient.mwapi.MwQueryPage;
+import org.wikipedia.dataclient.mwapi.MwQueryResponse;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.achievements.FeaturedImages;
 import fr.free.nrw.commons.achievements.FeedbackResponse;
@@ -20,25 +38,10 @@ import fr.free.nrw.commons.utils.ConfigUtils;
 import fr.free.nrw.commons.wikidata.model.GetWikidataEditCountResponse;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Random;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.apache.commons.lang3.StringUtils;
-import org.wikipedia.dataclient.mwapi.MwQueryPage;
-import org.wikipedia.dataclient.mwapi.MwQueryResponse;
-import org.wikipedia.dataclient.mwapi.RecentChange;
-import org.wikipedia.util.DateUtil;
 import timber.log.Timber;
 
 /**
@@ -417,81 +420,5 @@ public class OkHttpJsonApiClient {
      */
     private Map<String, String> getContinueValues(String keyword) {
         return defaultKvStore.getJson("query_continue_" + keyword, mapType);
-    }
-
-    /**
-     * Returns recent changes on commons
-     *
-     * @return list of recent changes made
-     */
-    @Nullable
-    public Single<List<RecentChange>> getRecentFileChanges() {
-        final int RANDOM_SECONDS = 60 * 60 * 24 * 30;
-        final String FILE_NAMESPACE = "6";
-        Random r = new Random();
-        Date now = new Date();
-        Date startDate = new Date(now.getTime() - r.nextInt(RANDOM_SECONDS) * 1000L);
-
-        String rcStart = DateUtil.iso8601DateFormat(startDate);
-        HttpUrl.Builder urlBuilder = HttpUrl
-                .parse(commonsBaseUrl)
-                .newBuilder()
-                .addQueryParameter("action", "query")
-                .addQueryParameter("format", "json")
-                .addQueryParameter("formatversion", "2")
-                .addQueryParameter("list", "recentchanges")
-                .addQueryParameter("rcstart", rcStart)
-                .addQueryParameter("rcnamespace", FILE_NAMESPACE)
-                .addQueryParameter("rcprop", "title|ids")
-                .addQueryParameter("rctype", "new|log")
-                .addQueryParameter("rctoponly", "1");
-
-        Request request = new Request.Builder()
-                .url(urlBuilder.build())
-                .build();
-
-        return Single.fromCallable(() -> {
-            Response response = okHttpClient.newCall(request).execute();
-            if (response.body() != null && response.isSuccessful()) {
-                String json = response.body().string();
-                MwQueryResponse mwQueryPage = gson.fromJson(json, MwQueryResponse.class);
-                return mwQueryPage.query().getRecentChanges();
-            }
-            return new ArrayList<>();
-        });
-    }
-
-    /**
-     * Returns the first revision of the file
-     *
-     * @return Revision object
-     */
-    @Nullable
-    public Single<MwQueryPage.Revision> getFirstRevisionOfFile(String filename) {
-        HttpUrl.Builder urlBuilder = HttpUrl
-                .parse(commonsBaseUrl)
-                .newBuilder()
-                .addQueryParameter("action", "query")
-                .addQueryParameter("format", "json")
-                .addQueryParameter("formatversion", "2")
-                .addQueryParameter("prop", "revisions")
-                .addQueryParameter("rvprop", "timestamp|ids|user")
-                .addQueryParameter("titles", filename)
-                .addQueryParameter("rvdir", "newer")
-                .addQueryParameter("rvlimit", "1");
-
-        Request request = new Request.Builder()
-                .url(urlBuilder.build())
-                .build();
-
-        return Single.fromCallable(() -> {
-            Response response = okHttpClient.newCall(request).execute();
-            if (response.body() != null && response.isSuccessful()) {
-                String json = response.body().string();
-                MwQueryResponse mwQueryPage = gson.fromJson(json, MwQueryResponse.class);
-                return mwQueryPage.query().firstPage().revisions().get(0);
-            }
-            return null;
-        });
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
@@ -12,13 +12,19 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+
+import com.facebook.drawee.view.SimpleDraweeView;
+import com.google.android.material.navigation.NavigationView;
+import com.viewpagerindicator.CirclePageIndicator;
+
+import java.util.ArrayList;
+
+import javax.inject.Inject;
+
 import androidx.appcompat.widget.Toolbar;
 import androidx.drawerlayout.widget.DrawerLayout;
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import com.facebook.drawee.view.SimpleDraweeView;
-import com.google.android.material.navigation.NavigationView;
-import com.viewpagerindicator.CirclePageIndicator;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.auth.AuthenticatedActivity;
@@ -29,8 +35,6 @@ import fr.free.nrw.commons.utils.ViewUtil;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
-import java.util.ArrayList;
-import javax.inject.Inject;
 
 public class ReviewActivity extends AuthenticatedActivity {
 

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
@@ -13,6 +13,9 @@ import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.appcompat.widget.Toolbar;
+import androidx.drawerlayout.widget.DrawerLayout;
+
 import com.facebook.drawee.view.SimpleDraweeView;
 import com.google.android.material.navigation.NavigationView;
 import com.viewpagerindicator.CirclePageIndicator;
@@ -21,8 +24,6 @@ import java.util.ArrayList;
 
 import javax.inject.Inject;
 
-import androidx.appcompat.widget.Toolbar;
-import androidx.drawerlayout.widget.DrawerLayout;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import fr.free.nrw.commons.Media;
@@ -143,7 +144,11 @@ public class ReviewActivity extends AuthenticatedActivity {
         compositeDisposable.add(reviewHelper.getRandomMedia()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(this::updateImage));
+                .subscribe(media -> {
+                    if (media != null) {
+                        updateImage(media);
+                    }
+                }));
         return true;
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewHelper.java
@@ -38,8 +38,15 @@ public class ReviewHelper {
         this.reviewInterface = reviewInterface;
     }
 
+    /**
+     * Fetches recent changes from MediaWiki API
+     * Calls the API to get 10 changes in the last 1 hour
+     * Earlier we were getting changes for the last 30 days but as the API returns just 10 results
+     * its best to fetch for just last 1 hour.
+     * @return
+     */
     private Observable<List<RecentChange>> getRecentChanges() {
-        final int RANDOM_SECONDS = 60 * 60 * 24 * 30;
+        final int RANDOM_SECONDS = 60 * 60;
         Random r = new Random();
         Date now = new Date();
         Date startDate = new Date(now.getTime() - r.nextInt(RANDOM_SECONDS) * 1000L);
@@ -83,11 +90,23 @@ public class ReviewHelper {
                 .firstOrError();
     }
 
+    /**
+     * Gets the first revision of the file from filename
+     * @param filename
+     * @return
+     */
     Observable<MwQueryPage.Revision> getFirstRevisionOfFile(String filename) {
         return reviewInterface.getFirstRevisionOfFile(filename)
                 .map(response -> response.query().firstPage().revisions().get(0));
     }
 
+    /**
+     * Checks if the change is reviewable or not.
+     * - checks the type and revisionId of the change
+     * - checks supported image extensions
+     * @param recentChange
+     * @return
+     */
     private boolean isChangeReviewable(RecentChange recentChange) {
         if (recentChange.getType().equals("log") && !(recentChange.getOldRevisionId() == 0)) {
             return false;

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewInterface.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewInterface.java
@@ -1,0 +1,15 @@
+package fr.free.nrw.commons.review;
+
+import org.wikipedia.dataclient.mwapi.MwQueryResponse;
+
+import io.reactivex.Observable;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+
+public interface ReviewInterface {
+    @GET("w/api.php?action=query&format=json&formatversion=2&list=recentchanges&rcprop=title|ids&rctype=new|log&rctoponly=1&rcnamespace=6")
+    Observable<MwQueryResponse> getRecentChanges(@Query("rcstart") String rcStart);
+
+    @GET("w/api.php?action=query&format=json&formatversion=2&prop=revisions&rvprop=timestamp|ids|user&rvdir=newer&rvlimit=1")
+    Observable<MwQueryResponse> getFirstRevisionOfFile(@Query("titles") String titles);
+}

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewInterface.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewInterface.java
@@ -6,6 +6,9 @@ import io.reactivex.Observable;
 import retrofit2.http.GET;
 import retrofit2.http.Query;
 
+/**
+ * Interface class for peer review calls
+ */
 public interface ReviewInterface {
     @GET("w/api.php?action=query&format=json&formatversion=2&list=recentchanges&rcprop=title|ids&rctype=new|log&rctoponly=1&rcnamespace=6")
     Observable<MwQueryResponse> getRecentChanges(@Query("rcstart") String rcStart);

--- a/app/src/test/kotlin/fr/free/nrw/commons/review/ReviewHelperTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/review/ReviewHelperTest.kt
@@ -63,8 +63,10 @@ class ReviewHelperTest {
         `when`(reviewInterface?.getFirstRevisionOfFile(ArgumentMatchers.anyString()))
                 .thenReturn(Observable.just(mockResponse))
 
+        val media = mock(Media::class.java)
+        `when`(media.filename).thenReturn("File:Test.jpg")
         `when`(okHttpJsonApiClient?.getMedia(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean()))
-                .thenReturn(Single.just(mock(Media::class.java)))
+                .thenReturn(Single.just(media))
     }
 
     /**

--- a/app/src/test/kotlin/fr/free/nrw/commons/review/ReviewHelperTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/review/ReviewHelperTest.kt
@@ -3,7 +3,10 @@ package fr.free.nrw.commons.review
 import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.mwapi.MediaWikiApi
 import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient
+import io.reactivex.Observable
 import io.reactivex.Single
+import junit.framework.Assert.assertNotNull
+import junit.framework.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -13,6 +16,8 @@ import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.MockitoAnnotations
 import org.wikipedia.dataclient.mwapi.MwQueryPage
+import org.wikipedia.dataclient.mwapi.MwQueryResponse
+import org.wikipedia.dataclient.mwapi.MwQueryResult
 import org.wikipedia.dataclient.mwapi.RecentChange
 
 /**
@@ -20,6 +25,8 @@ import org.wikipedia.dataclient.mwapi.RecentChange
  */
 class ReviewHelperTest {
 
+    @Mock
+    internal var reviewInterface: ReviewInterface? = null
     @Mock
     internal var okHttpJsonApiClient: OkHttpJsonApiClient? = null
     @Mock
@@ -35,6 +42,29 @@ class ReviewHelperTest {
     @Throws(Exception::class)
     fun setUp() {
         MockitoAnnotations.initMocks(this)
+
+        val mwQueryPage = mock(MwQueryPage::class.java)
+        val mockRevision = mock(MwQueryPage.Revision::class.java)
+        `when`(mockRevision.user).thenReturn("TestUser")
+        `when`(mwQueryPage.revisions()).thenReturn(listOf(mockRevision))
+
+        val recentChange = getMockRecentChange("test", "File:Test1.jpeg", 0)
+        val recentChange1 = getMockRecentChange("test", "File:Test2.png", 0)
+        val recentChange2 = getMockRecentChange("test", "File:Test3.jpg", 0)
+        val mwQueryResult = mock(MwQueryResult::class.java)
+        `when`(mwQueryResult.recentChanges).thenReturn(listOf(recentChange, recentChange1, recentChange2))
+        `when`(mwQueryResult.firstPage()).thenReturn(mwQueryPage)
+        `when`(mwQueryResult.pages()).thenReturn(listOf(mwQueryPage))
+        val mockResponse = mock(MwQueryResponse::class.java)
+        `when`(mockResponse.query()).thenReturn(mwQueryResult)
+        `when`(reviewInterface?.getRecentChanges(ArgumentMatchers.anyString()))
+                .thenReturn(Observable.just(mockResponse))
+
+        `when`(reviewInterface?.getFirstRevisionOfFile(ArgumentMatchers.anyString()))
+                .thenReturn(Observable.just(mockResponse))
+
+        `when`(okHttpJsonApiClient?.getMedia(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean()))
+                .thenReturn(Single.just(mock(Media::class.java)))
     }
 
     /**
@@ -42,40 +72,48 @@ class ReviewHelperTest {
      */
     @Test
     fun getRandomMedia() {
-        val recentChange = getMockRecentChange("test", "File:Test1.jpeg", 0)
-        val recentChange1 = getMockRecentChange("test", "File:Test2.png", 0)
-        val recentChange2 = getMockRecentChange("test", "File:Test3.jpg", 0)
-        `when`(okHttpJsonApiClient?.recentFileChanges)
-                .thenReturn(Single.just(listOf(recentChange, recentChange1, recentChange2)))
-
         `when`(mediaWikiApi?.pageExists(ArgumentMatchers.anyString()))
                 .thenReturn(Single.just(false))
-        `when`(okHttpJsonApiClient?.getMedia(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean()))
-                .thenReturn(Single.just(mock(Media::class.java)))
-
 
         val randomMedia = reviewHelper?.randomMedia?.blockingGet()
 
+        assertNotNull(randomMedia)
         assertTrue(randomMedia is Media)
+        verify(reviewInterface, times(1))!!.getRecentChanges(ArgumentMatchers.anyString())
     }
 
     /**
      * Test scenario when all media is already nominated for deletion
      */
-    @Test(expected = Exception::class)
+    @Test(expected = RuntimeException::class)
     fun getRandomMediaWithWithAllMediaNominatedForDeletion() {
-        val recentChange = getMockRecentChange("test", "File:Test1.jpeg", 0)
-        val recentChange1 = getMockRecentChange("test", "File:Test2.png", 0)
-        val recentChange2 = getMockRecentChange("test", "File:Test3.jpg", 0)
-        `when`(okHttpJsonApiClient?.recentFileChanges)
-                .thenReturn(Single.just(listOf(recentChange, recentChange1, recentChange2)))
-
         `when`(mediaWikiApi?.pageExists(ArgumentMatchers.anyString()))
                 .thenReturn(Single.just(true))
-        reviewHelper?.randomMedia?.blockingGet()
+        val media = reviewHelper?.randomMedia?.blockingGet()
+        assertNull(media)
+        verify(reviewInterface, times(1))!!.getRecentChanges(ArgumentMatchers.anyString())
     }
 
-    fun getMockRecentChange(type: String, title: String, oldRevisionId: Long): RecentChange {
+    /**
+     * Test scenario when first media is already nominated for deletion
+     */
+    @Test
+    fun getRandomMediaWithWithOneMediaNominatedForDeletion() {
+        `when`(mediaWikiApi?.pageExists("Commons:Deletion_requests/File:Test1.jpeg"))
+                .thenReturn(Single.just(true))
+        `when`(mediaWikiApi?.pageExists("Commons:Deletion_requests/File:Test2.png"))
+                .thenReturn(Single.just(false))
+        `when`(mediaWikiApi?.pageExists("Commons:Deletion_requests/File:Test3.jpg"))
+                .thenReturn(Single.just(true))
+
+        val media = reviewHelper?.randomMedia?.blockingGet()
+
+        assertNotNull(media)
+        assertTrue(media is Media)
+        verify(reviewInterface, times(1))!!.getRecentChanges(ArgumentMatchers.anyString())
+    }
+
+    private fun getMockRecentChange(type: String, title: String, oldRevisionId: Long): RecentChange {
         val recentChange = mock(RecentChange::class.java)
         `when`(recentChange!!.type).thenReturn(type)
         `when`(recentChange.title).thenReturn(title)
@@ -88,9 +126,7 @@ class ReviewHelperTest {
      */
     @Test
     fun getFirstRevisionOfFile() {
-        `when`(okHttpJsonApiClient?.getFirstRevisionOfFile(ArgumentMatchers.anyString()))
-                .thenReturn(Single.just(mock(MwQueryPage.Revision::class.java)))
-        val firstRevisionOfFile = reviewHelper?.getFirstRevisionOfFile("Test.jpg")?.blockingGet()
+        val firstRevisionOfFile = reviewHelper?.getFirstRevisionOfFile("Test.jpg")?.blockingFirst()
 
         assertTrue(firstRevisionOfFile is MwQueryPage.Revision)
     }


### PR DESCRIPTION
Fixes #2921

This is the first PR where we start leveraging the data client library. 

The APIs were not defined in the library so as defined in the documentation, I have created a `ReviewInterface` for the API calls. 

Check out the documentation to go through the steps. 

https://github.com/wikimedia/wikimedia-android-data-client