### PR TITLE
Upgrade to Robolectric 4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,7 +60,8 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$KOTLIN_VERSION"
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.robolectric:robolectric:3.7.1'
+    testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'com.nhaarman:mockito-kotlin:1.5.0'
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/MediaDataExtractorTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/MediaDataExtractorTest.kt
@@ -4,7 +4,7 @@ import fr.free.nrw.commons.mwapi.MediaResult
 import fr.free.nrw.commons.mwapi.MediaWikiApi
 import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient
 import io.reactivex.Single
-import junit.framework.Assert.assertTrue
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers

--- a/app/src/test/kotlin/fr/free/nrw/commons/MediaTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/MediaTest.kt
@@ -7,7 +7,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(21), application = TestCommonsApplication::class)
+@Config(sdk = [21], application = TestCommonsApplication::class)
 class MediaTest {
     @Test
     fun displayTitleShouldStripExtension() {

--- a/app/src/test/kotlin/fr/free/nrw/commons/NearbyControllerTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/NearbyControllerTest.kt
@@ -2,15 +2,15 @@ package fr.free.nrw.commons
 
 import fr.free.nrw.commons.location.LatLng
 import fr.free.nrw.commons.nearby.NearbyController.loadAttractionsFromLocationToBaseMarkerOptions
+import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = [21], application = TestCommonsApplication::class)
+@Config(sdk = [21], application = TestCommonsApplication::class)
 class NearbyControllerTest {
 
     @Test
@@ -18,7 +18,7 @@ class NearbyControllerTest {
         val location = LatLng(0.0, 0.0, 0f)
 
         val options = loadAttractionsFromLocationToBaseMarkerOptions(
-                location, null, RuntimeEnvironment.application, null)
+                location, null, ApplicationProvider.getApplicationContext(), null)
 
         assertEquals(0, options.size.toLong())
     }
@@ -28,7 +28,7 @@ class NearbyControllerTest {
         val location = LatLng(0.0, 0.0, 0f)
 
         val options = loadAttractionsFromLocationToBaseMarkerOptions(
-                location, emptyList(), RuntimeEnvironment.application, emptyList())
+                location, emptyList(), ApplicationProvider.getApplicationContext(), emptyList())
 
         assertEquals(0, options.size.toLong())
     }

