### PR TITLE
clear image cache on logout

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/SessionManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/SessionManager.java
@@ -9,6 +9,8 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.facebook.drawee.backends.pipeline.Fresco;
+import com.facebook.imagepipeline.core.ImagePipeline;
 import org.wikipedia.login.LoginResult;
 
 import javax.inject.Inject;
@@ -142,6 +144,15 @@ public class SessionManager {
                 .map(a -> accountManager.removeAccount(a, null, null).getResult()))
                 .doOnComplete(() -> {
                     currentAccount = null;
+                    clearImageCache();
                 });
+    }
+
+    /**
+     * Clear all images cache held by Fresco
+     */
+    private void clearImageCache(){
+        ImagePipeline imagePipeline = Fresco.getImagePipeline();
+        imagePipeline.clearCaches();
     }
 }


### PR DESCRIPTION
**Description (required)**

Fixes issue with wrong images displayed when logout/login

What changes did you make and why?
Clear image cache held with Fresco on logout
**Tests performed (required)**

Tested prodDebug with Samsung S7 API Level 27

