### PR TITLE
Fixes #3227 Nearby has many, many location markers

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyMapFragment.java
@@ -315,6 +315,7 @@ public class NearbyMapFragment extends CommonsDaggerSupportFragment
      */
     @Override
     public void addCurrentLocationMarker(LatLng curLatLng) {
+        removeCurrentLocationMarker();
         Timber.d("Adds current location marker");
 
         Icon icon = IconFactory.getInstance(getContext()).fromResource(R.drawable.current_location_marker);
@@ -336,8 +337,10 @@ public class NearbyMapFragment extends CommonsDaggerSupportFragment
 
     @Override
     public void removeCurrentLocationMarker() {
-        mapboxMap.removeMarker(currentLocationMarker);
-        mapboxMap.removePolygon(currentLocationPolygon);
+        if (currentLocationMarker != null) {
+            mapboxMap.removeMarker(currentLocationMarker);
+            mapboxMap.removePolygon(currentLocationPolygon);
+        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -832,7 +832,6 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     @Override
     public void recenterMap(fr.free.nrw.commons.location.LatLng curLatLng) {
-        nearbyMapFragment.removeCurrentLocationMarker();
         nearbyMapFragment.addCurrentLocationMarker(curLatLng);
         CameraPosition position;
 


### PR DESCRIPTION
**Description (required)**

Fixes #3227 Nearby has many, many location markers. Removes old location marker before adding new one.


**Tests performed (required)**

Tested betaDebug, manual testing
- Search this area tested
- Recenter button tested
- Movements tested with mock location app
