### PR TITLE
Categories related client API's migrated to retrofit

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
@@ -23,6 +23,7 @@ public class CategoriesModel{
     private static final int SEARCH_CATS_LIMIT = 25;
 
     private final MediaWikiApi mwApi;
+    private final CategoryClient categoryClient;
     private final CategoryDao categoryDao;
     private final JsonKvStore directKvStore;
 
@@ -32,9 +33,11 @@ public class CategoriesModel{
     @Inject GpsCategoryModel gpsCategoryModel;
     @Inject
     public CategoriesModel(MediaWikiApi mwApi,
+                           CategoryClient categoryClient,
                            CategoryDao categoryDao,
                            @Named("default_preferences") JsonKvStore directKvStore) {
         this.mwApi = mwApi;
+        this.categoryClient = categoryClient;
         this.categoryDao = categoryDao;
         this.directKvStore = directKvStore;
         this.categoriesCache = new HashMap<>();
@@ -121,8 +124,8 @@ public class CategoriesModel{
         }
 
         //otherwise, search API for matching categories
-        return mwApi
-                .allCategories(term, SEARCH_CATS_LIMIT)
+        return categoryClient
+                .searchCategories(term, SEARCH_CATS_LIMIT)
                 .map(name -> new CategoryItem(name, false));
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
@@ -188,7 +188,7 @@ public class CategoriesModel{
      * @return
      */
     private Observable<CategoryItem> getTitleCategories(String title) {
-        return mwApi.searchTitles(title, SEARCH_CATS_LIMIT)
+        return categoryClient.searchCategories(title, SEARCH_CATS_LIMIT)
                 .map(name -> new CategoryItem(name, false));
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
@@ -125,7 +125,7 @@ public class CategoriesModel{
 
         //otherwise, search API for matching categories
         return categoryClient
-                .searchCategories(term, SEARCH_CATS_LIMIT)
+                .searchCategoriesForPrefix(term, SEARCH_CATS_LIMIT)
                 .map(name -> new CategoryItem(name, false));
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
@@ -1,0 +1,32 @@
+package fr.free.nrw.commons.category;
+
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import io.reactivex.Single;
+import retrofit2.http.Query;
+
+/**
+ * Category Client to handle custom calls to Commons CategoryWiki APIs
+ */
+@Singleton
+public class CategoryClient {
+
+    private final CategoryInterface CategoryInterface;
+
+    @Inject
+    public CategoryClient(CategoryInterface CategoryInterface) {
+        this.CategoryInterface = CategoryInterface;
+    }
+
+    /**
+     *
+     */
+    public Single<Boolean> searchCategories(String filterValue, int searchCatsLimit) {
+        return CategoryInterface.searchCategories(filterValue, searchCatsLimit)
+                .map(mwQueryResponse -> mwQueryResponse
+                        .query().firstPage().pageId() > 0)
+                .singleOrError();
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
@@ -1,14 +1,18 @@
 package fr.free.nrw.commons.category;
 
 
+import org.wikipedia.dataclient.mwapi.MwQueryPage;
+
+import java.util.List;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Single;
-import retrofit2.http.Query;
+import io.reactivex.Observable;
+import timber.log.Timber;
 
 /**
- * Category Client to handle custom calls to Commons CategoryWiki APIs
+ * Category Client to handle custom calls to Commons MediaWiki APIs
  */
 @Singleton
 public class CategoryClient {
@@ -21,12 +25,24 @@ public class CategoryClient {
     }
 
     /**
+     * Searches for categories with the specified name.
      *
+     * @param filter    The string to be searched
+     * @param itemLimit How many results are returned
+     * @return
      */
-    public Single<Boolean> searchCategories(String filterValue, int searchCatsLimit) {
-        return CategoryInterface.searchCategories(filterValue, searchCatsLimit)
-                .map(mwQueryResponse -> mwQueryResponse
-                        .query().firstPage().pageId() > 0)
-                .singleOrError();
+    public Observable<String> searchCategories(String filter, int itemLimit) {
+        return CategoryInterface.searchCategories(filter, itemLimit)
+                .flatMap(mwQueryResponse -> {
+                    List<MwQueryPage> pages = mwQueryResponse.query().pages();
+                    if(pages != null)
+                        return Observable.fromIterable(pages);
+                    else
+                        Timber.d("No categories returned.");
+                        return Observable.empty();
+                })
+                .map(MwQueryPage::title)
+                .doOnEach(s->Timber.d("Category returned: %s", s))
+                .map(cat->cat.replace("Category:", ""));
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
@@ -2,6 +2,7 @@ package fr.free.nrw.commons.category;
 
 
 import org.wikipedia.dataclient.mwapi.MwQueryPage;
+import org.wikipedia.dataclient.mwapi.MwQueryResponse;
 
 import java.util.List;
 
@@ -25,24 +26,72 @@ public class CategoryClient {
     }
 
     /**
-     * Searches for categories with the specified name.
+     * Searches for categories containing the specified string.
+     *
+     * @param filter    The string to be searched
+     * @param itemLimit How many results are returned
+     * @param offset    Starts returning items from the nth result. If offset is 9, the response starts with the 9th item of the search result
+     * @return
+     */
+    public Observable<String> searchCategories(String filter, int itemLimit, int offset) {
+        return responseToCategoryName(CategoryInterface.searchCategories(filter, itemLimit, offset));
+
+    }
+
+    /**
+     * Searches for categories containing the specified string.
      *
      * @param filter    The string to be searched
      * @param itemLimit How many results are returned
      * @return
      */
     public Observable<String> searchCategories(String filter, int itemLimit) {
-        return CategoryInterface.searchCategories(filter, itemLimit)
+        return searchCategories(filter, itemLimit, 0);
+
+    }
+
+    /**
+     * Searches for categories starting with the specified string.
+     *
+     * @param prefix    The prefix to be searched
+     * @param itemLimit How many results are returned
+     * @param offset    Starts returning items from the nth result. If offset is 9, the response starts with the 9th item of the search result
+     * @return
+     */
+    public Observable<String> searchCategoriesForPrefix(String prefix, int itemLimit, int offset) {
+        return responseToCategoryName(CategoryInterface.searchCategoriesForPrefix(prefix, itemLimit, offset));
+    }
+
+    /**
+     * Searches for categories starting with the specified string.
+     *
+     * @param prefix    The prefix to be searched
+     * @param itemLimit How many results are returned
+     * @return
+     */
+    public Observable<String> searchCategoriesForPrefix(String prefix, int itemLimit) {
+        return searchCategoriesForPrefix(prefix, itemLimit, 0);
+    }
+
+
+    /**
+     * Internal function to reduce code reuse. Extracts the categories returned from MwQueryResponse.
+     *
+     * @param responseObservable The query response observable
+     * @return Observable emitting the categories returned. If our search yielded "Category:Test", "Test" is emitted.
+     */
+    private Observable<String> responseToCategoryName(Observable<MwQueryResponse> responseObservable) {
+        return responseObservable
                 .flatMap(mwQueryResponse -> {
                     List<MwQueryPage> pages = mwQueryResponse.query().pages();
-                    if(pages != null)
+                    if (pages != null)
                         return Observable.fromIterable(pages);
                     else
                         Timber.d("No categories returned.");
-                        return Observable.empty();
+                    return Observable.empty();
                 })
                 .map(MwQueryPage::title)
-                .doOnEach(s->Timber.d("Category returned: %s", s))
-                .map(cat->cat.replace("Category:", ""));
+                .doOnEach(s -> Timber.d("Category returned: %s", s))
+                .map(cat -> cat.replace("Category:", ""));
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryInterface.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryInterface.java
@@ -21,5 +21,11 @@ public interface CategoryInterface {
      */
     @GET("w/api.php?action=query&format=json&formatversion=2"
             + "&generator=search&gsrnamespace=14")
-    Observable<MwQueryResponse> searchCategories(@Query("gsrsearch") String filter, @Query("gsrlimit") int itemLimit);
+    Observable<MwQueryResponse> searchCategories(@Query("gsrsearch") String filter,
+                                                 @Query("gsrlimit") int itemLimit, @Query("gsroffset") int offset);
+
+    @GET("w/api.php?action=query&format=json&formatversion=2"
+            + "&generator=allcategories")
+    Observable<MwQueryResponse> searchCategoriesForPrefix(@Query("gacprefix") String prefix,
+                                                          @Query("gaclimit") int itemLimit, @Query("gacoffset") int offset);
 }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryInterface.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryInterface.java
@@ -1,0 +1,16 @@
+package fr.free.nrw.commons.category;
+
+import org.wikipedia.dataclient.mwapi.MwQueryResponse;
+
+import io.reactivex.Observable;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+
+/**
+ * Interface for interacting with Commons category related APIs
+ */
+public interface CategoryInterface {
+
+    @GET("w/api.php?action=query&format=json&formatversion=2")
+    Observable<MwQueryResponse> searchCategories(@Query("srsearch") String filterValue, @Query("srlimit") int searchCatsLimit);
+}

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryInterface.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryInterface.java
@@ -11,6 +11,15 @@ import retrofit2.http.Query;
  */
 public interface CategoryInterface {
 
-    @GET("w/api.php?action=query&format=json&formatversion=2")
-    Observable<MwQueryResponse> searchCategories(@Query("srsearch") String filterValue, @Query("srlimit") int searchCatsLimit);
+    /**
+     * Searches for categories with the specified name.
+     * Replaces ApacheHttpClientMediaWikiApi#allCategories
+     *
+     * @param filter    The string to be searched
+     * @param itemLimit How many results are returned
+     * @return
+     */
+    @GET("w/api.php?action=query&format=json&formatversion=2"
+            + "&generator=search&gsrnamespace=14")
+    Observable<MwQueryResponse> searchCategories(@Query("gsrsearch") String filter, @Query("gsrlimit") int itemLimit);
 }

--- a/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
@@ -18,6 +18,7 @@ import androidx.annotation.NonNull;
 import dagger.Module;
 import dagger.Provides;
 import fr.free.nrw.commons.BuildConfig;
+import fr.free.nrw.commons.category.CategoryInterface;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.media.MediaInterface;
 import fr.free.nrw.commons.mwapi.ApacheHttpClientMediaWikiApi;
@@ -131,5 +132,11 @@ public class NetworkingModule {
     @Singleton
     public MediaInterface provideMediaInterface(@Named(NAMED_COMMONS_WIKI_SITE) WikiSite commonsWikiSite) {
         return ServiceFactory.get(commonsWikiSite, BuildConfig.COMMONS_URL, MediaInterface.class);
+    }
+
+    @Provides
+    @Singleton
+    public CategoryInterface provideCategoryInterface(@Named(NAMED_COMMONS_WIKI_SITE) WikiSite commonsWikiSite) {
+        return ServiceFactory.get(commonsWikiSite, BuildConfig.COMMONS_URL, CategoryInterface.class);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/ApacheHttpClientMediaWikiApi.java
@@ -389,42 +389,6 @@ public class ApacheHttpClientMediaWikiApi implements MediaWikiApi {
 
     @Override
     @NonNull
-    public Observable<String> searchTitles(String title, int searchCatsLimit) {
-        return Single.fromCallable((Callable<List<String>>) () -> {
-            ArrayList<CustomApiResult> categoryNodes;
-
-            try {
-                categoryNodes = api.action("query")
-                        .param("format", "xml")
-                        .param("list", "search")
-                        .param("srwhat", "text")
-                        .param("srnamespace", "14")
-                        .param("srlimit", searchCatsLimit)
-                        .param("srsearch", title)
-                        .get()
-                        .getNodes("/api/query/search/p/@title");
-            } catch (IOException e) {
-                Timber.e(e, "Failed to obtain searchTitles");
-                return Collections.emptyList();
-            }
-
-            if (categoryNodes == null) {
-                return Collections.emptyList();
-            }
-
-            List<String> titleCategories = new ArrayList<>();
-            for (CustomApiResult categoryNode : categoryNodes) {
-                String cat = categoryNode.getDocument().getTextContent();
-                String catString = cat.replace("Category:", "");
-                titleCategories.add(catString);
-            }
-
-            return titleCategories;
-        }).flatMapObservable(Observable::fromIterable);
-    }
-
-    @Override
-    @NonNull
     public LogEventResult logEvents(String user, String lastModified, String queryContinue, int limit) throws IOException {
         CustomMwApi.RequestBuilder builder = api.action("query")
                 .param("list", "logevents")

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
@@ -35,9 +35,6 @@ public interface MediaWikiApi {
     List<String> getParentCategoryList(String categoryName);
 
     @NonNull
-    List<String> searchCategory(String title, int offset);
-
-    @NonNull
     Single<UploadStash> uploadFile(String filename, InputStream file,
                                    long dataLength, Uri fileUri, Uri contentProviderUri,
                                    final ProgressListener progressListener);
@@ -64,12 +61,6 @@ public interface MediaWikiApi {
 
     @NonNull
     Single<MediaResult> fetchMediaByFilename(String filename);
-
-    @NonNull
-    Observable<String> searchCategories(String filterValue, int searchCatsLimit);
-
-    @NonNull
-    Observable<String> allCategories(String filter, int searchCatsLimit);
 
     @NonNull
     List<Notification> getNotifications(boolean archived) throws IOException;

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
@@ -68,9 +68,6 @@ public interface MediaWikiApi {
     @NonNull
     boolean markNotificationAsRead(Notification notification) throws IOException;
 
-    @NonNull
-    Observable<String> searchTitles(String title, int searchCatsLimit);
-
     @Nullable
     String revisionsByFilename(String filename) throws IOException;
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryClientTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryClientTest.kt
@@ -31,11 +31,14 @@ class CategoryClientTest {
         val mockResponse = Mockito.mock(MwQueryResponse::class.java)
         Mockito.`when`(mockResponse.query()).thenReturn(mwQueryResult)
 
-        Mockito.`when`(categoryInterface!!.searchCategories(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt()))
+        Mockito.`when`(categoryInterface!!.searchCategories(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
                 .thenReturn(Observable.just(mockResponse))
 
         val actualCategoryName = categoryClient!!.searchCategories("tes", 10).blockingFirst()
         Assert.assertEquals("Test", actualCategoryName)
+
+        val actualCategoryName2 = categoryClient!!.searchCategories("tes", 10, 10).blockingFirst()
+        Assert.assertEquals("Test", actualCategoryName2)
     }
 
     @Test
@@ -45,9 +48,47 @@ class CategoryClientTest {
         val mockResponse = Mockito.mock(MwQueryResponse::class.java)
         Mockito.`when`(mockResponse.query()).thenReturn(mwQueryResult)
 
-        Mockito.`when`(categoryInterface!!.searchCategories(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt()))
+        Mockito.`when`(categoryInterface!!.searchCategories(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
                 .thenReturn(Observable.just(mockResponse))
+
         categoryClient!!.searchCategories("tes", 10).subscribe(
+                { Assert.fail("SearchCategories returned element when it shouldn't have.") },
+                { s -> throw s })
+        categoryClient!!.searchCategories("tes", 10, 10).subscribe(
+                { Assert.fail("SearchCategories returned element when it shouldn't have.") },
+                { s -> throw s })
+    }
+    @Test
+    fun searchCategoriesForPrefixFound() {
+        val mwQueryPage = Mockito.mock(MwQueryPage::class.java)
+        Mockito.`when`(mwQueryPage.title()).thenReturn("Category:Test")
+        val mwQueryResult = Mockito.mock(MwQueryResult::class.java)
+        Mockito.`when`(mwQueryResult.pages()).thenReturn(listOf(mwQueryPage))
+        val mockResponse = Mockito.mock(MwQueryResponse::class.java)
+        Mockito.`when`(mockResponse.query()).thenReturn(mwQueryResult)
+
+        Mockito.`when`(categoryInterface!!.searchCategoriesForPrefix(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
+                .thenReturn(Observable.just(mockResponse))
+
+        val actualCategoryName = categoryClient!!.searchCategoriesForPrefix("tes", 10).blockingFirst()
+        Assert.assertEquals("Test", actualCategoryName)
+        val actualCategoryName2 = categoryClient!!.searchCategoriesForPrefix("tes", 10, 10).blockingFirst()
+        Assert.assertEquals("Test", actualCategoryName2)
+    }
+
+    @Test
+    fun searchCategoriesForPrefixNull() {
+        val mwQueryResult = Mockito.mock(MwQueryResult::class.java)
+        Mockito.`when`(mwQueryResult.pages()).thenReturn(null)
+        val mockResponse = Mockito.mock(MwQueryResponse::class.java)
+        Mockito.`when`(mockResponse.query()).thenReturn(mwQueryResult)
+
+        Mockito.`when`(categoryInterface!!.searchCategoriesForPrefix(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
+                .thenReturn(Observable.just(mockResponse))
+        categoryClient!!.searchCategoriesForPrefix("tes", 10).subscribe(
+                { Assert.fail("SearchCategories returned element when it shouldn't have.") },
+                { s -> throw s })
+        categoryClient!!.searchCategoriesForPrefix("tes", 10, 10).subscribe(
                 { Assert.fail("SearchCategories returned element when it shouldn't have.") },
                 { s -> throw s })
     }

--- a/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryClientTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryClientTest.kt
@@ -1,0 +1,54 @@
+package fr.free.nrw.commons.category
+
+import io.reactivex.Observable
+import junit.framework.Assert
+import org.junit.Before
+import org.junit.Test
+import org.mockito.*
+import org.wikipedia.dataclient.mwapi.MwQueryPage
+import org.wikipedia.dataclient.mwapi.MwQueryResponse
+import org.wikipedia.dataclient.mwapi.MwQueryResult
+
+class CategoryClientTest {
+    @Mock
+    internal var categoryInterface: CategoryInterface? = null
+
+    @InjectMocks
+    var categoryClient: CategoryClient? = null
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+    }
+
+    @Test
+    fun searchCategoriesFound() {
+        val mwQueryPage = Mockito.mock(MwQueryPage::class.java)
+        Mockito.`when`(mwQueryPage.title()).thenReturn("Category:Test")
+        val mwQueryResult = Mockito.mock(MwQueryResult::class.java)
+        Mockito.`when`(mwQueryResult.pages()).thenReturn(listOf(mwQueryPage))
+        val mockResponse = Mockito.mock(MwQueryResponse::class.java)
+        Mockito.`when`(mockResponse.query()).thenReturn(mwQueryResult)
+
+        Mockito.`when`(categoryInterface!!.searchCategories(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt()))
+                .thenReturn(Observable.just(mockResponse))
+
+        val actualCategoryName = categoryClient!!.searchCategories("tes", 10).blockingFirst()
+        Assert.assertEquals("Test", actualCategoryName)
+    }
+
+    @Test
+    fun searchCategoriesNull() {
+        val mwQueryResult = Mockito.mock(MwQueryResult::class.java)
+        Mockito.`when`(mwQueryResult.pages()).thenReturn(null)
+        val mockResponse = Mockito.mock(MwQueryResponse::class.java)
+        Mockito.`when`(mockResponse.query()).thenReturn(mwQueryResult)
+
+        Mockito.`when`(categoryInterface!!.searchCategories(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt()))
+                .thenReturn(Observable.just(mockResponse))
+        categoryClient!!.searchCategories("tes", 10).subscribe(
+                { Assert.fail("SearchCategories returned element when it shouldn't have.") },
+                { s -> throw s })
+    }
+}


### PR DESCRIPTION
As per #3026 I'm migrating all category related client API's to retrofit.

- [x] searchCategory     
- [x] searchCategories   
- [x] allCategories

These 3 were merged into searchCategories as they were duplicates.

- [ ] getCategoryImages
- [ ] getSubCategoryList
- [ ] getParentCategoryList

I'll have these ready tomorrow, but they are independent of searchCategories.

By the way, should I delete the mwApi originals?