### PR TITLE
Removes the "Other" deletion option mentioned in #3174

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/delete/DeleteHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/delete/DeleteHelper.java
@@ -158,19 +158,17 @@ public class DeleteHelper {
         boolean[] checkedItems = {false, false, false, false};
         ArrayList<Integer> mUserReason = new ArrayList<>();
 
-        String[] reasonList = {"Reason 1", "Reason 2", "Reason 3", "Reason 4"};
+        String[] reasonList = {"Reason 1", "Reason 2", "Reason 3"};
 
 
         if (problem == ReviewController.DeleteReason.SPAM) {
             reasonList[0] = context.getString(R.string.delete_helper_ask_spam_selfie);
             reasonList[1] = context.getString(R.string.delete_helper_ask_spam_blurry);
             reasonList[2] = context.getString(R.string.delete_helper_ask_spam_nonsense);
-            reasonList[3] = context.getString(R.string.delete_helper_ask_spam_other);
         } else if (problem == ReviewController.DeleteReason.COPYRIGHT_VIOLATION) {
             reasonList[0] = context.getString(R.string.delete_helper_ask_reason_copyright_press_photo);
             reasonList[1] = context.getString(R.string.delete_helper_ask_reason_copyright_internet_photo);
             reasonList[2] = context.getString(R.string.delete_helper_ask_reason_copyright_logo);
-            reasonList[3] = context.getString(R.string.delete_helper_ask_reason_copyright_other);
         }
 
         alert.setMultiChoiceItems(reasonList, checkedItems, (dialogInterface, position, isChecked) -> {


### PR DESCRIPTION
**Removes the "Other" deletion option**

Fixes #3174 Items of Delete.Reason need to be changed

I removed the "Other" option on both "SPAM" and "COPYRIGHT_VIOLATION" reason dialog to keep the actual deletion reason efficient (see #3174)

As @misaochan wrote, this is a temporary fix and the issue should be kept open until a proper solution come along.

**Tests performed (required)**
Reviewed some images. After clicking the "No, out of scope" or "No, copyright violation" button, dialog doesn't show the "Other" option.

Tested betaDebug on Nexus 6P with API level 27.
Tested prodDebug on Nexus 6P with API level 27.
Tested prodDebug on Samsung Galaxy S7 API level 26.

**Screenshots showing what changed (optional - for UI changes)**
![Screenshot_1571863427](https://user-images.githubusercontent.com/7251970/67432593-cc470380-f5e6-11e9-8b5a-1611c7d782db.png)
![Screenshot_1571863419](https://user-images.githubusercontent.com/7251970/67432594-cc470380-f5e6-11e9-8bc8-465309955c90.png)