### PR TITLE
Remove redundant variable declaration from SettingsActivity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsActivity.java
@@ -13,8 +13,6 @@ import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.theme.NavigationBaseActivity;
 
 public class SettingsActivity extends NavigationBaseActivity {
-    private SettingsFragment settingsFragment;
-
     private AppCompatDelegate settingsDelegate;
 
     @Override
@@ -25,8 +23,6 @@ public class SettingsActivity extends NavigationBaseActivity {
         } else {
             setTheme(R.style.LightAppTheme);
         }
-
-        settingsFragment = (SettingsFragment) getFragmentManager().findFragmentById(R.id.settingsFragment);
 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_settings);


### PR DESCRIPTION
**Remove redundant variable declaration from SettingsActivity**

I don't think there was an issue raised for this.

I removed a redundant variable declaration from SettingsActivity, which was declared and given a value, but that value was never used.

**Tests performed**

Tested debug on Pixel 2 emulator with API level 25.

**Screenshots showing what changed**

No screenshots, since the pull request isn't intended to change any functionality.
