### PR TITLE
Solves 2909  "Requesting category check" notification even though I did not mark as such 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
@@ -3,6 +3,8 @@ package fr.free.nrw.commons.review;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -111,6 +113,7 @@ public class ReviewActivity extends AuthenticatedActivity {
         setSupportActionBar(toolbar);
         initDrawer();
 
+
         reviewController = new ReviewController(deleteHelper, this);
 
         reviewPagerAdapter = new ReviewPagerAdapter(getSupportFragmentManager());
@@ -118,6 +121,10 @@ public class ReviewActivity extends AuthenticatedActivity {
         reviewPagerAdapter.getItem(0);
         pagerIndicator.setViewPager(reviewPager);
         progressBar.setVisibility(View.VISIBLE);
+
+        Drawable d[]=btnSkipImage.getCompoundDrawablesRelative();
+        d[2].setColorFilter(getApplicationContext().getResources().getColor(R.color.button_blue), PorterDuff.Mode.SRC_IN);
+
 
         if (savedInstanceState != null) {
             updateImage(savedInstanceState.getParcelable(SAVED_MEDIA)); // Use existing media if we have one

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
@@ -122,9 +122,6 @@ public class ReviewActivity extends AuthenticatedActivity {
         pagerIndicator.setViewPager(reviewPager);
         progressBar.setVisibility(View.VISIBLE);
 
-        Drawable d[]=btnSkipImage.getCompoundDrawablesRelative();
-        d[2].setColorFilter(getApplicationContext().getResources().getColor(R.color.button_blue), PorterDuff.Mode.SRC_IN);
-
 
         if (savedInstanceState != null) {
             updateImage(savedInstanceState.getParcelable(SAVED_MEDIA)); // Use existing media if we have one

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewController.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewController.java
@@ -156,13 +156,14 @@ public class ReviewController {
             message = context.getString(messages[i]);
         }
 
-        notificationBuilder.setContentTitle(context.getString(R.string.check_category_notification_title, media.getDisplayTitle()))
+        if(i==2)// will build the notification for category check only if i==2
+        {notificationBuilder.setContentTitle(context.getString(R.string.check_category_notification_title, media.getDisplayTitle()))
                 .setStyle(new NotificationCompat.BigTextStyle()
                         .bigText(message))
                 .setSmallIcon(R.drawable.ic_launcher)
                 .setProgress(messages.length, i, false)
                 .setOngoing(true);
-        notificationManager.notify(NOTIFICATION_CHECK_CATEGORY, notificationBuilder.build());
+        notificationManager.notify(NOTIFICATION_CHECK_CATEGORY, notificationBuilder.build());}
     }
 
     @SuppressLint({"CheckResult", "StringFormatInvalid"})
@@ -193,7 +194,7 @@ public class ReviewController {
                 publishProgress(context, 1);
                 assert firstRevision != null;
                 mwApi.thank(editToken, firstRevision.getRevisionId());
-                publishProgress(context, 2);
+                publishProgress(context, 1); // i=2 sets  notification for categeory check
             } catch (Exception e) {
                 Timber.d(e);
                 return false;


### PR DESCRIPTION
Category check was requested when sending thanks to the contributor even though the category was not reported to be wrong by the reviewer.

Fixes #2909 "Requesting category check" notification even though I did not mark as such 

Changes made:

- There was a call for building the notification of "check category" while sending thanks which is not required. When a category check is requested the "reportwrongcategory" method is directly called, hence a call to publish progress for check category in the sendthanks method is not needed. I've changed the 'i' value that is sent with publishprogress to '1' as '2' corresponds to check category.

- I've added a condition in the publishprogress method which leads to checking whether a category check was requested and only then publish a "category check" notification. This prevents publishing the notification when only thanks is needed to be sent.

Tests performed 👍 
When category check is not requested by the reviewer and he sends thanks to the contributor category check is not requested.
Android version 7
API level supported: 19-21

Screenshots showing what changed:
Before:
![2909](https://user-images.githubusercontent.com/53351992/63454251-10dbe480-c468-11e9-96a6-6c05534f5fce.png)
After:
![sending thanks ss](https://user-images.githubusercontent.com/53351992/63454269-189b8900-c468-11e9-9871-0354264b6f88.jpg)



Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
