### PR TITLE
Fix ability to make POST requests to Wikidata.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'com.jakewharton.rxbinding2:rxbinding-design:2.1.1'
     implementation 'com.facebook.fresco:fresco:1.13.0'
     implementation 'org.apache.commons:commons-lang3:3.8.1'
-    implementation 'com.github.maskaravivek:wikimedia-android-data-client:v0.0.28'
+    implementation 'com.github.maskaravivek:wikimedia-android-data-client:v0.0.30'
 
     // UI
     implementation 'fr.avianey.com.viewpagerindicator:library:2.4.1.1@aar'
@@ -190,7 +190,7 @@ android {
             buildConfigField "String", "IMAGE_URL_BASE", "\"https://upload.wikimedia.org/wikipedia/commons\""
             buildConfigField "String", "HOME_URL", "\"https://commons.wikimedia.org/wiki/\""
             buildConfigField "String", "COMMONS_URL", "\"https://commons.wikimedia.org\""
-            buildConfigField "String", "WIKIDATA_URL", "\"https://wikidata.org\""
+            buildConfigField "String", "WIKIDATA_URL", "\"https://www.wikidata.org\""
             buildConfigField "String", "MOBILE_HOME_URL", "\"https://commons.m.wikimedia.org/wiki/\""
             buildConfigField "String", "SIGNUP_LANDING_URL", "\"https://commons.m.wikimedia.org/w/index.php?title=Special:CreateAccount&returnto=Main+Page&returntoquery=welcome%3Dyes\""
             buildConfigField "String", "SIGNUP_SUCCESS_REDIRECTION_URL", "\"https://commons.m.wikimedia.org/w/index.php?title=Main_Page&welcome=yes\""


### PR DESCRIPTION
Hey folks, I've just gotten around to being able to take a look at this issue you've been having.  Fortunately, the fix consists of one line of code.

The correct domain name of Wikidata is `www.wikidata.org`, not `wikidata.org`. This matters when making authenticated POST requests.

I was able to test this live in the app (see [this item](https://www.wikidata.org/wiki/Q49323665)), by working around the other crashes that happen when uploading from Nearby.