### PR TITLE
Closes #3061

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -199,7 +199,10 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
         }else if(layoutManager instanceof GridLayoutManager){
             lastVisibleItemPosition=((GridLayoutManager)layoutManager).findLastCompletelyVisibleItemPosition();
         }
-        outState.putString(VISIBLE_ITEM_ID,findIdOfItemWithPosition(lastVisibleItemPosition));
+        String idOfItemWithPosition = findIdOfItemWithPosition(lastVisibleItemPosition);
+        if (null != idOfItemWithPosition) {
+            outState.putString(VISIBLE_ITEM_ID, idOfItemWithPosition);
+        }
     }
 
     @Override
@@ -216,8 +219,13 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
      * @param position
      * @return
      */
+    @Nullable
     private String findIdOfItemWithPosition(int position) {
-        return callback.getContributionForPosition(position).getContentUri().getLastPathSegment();
+        Contribution contributionForPosition = callback.getContributionForPosition(position);
+        if (null != contributionForPosition) {
+            return contributionForPosition.getContentUri().getLastPathSegment();
+        }
+        return null;
     }
 
 }


### PR DESCRIPTION
* Added null check for contribution with position in ContributionsListFragment

**Description (required)**

Fixes #3061 App Crashes in ContributionListFragment

What changes did you make and why?
Null checks on Contribution before extracting the uri's lastPathSegment
**Tests performed (required)**

Tested betaDebug on Pixel Api 27
