### PR TITLE
Fixing#3210 When the place is not null but the descriptions list is empty there was a crash on getting the first element of the Descriptions list.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
@@ -142,6 +142,9 @@ public class UploadModel {
                 createdTimestampSource);
         if (place != null) {
             uploadItem.title.setTitleText(place.name);
+            if(uploadItem.descriptions.isEmpty()) {
+                uploadItem.descriptions.add(new Description());
+            }
             uploadItem.descriptions.get(0).setDescriptionText(place.getLongDescription());
             uploadItem.descriptions.get(0).setLanguageCode("en");
         }

--- a/app/src/main/res/values-tt-cyrl/error.xml
+++ b/app/src/main/res/values-tt-cyrl/error.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Authors:
-* Ерней
--->
-<resources>
-  <string name="crash_dialog_ok_toast">Рәхмәт!</string>
-</resources>

--- a/app/src/main/res/values-tt-cyrl/error.xml
+++ b/app/src/main/res/values-tt-cyrl/error.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Authors:
+* Ерней
+-->
+<resources>
+  <string name="crash_dialog_ok_toast">Рәхмәт!</string>
+</resources>


### PR DESCRIPTION
**Description (required)**
Fix for issue #3210: When the place is not null but the descriptions list is empty there was a crash on getting the first element of the Descriptions list.

Fixes #3210 Crash when uploading a picture via Nearby

What changes did you make and why?
I just check if the list is empty, and in that case I add a new Description to the list.

**Tests performed (required)**

Tested betaDebug on Asus ASUS_X00ID with API level 25
![Screenshot_20191119-194317](https://user-images.githubusercontent.com/17772227/69147369-0dd9aa00-0ad2-11ea-8fdf-0d70b4b8fc37.jpg)
.

**Screenshots showing what changed (optional - for UI changes)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
