### PR TITLE
Remove additional unnecessary dependencies.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,14 +77,11 @@ dependencies {
     androidTestUtil 'androidx.test:orchestrator:1.1.1'
 
     // Debugging
-    implementation 'com.facebook.stetho:stetho:1.5.0'
     debugImplementation "com.squareup.leakcanary:leakcanary-android:$LEAK_CANARY_VERSION"
     releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$LEAK_CANARY_VERSION"
     testImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$LEAK_CANARY_VERSION"
 
     // Support libraries
-    implementation "androidx.legacy:legacy-support-v4:1.0.0"
-    implementation "androidx.appcompat:appcompat:1.0.2"
     implementation "com.google.android.material:material:1.1.0-alpha04"
     implementation "androidx.browser:browser:1.0.0"
     implementation "androidx.cardview:cardview:1.0.0"

--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -12,7 +12,6 @@ import android.util.Log;
 
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.imagepipeline.core.ImagePipelineConfig;
-import com.facebook.stetho.Stetho;
 import com.squareup.leakcanary.LeakCanary;
 import com.squareup.leakcanary.RefWatcher;
 
@@ -141,10 +140,6 @@ public class CommonsApplication extends Application {
         } catch (Exception e) {
             Timber.e(e);
             // TODO: Remove when we're able to initialize Fresco in test builds.
-        }
-
-        if (BuildConfig.DEBUG && !isRoboUnitTest()) {
-            Stetho.initializeWithDefaults(this);
         }
 
         createNotificationChannel(this);

--- a/app/src/main/java/fr/free/nrw/commons/auth/SessionManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/SessionManager.java
@@ -7,7 +7,8 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.os.Bundle;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImageUtils.java
@@ -1,21 +1,12 @@
 package fr.free.nrw.commons.category;
 
-import androidx.annotation.NonNull;
-
-import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.wikipedia.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import javax.annotation.Nullable;
-
-import fr.free.nrw.commons.Media;
-import timber.log.Timber;
 
 public class CategoryImageUtils {
 

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
@@ -6,6 +6,8 @@ import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import androidx.annotation.Nullable;
+
 import com.drew.imaging.ImageMetadataReader;
 import com.drew.imaging.ImageProcessingException;
 import com.drew.metadata.Metadata;
@@ -14,8 +16,6 @@ import com.drew.metadata.exif.ExifSubIFDDirectory;
 import java.io.File;
 import java.io.IOException;
 import java.util.Date;
-
-import javax.annotation.Nullable;
 
 import fr.free.nrw.commons.upload.FileUtils;
 

--- a/app/src/main/java/fr/free/nrw/commons/kvstore/JsonKvStore.java
+++ b/app/src/main/java/fr/free/nrw/commons/kvstore/JsonKvStore.java
@@ -2,14 +2,14 @@ package fr.free.nrw.commons.kvstore;
 
 import android.content.Context;
 
+import androidx.annotation.Nullable;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.annotation.Nullable;
 
 public class JsonKvStore extends BasicKvStore {
     private final Gson gson;

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationUtils.java
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.notification;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -10,8 +11,6 @@ import org.w3c.dom.NodeList;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import javax.annotation.Nullable;
 
 import fr.free.nrw.commons.BuildConfig;
 import fr.free.nrw.commons.R;

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewHelper.java
@@ -6,10 +6,10 @@ import org.wikipedia.dataclient.mwapi.RecentChange;
 import java.util.List;
 import java.util.Random;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import androidx.annotation.Nullable;
 import androidx.core.util.Pair;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.mwapi.MediaWikiApi;

--- a/app/src/main/java/fr/free/nrw/commons/utils/NetworkUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/NetworkUtils.java
@@ -7,7 +7,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.telephony.TelephonyManager;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import fr.free.nrw.commons.utils.model.NetworkConnectionType;
 


### PR DESCRIPTION
This removes the dependencies on `androidx.legacy` and `androidx.appcompat` which are not used at all.

This also removes the dependency on the Facebook Stetho library, which is apparently a debug bridge for operating with Chrome dev tools. Do you use this? If so, how is it better than using the Android Studio debug tools?

A side effect of removing these dependencies is the correct usage of `Nullable` and `NonNull` annotations from `androidx` instead of `javax`.