### PR TITLE
Fixes #3237 App crashes if user taps my location button while the map is loading

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
@@ -42,6 +42,8 @@ public interface NearbyParentFragmentContract {
         void setCheckBoxAction();
         void setCheckBoxState(int state);
         void setFilterState();
+        void disableFABRecenter();
+        void enableFABRecenter();
     }
 
     interface NearbyListView {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -831,6 +831,16 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     }
 
     @Override
+    public void disableFABRecenter() {
+        fabRecenter.setEnabled(false);
+    }
+
+    @Override
+    public void enableFABRecenter() {
+        fabRecenter.setEnabled(true);
+    }
+
+    @Override
     public void recenterMap(fr.free.nrw.commons.location.LatLng curLatLng) {
         nearbyMapFragment.removeCurrentLocationMarker();
         nearbyMapFragment.addCurrentLocationMarker(curLatLng);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.java
@@ -198,6 +198,11 @@ public class NearbyParentFragmentPresenter
     @Override
     public void lockUnlockNearby(boolean isNearbyLocked) {
         this.isNearbyLocked = isNearbyLocked;
+        if (isNearbyLocked) {
+            nearbyParentFragmentView.disableFABRecenter();
+        } else {
+            nearbyParentFragmentView.enableFABRecenter();
+        }
     }
 
     public void registerUnregisterLocationListener(boolean removeLocationListener) {


### PR DESCRIPTION
**Description (required)**

Fixes #3237 App crashes if user taps my location button while the map is loading

Disables button during load so that user can not click when the location is not ready yet.

**Tests performed (required)**

BetaDebug, manual tests

