### PR TITLE
Issue #171 - Fixing Some Lint Warnings

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/Bookmark.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/Bookmark.java
@@ -2,12 +2,10 @@ package fr.free.nrw.commons.bookmarks;
 
 import android.net.Uri;
 
-import fr.free.nrw.commons.bookmarks.pictures.BookmarkPicturesContentProvider;
-
 public class Bookmark {
     private Uri contentUri;
-    private String mediaName;
-    private String mediaCreator;
+    private final String mediaName;
+    private final String mediaCreator;
 
     public Bookmark(String mediaName, String mediaCreator, Uri contentUri) {
         this.contentUri = contentUri;

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkPages.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkPages.java
@@ -5,9 +5,9 @@ import androidx.fragment.app.Fragment;
 /**
  * Data class for handling a bookmark fragment and it title
  */
-public class BookmarkPages {
-    private Fragment page;
-    private String title;
+class BookmarkPages {
+    private final Fragment page;
+    private final String title;
 
     BookmarkPages(Fragment fragment, String title) {
         this.title = title;

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarksActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarksActivity.java
@@ -2,7 +2,6 @@ package fr.free.nrw.commons.bookmarks;
 
 import android.content.Context;
 import android.content.Intent;
-import android.database.DataSetObserver;
 import android.os.Bundle;
 import com.google.android.material.tabs.TabLayout;
 import androidx.fragment.app.FragmentManager;

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarksPagerAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarksPagerAdapter.java
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.bookmarks;
 
 import android.content.Context;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -13,9 +14,9 @@ import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.bookmarks.locations.BookmarkLocationsFragment;
 import fr.free.nrw.commons.bookmarks.pictures.BookmarkPicturesFragment;
 
-public class BookmarksPagerAdapter extends FragmentPagerAdapter {
+class BookmarksPagerAdapter extends FragmentPagerAdapter {
 
-    private ArrayList<BookmarkPages> pages;
+    private final ArrayList<BookmarkPages> pages;
 
     BookmarksPagerAdapter(FragmentManager fm, Context context) {
         super(fm);
@@ -32,6 +33,7 @@ public class BookmarksPagerAdapter extends FragmentPagerAdapter {
     }
 
     @Override
+    @NonNull
     public Fragment getItem(int position) {
         return pages.get(position).getPage();
     }
@@ -51,7 +53,7 @@ public class BookmarksPagerAdapter extends FragmentPagerAdapter {
      * Return the Adapter used to display the picture gridview
      * @return adapter
      */
-    public ListAdapter getMediaAdapter() {
+    ListAdapter getMediaAdapter() {
         BookmarkPicturesFragment fragment = (BookmarkPicturesFragment)(pages.get(0).getPage());
         return fragment.getAdapter();
     }
@@ -59,7 +61,7 @@ public class BookmarksPagerAdapter extends FragmentPagerAdapter {
     /**
      * Update the pictures list for the bookmark fragment
      */
-    public void requestPictureListUpdate() {
+    void requestPictureListUpdate() {
         BookmarkPicturesFragment fragment = (BookmarkPicturesFragment)(pages.get(0).getPage());
         fragment.onResume();
     }

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsController.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsController.java
@@ -8,19 +8,21 @@ import javax.inject.Singleton;
 import fr.free.nrw.commons.nearby.Place;
 
 @Singleton
-public class BookmarkLocationsController {
+class BookmarkLocationsController {
 
     @Inject
     BookmarkLocationsDao bookmarkLocationDao;
 
     @Inject
-    public BookmarkLocationsController() {}
+    public BookmarkLocationsController() {
+        // for injector
+    }
 
     /**
      * Load from DB the bookmarked locations
      * @return a list of Place objects.
      */
-    public List<Place> loadFavoritesLocations() {
+    List<Place> loadFavoritesLocations() {
         return bookmarkLocationDao.getAllBookmarksLocations();
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsFragment.java
@@ -60,7 +60,7 @@ public class BookmarkLocationsFragment extends DaggerFragment {
     }
 
     @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         progressBar.setVisibility(View.VISIBLE);
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
@@ -80,7 +80,7 @@ public class BookmarkLocationsFragment extends DaggerFragment {
         List<Place> places = controller.loadFavoritesLocations();
         adapterFactory.updateAdapterData(places, (RVRendererAdapter<Place>) recyclerView.getAdapter());
         progressBar.setVisibility(View.GONE);
-        if (places.size() <= 0) {
+        if (places.isEmpty()) {
             statusTextView.setText(R.string.bookmark_empty);
             statusTextView.setVisibility(View.VISIBLE);
         } else {

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/pictures/BookmarkPicturesDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/pictures/BookmarkPicturesDao.java
@@ -7,6 +7,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.os.RemoteException;
 import androidx.annotation.NonNull;
 import fr.free.nrw.commons.bookmarks.Bookmark;
+import fr.free.nrw.commons.data.DAOException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,24 +37,20 @@ public class BookmarkPicturesDao {
     @NonNull
     public List<Bookmark> getAllBookmarks() {
         List<Bookmark> items = new ArrayList<>();
-        Cursor cursor = null;
         ContentProviderClient db = clientProvider.get();
-        try {
-            cursor = db.query(
+        try (Cursor cursor = db.query(
                     BookmarkPicturesContentProvider.BASE_URI,
                     Table.ALL_FIELDS,
                     null,
                     new String[]{},
-                    null);
+                    null)) {
+
             while (cursor != null && cursor.moveToNext()) {
                 items.add(fromCursor(cursor));
             }
         } catch (RemoteException e) {
-            throw new RuntimeException(e);
+            throw new DAOException(e);
         } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
             db.release();
         }
         return items;
@@ -86,7 +83,7 @@ public class BookmarkPicturesDao {
         try {
             db.insert(BASE_URI, toContentValues(bookmark));
         } catch (RemoteException e) {
-            throw new RuntimeException(e);
+            throw new DAOException(e);
         } finally {
             db.release();
         }
@@ -101,12 +98,12 @@ public class BookmarkPicturesDao {
         ContentProviderClient db = clientProvider.get();
         try {
             if (bookmark.getContentUri() == null) {
-                throw new RuntimeException("tried to delete item with no content URI");
+                throw new DAOException("tried to delete item with no content URI");
             } else {
                 db.delete(bookmark.getContentUri(), null, null);
             }
         } catch (RemoteException e) {
-            throw new RuntimeException(e);
+            throw new DAOException(e);
         } finally {
             db.release();
         }
@@ -123,25 +120,21 @@ public class BookmarkPicturesDao {
             return false;
         }
 
-        Cursor cursor = null;
         ContentProviderClient db = clientProvider.get();
-        try {
-            cursor = db.query(
+        try (Cursor cursor = db.query(
                     BookmarkPicturesContentProvider.BASE_URI,
                     Table.ALL_FIELDS,
                     Table.COLUMN_MEDIA_NAME + "=?",
                     new String[]{bookmark.getMediaName()},
-                    null);
+                    null)) {
+
             if (cursor != null && cursor.moveToFirst()) {
                 return true;
             }
         } catch (RemoteException e) {
             // This feels lazy, but to hell with checked exceptions. :)
-            throw new RuntimeException(e);
+            throw new DAOException(e);
         } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
             db.release();
         }
         return false;
@@ -172,7 +165,7 @@ public class BookmarkPicturesDao {
         public static final String COLUMN_CREATOR = "media_creator";
 
         // NOTE! KEEP IN SAME ORDER AS THEY ARE DEFINED UP THERE. HELPS HARD CODE COLUMN INDICES.
-        public static final String[] ALL_FIELDS = {
+        static final String[] ALL_FIELDS = {
                 COLUMN_MEDIA_NAME,
                 COLUMN_CREATOR
         };
@@ -180,9 +173,12 @@ public class BookmarkPicturesDao {
         public static final String DROP_TABLE_STATEMENT = "DROP TABLE IF EXISTS " + TABLE_NAME;
 
         public static final String CREATE_TABLE_STATEMENT = "CREATE TABLE " + TABLE_NAME + " ("
-                + COLUMN_MEDIA_NAME + " STRING PRIMARY KEY,"
-                + COLUMN_CREATOR + " STRING"
+                + COLUMN_MEDIA_NAME + " TEXT PRIMARY KEY,"
+                + COLUMN_CREATOR + " TEXT"
                 + ");";
+
+        private Table() {
+        }
 
         public static void onCreate(SQLiteDatabase db) {
             db.execSQL(CREATE_TABLE_STATEMENT);
@@ -215,7 +211,6 @@ public class BookmarkPicturesDao {
             if (from == 8) {
                 from++;
                 onUpdate(db, from, to);
-                return;
             }
         }
     }

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/pictures/BookmarkPicturesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/pictures/BookmarkPicturesFragment.java
@@ -41,7 +41,7 @@ public class BookmarkPicturesFragment extends DaggerFragment {
     private static final int TIMEOUT_SECONDS = 15;
 
     private GridViewAdapter gridAdapter;
-    private CompositeDisposable compositeDisposable = new CompositeDisposable();
+    private final CompositeDisposable compositeDisposable = new CompositeDisposable();
 
     @BindView(R.id.statusMessage) TextView statusTextView;
     @BindView(R.id.loadingImagesProgressBar) ProgressBar progressBar;
@@ -71,7 +71,7 @@ public class BookmarkPicturesFragment extends DaggerFragment {
     }
 
     @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         gridView.setOnItemClickListener((AdapterView.OnItemClickListener) getActivity());
         initList();
@@ -99,7 +99,7 @@ public class BookmarkPicturesFragment extends DaggerFragment {
                 try {
                     ((BookmarksActivity) getContext()).viewPagerNotifyDataSetChanged();
                 }catch (Exception e){
-                    e.printStackTrace();
+                    Timber.e(e);
                 }
             }
             initList();
@@ -150,7 +150,7 @@ public class BookmarkPicturesFragment extends DaggerFragment {
             ViewUtil.showShortSnackbar(parentLayout, R.string.error_loading_images);
             initErrorView();
         }catch (Exception e){
-            e.printStackTrace();
+            Timber.e(e);
         }
     }
 
@@ -204,8 +204,8 @@ public class BookmarkPicturesFragment extends DaggerFragment {
             gridAdapter.addItems(collection);
             try {
                 ((BookmarksActivity) getContext()).viewPagerNotifyDataSetChanged();
-            }catch (Exception e){
-                e.printStackTrace();
+            } catch (Exception e){
+                Timber.e(e);
             }
         }
         progressBar.setVisibility(GONE);

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesAdapterFactory.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesAdapterFactory.java
@@ -6,7 +6,7 @@ import com.pedrogomez.renderers.RendererBuilder;
 import java.util.Collections;
 import java.util.List;
 
-public class CategoriesAdapterFactory {
+class CategoriesAdapterFactory {
     private final CategoryClickedListener listener;
 
     public CategoriesAdapterFactory(CategoryClickedListener listener) {
@@ -17,7 +17,7 @@ public class CategoriesAdapterFactory {
         RendererBuilder<CategoryItem> builder = new RendererBuilder<CategoryItem>()
                 .bind(CategoryItem.class, new CategoriesRenderer(listener));
         ListAdapteeCollection<CategoryItem> collection = new ListAdapteeCollection<>(
-                placeList != null ? placeList : Collections.<CategoryItem>emptyList());
+                placeList != null ? placeList : Collections.emptyList());
         return new CategoryRendererAdapter(builder, collection);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
@@ -8,7 +8,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-
+import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -21,15 +21,15 @@ import timber.log.Timber;
 /**
  * The model class for categories in upload
  */
-public class CategoriesModel{
+public class CategoriesModel {
     private static final int SEARCH_CATS_LIMIT = 25;
 
     private final CategoryClient categoryClient;
     private final CategoryDao categoryDao;
     private final JsonKvStore directKvStore;
 
-    private HashMap<String, ArrayList<String>> categoriesCache;
-    private List<CategoryItem> selectedCategories;
+    private final Map<String, ArrayList<String>> categoriesCache;
+    private final List<CategoryItem> selectedCategories;
 
     @Inject GpsCategoryModel gpsCategoryModel;
     @Inject
@@ -82,7 +82,7 @@ public class CategoriesModel{
      * Updates category count in category dao
      * @param item
      */
-    public void updateCategoryCount(CategoryItem item) {
+    private void updateCategoryCount(CategoryItem item) {
         Category category = categoryDao.find(item.getName());
 
         // Newly used category...
@@ -94,7 +94,7 @@ public class CategoriesModel{
         categoryDao.save(category);
     }
 
-    boolean cacheContainsKey(String term) {
+    private boolean cacheContainsKey(String term) {
         return categoriesCache.containsKey(term);
     }
     //endregion
@@ -111,7 +111,7 @@ public class CategoriesModel{
             Observable<CategoryItem> categoryItemObservable = gpsCategories()
                     .concatWith(titleCategories(imageTitleList));
             if (hasDirectCategories()) {
-                categoryItemObservable.concatWith(directCategories().concatWith(recentCategories()));
+                categoryItemObservable = categoryItemObservable.concatWith(directCategories().concatWith(recentCategories()));
             }
             return categoryItemObservable;
         }
@@ -153,11 +153,11 @@ public class CategoriesModel{
     private Observable<CategoryItem> directCategories() {
         String directCategory = directKvStore.getString("Category", "");
         List<String> categoryList = new ArrayList<>();
-        Timber.d("Direct category found: " + directCategory);
+        Timber.d("Direct category found: %s", directCategory);
 
         if (!directCategory.equals("")) {
             categoryList.add(directCategory);
-            Timber.d("DirectCat does not equal emptyString. Direct Cat list has " + categoryList);
+            Timber.d("DirectCat does not equal emptyString. Direct Cat list has %s", categoryList);
         }
         return Observable.fromIterable(categoryList).map(name -> new CategoryItem(name, false));
     }
@@ -166,7 +166,7 @@ public class CategoriesModel{
      * Returns GPS categories
      * @return
      */
-    Observable<CategoryItem> gpsCategories() {
+    private Observable<CategoryItem> gpsCategories() {
         return Observable.fromIterable(gpsCategoryModel.getCategoryList())
                 .map(name -> new CategoryItem(name, false));
     }
@@ -217,7 +217,7 @@ public class CategoriesModel{
      * Select's category
      * @param item
      */
-    public void selectCategory(CategoryItem item) {
+    private void selectCategory(CategoryItem item) {
         selectedCategories.add(item);
     }
 
@@ -225,7 +225,7 @@ public class CategoriesModel{
      * Unselect Category
      * @param item
      */
-    public void unselectCategory(CategoryItem item) {
+    private void unselectCategory(CategoryItem item) {
         selectedCategories.remove(item);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -2,7 +2,6 @@ package fr.free.nrw.commons.category;
 
 import android.content.Context;
 import android.content.Intent;
-import android.database.DataSetObserver;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.Menu;
@@ -39,6 +38,7 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
         implements MediaDetailPagerFragment.MediaDetailProvider,
                     AdapterView.OnItemClickListener{
 
+    private static final String CATEGORY_NAME = "categoryName";
 
     private FragmentManager supportFragmentManager;
     private CategoryImagesListFragment categoryImagesListFragment;
@@ -48,7 +48,7 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
     @BindView(R.id.tab_layout) TabLayout tabLayout;
     @BindView(R.id.viewPager) ViewPager viewPager;
 
-    ViewPagerAdapter viewPagerAdapter;
+    private ViewPagerAdapter viewPagerAdapter;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -76,15 +76,15 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
         categoryImagesListFragment = new CategoryImagesListFragment();
         SubCategoryListFragment subCategoryListFragment = new SubCategoryListFragment();
         SubCategoryListFragment parentCategoryListFragment = new SubCategoryListFragment();
-        categoryName = getIntent().getStringExtra("categoryName");
+        categoryName = getIntent().getStringExtra(CATEGORY_NAME);
         if (getIntent() != null && categoryName != null) {
             Bundle arguments = new Bundle();
-            arguments.putString("categoryName", categoryName);
+            arguments.putString(CATEGORY_NAME, categoryName);
             arguments.putBoolean("isParentCategory", false);
             categoryImagesListFragment.setArguments(arguments);
             subCategoryListFragment.setArguments(arguments);
             Bundle parentCategoryArguments = new Bundle();
-            parentCategoryArguments.putString("categoryName", categoryName);
+            parentCategoryArguments.putString(CATEGORY_NAME, categoryName);
             parentCategoryArguments.putBoolean("isParentCategory", true);
             parentCategoryListFragment.setArguments(parentCategoryArguments);
         }
@@ -103,8 +103,8 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
      * Gets the passed categoryName from the intents and displays it as the page title
      */
     private void setPageTitle() {
-        if (getIntent() != null && getIntent().getStringExtra("categoryName") != null) {
-            setTitle(getIntent().getStringExtra("categoryName"));
+        if (getIntent() != null && getIntent().getStringExtra(CATEGORY_NAME) != null) {
+            setTitle(getIntent().getStringExtra(CATEGORY_NAME));
         }
     }
 
@@ -119,13 +119,13 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
         if (mediaDetails == null || !mediaDetails.isVisible()) {
             // set isFeaturedImage true for featured images, to include author field on media detail
             mediaDetails = new MediaDetailPagerFragment(false, true);
-            FragmentManager supportFragmentManager = getSupportFragmentManager();
-            supportFragmentManager
+            FragmentManager fragmentManager = getSupportFragmentManager();
+            fragmentManager
                     .beginTransaction()
                     .replace(R.id.mediaContainer, mediaDetails)
                     .addToBackStack(null)
                     .commit();
-            supportFragmentManager.executePendingTransactions();
+            fragmentManager.executePendingTransactions();
         }
         mediaDetails.showImage(i);
         forceInitBackButton();
@@ -140,7 +140,7 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
     public static void startYourself(Context context, String categoryName) {
         Intent intent = new Intent(context, CategoryDetailsActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        intent.putExtra("categoryName", categoryName);
+        intent.putExtra(CATEGORY_NAME, categoryName);
         context.startActivity(intent);
     }
 
@@ -191,12 +191,11 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
     public boolean onOptionsItemSelected(MenuItem item) {
 
         // Handle item selection
-        switch (item.getItemId()) {
-            case R.id.menu_browser_current_category:
-                Utils.handleWebUrl(this, Uri.parse(Utils.getPageTitle(categoryName).getCanonicalUri()));
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
+        if (item.getItemId() == R.id.menu_browser_current_category) {
+            Utils.handleWebUrl(this, Uri.parse(Utils.getPageTitle(categoryName).getCanonicalUri()));
+            return true;
+        } else {
+            return super.onOptionsItemSelected(item);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesActivity.java
@@ -32,6 +32,8 @@ public class CategoryImagesActivity
                     MediaDetailPagerFragment.MediaDetailProvider,
                     AdapterView.OnItemClickListener{
 
+    private static final String CATEGORY_NAME = "categoryName";
+    private static final String TITLE = "title";
 
     private FragmentManager supportFragmentManager;
     private CategoryImagesListFragment categoryImagesListFragment;
@@ -67,10 +69,10 @@ public class CategoryImagesActivity
      */
     private void setCategoryImagesFragment() {
         categoryImagesListFragment = new CategoryImagesListFragment();
-        String categoryName = getIntent().getStringExtra("categoryName");
+        String categoryName = getIntent().getStringExtra(CATEGORY_NAME);
         if (getIntent() != null && categoryName != null) {
             Bundle arguments = new Bundle();
-            arguments.putString("categoryName", categoryName);
+            arguments.putString(CATEGORY_NAME, categoryName);
             categoryImagesListFragment.setArguments(arguments);
             FragmentTransaction transaction = supportFragmentManager.beginTransaction();
             transaction
@@ -83,13 +85,14 @@ public class CategoryImagesActivity
      * Gets the passed title from the intents and displays it as the page title
      */
     private void setPageTitle() {
-        if (getIntent() != null && getIntent().getStringExtra("title") != null) {
-            setTitle(getIntent().getStringExtra("title"));
+        if (getIntent() != null && getIntent().getStringExtra(TITLE) != null) {
+            setTitle(getIntent().getStringExtra(TITLE));
         }
     }
 
     @Override
     public void onBackStackChanged() {
+        // do nothing
     }
 
     /**
@@ -100,10 +103,10 @@ public class CategoryImagesActivity
         if (mediaDetails == null || !mediaDetails.isVisible()) {
             // set isFeaturedImage true for featured images, to include author field on media detail
             mediaDetails = new MediaDetailPagerFragment(false, true);
-            FragmentManager supportFragmentManager = getSupportFragmentManager();
-            supportFragmentManager
+            FragmentManager fragmentManager = getSupportFragmentManager();
+            fragmentManager
                     .beginTransaction()
-                    .hide(supportFragmentManager.getFragments().get(supportFragmentManager.getBackStackEntryCount()))
+                    .hide(fragmentManager.getFragments().get(fragmentManager.getBackStackEntryCount()))
                     .add(R.id.fragmentContainer, mediaDetails)
                     .addToBackStack(null)
                     .commit();
@@ -124,8 +127,8 @@ public class CategoryImagesActivity
     public static void startYourself(Context context, String title, String categoryName) {
         Intent intent = new Intent(context, CategoryImagesActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        intent.putExtra("title", title);
-        intent.putExtra("categoryName", categoryName);
+        intent.putExtra(TITLE, title);
+        intent.putExtra(CATEGORY_NAME, categoryName);
         context.startActivity(intent);
     }
 
@@ -186,12 +189,11 @@ public class CategoryImagesActivity
     public boolean onOptionsItemSelected(MenuItem item) {
 
         // Handle item selection
-        switch (item.getItemId()) {
-            case R.id.action_search:
-                NavigationBaseActivity.startActivityWithFlags(this, SearchActivity.class);
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
+        if (item.getItemId() == R.id.action_search) {
+            NavigationBaseActivity.startActivityWithFlags(this, SearchActivity.class);
+            return true;
+        } else {
+            return super.onOptionsItemSelected(item);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -43,7 +44,7 @@ import static android.view.View.VISIBLE;
  */
 public class CategoryImagesListFragment extends DaggerFragment {
 
-    private static int TIMEOUT_SECONDS = 15;
+    private static final int TIMEOUT_SECONDS = 15;
 
     private GridViewAdapter gridAdapter;
 
@@ -52,7 +53,7 @@ public class CategoryImagesListFragment extends DaggerFragment {
     @BindView(R.id.loadingImagesProgressBar) ProgressBar progressBar;
     @BindView(R.id.categoryImagesList) GridView gridView;
     @BindView(R.id.parentLayout) RelativeLayout parentLayout;
-    private CompositeDisposable compositeDisposable = new CompositeDisposable();
+    private final CompositeDisposable compositeDisposable = new CompositeDisposable();
     private boolean hasMoreImages = true;
     private boolean isLoading = true;
     private String categoryName = null;
@@ -70,7 +71,7 @@ public class CategoryImagesListFragment extends DaggerFragment {
     }
 
     @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         gridView.setOnItemClickListener((AdapterView.OnItemClickListener) getActivity());
         initViews();
@@ -143,11 +144,11 @@ public class CategoryImagesListFragment extends DaggerFragment {
      */
     private void handleError(Throwable throwable) {
         Timber.e(throwable, "Error occurred while loading images inside a category");
-        try{
+        try {
             ViewUtil.showShortSnackbar(parentLayout, R.string.error_loading_images);
             initErrorView();
-        }catch (Exception e){
-            e.printStackTrace();
+        } catch (Exception e){
+            Timber.e(e);
         }
 
     }
@@ -183,6 +184,7 @@ public class CategoryImagesListFragment extends DaggerFragment {
         gridView.setOnScrollListener(new AbsListView.OnScrollListener() {
             @Override
             public void onScrollStateChanged(AbsListView view, int scrollState) {
+                // do nothing
             }
 
             @Override
@@ -252,18 +254,18 @@ public class CategoryImagesListFragment extends DaggerFragment {
             gridAdapter.addItems(collection);
             try {
                 ((CategoryImagesActivity) getContext()).viewPagerNotifyDataSetChanged();
-            }catch (Exception e){
-                e.printStackTrace();
+            } catch (Exception e) {
+                Timber.e(e);
             }
             try {
                 ((CategoryDetailsActivity) getContext()).viewPagerNotifyDataSetChanged();
-            }catch (Exception e){
-                e.printStackTrace();
+            } catch (Exception e) {
+                Timber.e(e);
             }
             try {
                 ((ExploreActivity) getContext()).viewPagerNotifyDataSetChanged();
-            }catch (Exception e){
-                e.printStackTrace();
+            } catch (Exception e) {
+                Timber.e(e);
             }
         }
         progressBar.setVisibility(GONE);

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryItem.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryItem.java
@@ -3,11 +3,13 @@ package fr.free.nrw.commons.category;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import androidx.annotation.NonNull;
+
 public class CategoryItem implements Parcelable {
     private final String name;
     private boolean selected;
 
-    public static Creator<CategoryItem> CREATOR = new Creator<CategoryItem>() {
+    public static final Creator<CategoryItem> CREATOR = new Creator<CategoryItem>() {
         @Override
         public CategoryItem createFromParcel(Parcel parcel) {
             return new CategoryItem(parcel);
@@ -73,6 +75,7 @@ public class CategoryItem implements Parcelable {
     }
 
     @Override
+    @NonNull
     public String toString() {
         return "CategoryItem: '" + name + '\'';
     }

--- a/app/src/main/java/fr/free/nrw/commons/category/GridViewAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/GridViewAdapter.java
@@ -8,6 +8,9 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.facebook.drawee.view.SimpleDraweeView;
 
 import java.util.ArrayList;
@@ -21,7 +24,7 @@ import fr.free.nrw.commons.R;
  * This is created to only display UI implementation. Needs to be changed in real implementation
  */
 
-public class GridViewAdapter extends ArrayAdapter {
+public class GridViewAdapter extends ArrayAdapter<Media> {
     private List<Media> data;
 
     public GridViewAdapter(Context context, int layoutResourceId, List<Media> data) {
@@ -55,7 +58,7 @@ public class GridViewAdapter extends ArrayAdapter {
             data = new ArrayList<>();
             return false;
         }
-        if (data.size() <= 0) {
+        if (data.isEmpty()) {
             return false;
         }
         String fileName = data.get(0).getFilename();
@@ -75,8 +78,9 @@ public class GridViewAdapter extends ArrayAdapter {
      * @param parent
      * @return
      */
+    @NonNull
     @Override
-    public View getView(int position, View convertView, ViewGroup parent) {
+    public View getView(int position, View convertView, @Nullable ViewGroup parent) {
 
         if (convertView == null) {
             convertView = LayoutInflater.from(getContext()).inflate(R.layout.layout_category_images, null);

--- a/app/src/main/java/fr/free/nrw/commons/category/QueryContinue.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/QueryContinue.java
@@ -5,8 +5,8 @@ package fr.free.nrw.commons.category;
  * https://www.mediawiki.org/wiki/API:Raw_query_continue
  */
 public class QueryContinue {
-    private String continueParam;
-    private String gcmContinueParam;
+    private final String continueParam;
+    private final String gcmContinueParam;
 
     public QueryContinue(String continueParam, String gcmContinueParam) {
         this.continueParam = continueParam;

--- a/app/src/main/java/fr/free/nrw/commons/category/SubCategoryListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/SubCategoryListFragment.java
@@ -42,7 +42,7 @@ import static android.view.View.VISIBLE;
 
 public class SubCategoryListFragment extends CommonsDaggerSupportFragment {
 
-    private static int TIMEOUT_SECONDS = 15;
+    private static final int TIMEOUT_SECONDS = 15;
 
     @BindView(R.id.imagesListBox)
     RecyclerView categoriesRecyclerView;
@@ -88,7 +88,7 @@ public class SubCategoryListFragment extends CommonsDaggerSupportFragment {
      * Checks for internet connection and then initializes the recycler view with all(max 500) categories of the searched query
      * Clearing categoryAdapter every time new keyword is searched so that user can see only new results
      */
-    public void initSubCategoryList() {
+    private void initSubCategoryList() {
         categoriesNotFoundView.setVisibility(GONE);
         if (!NetworkUtils.isInternetConnectionEstablished(getContext())) {
             handleNoInternet();

--- a/app/src/main/java/fr/free/nrw/commons/data/DAOException.java
+++ b/app/src/main/java/fr/free/nrw/commons/data/DAOException.java
@@ -1,0 +1,12 @@
+package fr.free.nrw.commons.data;
+
+public class DAOException extends RuntimeException {
+
+    public DAOException(String message) {
+        super(message);
+    }
+
+    public DAOException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/locations/BookMarkLocationDaoTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/locations/BookMarkLocationDaoTest.kt
@@ -8,7 +8,6 @@ import android.database.sqlite.SQLiteDatabase
 import android.net.Uri
 import android.os.RemoteException
 import com.nhaarman.mockito_kotlin.*
-import fr.free.nrw.commons.BuildConfig
 import fr.free.nrw.commons.TestCommonsApplication
 import fr.free.nrw.commons.bookmarks.locations.BookmarkLocationsContentProvider.BASE_URI
 import fr.free.nrw.commons.bookmarks.locations.BookmarkLocationsDao.Table.*
@@ -16,7 +15,7 @@ import fr.free.nrw.commons.location.LatLng
 import fr.free.nrw.commons.nearby.Label
 import fr.free.nrw.commons.nearby.Place
 import fr.free.nrw.commons.nearby.Sitelinks
-import junit.framework.Assert.*
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -88,8 +87,8 @@ class BookMarkLocationDaoTest {
                 assertEquals("placeName", it.name)
                 assertEquals(Label.FOREST, it.label)
                 assertEquals("placeDescription", it.longDescription)
-                assertEquals(40.0, it.location.latitude)
-                assertEquals(51.4, it.location.longitude)
+                assertEquals(40.0, it.location.latitude, 0.00000001)
+                assertEquals(51.4, it.location.longitude, 0.00000001)
                 assertEquals("placeCategory", it.category)
                 assertEquals(builder.build().wikipediaLink, it.siteLinks.wikipediaLink)
                 assertEquals(builder.build().wikidataLink, it.siteLinks.wikidataLink)
@@ -151,8 +150,8 @@ class BookMarkLocationDaoTest {
             assertEquals(examplePlaceBookmark.longDescription, cv.getAsString(COLUMN_DESCRIPTION))
             assertEquals(examplePlaceBookmark.label.text, cv.getAsString(COLUMN_LABEL_TEXT))
             assertEquals(examplePlaceBookmark.category, cv.getAsString(COLUMN_CATEGORY))
-            assertEquals(examplePlaceBookmark.location.latitude, cv.getAsDouble(COLUMN_LAT))
-            assertEquals(examplePlaceBookmark.location.longitude, cv.getAsDouble(COLUMN_LONG))
+            assertEquals(examplePlaceBookmark.location.latitude, cv.getAsDouble(COLUMN_LAT), 0.00000001)
+            assertEquals(examplePlaceBookmark.location.longitude, cv.getAsDouble(COLUMN_LONG), 0.00000001)
             assertEquals(examplePlaceBookmark.siteLinks.wikipediaLink.toString(), cv.getAsString(COLUMN_WIKIPEDIA_LINK))
             assertEquals(examplePlaceBookmark.siteLinks.wikidataLink.toString(), cv.getAsString(COLUMN_WIKIDATA_LINK))
             assertEquals(examplePlaceBookmark.siteLinks.commonsLink.toString(), cv.getAsString(COLUMN_COMMONS_LINK))

--- a/app/src/test/kotlin/fr/free/nrw/commons/review/ReviewHelperTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/review/ReviewHelperTest.kt
@@ -4,8 +4,8 @@ import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.media.MediaClient
 import io.reactivex.Observable
 import io.reactivex.Single
-import junit.framework.Assert.assertNotNull
-import junit.framework.Assert.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/FileMetadataUtilsTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/FileMetadataUtilsTest.kt
@@ -1,7 +1,7 @@
 package fr.free.nrw.commons.upload
 
 import androidx.exifinterface.media.ExifInterface.*
-import junit.framework.Assert.assertTrue
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.*
 


### PR DESCRIPTION
**Description (required)**

Fixes part of #171 Fix Lint errors/warnings

Fixing Some Android Lint and SonarLint Warnings in these packages:
* `fr.free.nrw.commons.bookmarks`
* `fr.free.nrw.commons.bookmarks.locations`
* `fr.free.nrw.commons.bookmarks.pictures`
* `fr.free.nrw.commons.category`

Some of the changes were:
* Switching the try/catch/finally blocks for database querying into try-with-resources blocks, with the `Cursor` object getting set as the closable resource
* Switching a lot of field types in the sqlite "Create Table Statements" from STRING to TEXT
* Creating `DAOException` and throwing that instead of a generic `RuntimeException` in a few places ([SonarLint: RSPEC-112](https://rules.sonarsource.com/java/RSPEC-112))
* Logging some Exceptions using Timber instead of `e.printStackTrace()` ([SonarLint: RSPEC-1148](https://rules.sonarsource.com/java/RSPEC-1148))
* Changing a few access modifiers to be more restrictive
* Adding `final` to a few variables that are never changed
* Adding a private constructor to some utility or static inner classes ([SonarLint: RSPEC-1118](https://rules.sonarsource.com/java/RSPEC-1118)) 
* Made some constant String variables for recurring Strings ([SonarLint: RSPEC-1192](https://rules.sonarsource.com/java/RSPEC-1192))
* Changing the switch cases with only one case into if/else statements ([SonarLint: RSPEC-1301](https://rules.sonarsource.com/java/RSPEC-1301))
* Adding some `@NonNull` and `@Nullable` annotations to methods that inherit methods that use those annotations
* Replacing some `junit.framework` package imports in some Kotlin test classes with `org.junit` because the former is deprecated

**Tests performed (required)**
Ran the Gradle Tests and Tested ProdDebug on the Nexus 6 Emulator with API level 22.

---

Please let me know if there's anything I should change back or if there's anything I should elaborate on!
