### PR TITLE
Fixes #3231 "Nearby" always first puts me in Punta Arenas

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
@@ -5,8 +5,6 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.RemoteException;
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
@@ -5,6 +5,8 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.RemoteException;
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 
@@ -19,6 +21,7 @@ import fr.free.nrw.commons.location.LatLng;
 import fr.free.nrw.commons.nearby.Label;
 import fr.free.nrw.commons.nearby.Place;
 import fr.free.nrw.commons.nearby.Sitelinks;
+import timber.log.Timber;
 
 import static fr.free.nrw.commons.bookmarks.locations.BookmarkLocationsContentProvider.BASE_URI;
 
@@ -239,6 +242,7 @@ public class BookmarkLocationsDao {
         }
 
         public static void onUpdate(SQLiteDatabase db, int from, int to) {
+            Timber.d("bookmarksLocations db is updated from:"+from+", to:"+to);
             if (from == to) {
                 return;
             }
@@ -258,6 +262,11 @@ public class BookmarkLocationsDao {
             if (from == 8) {
                 from++;
                 onUpdate(db, from, to);
+                return;
+            }
+            if (from == 10 && to == 11) {
+                from++;
+                db.execSQL("ALTER TABLE bookmarksLocations ADD COLUMN location_pic STRING;");
                 return;
             }
         }

--- a/app/src/main/java/fr/free/nrw/commons/data/DBOpenHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/data/DBOpenHelper.java
@@ -13,7 +13,7 @@ import fr.free.nrw.commons.explore.recentsearches.RecentSearchesDao;
 public class DBOpenHelper  extends SQLiteOpenHelper {
 
     private static final String DATABASE_NAME = "commons.db";
-    private static final int DATABASE_VERSION = 10;
+    private static final int DATABASE_VERSION = 11;
 
     /**
      * Do not use directly - @Inject an instance where it's needed and let


### PR DESCRIPTION
**Description (required)**

Fixes #3231 "Nearby" always first puts me in Punta Arenas and Fixes #3233 
No items shown in Nearby. Previously BookmarkLocationDao tables were updates with an extra column. But upgradeDb method is not called. currently I upgraded and altered new column. However, since our app is on production, I am not sure if this will solve the issue for everyone. Please someone  with more experiences with upgrading databases "safely" consider them during review. Solves issue for me.

