### PR TITLE
Issue #171 - Fixing Some Lint Warnings 2

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
@@ -5,13 +5,10 @@ import android.net.Uri;
 import android.os.Parcel;
 
 import org.apache.commons.lang3.StringUtils;
-import org.wikipedia.util.DateUtil;
 
 import java.lang.annotation.Retention;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
-import java.util.TimeZone;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.StringDef;
@@ -23,7 +20,7 @@ import fr.free.nrw.commons.utils.ConfigUtils;
 
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
-public class  Contribution extends Media {
+public class Contribution extends Media {
 
     //{{According to EXIF data|2009-01-09}}
     private static final String TEMPLATE_DATE_ACC_TO_EXIF = "{{According to EXIF data|%s}}";
@@ -31,7 +28,7 @@ public class  Contribution extends Media {
     //{{date|2009|1|9}} → 9 January 2009
     private static final String TEMPLATE_DATA_OTHER_SOURCE = "{{date|%s}}";
 
-    public static Creator<Contribution> CREATOR = new Creator<Contribution>() {
+    public static final Creator<Contribution> CREATOR = new Creator<Contribution>() {
         @Override
         public Contribution createFromParcel(Parcel parcel) {
             return new Contribution(parcel);
@@ -101,7 +98,7 @@ public class  Contribution extends Media {
         this.state=state;
     }
 
-    public Contribution(Parcel in) {
+    private Contribution(Parcel in) {
         super(in);
         contentUri = in.readParcelable(Uri.class.getClassLoader());
         source = in.readString();
@@ -193,7 +190,7 @@ public class  Contribution extends Media {
                 .append(licenseTemplateFor(getLicense())).append("\n\n")
                 .append("{{Uploaded from Mobile|platform=Android|version=")
                 .append(ConfigUtils.getVersionNameWithSha(applicationContext)).append("}}\n");
-        if(categories!=null&&categories.size()!=0) {
+        if (categories != null && !categories.isEmpty()) {
             for (int i = 0; i < categories.size(); i++) {
                 String category = categories.get(i);
                 buffer.append("\n[[Category:").append(category).append("]]");
@@ -229,7 +226,7 @@ public class  Contribution extends Media {
         this.imageUrl = imageUrl;
     }
 
-    public Contribution() {
+    protected Contribution() {
 
     }
 
@@ -262,9 +259,9 @@ public class  Contribution extends Media {
                 return "{{self|cc-by-sa-4.0}}";
             case Prefs.Licenses.CC0:
                 return "{{self|cc-zero}}";
+            default:
+                throw new RuntimeException("Unrecognized license value: " + license);
         }
-
-        throw new RuntimeException("Unrecognized license value: " + license);
     }
 
     public String getWikiDataEntityId() {

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionDao.java
@@ -9,6 +9,7 @@ import android.net.Uri;
 import android.os.RemoteException;
 import androidx.annotation.Nullable;
 import android.text.TextUtils;
+import fr.free.nrw.commons.data.DAOException;
 import fr.free.nrw.commons.settings.Prefs;
 
 import org.apache.commons.lang3.StringUtils;
@@ -65,7 +66,7 @@ public class ContributionDao {
                 db.update(contribution.getContentUri(), toContentValues(contribution), null, null);
             }
         } catch (RemoteException e) {
-            throw new RuntimeException(e);
+            throw new DAOException(e);
         } finally {
             db.release();
         }
@@ -76,12 +77,12 @@ public class ContributionDao {
         try {
             if (contribution.getContentUri() == null) {
                 // noooo
-                throw new RuntimeException("tried to delete item with no content URI");
+                throw new DAOException("tried to delete item with no content URI");
             } else {
                 db.delete(contribution.getContentUri(), null, null);
             }
         } catch (RemoteException e) {
-            throw new RuntimeException(e);
+            throw new DAOException(e);
         } finally {
             db.release();
         }
@@ -169,7 +170,7 @@ public class ContributionDao {
         public static final String TABLE_NAME = "contributions";
 
         public static final String COLUMN_ID = "_id";
-        public static final String COLUMN_FILENAME = "filename";
+        static final String COLUMN_FILENAME = "filename";
         public static final String COLUMN_LOCAL_URI = "local_uri";
         public static final String COLUMN_IMAGE_URL = "image_url";
         public static final String COLUMN_TIMESTAMP = "timestamp";
@@ -184,10 +185,10 @@ public class ContributionDao {
         public static final String COLUMN_WIDTH = "width";
         public static final String COLUMN_HEIGHT = "height";
         public static final String COLUMN_LICENSE = "license";
-        public static final String COLUMN_WIKI_DATA_ENTITY_ID = "wikidataEntityID";
+        static final String COLUMN_WIKI_DATA_ENTITY_ID = "wikidataEntityID";
 
         // NOTE! KEEP IN SAME ORDER AS THEY ARE DEFINED UP THERE. HELPS HARD CODE COLUMN INDICES.
-        public static final String[] ALL_FIELDS = {
+        protected static final String[] ALL_FIELDS = {
                 COLUMN_ID,
                 COLUMN_FILENAME,
                 COLUMN_LOCAL_URI,
@@ -211,27 +212,27 @@ public class ContributionDao {
 
         public static final String CREATE_TABLE_STATEMENT = "CREATE TABLE " + TABLE_NAME + " ("
                 + "_id INTEGER PRIMARY KEY,"
-                + "filename STRING,"
-                + "local_uri STRING,"
-                + "image_url STRING,"
+                + "filename TEXT,"
+                + "local_uri TEXT,"
+                + "image_url TEXT,"
                 + "uploaded INTEGER,"
                 + "timestamp INTEGER,"
                 + "state INTEGER,"
                 + "length INTEGER,"
                 + "transferred INTEGER,"
-                + "source STRING,"
-                + "description STRING,"
-                + "creator STRING,"
+                + "source TEXT,"
+                + "description TEXT,"
+                + "creator TEXT,"
                 + "multiple INTEGER,"
                 + "width INTEGER,"
                 + "height INTEGER,"
-                + "LICENSE STRING,"
-                + "wikidataEntityID STRING"
+                + "LICENSE TEXT,"
+                + "wikidataEntityID TEXT"
                 + ");";
 
         // Upgrade from version 1 ->
-        static final String ADD_CREATOR_FIELD = "ALTER TABLE " + TABLE_NAME + " ADD COLUMN creator STRING;";
-        static final String ADD_DESCRIPTION_FIELD = "ALTER TABLE " + TABLE_NAME + " ADD COLUMN description STRING;";
+        static final String ADD_CREATOR_FIELD = "ALTER TABLE " + TABLE_NAME + " ADD COLUMN creator TEXT;";
+        static final String ADD_DESCRIPTION_FIELD = "ALTER TABLE " + TABLE_NAME + " ADD COLUMN description TEXT;";
 
         // Upgrade from version 2 ->
         static final String ADD_MULTIPLE_FIELD = "ALTER TABLE " + TABLE_NAME + " ADD COLUMN multiple INTEGER;";
@@ -242,12 +243,14 @@ public class ContributionDao {
         static final String SET_DEFAULT_WIDTH = "UPDATE " + TABLE_NAME + " SET width = 0";
         static final String ADD_HEIGHT_FIELD = "ALTER TABLE " + TABLE_NAME + " ADD COLUMN height INTEGER;";
         static final String SET_DEFAULT_HEIGHT = "UPDATE " + TABLE_NAME + " SET height = 0";
-        static final String ADD_LICENSE_FIELD = "ALTER TABLE " + TABLE_NAME + " ADD COLUMN license STRING;";
+        static final String ADD_LICENSE_FIELD = "ALTER TABLE " + TABLE_NAME + " ADD COLUMN license TEXT;";
         static final String SET_DEFAULT_LICENSE = "UPDATE " + TABLE_NAME + " SET license='" + Prefs.Licenses.CC_BY_SA_3 + "';";
 
         // Upgrade from version 8 ->
-        static final String ADD_WIKI_DATA_ENTITY_ID_FIELD = "ALTER TABLE " + TABLE_NAME + " ADD COLUMN wikidataEntityID STRING;";
+        static final String ADD_WIKI_DATA_ENTITY_ID_FIELD = "ALTER TABLE " + TABLE_NAME + " ADD COLUMN wikidataEntityID TEXT;";
 
+        private Table() {
+        }
 
         public static void onCreate(SQLiteDatabase db) {
             db.execSQL(CREATE_TABLE_STATEMENT);
@@ -308,7 +311,6 @@ public class ContributionDao {
                 // Added place field
                 from=to;
                 onUpdate(db, from, to);
-                return;
             }
         }
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionViewHolder.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionViewHolder.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.contributions;
 
-import android.net.Uri;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
@@ -45,13 +44,13 @@ public class ContributionViewHolder extends RecyclerView.ViewHolder {
     LruCache<String, String> thumbnailCache;
 
     private DisplayableContribution contribution;
-    private CompositeDisposable compositeDisposable = new CompositeDisposable();
+    private final CompositeDisposable compositeDisposable = new CompositeDisposable();
     private int position;
 
     ContributionViewHolder(View parent, Callback callback) {
         super(parent);
         ButterKnife.bind(this, parent);
-        this.callback=callback;
+        this.callback = callback;
     }
 
     public void init(int position, DisplayableContribution contribution) {

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListAdapter.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.contributions;
 
-import android.database.DataSetObserver;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;
@@ -8,21 +7,20 @@ import androidx.recyclerview.widget.RecyclerView;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.contributions.model.DisplayableContribution;
 
-public class ContributionsListAdapter extends RecyclerView.Adapter<ContributionViewHolder> {
+class ContributionsListAdapter extends RecyclerView.Adapter<ContributionViewHolder> {
 
-    private Callback callback;
+    private final Callback callback;
 
-    public ContributionsListAdapter(Callback callback) {
+    ContributionsListAdapter(Callback callback) {
         this.callback = callback;
     }
 
     @NonNull
     @Override
     public ContributionViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        ContributionViewHolder viewHolder = new ContributionViewHolder(
+        return new ContributionViewHolder(
                 LayoutInflater.from(parent.getContext())
                         .inflate(R.layout.layout_contribution, parent, false), callback);
-        return viewHolder;
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -41,6 +41,8 @@ import static android.view.View.VISIBLE;
 public class ContributionsListFragment extends CommonsDaggerSupportFragment {
 
     private static final String VISIBLE_ITEM_ID = "visible_item_id";
+    private static final int SPAN_COUNT = 3;
+
     @BindView(R.id.contributionsList)
     RecyclerView rvContributionsList;
     @BindView(R.id.loadingContributionsProgressBar)
@@ -61,10 +63,10 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
     @Inject
     WikidataClient wikidataClient;
 
-    private Animation fab_close;
-    private Animation fab_open;
-    private Animation rotate_forward;
-    private Animation rotate_backward;
+    private Animation fabClose;
+    private Animation fabOpen;
+    private Animation rotateForward;
+    private Animation rotateBackward;
 
 
     private boolean isFabOpen = false;
@@ -73,8 +75,6 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
 
     private Callback callback;
     private String lastVisibleItemID;
-
-    private int SPAN_COUNT=3;
 
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_contributions_list, container, false);
@@ -92,7 +92,7 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
     }
 
     @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         initRecyclerView();
         initializeAnimations();
@@ -110,7 +110,7 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
     }
 
     @Override
-    public void onConfigurationChanged(Configuration newConfig) {
+    public void onConfigurationChanged(@NonNull Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
         // check orientation
         if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE) {
@@ -123,10 +123,10 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
     }
 
     private void initializeAnimations() {
-        fab_open = AnimationUtils.loadAnimation(getActivity(), R.anim.fab_open);
-        fab_close = AnimationUtils.loadAnimation(getActivity(), R.anim.fab_close);
-        rotate_forward = AnimationUtils.loadAnimation(getActivity(), R.anim.rotate_forward);
-        rotate_backward = AnimationUtils.loadAnimation(getActivity(), R.anim.rotate_backward);
+        fabOpen = AnimationUtils.loadAnimation(getActivity(), R.anim.fab_open);
+        fabClose = AnimationUtils.loadAnimation(getActivity(), R.anim.fab_close);
+        rotateForward = AnimationUtils.loadAnimation(getActivity(), R.anim.rotate_forward);
+        rotateBackward = AnimationUtils.loadAnimation(getActivity(), R.anim.rotate_backward);
     }
 
     private void setListeners() {
@@ -145,15 +145,15 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
         this.isFabOpen = !isFabOpen;
         if (fabPlus.isShown()){
             if (isFabOpen) {
-                fabPlus.startAnimation(rotate_backward);
-                fabCamera.startAnimation(fab_close);
-                fabGallery.startAnimation(fab_close);
+                fabPlus.startAnimation(rotateBackward);
+                fabCamera.startAnimation(fabClose);
+                fabGallery.startAnimation(fabClose);
                 fabCamera.hide();
                 fabGallery.hide();
             } else {
-                fabPlus.startAnimation(rotate_forward);
-                fabCamera.startAnimation(fab_open);
-                fabGallery.startAnimation(fab_open);
+                fabPlus.startAnimation(rotateForward);
+                fabCamera.startAnimation(fabOpen);
+                fabGallery.startAnimation(fabOpen);
                 fabCamera.show();
                 fabGallery.show();
             }
@@ -164,7 +164,7 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
     /**
      * Shows welcome message if user has no contributions yet i.e. new user.
      */
-    public void showWelcomeTip(boolean shouldShow) {
+    void showWelcomeTip(boolean shouldShow) {
         noContributionsYet.setVisibility(shouldShow ? VISIBLE : GONE);
     }
 
@@ -177,11 +177,11 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
         progressBar.setVisibility(shouldShow ? VISIBLE : GONE);
     }
 
-    public void showNoContributionsUI(boolean shouldShow) {
+    void showNoContributionsUI(boolean shouldShow) {
         noContributionsYet.setVisibility(shouldShow ? VISIBLE : GONE);
     }
 
-    public void onDataSetChanged() {
+    void onDataSetChanged() {
         if (null != adapter) {
             adapter.notifyDataSetChanged();
             //Restoring last visible item position in cases of orientation change
@@ -201,11 +201,11 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         LayoutManager layoutManager = rvContributionsList.getLayoutManager();
-        int lastVisibleItemPosition=0;
-        if(layoutManager instanceof  LinearLayoutManager){
-            lastVisibleItemPosition= ((LinearLayoutManager) layoutManager).findLastCompletelyVisibleItemPosition();
+        int lastVisibleItemPosition = 0;
+        if(layoutManager instanceof LinearLayoutManager){
+            lastVisibleItemPosition = ((LinearLayoutManager) layoutManager).findLastCompletelyVisibleItemPosition();
         }else if(layoutManager instanceof GridLayoutManager){
-            lastVisibleItemPosition=((GridLayoutManager)layoutManager).findLastCompletelyVisibleItemPosition();
+            lastVisibleItemPosition = ((GridLayoutManager) layoutManager).findLastCompletelyVisibleItemPosition();
         }
         String idOfItemWithPosition = findIdOfItemWithPosition(lastVisibleItemPosition);
         if (null != idOfItemWithPosition) {
@@ -217,7 +217,7 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
     public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
         super.onViewStateRestored(savedInstanceState);
         if(null!=savedInstanceState){
-            lastVisibleItemID =savedInstanceState.getString(VISIBLE_ITEM_ID, null);
+            lastVisibleItemID = savedInstanceState.getString(VISIBLE_ITEM_ID, null);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsPresenter.java
@@ -126,12 +126,11 @@ public class ContributionsPresenter extends DataSetObserver implements UserActio
     /**
      * Get contribution position  with id
      */
-    public int getChildPositionWithId(String id) {
+    int getChildPositionWithId(String id) {
         int position = 0;
         cursor.moveToFirst();
         while (null != cursor && cursor.moveToNext()) {
-            if (getContributionsFromCursor(cursor).getContentUri().getLastPathSegment()
-                    .equals(id)) {
+            if (id.equals(getContributionsFromCursor(cursor).getContentUri().getLastPathSegment())) {
                 position = cursor.getPosition();
                 break;
             }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsRepository.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsRepository.java
@@ -8,7 +8,7 @@ import javax.inject.Inject;
  */
 public class ContributionsRepository {
 
-    private ContributionsLocalDataSource localDataSource;
+    private final ContributionsLocalDataSource localDataSource;
 
     @Inject
     public ContributionsRepository(ContributionsLocalDataSource localDataSource) {

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsSyncAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsSyncAdapter.java
@@ -11,6 +11,7 @@ import android.database.Cursor;
 import android.os.Bundle;
 import android.os.RemoteException;
 
+import fr.free.nrw.commons.data.DAOException;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -26,14 +27,9 @@ import static fr.free.nrw.commons.contributions.ContributionsContentProvider.BAS
 @SuppressWarnings("WeakerAccess")
 public class ContributionsSyncAdapter extends AbstractThreadedSyncAdapter {
 
-    private static final String[] existsQuery = {COLUMN_FILENAME};
-    private static final String existsSelection = COLUMN_FILENAME + " = ?";
+    private static final String[] EXISTS_QUERY = {COLUMN_FILENAME};
+    private static final String EXISTS_SELECTION = COLUMN_FILENAME + " = ?";
     private static final ContentValues[] EMPTY = {};
-    private static int COMMIT_THRESHOLD = 10;
-
-    // Arbitrary limit to cap the number of contributions to ever load. This is a maximum built
-    // into the app, rather than the user's setting. Also see Github issue #52.
-    public static final int ABSOLUTE_CONTRIBUTIONS_LOAD_LIMIT = 500;
 
     @Inject
     UserClient userClient;
@@ -50,14 +46,14 @@ public class ContributionsSyncAdapter extends AbstractThreadedSyncAdapter {
             return false;
         }
         try (Cursor cursor = client.query(BASE_URI,
-                existsQuery,
-                existsSelection,
+                EXISTS_QUERY,
+                EXISTS_SELECTION,
                 new String[]{filename},
                 ""
         )) {
             return cursor != null && cursor.getCount() != 0;
         } catch (RemoteException e) {
-            throw new RuntimeException(e);
+            throw new DAOException(e);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -5,7 +5,6 @@ import android.app.AlertDialog;
 import android.content.ContentResolver;
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.PersistableBundle;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -14,6 +13,7 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.view.GravityCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
@@ -68,17 +68,16 @@ public class MainActivity extends NavigationBaseActivity implements FragmentMana
     QuizChecker quizChecker;
 
 
-    public Intent uploadServiceIntent;
+    Intent uploadServiceIntent;
 
     public ContributionsActivityPagerAdapter contributionsActivityPagerAdapter;
     public static final int CONTRIBUTIONS_TAB_POSITION = 0;
     public static final int NEARBY_TAB_POSITION = 1;
 
-    public boolean isContributionsFragmentVisible = true; // False means nearby fragment is visible
-    public boolean onOrientationChanged;
+    private boolean isContributionsFragmentVisible = true; // False means nearby fragment is visible
+    private boolean onOrientationChanged;
     private Menu menu;
 
-    private MenuItem notificationsMenuItem;
     private TextView notificationCount;
 
     public void onCreate(Bundle savedInstanceState) {
@@ -108,7 +107,7 @@ public class MainActivity extends NavigationBaseActivity implements FragmentMana
     }
 
     @Override
-    protected void onSaveInstanceState(Bundle outState) {
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putInt("viewPagerCurrentItem", viewPager.getCurrentItem());
     }
@@ -174,7 +173,7 @@ public class MainActivity extends NavigationBaseActivity implements FragmentMana
         viewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
             @Override
             public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-
+                // no-op
             }
 
             @Override
@@ -202,7 +201,7 @@ public class MainActivity extends NavigationBaseActivity implements FragmentMana
 
             @Override
             public void onPageScrollStateChanged(int state) {
-
+                // no-op
             }
         });
 
@@ -214,12 +213,12 @@ public class MainActivity extends NavigationBaseActivity implements FragmentMana
 
             @Override
             public void onTabUnselected(TabLayout.Tab tab) {
-
+                // no-op
             }
 
             @Override
             public void onTabReselected(TabLayout.Tab tab) {
-
+                // no-op
             }
         });
     }
@@ -284,12 +283,12 @@ public class MainActivity extends NavigationBaseActivity implements FragmentMana
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.contribution_activity_notification_menu, menu);
 
-        notificationsMenuItem = menu.findItem(R.id.notifications);
+        MenuItem notificationsMenuItem = menu.findItem(R.id.notifications);
         final View notification = notificationsMenuItem.getActionView();
         notificationCount = notification.findViewById(R.id.notification_count_badge);
-        notification.setOnClickListener(view -> {
-            NotificationActivity.startYourself(MainActivity.this, "unread");
-        });
+        notification.setOnClickListener(view ->
+            NotificationActivity.startYourself(MainActivity.this, "unread")
+        );
         this.menu = menu;
         updateMenuItem();
         setNotificationCount();
@@ -343,9 +342,7 @@ public class MainActivity extends NavigationBaseActivity implements FragmentMana
                 NotificationActivity.startYourself(this, "unread");
                 return true;
             case R.id.list_sheet:
-                if (contributionsActivityPagerAdapter.getItem(1) != null) {
-                    ((NearbyParentFragment)contributionsActivityPagerAdapter.getItem(1)).listOptionMenuItemClicked();
-                }
+                ((NearbyParentFragment) contributionsActivityPagerAdapter.getItem(1)).listOptionMenuItemClicked();
                 return true;
             default:
                 return super.onOptionsItemSelected(item);
@@ -353,9 +350,9 @@ public class MainActivity extends NavigationBaseActivity implements FragmentMana
     }
 
     public class ContributionsActivityPagerAdapter extends FragmentPagerAdapter {
-        FragmentManager fragmentManager;
+        final FragmentManager fragmentManager;
 
-        public ContributionsActivityPagerAdapter(FragmentManager fragmentManager) {
+        ContributionsActivityPagerAdapter(FragmentManager fragmentManager) {
             super(fragmentManager);
             this.fragmentManager = fragmentManager;
         }
@@ -422,7 +419,7 @@ public class MainActivity extends NavigationBaseActivity implements FragmentMana
          * @param index index of tabs, in our case 0 or 1
          * @return
          */
-        public String makeFragmentName(int viewId, int index) {
+        String makeFragmentName(int viewId, int index) {
             return "android:switcher:" + viewId + ":" + index;
         }
 
@@ -435,6 +432,7 @@ public class MainActivity extends NavigationBaseActivity implements FragmentMana
         controller.handleActivityResult(this, requestCode, resultCode, data);
     }
 
+    @Override
     protected void onResume() {
         super.onResume();
         setNotificationCount();
@@ -447,5 +445,9 @@ public class MainActivity extends NavigationBaseActivity implements FragmentMana
         // Remove ourself from hashmap to prevent memory leaks
         locationManager = null;
         super.onDestroy();
+    }
+
+    Intent getUploadServiceIntent() {
+        return uploadServiceIntent;
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/data/DAOException.java
+++ b/app/src/main/java/fr/free/nrw/commons/data/DAOException.java
@@ -1,0 +1,12 @@
+package fr.free.nrw.commons.data;
+
+public class DAOException extends RuntimeException {
+
+    public DAOException(String message) {
+        super(message);
+    }
+
+    public DAOException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/data/DBOpenHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/data/DBOpenHelper.java
@@ -10,7 +10,7 @@ import fr.free.nrw.commons.category.CategoryDao;
 import fr.free.nrw.commons.contributions.ContributionDao;
 import fr.free.nrw.commons.explore.recentsearches.RecentSearchesDao;
 
-public class DBOpenHelper  extends SQLiteOpenHelper {
+public class DBOpenHelper extends SQLiteOpenHelper {
 
     private static final String DATABASE_NAME = "commons.db";
     private static final int DATABASE_VERSION = 10;

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.explore;
 
-import android.database.DataSetObserver;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.View;
@@ -48,7 +47,7 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
     private RecentSearchesFragment recentSearchesFragment;
     private FragmentManager supportFragmentManager;
     private MediaDetailPagerFragment mediaDetails;
-    ViewPagerAdapter viewPagerAdapter;
+    private ViewPagerAdapter viewPagerAdapter;
     private String query;
 
     @Override
@@ -84,7 +83,7 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
     /**
      * Sets the titles in the tabLayout and fragments in the viewPager
      */
-    public void setTabs() {
+    private void setTabs() {
         List<Fragment> fragmentList = new ArrayList<>();
         List<String> titleList = new ArrayList<>();
         searchImageFragment = new SearchImageFragment();
@@ -167,17 +166,17 @@ public class SearchActivity extends NavigationBaseActivity implements MediaDetai
         if (mediaDetails == null || !mediaDetails.isVisible()) {
             // set isFeaturedImage true for featured images, to include author field on media detail
             mediaDetails = new MediaDetailPagerFragment(false, true);
-            FragmentManager supportFragmentManager = getSupportFragmentManager();
-            supportFragmentManager
+            FragmentManager fragmentManager = getSupportFragmentManager();
+            fragmentManager
                     .beginTransaction()
-                    .hide(supportFragmentManager.getFragments().get(supportFragmentManager.getBackStackEntryCount()))
+                    .hide(fragmentManager.getFragments().get(fragmentManager.getBackStackEntryCount()))
                     .add(R.id.mediaContainer, mediaDetails)
                     .addToBackStack(null)
                     .commit();
             // Reason for using hide, add instead of replace is to maintain scroll position after
             // coming back to the search activity. See https://github.com/commons-app/apps-android-commons/issues/1631
             // https://stackoverflow.com/questions/11353075/how-can-i-maintain-fragment-state-when-added-to-the-back-stack/19022550#19022550
-            supportFragmentManager.executePendingTransactions();
+            fragmentManager.executePendingTransactions();
         }
         mediaDetails.showImage(index);
         forceInitBackButton();

--- a/app/src/main/java/fr/free/nrw/commons/explore/ViewPagerAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/ViewPagerAdapter.java
@@ -1,5 +1,6 @@
 package fr.free.nrw.commons.explore;
 
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
@@ -23,6 +24,7 @@ public class ViewPagerAdapter extends FragmentPagerAdapter {
      * @param position
      */
     @Override
+    @NonNull
     public Fragment getItem(int position) {
         return fragmentList.get(position);
     }

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/ExploreActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/ExploreActivity.java
@@ -2,7 +2,6 @@ package fr.free.nrw.commons.explore.categories;
 
 import android.content.Context;
 import android.content.Intent;
-import android.database.DataSetObserver;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -32,8 +31,6 @@ import fr.free.nrw.commons.theme.NavigationBaseActivity;
 /**
  * This activity displays featured images and images uploaded via mobile
  */
-
-
 public class ExploreActivity
         extends NavigationBaseActivity
         implements MediaDetailPagerFragment.MediaDetailProvider,
@@ -49,7 +46,7 @@ public class ExploreActivity
     TabLayout tabLayout;
     @BindView(R.id.viewPager)
     ViewPager viewPager;
-    ViewPagerAdapter viewPagerAdapter;
+    private ViewPagerAdapter viewPagerAdapter;
     private FragmentManager supportFragmentManager;
     private MediaDetailPagerFragment mediaDetails;
     private CategoryImagesListFragment mobileImagesListFragment;
@@ -84,7 +81,7 @@ public class ExploreActivity
     /**
      * Sets the titles in the tabLayout and fragments in the viewPager
      */
-    public void setTabs() {
+    private void setTabs() {
         List<Fragment> fragmentList = new ArrayList<>();
         List<String> titleList = new ArrayList<>();
 
@@ -191,10 +188,10 @@ public class ExploreActivity
         if (mediaDetails == null || !mediaDetails.isVisible()) {
             // set isFeaturedImage true for featured images, to include author field on media detail
             mediaDetails = new MediaDetailPagerFragment(false, true);
-            FragmentManager supportFragmentManager = getSupportFragmentManager();
-            supportFragmentManager
+            FragmentManager fragmentManager = getSupportFragmentManager();
+            fragmentManager
                     .beginTransaction()
-                    .hide(supportFragmentManager.getFragments().get(supportFragmentManager.getBackStackEntryCount()))
+                    .hide(fragmentManager.getFragments().get(fragmentManager.getBackStackEntryCount()))
                     .add(R.id.mediaContainer, mediaDetails)
                     .addToBackStack(null)
                     .commit();
@@ -224,12 +221,11 @@ public class ExploreActivity
     public boolean onOptionsItemSelected(MenuItem item) {
 
         // Handle item selection
-        switch (item.getItemId()) {
-            case R.id.action_search:
-                NavigationBaseActivity.startActivityWithFlags(this, SearchActivity.class);
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
+        if (item.getItemId() == R.id.action_search) {
+            NavigationBaseActivity.startActivityWithFlags(this, SearchActivity.class);
+            return true;
+        } else {
+            return super.onOptionsItemSelected(item);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesAdapterFactory.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoriesAdapterFactory.java
@@ -26,7 +26,7 @@ public class SearchCategoriesAdapterFactory {
     public RVRendererAdapter<String> create(List<String> searchImageItemList) {
         RendererBuilder<String> builder = new RendererBuilder<String>().bind(String.class, new SearchCategoriesRenderer(listener));
         ListAdapteeCollection<String> collection = new ListAdapteeCollection<>(
-                searchImageItemList != null ? searchImageItemList : Collections.<String>emptyList());
+                searchImageItemList != null ? searchImageItemList : Collections.emptyList());
         return new RVRendererAdapter<>(builder, collection);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -9,6 +9,7 @@ import android.view.ViewGroup;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -47,7 +48,7 @@ import static android.view.View.VISIBLE;
 
 public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
 
-    private static int TIMEOUT_SECONDS = 15;
+    private static final int TIMEOUT_SECONDS = 15;
 
     @BindView(R.id.imagesListBox)
     RecyclerView categoriesRecyclerView;
@@ -55,10 +56,10 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
     ProgressBar progressBar;
     @BindView(R.id.imagesNotFound)
     TextView categoriesNotFoundView;
-    String query;
+    private String query;
     @BindView(R.id.bottomProgressBar)
     ProgressBar bottomProgressBar;
-    boolean isLoadingCategories;
+    private boolean isLoadingCategories;
 
     @Inject RecentSearchesDao recentSearchesDao;
     @Inject CategoryClient categoryClient;
@@ -111,7 +112,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
         categoriesRecyclerView.setAdapter(categoriesAdapter);
         categoriesRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
             @Override
-            public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
+            public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
                 super.onScrollStateChanged(recyclerView, newState);
                 // check if end of recycler view is reached, if yes then add more results to existing results
                 if (!recyclerView.canScrollVertically(1)) {
@@ -150,7 +151,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
     /**
      * Adds 25 more results to existing search results
      */
-    public void addCategoriesToList(String query) {
+    private void addCategoriesToList(String query) {
         if(isLoadingCategories) return;
         isLoadingCategories=true;
         this.query = query;
@@ -206,7 +207,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
             initErrorView();
             ViewUtil.showShortSnackbar(categoriesRecyclerView, R.string.error_loading_categories);
         }catch (Exception e){
-            e.printStackTrace();
+            Timber.e(e);
         }
 
     }

--- a/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -47,7 +48,7 @@ import static android.view.View.VISIBLE;
 
 public class SearchImageFragment extends CommonsDaggerSupportFragment {
 
-    private static int TIMEOUT_SECONDS = 15;
+    private static final int TIMEOUT_SECONDS = 15;
 
     @BindView(R.id.imagesListBox)
     RecyclerView imagesRecyclerView;
@@ -55,7 +56,7 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
     ProgressBar progressBar;
     @BindView(R.id.imagesNotFound)
     TextView imagesNotFoundView;
-    String query;
+    private String query;
     @BindView(R.id.bottomProgressBar)
     ProgressBar bottomProgressBar;
 
@@ -111,7 +112,7 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
         imagesRecyclerView.setAdapter(imagesAdapter);
         imagesRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
             @Override
-            public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
+            public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
                 super.onScrollStateChanged(recyclerView, newState);
                 // check if end of recycler view is reached, if yes then add more results to existing results
                 if (!recyclerView.canScrollVertically(1)) {
@@ -172,7 +173,7 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
     private void handlePaginationSuccess(List<Media> mediaList) {
         progressBar.setVisibility(View.GONE);
         bottomProgressBar.setVisibility(GONE);
-        if (mediaList.size() != 0 && !queryList.get(queryList.size() - 1).getFilename().equals(mediaList.get(mediaList.size() - 1).getFilename())) {
+        if (!mediaList.isEmpty() && !queryList.get(queryList.size() - 1).getFilename().equals(mediaList.get(mediaList.size() - 1).getFilename())) {
             queryList.addAll(mediaList);
             imagesAdapter.addAll(mediaList);
             imagesAdapter.notifyDataSetChanged();
@@ -210,7 +211,7 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
         try {
             ViewUtil.showShortSnackbar(imagesRecyclerView, R.string.error_loading_images);
         }catch (Exception e){
-            e.printStackTrace();
+            Timber.e(e);
         }
     }
 
@@ -264,7 +265,8 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
         }
     }
 
-    @Override public void onDestroyView() {
+    @Override
+    public void onDestroyView() {
         super.onDestroyView();
         compositeDisposable.clear();
     }

--- a/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImagesAdapterFactory.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImagesAdapterFactory.java
@@ -29,7 +29,7 @@ class SearchImagesAdapterFactory {
         RendererBuilder<Media> builder = new RendererBuilder<Media>()
                 .bind(Media.class, new SearchImagesRenderer(listener));
         ListAdapteeCollection<Media> collection = new ListAdapteeCollection<>(
-                searchImageItemList != null ? searchImageItemList : Collections.<Media>emptyList());
+                searchImageItemList != null ? searchImageItemList : Collections.emptyList());
         return new RVRendererAdapter<>(builder, collection);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearch.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearch.java
@@ -10,7 +10,7 @@ import java.util.Date;
  */
 public class RecentSearch {
     private Uri contentUri;
-    private String query;
+    private final String query;
     private Date lastSearched;
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
@@ -5,7 +5,6 @@ import androidx.appcompat.app.AlertDialog;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.ListView;
@@ -29,8 +28,8 @@ import fr.free.nrw.commons.explore.SearchActivity;
 public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
     @Inject RecentSearchesDao recentSearchesDao;
     @BindView(R.id.recent_searches_list) ListView recentSearchesList;
-    List<String> recentSearches;
-    ArrayAdapter adapter;
+    private List<String> recentSearches;
+    private ArrayAdapter adapter;
     @BindView(R.id.recent_searches_delete_button)
     ImageView recent_searches_delete_button;
     @BindView(R.id.recent_searches_text_view)
@@ -48,7 +47,7 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
             recent_searches_text_view.setText(R.string.no_recent_searches);
         }
   
-        recent_searches_delete_button.setOnClickListener(v -> {
+        recent_searches_delete_button.setOnClickListener(v ->
             new AlertDialog.Builder(getContext())
                 .setMessage(getString(R.string.delete_recent_searches_dialog))
                 .setPositiveButton(android.R.string.yes, (dialog, which) -> {
@@ -64,8 +63,8 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
                 })
                 .setNegativeButton(android.R.string.no, null)
                 .create()
-                .show();
-        });
+                .show()
+        );
 
         adapter = new ArrayAdapter<>(requireContext(), R.layout.item_recent_searches, recentSearches);
         recentSearchesList.setAdapter(adapter);

--- a/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionDaoTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionDaoTest.kt
@@ -7,9 +7,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.net.Uri
 import android.os.RemoteException
 import com.nhaarman.mockito_kotlin.*
-import fr.free.nrw.commons.BuildConfig
 import fr.free.nrw.commons.TestCommonsApplication
-import fr.free.nrw.commons.Utils
 import fr.free.nrw.commons.contributions.Contribution.*
 import fr.free.nrw.commons.contributions.ContributionDao.Table
 import fr.free.nrw.commons.contributions.ContributionsContentProvider.BASE_URI

--- a/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionsPresenterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionsPresenterTest.kt
@@ -23,9 +23,9 @@ class ContributionsPresenterTest {
 
     private lateinit var cursor: Cursor
 
-    lateinit var contribution: Contribution
+    private lateinit var contribution: Contribution
 
-    lateinit var loader: Loader<Cursor>
+    private lateinit var loader: Loader<Cursor>
 
     /**
      * initial setup


### PR DESCRIPTION
**Description (required)**

Fixes part of #171 Fix Lint errors/warnings

Fixing Some Android Lint and SonarLint Warnings in these packages:
* `fr.free.nrw.commons.explore`
* `fr.free.nrw.commons.explore.categories`
* `fr.free.nrw.commons.explore.images`
* `fr.free.nrw.commons.explore.recentsearches`
* `fr.free.nrw.commons.contributions`

Some of the changes were:
* Switching the try/catch/finally blocks for database querying into try-with-resources blocks, with the `Cursor` object getting set as the closable resource
* Switching a lot of field types in the sqlite "Create Table Statements" from STRING to TEXT
* Creating `DAOException` and throwing that instead of a generic `RuntimeException` in a few places ([SonarLint: RSPEC-112](https://rules.sonarsource.com/java/RSPEC-112))
* Logging some Exceptions using Timber instead of `e.printStackTrace()` ([SonarLint: RSPEC-1148](https://rules.sonarsource.com/java/RSPEC-1148))
* Changing a few access modifiers to be more restrictive
* Adding `final` to a few variables that are never changed
* Adding a private constructor to some utility or static inner classes ([SonarLint: RSPEC-1118](https://rules.sonarsource.com/java/RSPEC-1118)) 
* Made some constant String variables for recurring Strings ([SonarLint: RSPEC-1192](https://rules.sonarsource.com/java/RSPEC-1192))
* Changing the switch cases with only one case into if/else statements ([SonarLint: RSPEC-1301](https://rules.sonarsource.com/java/RSPEC-1301))
* Adding some `@NonNull` and `@Nullable` annotations to methods that inherit methods that use those annotations

**Tests performed (required)**
Ran the Gradle Tests and Tested ProdDebug on the Nexus 6 Emulator with API level 22.

---

Please let me know if there's anything I should change back or if there's anything I should elaborate on!
