### PR TITLE
Removed some jargon/slang from strings.xml

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -332,7 +332,7 @@
   <string name="explore_tab_title_featured">Featured</string>
   <string name="explore_tab_title_mobile">Uploaded via mobile</string>
 
-  <string name="successful_wikidata_edit">Image successfully added to %1$s on Wikidata!</string>
+  <string name="successful_wikidata_edit">Image added to %1$s on Wikidata!</string>
   <string name="wikidata_edit_failure">Failed to update corresponding Wikidata entity!</string>
   <string name="menu_set_wallpaper">Set as wallpaper</string>
   <string name="wallpaper_set_successfully">Wallpaper set successfully!</string>
@@ -472,7 +472,7 @@ Upload your first media by tapping on the add button.</string>
     <string name="check_category_edit_summary">Requesting category check</string>
   <string name="check_category_success_title">Category check requested</string>
   <string name="check_category_failure_title">Category check request didn\'t work</string>
-  <string name="check_category_success_message">Successfully requested category check for %1$s</string>
+  <string name="check_category_success_message">Requested category check for %1$s</string>
   <string name="check_category_failure_message">Could not request category check for %1$s</string>
   <string name="check_category_toast">Requesting category check for %1$s</string>
   <string name="nominate_for_deletion_edit_file_page">Adding delete message to file</string>
@@ -563,7 +563,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="delete_helper_make_deletion_toast">Trying to nominate %1$s for deletion</string>
   <string name="delete_helper_show_deletion_title">Nominating for deletion</string>
   <string name="delete_helper_show_deletion_title_success">Success</string>
-  <string name="delete_helper_show_deletion_message_if">Successfully nominated %1$s for deletion.</string>
+  <string name="delete_helper_show_deletion_message_if">Nominated %1$s for deletion.</string>
   <string name="delete_helper_show_deletion_title_failed">Failed</string>
   <string name="delete_helper_show_deletion_message_else">Could not request deletion.</string>
   <string name="delete_helper_ask_spam_selfie">A selfie</string>


### PR DESCRIPTION
Removed arbitrary instances of "success" in strings.xml

Fixes #2874 "check category failure title" and "check category success title" shouldn't use the words "success" and "failure"

What changes did you make and why?
Removed unnecessary instances of "success" and its variants to make the messages more concise

Tested ProdDebug on Google Pixel 2, API Level 27