### PR TITLE
Remove unnecessary use of String.valueOf() from GPSExtractor

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/GPSExtractor.java
@@ -122,7 +122,7 @@ class GPSExtractor {
             decLongitude = 0 - convertToDegree(longitude);
         }
 
-        String decimalCoords = String.valueOf(decLatitude) + "|" + String.valueOf(decLongitude);
+        String decimalCoords = decLatitude + "|" + decLongitude;
         Timber.d("Latitude and Longitude are %s", decimalCoords);
         return decimalCoords;
     }


### PR DESCRIPTION
**Remove unnecessary use of String.valueOf() from GPSExtractor**

valueOf() was being used in cases where it wasn't necessary because the method is called implicitly; this patch removes these usages to make the code clearer and easier to read.

**Tests performed (required)**

Tested prodDebug on Pixel 2 emulator with API level 25.

**Screenshots showing what changed**

No interfaces changes, so no screenshots.