### PR TITLE
BugFix Issue #2991

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
@@ -86,7 +86,7 @@ public class OkHttpJsonApiClient {
     public Single<Integer> getUploadCount(String userName) {
         HttpUrl.Builder urlBuilder = wikiMediaToolforgeUrl.newBuilder();
         urlBuilder
-                .addPathSegments("/uploadsbyuser.py")
+                .addPathSegments("uploadsbyuser.py")
                 .addQueryParameter("user", userName);
 
         if (ConfigUtils.isBetaFlavour()) {
@@ -112,7 +112,7 @@ public class OkHttpJsonApiClient {
     public Single<Integer> getWikidataEdits(String userName) {
         HttpUrl.Builder urlBuilder = wikiMediaToolforgeUrl.newBuilder();
         urlBuilder
-                .addPathSegments("/wikidataedits.py")
+                .addPathSegments("wikidataedits.py")
                 .addQueryParameter("user", userName);
 
         if (ConfigUtils.isBetaFlavour()) {


### PR DESCRIPTION

**Description (required)**
Path Segments need not be preceded by "/"

Fixes #2991 Double slash in URL

What changes did you make and why?
Removed "/" from path segments
**Tests performed (required)**

Tested {build variant, ProdDebug} on Samsung S7 with API level 27


