### PR TITLE
Remove CDATA and <u> tags from strings.xml

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
@@ -33,7 +33,10 @@ public class AboutActivity extends NavigationBaseActivity {
     @BindView(R.id.about_license) HtmlTextView aboutLicenseText;
     @BindView(R.id.about_faq) TextView faqText;
     @BindView(R.id.about_improve) HtmlTextView improve;
-
+    @BindView(R.id.about_rate_us) TextView rateUsText;
+    @BindView(R.id.about_privacy_policy) TextView privacyPolicyText;
+    @BindView(R.id.about_translate) TextView translateText;
+    @BindView(R.id.about_credits) TextView creditsText;
     /**
      * This method helps in the creation About screen
      *
@@ -54,22 +57,13 @@ public class AboutActivity extends NavigationBaseActivity {
         String improveText = String.format(getString(R.string.about_improve), Urls.NEW_ISSUE_URL);
         improve.setHtmlText(improveText);
 
-        SpannableString content = new SpannableString(getString(R.string.about_faq));
-        content.setSpan(new UnderlineSpan(), 0, content.length(), 0);
-        faqText.setText(content);
-
         versionText.setText(ConfigUtils.getVersionNameWithSha(getApplicationContext()));
 
-        TextView rate_us = findViewById(R.id.about_rate_us);
-        TextView privacy_policy = findViewById(R.id.about_privacy_policy);
-        TextView translate = findViewById(R.id.about_translate);
-        TextView credits = findViewById(R.id.about_credits);
-        TextView faq = findViewById(R.id.about_faq);
-        rate_us.setText(StringUtil.fromHtml(getString(R.string.about_rate_us)));
-        privacy_policy.setText(StringUtil.fromHtml(getString(R.string.about_privacy_policy)));
-        translate.setText(StringUtil.fromHtml(getString(R.string.about_translate)));
-        credits.setText(StringUtil.fromHtml(getString(R.string.about_credits)));
-        faq.setText(StringUtil.fromHtml(getString(R.string.about_faq)));
+        Utils.setUnderlinedText(faqText, R.string.about_faq, getApplicationContext());
+        Utils.setUnderlinedText(rateUsText, R.string.about_rate_us, getApplicationContext());
+        Utils.setUnderlinedText(privacyPolicyText, R.string.about_privacy_policy, getApplicationContext());
+        Utils.setUnderlinedText(translateText, R.string.about_translate, getApplicationContext());
+        Utils.setUnderlinedText(creditsText, R.string.about_credits, getApplicationContext());
 
         initDrawer();
     }

--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -6,7 +6,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.text.SpannableString;
+import android.text.style.UnderlineSpan;
 import android.view.View;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -183,6 +186,19 @@ public class Utils {
         ClipboardManager clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
         ClipData clip = ClipData.newPlainText(label, text);
         clipboard.setPrimaryClip(clip);
+    }
+
+    /**
+     * This method sets underlined string text to a TextView
+     *
+     * @param textView TextView associated with string resource
+     * @param stringResourceName string resource name
+     * @param context
+     */
+    public static void setUnderlinedText(TextView textView, int stringResourceName, Context context) {
+        SpannableString content = new SpannableString(context.getString(stringResourceName));
+        content.setSpan(new UnderlineSpan(), 0, content.length(), 0);
+        textView.setText(content);
     }
 
 }

