### PR TITLE
fixed colorAccent in darkTheme

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -13,7 +13,7 @@
         <item name="icon">@color/primaryTextColor</item>
         <item name="colorPrimary">@color/primaryColor</item>
         <item name="colorPrimaryDark">@color/primaryDarkColor</item>
-        <item name="colorAccent">@color/white</item>
+        <item name="colorAccent">@color/primaryColor</item>
         <item name="colorButtonNormal">@color/primaryColor</item>
         <item name="bookmarkButtonColor">@color/button_blue_dark</item>
         <item name="rowButtonColor">@color/button_blue_dark</item>


### PR DESCRIPTION
Fixes #3249

changed the color accent to primaryColor of the app.
previous:
toggle switch were not easily identifiable wheter on/off 
![photo_2019-11-29_14-50-39](https://user-images.githubusercontent.com/45892437/69859309-e8128900-12b9-11ea-9702-5d45f995c21f.jpg )<br/>
Now:
![photo_2019-11-29_14-50-38](https://user-images.githubusercontent.com/45892437/69859616-7d158200-12ba-11ea-98d2-95b24ffe1e8b.jpg)<br/>
other screenshots:
![photo_2019-11-29_14-50-39 (3)](https://user-images.githubusercontent.com/45892437/69859685-a0403180-12ba-11ea-9a37-ea787597aec9.jpg)
<br/>
![photo_2019-11-29_14-50-38 (2)](https://user-images.githubusercontent.com/45892437/69859700-a9c99980-12ba-11ea-8e24-85469804e103.jpg)

