### PR TITLE
Use mockito for all tests instead of just for UI tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.12.1'
     testImplementation "org.powermock:powermock-module-junit4:2.0.0-beta.5"
     testImplementation "org.powermock:powermock-api-mockito2:2.0.0-beta.5"
+    testImplementation 'org.mockito:mockito-core:2.23.0'
 
     // Android testing
     androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
@@ -78,7 +79,6 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.annotation:annotation:1.1.0'
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.12.1'
-    androidTestImplementation 'org.mockito:mockito-core:2.13.0'
     androidTestUtil 'androidx.test:orchestrator:1.2.0'
 
     // Debugging


### PR DESCRIPTION
Currently, mockito was added as an `androidTestImplementation` dependency, changed it to `testImplementation` so that its available for unit tests as well. 

Also, it bumps the mockito version to the latest version. 