### PR TITLE
Trim accidentally added space at the end of filename

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -815,7 +815,7 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
                 return new UploadResult(resultStatus, errorCode);
             } else {
                 Date dateUploaded = parseMWDate(result.getString("/api/upload/imageinfo/@timestamp"));
-                String canonicalFilename = "File:" + result.getString("/api/upload/@filename").replace("_", " "); // Title vs Filename
+                String canonicalFilename = "File:" + result.getString("/api/upload/@filename"); //.replace("_", " "); // Title vs Filename
                 String imageUrl = result.getString("/api/upload/imageinfo/@url");
                 return new UploadResult(resultStatus, dateUploaded, canonicalFilename, imageUrl);
             }

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -815,7 +815,9 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
                 return new UploadResult(resultStatus, errorCode);
             } else {
                 Date dateUploaded = parseMWDate(result.getString("/api/upload/imageinfo/@timestamp"));
-                String canonicalFilename = "File:" + result.getString("/api/upload/@filename"); //.replace("_", " "); // Title vs Filename
+                String canonicalFilename = "File:" + result.getString("/api/upload/@filename")
+                        .replace("_", " ")
+                        .trim(); // Title vs Filename
                 String imageUrl = result.getString("/api/upload/imageinfo/@url");
                 return new UploadResult(resultStatus, dateUploaded, canonicalFilename, imageUrl);
             }


### PR DESCRIPTION
**Description (required)**
Trims accidentally added space at the end of filename. 

Fixes #{GitHub issue number} {Github issue title}
#2917 App adds space at end of filename sometimes

What changes did you make and why?
Applied trim() method to filename string in ApacheHttpClientMediaWikiApi.uploadFileFinalize().

**Tests performed (required)**
Tested ProdDebug on emulator with API level 28.


