### PR TITLE
EXIF removal set to off by default (base 2.11-release)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -1,15 +1,12 @@
 package fr.free.nrw.commons.settings;
 
 import android.Manifest;
-import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.EditTextPreference;
-import android.preference.MultiSelectListPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
-import android.preference.PreferenceManager;
 import android.preference.SwitchPreference;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -31,6 +28,7 @@ import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.di.ApplicationlessInjection;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.logging.CommonsLogSender;
+import fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleMultiSelectListPreference;
 import fr.free.nrw.commons.utils.PermissionUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
 import fr.free.nrw.commons.upload.Language;
@@ -70,8 +68,9 @@ public class SettingsFragment extends PreferenceFragment {
             return true;
         });
 
-        MultiSelectListPreference multiSelectListPref = (MultiSelectListPreference) findPreference("manageExifTags");
+        LongTitleMultiSelectListPreference multiSelectListPref = (LongTitleMultiSelectListPreference) findPreference("manageExifTags");
         if (multiSelectListPref != null) {
+            defaultKvStore.putJson(Prefs.MANAGED_EXIF_TAGS, multiSelectListPref.getValues());
             multiSelectListPref.setOnPreferenceChangeListener((preference, newValue) -> {
                 defaultKvStore.putJson(Prefs.MANAGED_EXIF_TAGS, newValue);
                 return true;

--- a/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.java
@@ -105,13 +105,13 @@ public class FileProcessor implements Callback {
      */
     private Set<String> getExifTagsToRedact(Context context) {
         Type setType = new TypeToken<Set<String>>() {}.getType();
-        Set<String> prefManageEXIFTags = defaultKvStore.getJson(Prefs.MANAGED_EXIF_TAGS, setType);
+        Set<String> selectedExifTags = defaultKvStore.getJson(Prefs.MANAGED_EXIF_TAGS, setType);
 
         Set<String> redactTags = new HashSet<>(Arrays.asList(
                 context.getResources().getStringArray(R.array.pref_exifTag_values)));
-        Timber.d(redactTags.toString());
 
-        if (prefManageEXIFTags != null) redactTags.removeAll(prefManageEXIFTags);
+        if (selectedExifTags != null) redactTags.removeAll(selectedExifTags);
+        else redactTags.clear();
 
         return redactTags;
     }

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -70,6 +70,7 @@
         <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleMultiSelectListPreference
             android:entries="@array/pref_exifTag_entries"
             android:entryValues="@array/pref_exifTag_values"
+            android:defaultValue="@array/pref_exifTag_values"
             android:key="manageExifTags"
             android:title="@string/manage_exif_tags"
             android:summary="@string/manage_exif_tags_summary"/>


### PR DESCRIPTION
**Description (required)**
Settings -> Privacy -> Manage EXIF TAGS -> all tags checked

Based upon discussion https://github.com/commons-app/apps-android-commons/pull/2863#issuecomment-506602059 and https://github.com/commons-app/apps-android-commons/pull/3043#issuecomment-511102967

What changes did you make and why?
Set default values to ON for manageExifTags preference.

Tested betaDebug on emulator with API level 28.