--- a/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/locations/BookMarkLocationDaoTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/locations/BookMarkLocationDaoTest.kt
@@ -24,7 +24,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = [21], application = TestCommonsApplication::class)
+@Config(sdk = [21], application = TestCommonsApplication::class)
 class BookMarkLocationDaoTest {
     private val columns = arrayOf(COLUMN_NAME,
             COLUMN_DESCRIPTION,

--- a/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/pictures/BookmarkPictureDaoTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/pictures/BookmarkPictureDaoTest.kt
@@ -21,7 +21,7 @@ import org.junit.Before
 import org.junit.Test
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = [21], application = TestCommonsApplication::class)
+@Config(sdk = [21], application = TestCommonsApplication::class)
 class BookmarkPictureDaoTest {
 
     private val columns = arrayOf(COLUMN_MEDIA_NAME, COLUMN_CREATOR)

--- a/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryDaoTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryDaoTest.kt
@@ -21,7 +21,7 @@ import org.robolectric.annotation.Config
 import java.util.*
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = [21], application = TestCommonsApplication::class)
+@Config(sdk = [21], application = TestCommonsApplication::class)
 class CategoryDaoTest {
 
     private val columns = arrayOf(COLUMN_ID, COLUMN_NAME, COLUMN_LAST_USED, COLUMN_TIMES_USED)

--- a/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionDaoTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionDaoTest.kt
@@ -23,7 +23,7 @@ import org.robolectric.annotation.Config
 import java.util.*
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = [21], application = TestCommonsApplication::class)
+@Config(sdk = [21], application = TestCommonsApplication::class)
 class ContributionDaoTest {
     private val localUri = "http://example.com/"
     private val client: ContentProviderClient = mock()

--- a/app/src/test/kotlin/fr/free/nrw/commons/delete/DeleteHelperTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/delete/DeleteHelperTest.kt
@@ -7,7 +7,7 @@ import fr.free.nrw.commons.auth.SessionManager
 import fr.free.nrw.commons.mwapi.MediaWikiApi
 import fr.free.nrw.commons.notification.NotificationHelper
 import fr.free.nrw.commons.utils.ViewUtilWrapper
-import junit.framework.Assert.*
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.mockito.InjectMocks

--- a/app/src/test/kotlin/fr/free/nrw/commons/explore/recentsearches/RecentSearchesDaoTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/explore/recentsearches/RecentSearchesDaoTest.kt
@@ -21,7 +21,7 @@ import org.robolectric.annotation.Config
 import java.util.*
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = [21], application = TestCommonsApplication::class)
+@Config(sdk = [21], application = TestCommonsApplication::class)
 class RecentSearchesDaoTest {
 
     private val columns = arrayOf(COLUMN_ID, COLUMN_NAME, COLUMN_LAST_USED)

--- a/app/src/test/kotlin/fr/free/nrw/commons/modifications/ModifierSequenceDaoTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/modifications/ModifierSequenceDaoTest.kt
@@ -20,7 +20,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = [21], application = TestCommonsApplication::class)
+@Config(sdk = [21], application = TestCommonsApplication::class)
 class ModifierSequenceDaoTest {
 
     private val mediaUrl = "http://example.com/"

--- a/app/src/test/kotlin/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApiTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApiTest.kt
@@ -1,8 +1,8 @@
 package fr.free.nrw.commons.mwapi
 
 import android.os.Build
+import androidx.test.core.app.ApplicationProvider
 import com.google.gson.Gson
-import fr.free.nrw.commons.BuildConfig
 import fr.free.nrw.commons.TestCommonsApplication
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import fr.free.nrw.commons.utils.ConfigUtils
@@ -17,14 +17,13 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wikipedia.util.DateUtil
 import java.net.URLDecoder
 import java.util.*
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(21), application = TestCommonsApplication::class)
+@Config(sdk = [21], application = TestCommonsApplication::class)
 class ApacheHttpClientMediaWikiApiTest {
 
     private lateinit var testObject: ApacheHttpClientMediaWikiApi
@@ -39,7 +38,7 @@ class ApacheHttpClientMediaWikiApiTest {
         wikidataServer = MockWebServer()
         okHttpClient = OkHttpClient()
         sharedPreferences = mock(JsonKvStore::class.java)
-        testObject = ApacheHttpClientMediaWikiApi(RuntimeEnvironment.application, "http://" + server.hostName + ":" + server.port + "/", "http://" + wikidataServer.hostName + ":" + wikidataServer.port + "/", sharedPreferences, Gson())
+        testObject = ApacheHttpClientMediaWikiApi(ApplicationProvider.getApplicationContext(), "http://" + server.hostName + ":" + server.port + "/", "http://" + wikidataServer.hostName + ":" + wikidataServer.port + "/", sharedPreferences, Gson())
     }
 
     @After
@@ -319,7 +318,7 @@ class ApacheHttpClientMediaWikiApiTest {
     private fun assertBasicRequestParameters(server: MockWebServer, method: String): RecordedRequest = server.takeRequest().let {
         assertEquals("/", it.requestUrl.encodedPath())
         assertEquals(method, it.method)
-        assertEquals("Commons/${ConfigUtils.getVersionNameWithSha(RuntimeEnvironment.application)} (https://mediawiki.org/wiki/Apps/Commons) Android/${Build.VERSION.RELEASE}",
+        assertEquals("Commons/${ConfigUtils.getVersionNameWithSha(ApplicationProvider.getApplicationContext())} (https://mediawiki.org/wiki/Apps/Commons) Android/${Build.VERSION.RELEASE}",
                 it.getHeader("User-Agent"))
         if ("POST" == method) {
             assertEquals("application/x-www-form-urlencoded", it.getHeader("Content-Type"))

--- a/app/src/test/kotlin/fr/free/nrw/commons/mwapi/OkHttpJsonApiClientTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/mwapi/OkHttpJsonApiClientTest.kt
@@ -29,7 +29,7 @@ import kotlin.random.Random
  * Mock web server based tests for ok http json api client
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = [23], application = TestCommonsApplication::class)
+@Config(sdk = [23], application = TestCommonsApplication::class)
 class OkHttpJsonApiClientTest {
 
     private lateinit var testObject: OkHttpJsonApiClient

--- a/app/src/test/kotlin/fr/free/nrw/commons/review/ReviewHelperTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/review/ReviewHelperTest.kt
@@ -4,7 +4,7 @@ import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.mwapi.MediaWikiApi
 import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient
 import io.reactivex.Single
-import junit.framework.Assert.assertTrue
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@
 #Thu Mar 01 15:28:48 IST 2018
 org.gradle.jvmargs=-Xmx1536M
 android.enableBuildCache=true
+android.enableUnitTestBinaryResources=true
 
 KOTLIN_VERSION=1.3.21
 BUTTERKNIFE_VERSION=10.1.0


### PR DESCRIPTION
**Description (required)**

Upgrade to Roboelectric 4. This is so we can upgrade Gradle and various other components so the app is more stable and we can get instrumentation tests working again (#2868).

What changes did you make and why?
- Upgrade to Robolectric 4
- Added missing androidx test dependency
- Removed deprecated code (e.g. some imports, the `@Config` constants field)
- Added android.enableUnitTestBinaryResources as per the [migration guide](http://robolectric.org/migrating/). This causes a compile time warning but does not cause any actual problems. Upgrading the Android Gradle plugin will remove this warning (see known issues under https://github.com/robolectric/robolectric/releases/tag/robolectric-4.0.2), however I think this is best done when updating Gradle (#2824) or as a separate PR.

**Tests performed (required)**

Tested `betaDebug` on API level `28`
All unit tests pass