### PR TITLE
Remove unnecessary Integer.toString() calls

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -356,7 +356,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
                 (achievements.getUniqueUsedImages() + "/" + levelInfo.getMaxUniqueImages());
         imagesFeatured.setText(String.valueOf(achievements.getFeaturedImages()));
         String levelUpInfoString = getString(R.string.level);
-        levelUpInfoString += " " + Integer.toString(levelInfo.getLevelNumber());
+        levelUpInfoString += " " + levelInfo.getLevelNumber();
         levelNumber.setText(levelUpInfoString);
         imageView.setImageDrawable(VectorDrawableCompat.create(getResources(), R.drawable.badge,
                 new ContextThemeWrapper(this, levelInfo.getLevelStyle()).getTheme()));

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -516,10 +516,10 @@ public class UploadActivity extends BaseActivity implements UploadView, SimilarI
         int descCount = directKvStore.getInt(name + "descCount");
         for (int i = 0; i < descCount; i++) {
             Description description= new Description();
-            String desc = directKvStore.getString(name + "description_<"+Integer.toString(i)+">");
+            String desc = directKvStore.getString(name + "description_<" + i + ">");
             description.setDescriptionText(desc);
             finalDesc.add(description);
-            int position = directKvStore.getInt(name + "spinnerPosition_<"+Integer.toString(i)+">");
+            int position = directKvStore.getInt(name + "spinnerPosition_<" + i + ">");
             description.setSelectedLanguageIndex(position);
         }
         prevTitleDecs.setOnTouchListener((v, event) -> {
@@ -744,8 +744,8 @@ public class UploadActivity extends BaseActivity implements UploadView, SimilarI
         int n = descriptionsAdapter.getItemCount() - 1;
         directKvStore.putInt(name + "descCount", n);
         for (int i = 0; i < n; i++) {
-            directKvStore.putString(name + "description_<"+Integer.toString(i)+">", descriptionsAdapter.getDescriptions().get(i).getDescriptionText());
-            directKvStore.putInt(name + "spinnerPosition_<" + Integer.toString(i) + ">", descriptionsAdapter.getDescriptions().get(i).getSelectedLanguageIndex());
+            directKvStore.putString(name + "description_<" + i + ">", descriptionsAdapter.getDescriptions().get(i).getDescriptionText());
+            directKvStore.putInt(name + "spinnerPosition_<" + i + ">", descriptionsAdapter.getDescriptions().get(i).getSelectedLanguageIndex());
         }
     }
 }


### PR DESCRIPTION
**Remove unnecessary Integer.toString() calls**

In cases where an integer is directly concatenated onto a string, toString() is not needed because it is called implicitly; this patch removes the calls to improve code readability.

**Tests performed (required)**

Tested prodDebug on Pixel 2 emulator with API level 25.

**Screenshots showing what changed**

Code style and performance improvement, so no screenshots.