### PR TITLE
Remove variable that was set but never used in SimilarImageDialogFragment

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/SimilarImageDialogFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/SimilarImageDialogFragment.java
@@ -15,12 +15,8 @@ import android.widget.Button;
 
 import com.facebook.drawee.generic.GenericDraweeHierarchyBuilder;
 import com.facebook.drawee.view.SimpleDraweeView;
-import com.facebook.imagepipeline.listener.RequestListener;
-import com.facebook.imagepipeline.listener.RequestLoggingListener;
 
 import java.io.File;
-import java.util.HashSet;
-import java.util.Set;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -56,8 +52,6 @@ public class SimilarImageDialogFragment extends DialogFragment {
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view =  inflater.inflate(R.layout.fragment_similar_image_dialog, container, false);
         ButterKnife.bind(this,view);
-        Set<RequestListener> requestListeners = new HashSet<>();
-        requestListeners.add(new RequestLoggingListener());
 
         originalImage.setHierarchy(GenericDraweeHierarchyBuilder
                 .newInstance(getResources())


### PR DESCRIPTION
**Remove variable that was set but never used in SimilarImageDialogFragment**

There was a variable that was being set in SimilarImageDialogFragment that was never subsequently used; this patch removes it, and all of the imports that become redundant.

**Tests performed**

Tested prodDebug on Pixel 2 emulator with API level 25.

**Screenshots showing what changed**

There is no change in user behaviour, so no screenshots.