### PR TITLE
Fixes #2940 Problem with color of info icon

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
@@ -3,6 +3,8 @@ package fr.free.nrw.commons.review;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -111,6 +113,7 @@ public class ReviewActivity extends AuthenticatedActivity {
         setSupportActionBar(toolbar);
         initDrawer();
 
+
         reviewController = new ReviewController(deleteHelper, this);
 
         reviewPagerAdapter = new ReviewPagerAdapter(getSupportFragmentManager());
@@ -118,6 +121,10 @@ public class ReviewActivity extends AuthenticatedActivity {
         reviewPagerAdapter.getItem(0);
         pagerIndicator.setViewPager(reviewPager);
         progressBar.setVisibility(View.VISIBLE);
+
+        Drawable d[]=btnSkipImage.getCompoundDrawablesRelative();
+        d[2].setColorFilter(getApplicationContext().getResources().getColor(R.color.button_blue), PorterDuff.Mode.SRC_IN);
+
 
         if (savedInstanceState != null) {
             updateImage(savedInstanceState.getParcelable(SAVED_MEDIA)); // Use existing media if we have one


### PR DESCRIPTION
**Info icon will be visible in light theme**

Fixes #[2940](https://github.com/commons-app/apps-android-commons/issues/2940) Problem with color of info icon
The icon is now visible on Android 5and+ versions

Android Version 5
minimum API level supported 19
Before:
![icon not seen](https://user-images.githubusercontent.com/53351992/61990585-d2b5f580-b060-11e9-8105-1e8ec4257bcd.jpg)
After
![img2](https://user-images.githubusercontent.com/53351992/61990588-dba6c700-b060-11e9-80b7-03f2177f9773.jpeg)


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
