### PR TITLE
Closes #3094

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/DescriptionsAdapter.java
@@ -147,7 +147,6 @@ public class DescriptionsAdapter extends RecyclerView.Adapter<DescriptionsAdapte
                     spinnerDescriptionLanguages.getContext(),
                     R.layout.row_item_languages_spinner, selectedLanguages,
                     savedLanguageValue);
-            languagesAdapter.notifyDataSetChanged();
             spinnerDescriptionLanguages.setAdapter(languagesAdapter);
 
             spinnerDescriptionLanguages.setOnItemSelectedListener(new OnItemSelectedListener() {
@@ -162,6 +161,7 @@ public class DescriptionsAdapter extends RecyclerView.Adapter<DescriptionsAdapte
                     selectedLanguages.put(adapterView, languageCode);
                     ((SpinnerLanguagesAdapter) adapterView
                             .getAdapter()).selectedLangCode = languageCode;
+                    spinnerDescriptionLanguages.setSelection(position);
                     Timber.d("Description language code is: "+languageCode);
                 }
 
@@ -171,7 +171,7 @@ public class DescriptionsAdapter extends RecyclerView.Adapter<DescriptionsAdapte
             });
 
             if (description.getSelectedLanguageIndex() == -1) {
-                if (savedLanguageValue != null) {
+                if (!TextUtils.isEmpty(savedLanguageValue)) {
                     // If user has chosen a default language from settings activity savedLanguageValue is not null
                     spinnerDescriptionLanguages.setSelection(languagesAdapter.getIndexOfLanguageCode(savedLanguageValue));
                 } else {
@@ -180,7 +180,7 @@ public class DescriptionsAdapter extends RecyclerView.Adapter<DescriptionsAdapte
                                 .getIndexOfUserDefaultLocale(spinnerDescriptionLanguages.getContext());
                         spinnerDescriptionLanguages.setSelection(defaultLocaleIndex, true);
                     } else {
-                        spinnerDescriptionLanguages.setSelection(0);
+                        spinnerDescriptionLanguages.setSelection(0,true);
                     }
                 }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/SpinnerLanguagesAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/SpinnerLanguagesAdapter.java
@@ -139,14 +139,7 @@ public class SpinnerLanguagesAdapter extends ArrayAdapter {
             String languageCode = LangCodeUtils.fixLanguageCode(languageCodesList.get(position));
             final String languageName = StringUtils.capitalize(languageNamesList.get(position));
 
-            if(savedLanguageValue.equals("")){
-                savedLanguageValue = Locale.getDefault().getLanguage();
-            }
-
             if (!isDropDownView) {
-                    if( !dropDownClicked){
-                    languageCode = LangCodeUtils.fixLanguageCode(savedLanguageValue);
-                }
                 view.setVisibility(View.GONE);
                 if (languageCode.length() > 2)
                     tvLanguage.setText(languageCode.substring(0, 2));


### PR DESCRIPTION
**Description (required)**
* BugFix in SpinnerDescriptionsAdapter and SpinnerLanguagesAdapter (use the language code provided by the spinner, do not set the language to the one returned by the locale)

Fixes #3094 Inconsistent descriptions for uploaded Image

What changes did you make and why?
Use the language code provided by the spinner, do not set the language to the one returned by the locale
**Tests performed (required)**

Tested prodDebug on Samsung S7 Api-27

**Screenshots showing what changed (optional - for UI changes)**
![device-2019-07-28-161803](https://user-images.githubusercontent.com/17375274/62005635-ce1e3980-b153-11e9-9ead-574c3e647ed5.png)
<img width="718" alt="Screenshot 2019-07-28 at 4 19 03 PM" src="https://user-images.githubusercontent.com/17375274/62005636-ce1e3980-b153-11e9-97fb-fa459c98e4e2.png">

