### PR TITLE
BugFix #2993

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
@@ -3,28 +3,8 @@ package fr.free.nrw.commons.mwapi;
 import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-
-import org.apache.commons.lang3.StringUtils;
-import org.wikipedia.dataclient.mwapi.MwQueryPage;
-import org.wikipedia.dataclient.mwapi.MwQueryResponse;
-import org.wikipedia.dataclient.mwapi.RecentChange;
-import org.wikipedia.util.DateUtil;
-
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Random;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.achievements.FeaturedImages;
 import fr.free.nrw.commons.achievements.FeedbackResponse;
@@ -40,10 +20,25 @@ import fr.free.nrw.commons.utils.ConfigUtils;
 import fr.free.nrw.commons.wikidata.model.GetWikidataEditCountResponse;
 import io.reactivex.Observable;
 import io.reactivex.Single;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.apache.commons.lang3.StringUtils;
+import org.wikipedia.dataclient.mwapi.MwQueryPage;
+import org.wikipedia.dataclient.mwapi.MwQueryResponse;
+import org.wikipedia.dataclient.mwapi.RecentChange;
+import org.wikipedia.util.DateUtil;
 import timber.log.Timber;
 
 /**
@@ -132,7 +127,9 @@ public class OkHttpJsonApiClient {
                     return 0;
                 }
                 GetWikidataEditCountResponse countResponse = gson.fromJson(json, GetWikidataEditCountResponse.class);
-                return countResponse.getWikidataEditCount();
+                if (null != countResponse) {
+                    return countResponse.getWikidataEditCount();
+                }
             }
             return 0;
         });


### PR DESCRIPTION


**Description (required)**
* Added null check on countResponse in OkHttpJsonApiClient$getWikidataEdits
Fixes #2993 Achievement crashes when GetWikidataEditCountResponse is null. 

What changes did you make and why?
* Added null check on countResponse in OkHttpJsonApiClient$getWikidataEdits

**Tests performed (required)**

Tested ProdDebug on Samsung S7, API level 27