--- a/app/src/main/java/fr/free/nrw/commons/WelcomePagerAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/WelcomePagerAdapter.java
@@ -47,7 +47,7 @@ public class WelcomePagerAdapter extends PagerAdapter {
         if (position == PAGE_LAYOUTS.length - 1) {
             // Add link to more information
             TextView moreInfo = layout.findViewById(R.id.welcomeInfo);
-            moreInfo.setText(Html.fromHtml(container.getContext().getString(R.string.welcome_help_button_text)));
+            Utils.setUnderlinedText(moreInfo, R.string.welcome_help_button_text, container.getContext());
             moreInfo.setOnClickListener(view -> Utils.handleWebUrl(
                     container.getContext(),
                     Uri.parse("https://commons.wikimedia.org/wiki/Help:Contents")

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -186,7 +186,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         final View view = inflater.inflate(R.layout.fragment_media_detail, container, false);
 
         ButterKnife.bind(this,view);
-        seeMore.setText(StringUtil.fromHtml(getString(R.string.nominated_see_more)));
+        Utils.setUnderlinedText(seeMore, R.string.nominated_see_more, container.getContext());
 
         if (isCategoryImage){
             authorLayout.setVisibility(VISIBLE);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,8 +93,8 @@
   <string name="about_license">The Wikimedia Commons app is an open-source app created and maintained by grantees and volunteers of the Wikimedia community. The Wikimedia Foundation is not involved in the creation, development, or maintenance of the app. </string>
   <string name="trademarked_name" translatable="false">Wikimedia Commons</string>
   <string name="about_improve">Create a new &lt;a href=\"%1$s\"&gt;GitHub issue&lt;/a&gt; for bug reports and suggestions.</string>
-  <string name="about_privacy_policy"><![CDATA[<u>Privacy policy</u>]]></string>
-  <string name="about_credits"><![CDATA[<u>Credits</u>]]></string>
+  <string name="about_privacy_policy">Privacy policy</string>
+  <string name="about_credits">Credits</string>
   <string name="title_activity_about">About</string>
   <string name="menu_feedback">Send Feedback (via Email)</string>
   <string name="no_email_client">No email client installed</string>
@@ -155,7 +155,7 @@
   <string name="welcome_copyright_subtext">Avoid copyrighted materials you found from the Internet as well as images of posters, book covers, etc.</string>
   <string name="welcome_final_text">You think you got it?</string>
   <string name="welcome_final_button_text">Yes!</string>
-  <string name="welcome_help_button_text"><![CDATA[<u>More Information</u>]]></string>
+  <string name="welcome_help_button_text">More Information</string>
   <string name="detail_panel_cats_label">Categories</string>
   <string name="detail_panel_cats_loading">Loading…</string>
   <string name="detail_panel_cats_none">None selected</string>
@@ -264,7 +264,7 @@
   <string name="null_url">Error! URL not found</string>
   <string name="nominate_deletion">Nominate for Deletion</string>
   <string name="nominated_for_deletion">This image has been nominated for deletion.</string>
-  <string name="nominated_see_more"><![CDATA[<u>See webpage for details</u>]]></string>
+  <string name="nominated_see_more">See webpage for details</string>
   <string name="nominating_file_for_deletion">Nominating %1$s for deletion.</string>
   <string name="nominating_for_deletion_status">Nominating file for deletion: %1$s</string>
   <string name="view_browser">View in Browser</string>
@@ -291,8 +291,8 @@
   <string name="nearby_wikidata">Wikidata</string>
   <string name="nearby_wikipedia">Wikipedia</string>
   <string name="nearby_commons">Commons</string>
-  <string name="about_rate_us"><![CDATA[<u>Rate us</u>]]></string>
-  <string name="about_faq"><![CDATA[<u>FAQ</u>]]></string>
+  <string name="about_rate_us">Rate us</string>
+  <string name="about_faq">FAQ</string>
   <string name="welcome_skip_button">Skip Tutorial</string>
   <string name="no_internet">Internet unavailable</string>
   <string name="internet_established">Internet available</string>
@@ -300,7 +300,7 @@
   <string name="error_review">Error fetching image for review. Press refresh to try again.</string>
   <string name="error_review_categories">Error fetching image categories for review. Press refresh to try again.</string>
   <string name="no_notifications">No notifications found</string>
-  <string name="about_translate"><![CDATA[<u>Translate</u>]]></string>
+  <string name="about_translate">Translate</string>
   <string name="about_translate_title">Languages</string>
   <string name="about_translate_message">Select the language that you would like to submit translations for</string>
   <string name="about_translate_proceed">Proceed</string>


### PR DESCRIPTION
Remove CDATA and <u> tags from string resources. Instead use setUnderlinedText() method added in Utils to create underlined string resources.

**Description (required)**

Fixes #2782 Remove unnecessary tags from string resources

What changes did you make and why?

Deleted CDATA and <u> tags from string resource file. To underline strings without <u> tag, I added setUnderlineText() in Utils. Also added butterknife bindings for TextVews in AboutActivity.  

**Tests performed (required)**

Tested 2.12.0 on Moto G (5S), API level 27.

**Screenshots showing what changed (optional - for UI changes)**
