### PR TITLE
BugFix invalid upload count string

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
@@ -1,5 +1,6 @@
 package fr.free.nrw.commons.mwapi;
 
+import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.gson.Gson;
@@ -91,7 +92,9 @@ public class OkHttpJsonApiClient {
         return Single.fromCallable(() -> {
             Response response = okHttpClient.newCall(request).execute();
             if (response != null && response.isSuccessful()) {
-                return Integer.parseInt(response.body().string().trim());
+                if(!TextUtils.isEmpty(response.body().string().trim())){
+                    return Integer.parseInt(response.body().string().trim());
+                }
             }
             return 0;
         });


### PR DESCRIPTION
* Added non empty check in response.body() in OkHttpJsonApiClient$getUploadCount

**Description (required)**

Fixes  #2987 App crashes when response body is empty [but not null] in getUploadCount()

What changes did you make and why?
Added non-empty check in response.body() in getUploadCount()
**Tests performed (required)**

Tested {ProdDebug} on Samsung S6 with Api Level 27

**Screenshots showing what changed (optional - for UI changes)**

NA

