### PR TITLE
[Dependency fluent]: Remove unused dependency fluent

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,7 +19,6 @@ dependencies {
     // Utils
     implementation 'com.github.nicolas-raoul:Quadtree:ac16ea8035bf07'
     implementation 'com.google.code.gson:gson:2.8.5'
-    implementation 'in.yuvi:http.fluent:1.3'
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'
     implementation 'com.squareup.okio:okio:1.15.0'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'


### PR DESCRIPTION
**Description (required)**

Part of #3128 

What changes did you make and why?

As we have now started using OkHttp. This dependency is no longer required. 