### PR TITLE
Removed hardcoded strings in DeleteHelper

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/delete/DeleteHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/delete/DeleteHelper.java
@@ -17,6 +17,7 @@ import javax.inject.Singleton;
 
 import fr.free.nrw.commons.BuildConfig;
 import fr.free.nrw.commons.Media;
+import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.auth.SessionManager;
 import fr.free.nrw.commons.mwapi.MediaWikiApi;
 import fr.free.nrw.commons.notification.NotificationHelper;
@@ -161,15 +162,15 @@ public class DeleteHelper {
 
 
         if (problem == ReviewController.DeleteReason.SPAM) {
-            reasonList[0] = "A selfie";
-            reasonList[1] = "Blurry";
-            reasonList[2] = "Nonsense";
-            reasonList[3] = "Other";
+            reasonList[0] = context.getResources().getString(R.string.delete_reason_spam_selfie);
+            reasonList[1] = context.getResources().getString(R.string.delete_reason_spam_blurry);
+            reasonList[2] = context.getResources().getString(R.string.delete_reason_spam_nonsense);
+            reasonList[3] = context.getResources().getString(R.string.delete_reason_spam_other);
         } else if (problem == ReviewController.DeleteReason.COPYRIGHT_VIOLATION) {
-            reasonList[0] = "Press photo";
-            reasonList[1] = "Random photo from internet";
-            reasonList[2] = "Logo";
-            reasonList[3] = "Other";
+            reasonList[0] = context.getResources().getString(R.string.delete_reason_copyright_pressphoto);
+            reasonList[1] = context.getResources().getString(R.string.delete_reason_copyright_internetphoto);
+            reasonList[2] = context.getResources().getString(R.string.delete_reason_copyright_logo);
+            reasonList[3] = context.getResources().getString(R.string.delete_reason_copyright_other);
         }
 
         alert.setMultiChoiceItems(reasonList, checkedItems, (dialogInterface, position, isChecked) -> {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -547,12 +547,4 @@
   <string name="dialog_box_text_nomination">Почему %1$s должно быть удалено?</string>
   <string name="review_is_uploaded_by">%1$s загружено с помощью: %2$s</string>
   <string name="default_description_language">Язык описаний по умолчанию</string>
-  <string name="delete_reason_spam_selfie">Селфи</string>
-  <string name="delete_reason_spam_blurry">Размыто</string>
-  <string name="delete_reason_spam_nonsense">Ерунда</string>
-  <string name="delete_reason_spam_other">Другое</string>
-  <string name="delete_reason_copyright_pressphoto">Фото из прессы</string>
-  <string name="delete_reason_copyright_internetphoto">Случайное фото из интернета</string>
-  <string name="delete_reason_copyright_logo">Логотип</string>
-  <string name="delete_reason_copyright_other">Другое</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -547,4 +547,12 @@
   <string name="dialog_box_text_nomination">Почему %1$s должно быть удалено?</string>
   <string name="review_is_uploaded_by">%1$s загружено с помощью: %2$s</string>
   <string name="default_description_language">Язык описаний по умолчанию</string>
+  <string name="delete_reason_spam_selfie">Селфи</string>
+  <string name="delete_reason_spam_blurry">Размыто</string>
+  <string name="delete_reason_spam_nonsense">Ерунда</string>
+  <string name="delete_reason_spam_other">Другое</string>
+  <string name="delete_reason_copyright_pressphoto">Фото из прессы</string>
+  <string name="delete_reason_copyright_internetphoto">Случайное фото из интернета</string>
+  <string name="delete_reason_copyright_logo">Логотип</string>
+  <string name="delete_reason_copyright_other">Другое</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -560,4 +560,12 @@ Upload your first media by tapping on the add button.</string>
   <string name="dialog_box_text_nomination">Why should %1$s be deleted?</string>
   <string name="review_is_uploaded_by">%1$s is uploaded by: %2$s</string>
   <string name="default_description_language">Default description language</string>
+  <string name="delete_reason_spam_selfie">A selfie</string>
+  <string name="delete_reason_spam_blurry">Blurry</string>
+  <string name="delete_reason_spam_nonsense">Nonsense</string>
+  <string name="delete_reason_spam_other">Other</string>
+  <string name="delete_reason_copyright_pressphoto">Press photo</string>
+  <string name="delete_reason_copyright_internetphoto">Random photo from internet</string>
+  <string name="delete_reason_copyright_logo">Logo</string>
+  <string name="delete_reason_copyright_other">Other</string>
 </resources>


### PR DESCRIPTION
Fixes #3050
Welcome from Belarus!) I'm beginner in programming for Android. And this is my first open-source project.
I hope I can be helpful in this project.

Fixes hardcoded strings in delete/DeleteHelper.java

A small change in the class for the possibility of localization of strings. Adding these strings with localization in Russian.


Tested on Xiaomi Redmi4x and Nexus One(emulator) with API level 25 and 22.
![Снимок экрана от 2019-07-01 17-55-28](https://user-images.githubusercontent.com/52326878/60446281-bd98a300-9c29-11e9-9f89-d39e4e719c53.png)

![photo_2019-07-01_17-58-57](https://user-images.githubusercontent.com/52326878/60446414-fdf82100-9c29-11e9-9175-8a40e452552a.jpg)




