### PR TITLE
Gradle 5 update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'com.facebook.fresco:fresco:1.13.0'
     implementation 'com.drewnoakes:metadata-extractor:2.11.0'
     implementation 'com.dmitrybrant:wikimedia-android-data-client:0.0.18'
+    implementation 'org.apache.commons:commons-lang3:3.8.1'
 
     // UI
     implementation 'fr.avianey.com.viewpagerindicator:library:2.4.1.1@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'com.github.triplet.play' version '2.2.1' apply false
+}
+
 apply from: '../gitutils.gradle'
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,6 @@ buildscript {
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
-
-        classpath "com.github.triplet.gradle:play-publisher:2.0.0-rc1"
         classpath 'org.codehaus.groovy:groovy-all:2.4.15'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,4 @@ systemProp.http.proxyPort=0
 systemProp.http.proxyHost=
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableR8=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
**Description (required)**

Fixes #2824, and #3018

What changes did you make and why?
- Updated Gradle
- Disabled R8 for Fresco compatibility
- Added missing commons-lang3 dependency ([explanation](https://github.com/commons-app/apps-android-commons/pull/2860#issuecomment-484973872))
- Updated gradle play publisher for Gradle 5 compatibility (see https://github.com/Triple-T/gradle-play-publisher/issues/451)

**Tests performed (required)**
- Tested app on API 28
- Tested that gradle play publisher looks like it should work (not 100% sure as not really able to replicate the setup - can revert if causes issues again but think it should be fine this time)