### PR TITLE
Correction in passed file name to checkPageExistsUsingTitle, function…

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -309,7 +309,7 @@ public class UploadService extends HandlerService<Contribution> {
                     sequenceFileName = regexMatcher.replaceAll("$1 " + sequenceNumber + "$2");
                 }
             }
-            if (!mediaClient.checkPageExistsUsingTitle(sequenceFileName).blockingGet()
+            if (!mediaClient.checkPageExistsUsingTitle(String.format("File:%s",sequenceFileName)).blockingGet()
                     && !unfinishedUploads.contains(sequenceFileName)) {
                 break;
             }


### PR DESCRIPTION
**Description (required)**

Fixes file override bug mentioned in #3026 

What changes did you make and why?
Correction in passed file name to checkPageExistsUsingTitle, function expects file name prefixed with File:


**Tests performed (required)**

Tested betaDebug on MotoX-4 with API level 27. Duplicate file names are suffixed with numbers
