### PR TITLE
With proguard config for parcelable class

### DIFF
--- a/app/proguard-rules.txt
+++ b/app/proguard-rules.txt
@@ -75,3 +75,8 @@
 -keep class org.acra.** { *; }
 -keepattributes SourceFile,LineNumberTable
 -keepattributes *Annotation*
+
+# --- Parcelable ---
+-keepclassmembers class * implements android.os.Parcelable {
+    static ** CREATOR;
+}


### PR DESCRIPTION
**Description (required)**

Probably fixes #3244

What changes did you make and why?

https://stackoverflow.com/questions/21342700/proguard-causing-runtimeexception-unmarshalling-unknown-type-code-in-parcelabl

**Tests performed (required)**

Couldn't test it as I couldn't build a release APK for prod. @misaochan can you try this fix and see if it works. 