### PR TITLE
Closes #3262, NPE in touching edit text drawable area while uploading images

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -1,5 +1,7 @@
 package fr.free.nrw.commons.upload.mediaDetails;
 
+import static fr.free.nrw.commons.utils.ImageUtils.getErrorMessageForResult;
+
 import android.content.Context;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -11,29 +13,17 @@ import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatButton;
 import androidx.appcompat.widget.AppCompatImageButton;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-
-import com.github.chrisbanes.photoview.PhotoView;
-import com.jakewharton.rxbinding2.widget.RxTextView;
-
-import org.apache.commons.lang3.StringUtils;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+import com.github.chrisbanes.photoview.PhotoView;
+import com.jakewharton.rxbinding2.widget.RxTextView;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.filepicker.UploadableFile;
@@ -52,9 +42,13 @@ import fr.free.nrw.commons.utils.DialogUtil;
 import fr.free.nrw.commons.utils.ImageUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
 import io.reactivex.disposables.Disposable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.apache.commons.lang3.StringUtils;
 import timber.log.Timber;
-
-import static fr.free.nrw.commons.utils.ImageUtils.getErrorMessageForResult;
 
 public class UploadMediaDetailFragment extends UploadBaseFragment implements
         UploadMediaDetailsContract.View {
@@ -179,8 +173,12 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
         etTitle.setOnTouchListener((v, event) -> {
             //2 is for drawable right
             float twelveDpInPixels = convertDpToPixel(12, getContext());
-            if (event.getAction() == MotionEvent.ACTION_UP && etTitle.getCompoundDrawables()[2].getBounds().contains((int)(etTitle.getWidth()-(event.getX()+twelveDpInPixels)),(int)(event.getY()-twelveDpInPixels))){
-                showInfoAlert(R.string.media_detail_title,R.string.title_info);
+            if (event.getAction() == MotionEvent.ACTION_UP && etTitle.getCompoundDrawables() != null
+                    && etTitle.getCompoundDrawables().length > 2 && etTitle
+                    .getCompoundDrawables()[2].getBounds()
+                    .contains((int) (etTitle.getWidth() - (event.getX() + twelveDpInPixels)),
+                            (int) (event.getY() - twelveDpInPixels))) {
+                showInfoAlert(R.string.media_detail_title, R.string.title_info);
                 return true;
             }
             return false;


### PR DESCRIPTION
**Description (required)**

Fixes #3262 App Crashes when clicking on Title Info when uploading images

What changes did you make and why?
Handled the possibility of null drawable on the title edit-text
**Tests performed (required)**

Tested betaDebug on OnePlus 3T, API 27
