### PR TITLE
Remove redundant empty if/else statement in NotificationActivity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -485,8 +485,6 @@ public class MainActivity extends AuthenticatedActivity implements FragmentManag
                         viewPager.setCurrentItem(CONTRIBUTIONS_TAB_POSITION);
 
                         // TODO: If contrib fragment is visible and location permission is not given, display permission request button
-                    } else {
-
                     }
                 }
                 return;

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -157,7 +157,6 @@ public class NotificationActivity extends NavigationBaseActivity {
                             no_notification.setVisibility(View.VISIBLE);
                         } else {
                             setAdapter(notificationList);
-                        } if (notificationMenuItem != null) {
                         }
                         progressBar.setVisibility(View.GONE);
                     }, throwable -> {


### PR DESCRIPTION
**Remove redundant empty if/else statement**

This patch removes an empty if/else statement that has no effect on the execution flow of the program, which makes the code simpler.

**Tests performed**

Tested prodDebug on Pixel 2 with API level 25.

**Screenshots showing what changed**

This patch doesn't change any functionality, so there's no screenshots.