### PR TITLE
Refactor onRequestPermissionsResult to be simpler

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -470,28 +470,22 @@ public class MainActivity extends AuthenticatedActivity implements FragmentManag
 
     @Override
     public void onRequestPermissionsResult(int requestCode,
-                                           String permissions[], int[] grantResults) {
-        switch (requestCode) {
-            case LOCATION_REQUEST: {
-                // If request is cancelled, the result arrays are empty.
-                if (grantResults.length > 0
-                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    Timber.d("Location permission given");
-                    ((ContributionsFragment)contributionsActivityPagerAdapter
-                            .getItem(0)).locationManager.registerLocationManager();
-                } else {
-                    // If nearby fragment is visible and location permission is not given, send user back to contrib fragment
-                    if (!isContributionsFragmentVisible) {
-                        viewPager.setCurrentItem(CONTRIBUTIONS_TAB_POSITION);
+                                           String[] permissions, int[] grantResults) {
+        if (requestCode == LOCATION_REQUEST) {
+            // If request is cancelled, the result arrays are empty.
+            if (grantResults.length > 0
+                    && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                Timber.d("Location permission given");
+                ((ContributionsFragment)contributionsActivityPagerAdapter
+                        .getItem(0)).locationManager.registerLocationManager();
+            } else {
+                // If nearby fragment is visible and location permission is not given, send user back to contrib fragment
+                if (!isContributionsFragmentVisible) {
+                    viewPager.setCurrentItem(CONTRIBUTIONS_TAB_POSITION);
 
-                        // TODO: If contrib fragment is visible and location permission is not given, display permission request button
-                    }
+                    // TODO: If contrib fragment is visible and location permission is not given, display permission request button
                 }
-                return;
             }
-
-            default:
-                return;
         }
     }
 


### PR DESCRIPTION
**Refactor onRequestPermissionsResult to be simpler**

onRequestPermissionsResult has a switch statement with a single case, and a functionally empty default; this patch refactors it into an if statement to simplify the code. This patch also changes a C-style array declaration (String permissions[]) to the more standard Java style (String[] permissions). There's no change in functionality, just in code style.

**Tests performed**

Tested prodDebug on Pixel 2 emulator with API level 25.

**Screenshots showing what changed**

No change in functionality, so no screenshots.