### PR TITLE
Replace with enum two strings that were in strings.xml but were used as

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/delete/DeleteHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/delete/DeleteHelper.java
@@ -20,6 +20,7 @@ import fr.free.nrw.commons.mwapi.MediaWikiApi;
 import fr.free.nrw.commons.notification.NotificationHelper;
 import fr.free.nrw.commons.review.ReviewActivity;
 import fr.free.nrw.commons.utils.ViewUtil;
+import fr.free.nrw.commons.review.ReviewController;
 import fr.free.nrw.commons.utils.ViewUtilWrapper;
 import io.reactivex.Single;
 import timber.log.Timber;
@@ -142,7 +143,7 @@ public class DeleteHelper {
      * @param question
      * @param problem
      */
-    public void askReasonAndExecute(Media media, Context context, String question, String problem) {
+    public void askReasonAndExecute(Media media, Context context, String question, ReviewController.DeleteReason problem) {
         AlertDialog.Builder alert = new AlertDialog.Builder(context);
         alert.setTitle(question);
 
@@ -152,12 +153,12 @@ public class DeleteHelper {
         String[] reasonList = {"Reason 1", "Reason 2", "Reason 3", "Reason 4"};
 
 
-        if (problem.equals("spam")) {
+        if (problem == ReviewController.DeleteReason.SPAM) {
             reasonList[0] = "A selfie";
             reasonList[1] = "Blurry";
             reasonList[2] = "Nonsense";
             reasonList[3] = "Other";
-        } else if (problem.equals("copyRightViolation")) {
+        } else if (problem == ReviewController.DeleteReason.COPYRIGHT_VIOLATION) {
             reasonList[0] = "Press photo";
             reasonList[1] = "Random photo from internet";
             reasonList[2] = "Logo";

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewController.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewController.java
@@ -74,18 +74,23 @@ public class ReviewController {
         }
     }
 
+    public enum DeleteReason {
+        SPAM,
+        COPYRIGHT_VIOLATION
+    }
+
     public void reportSpam(@NonNull Activity activity) {
         deleteHelper.askReasonAndExecute(new Media("File:" + fileName),
                 activity,
                 activity.getResources().getString(R.string.review_spam_report_question),
-                activity.getResources().getString(R.string.review_spam_report_problem));
+                DeleteReason.SPAM);
     }
 
     public void reportPossibleCopyRightViolation(@NonNull Activity activity) {
         deleteHelper.askReasonAndExecute(new Media("File:" + fileName),
                 activity,
                 activity.getResources().getString(R.string.review_c_violation_report_question),
-                activity.getResources().getString(R.string.review_c_violation_report_problem));
+                DeleteReason.COPYRIGHT_VIOLATION);
     }
 
     @SuppressLint("CheckResult")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -497,9 +497,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="review_no_category">Oh, this is not even categorized!</string>
   <string name="review_category_explanation">This image is under %1$s categories.</string>
   <string name="review_spam_report_question">It is out of scope because it is</string>
-  <string name="review_spam_report_problem">spam</string>
   <string name="review_c_violation_report_question">It is copyright violation because it is </string>
-  <string name="review_c_violation_report_problem">copyRightViolation</string>
     <string name="review_category_yes_button_text">No, mis-categorized</string>
     <string name="review_category_no_button_text">Seems fine</string>
     <string name="review_spam_yes_button_text">No, out of scope</string>


### PR DESCRIPTION
constants. Remove strings from strings.xml Issue # 2931

**Description (required)**
Two strings in strings.xml were being used as constants. Therefore, did not need to be strings, much less translatable strings, so changed to an enum and removed strings from strings.xml.

Fixes #2931 Remove the strings which have to be stored as constant from strings.xml

What changes did you make and why?
defined an enum, ReviewController.DelteReason, and removed strings from strings.xml.

**Tests performed (required)**
ReviewHelperTest
DeleteHelperTest
Ran app through the IDE on an Android device running 8.0.0. Used the Review feature.

Tested {build variant, e.g. ProdDebug} on {name of device or emulator} with API level {API level}.
Tested betaDebug on HTC U Ultra phone with API level 26.

**Screenshots showing what changed (optional - for UI changes)**
No UI changes.

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
yep.
