### PR TITLE
Fixes #3239 Typed "bridge" then tapped bridge entry 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFilterSearchRecyclerViewAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFilterSearchRecyclerViewAdapter.java
@@ -84,11 +84,6 @@ public class NearbyFilterSearchRecyclerViewAdapter
                 selectedLabels.remove(label);
             } else {
                 selectedLabels.add(label);
-                displayedLabels.remove(label);
-                displayedLabels.add(selectedLabels.size()-1, label);
-                notifyDataSetChanged();
-                smoothScroller.setTargetPosition(0);
-                recyclerView.getLayoutManager().startSmoothScroll(smoothScroller);
             }
             label.setSelected(!label.isSelected());
             holder.placeTypeLayout.setBackgroundColor(label.isSelected() ? ContextCompat.getColor(context, R.color.divider_grey) : Color.WHITE);


### PR DESCRIPTION
**Description (required)**

Fixes #3239 Typed "bridge" then tapped bridge entry. this issue was caused the logic I used to reorder place type list after each selection so that selected item will appear at beginning. Since we are in a hurry now, I think it is better to sacrifice this small feature and prevent crash. This feature can always be added, I created the issue for this.

Note: I don't link the issue here to prevent auto closing after merge, the issue title is "Display selected place types at top" if you are interested.

**Tests performed (required)**

betaDebug manual tests.
