### PR TITLE
Fixes #3303 Nearby crashes when options menu is clicked

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -56,6 +56,7 @@ import javax.inject.Named;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
@@ -158,6 +159,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private boolean isFABsExpanded;
     private Marker selectedMarker;
     private Place selectedPlace;
+    private Unbinder unbinder;
 
     private final double CAMERA_TARGET_SHIFT_FACTOR_PORTRAIT = 0.005;
     private final double CAMERA_TARGET_SHIFT_FACTOR_LANDSCAPE = 0.004;
@@ -172,7 +174,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         view = inflater.inflate(R.layout.fragment_nearby_parent, container, false);
-        ButterKnife.bind(this, view);
+        unbinder = ButterKnife.bind(this, view);
         // Inflate the layout for this fragment
         return view;
 
@@ -185,6 +187,11 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         nearbyListFragment = getListFragment();
     }
 
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbinder.unbind();
+    }
 
     private void initViews() {
         Timber.d("init views called");

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -91,6 +91,7 @@ import static fr.free.nrw.commons.contributions.MainActivity.CONTRIBUTIONS_TAB_P
 import static fr.free.nrw.commons.location.LocationServiceManager.LocationChangeType.LOCATION_SIGNIFICANTLY_CHANGED;
 import static fr.free.nrw.commons.location.LocationServiceManager.LocationChangeType.MAP_UPDATED;
 import static fr.free.nrw.commons.nearby.Label.TEXT_TO_DESCRIPTION;
+import static fr.free.nrw.commons.nearby.presenter.NearbyParentFragmentPresenter.presenterInstance;
 import static fr.free.nrw.commons.wikidata.WikidataConstants.PLACE_OBJECT;
 
 
@@ -473,7 +474,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private void removeListFragment() {
         if (nearbyListFragment != null) {
             FragmentManager fm = getChildFragmentManager();
-            fm.beginTransaction().remove(nearbyListFragment).commit();
+            fm.beginTransaction().remove(nearbyListFragment).commitAllowingStateLoss();
             nearbyListFragment = null;
         }
     }
@@ -481,7 +482,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private void removeMapFragment() {
         if (nearbyMapFragment != null) {
             FragmentManager fm = getChildFragmentManager();
-            fm.beginTransaction().remove(nearbyMapFragment).commit();
+            fm.beginTransaction().remove(nearbyMapFragment).commitAllowingStateLoss();
             nearbyMapFragment = null;
         }
     }
@@ -624,7 +625,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
                         throwable -> {
                             Timber.d(throwable);
                             // TODO: find out why NPE occurs here
-                            // showErrorMessage(getString(R.string.error_fetching_nearby_places));
+                            showErrorMessage(getString(R.string.error_fetching_nearby_places));
                             setProgressBarVisibility(false);
                             nearbyParentFragmentPresenter.lockUnlockNearby(false);
                         }));
@@ -1026,6 +1027,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             locationManager.removeLocationListener(nearbyParentFragmentPresenter);
             locationManager.unregisterLocationManager();
         }
+        presenterInstance = null;
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
@@ -1,5 +1,6 @@
 package fr.free.nrw.commons.theme;
 
+import android.content.Intent;
 import android.os.Bundle;
 
 import javax.inject.Inject;
@@ -29,7 +30,9 @@ public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
     protected void onResume() {
         // Restart activity if theme is changed
         if (wasPreviouslyDarkTheme != defaultKvStore.getBoolean("theme", false)) {
-            recreate();
+            Intent intent = getIntent();
+            finish();
+            startActivity(intent);
         }
 
         super.onResume();


### PR DESCRIPTION
**Description (required)**

Fixes #3303 Nearby crashes when options menu is clicked. Nullifies presenter so that all operations will start again. Otherwise nothing happens because the code thing presenter is already ready.

**Tests performed (required)**

Tested beta debug, Emulator 
