### PR TITLE
Fixes: #3179 Make category search non case-sensitive

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
@@ -123,8 +123,9 @@ public class CategoriesModel{
         }
 
         //otherwise, search API for matching categories
+        //term passed as lower case to make search case-insensitive(taking only lower case for everything)
         return categoryClient
-                .searchCategoriesForPrefix(term, SEARCH_CATS_LIMIT)
+                .searchCategoriesForPrefix(term.toLowerCase(), SEARCH_CATS_LIMIT)
                 .map(name -> new CategoryItem(name, false));
     }
 
@@ -183,11 +184,12 @@ public class CategoriesModel{
 
     /**
      * Return category for single title
+     * title is converted to lower case to make search case-insensitive
      * @param title
      * @return
      */
     private Observable<CategoryItem> getTitleCategories(String title) {
-        return categoryClient.searchCategories(title, SEARCH_CATS_LIMIT)
+        return categoryClient.searchCategories(title.toLowerCase(), SEARCH_CATS_LIMIT)
                 .map(name -> new CategoryItem(name, false));
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
@@ -123,8 +123,9 @@ public class CategoriesModel{
         }
 
         //otherwise, search API for matching categories
+        //term passed as lower case to make search case-insensitive(taking only lower case for everything)
         return categoryClient
-                .searchCategoriesForPrefix(term, SEARCH_CATS_LIMIT)
+                .searchCategoriesForPrefix(term.toLowerCase(), SEARCH_CATS_LIMIT)
                 .map(name -> new CategoryItem(name, false));
     }
 
@@ -188,7 +189,7 @@ public class CategoriesModel{
      * @return
      */
     private Observable<CategoryItem> getTitleCategories(String title) {
-        return categoryClient.searchCategories(title, SEARCH_CATS_LIMIT)
+        return categoryClient.searchCategories(title.toLowerCase(), SEARCH_CATS_LIMIT)
                 .map(name -> new CategoryItem(name, false));
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
@@ -123,9 +123,8 @@ public class CategoriesModel{
         }
 
         //otherwise, search API for matching categories
-        //term passed as lower case to make search case-insensitive(taking only lower case for everything)
         return categoryClient
-                .searchCategoriesForPrefix(term.toLowerCase(), SEARCH_CATS_LIMIT)
+                .searchCategoriesForPrefix(term, SEARCH_CATS_LIMIT)
                 .map(name -> new CategoryItem(name, false));
     }
 
@@ -189,7 +188,7 @@ public class CategoriesModel{
      * @return
      */
     private Observable<CategoryItem> getTitleCategories(String title) {
-        return categoryClient.searchCategories(title.toLowerCase(), SEARCH_CATS_LIMIT)
+        return categoryClient.searchCategories(title, SEARCH_CATS_LIMIT)
                 .map(name -> new CategoryItem(name, false));
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
@@ -30,7 +30,6 @@ public class CategoryClient {
 
     /**
      * Searches for categories containing the specified string.
-     * It will be converted to Lower Case as the server performs Case-insensitive search.
      *
      * @param filter    The string to be searched
      * @param itemLimit How many results are returned
@@ -38,7 +37,7 @@ public class CategoryClient {
      * @return
      */
     public Observable<String> searchCategories(String filter, int itemLimit, int offset) {
-        return responseToCategoryName(CategoryInterface.searchCategories(filter.toLowerCase(), itemLimit, offset));
+        return responseToCategoryName(CategoryInterface.searchCategories(filter, itemLimit, offset));
 
     }
 
@@ -56,7 +55,6 @@ public class CategoryClient {
 
     /**
      * Searches for categories starting with the specified string.
-     * It will be converted to Lower Case as the server performs Case-insensitive search.
      *
      * @param prefix    The prefix to be searched
      * @param itemLimit How many results are returned
@@ -64,7 +62,7 @@ public class CategoryClient {
      * @return
      */
     public Observable<String> searchCategoriesForPrefix(String prefix, int itemLimit, int offset) {
-        return responseToCategoryName(CategoryInterface.searchCategoriesForPrefix(prefix.toLowerCase(), itemLimit, offset));
+        return responseToCategoryName(CategoryInterface.searchCategoriesForPrefix(prefix, itemLimit, offset));
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
@@ -30,7 +30,6 @@ public class CategoryClient {
 
     /**
      * Searches for categories containing the specified string.
-     * filter passed as lower case to make search case-insensitive(taking only lower case for everything)
      *
      * @param filter    The string to be searched
      * @param itemLimit How many results are returned
@@ -38,7 +37,7 @@ public class CategoryClient {
      * @return
      */
     public Observable<String> searchCategories(String filter, int itemLimit, int offset) {
-        return responseToCategoryName(CategoryInterface.searchCategories(filter.toLowerCase(), itemLimit, offset));
+        return responseToCategoryName(CategoryInterface.searchCategories(filter, itemLimit, offset));
 
     }
 
@@ -56,7 +55,6 @@ public class CategoryClient {
 
     /**
      * Searches for categories starting with the specified string.
-     * prefix passed as lower case to make search case-insensitive
      * 
      * @param prefix    The prefix to be searched
      * @param itemLimit How many results are returned
@@ -64,7 +62,7 @@ public class CategoryClient {
      * @return
      */
     public Observable<String> searchCategoriesForPrefix(String prefix, int itemLimit, int offset) {
-        return responseToCategoryName(CategoryInterface.searchCategoriesForPrefix(prefix.toLowerCase(), itemLimit, offset));
+        return responseToCategoryName(CategoryInterface.searchCategoriesForPrefix(prefix, itemLimit, offset));
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
@@ -30,6 +30,7 @@ public class CategoryClient {
 
     /**
      * Searches for categories containing the specified string.
+     * It will be converted to Lower Case as the server performs Case-insensitive search.
      *
      * @param filter    The string to be searched
      * @param itemLimit How many results are returned
@@ -37,7 +38,7 @@ public class CategoryClient {
      * @return
      */
     public Observable<String> searchCategories(String filter, int itemLimit, int offset) {
-        return responseToCategoryName(CategoryInterface.searchCategories(filter, itemLimit, offset));
+        return responseToCategoryName(CategoryInterface.searchCategories(filter.toLowerCase(), itemLimit, offset));
 
     }
 
@@ -55,6 +56,7 @@ public class CategoryClient {
 
     /**
      * Searches for categories starting with the specified string.
+     * It will be converted to Lower Case as the server performs Case-insensitive search.
      *
      * @param prefix    The prefix to be searched
      * @param itemLimit How many results are returned
@@ -62,7 +64,7 @@ public class CategoryClient {
      * @return
      */
     public Observable<String> searchCategoriesForPrefix(String prefix, int itemLimit, int offset) {
-        return responseToCategoryName(CategoryInterface.searchCategoriesForPrefix(prefix, itemLimit, offset));
+        return responseToCategoryName(CategoryInterface.searchCategoriesForPrefix(prefix.toLowerCase(), itemLimit, offset));
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
@@ -30,6 +30,7 @@ public class CategoryClient {
 
     /**
      * Searches for categories containing the specified string.
+     * filter passed as lower case to make search case-insensitive(taking only lower case for everything)
      *
      * @param filter    The string to be searched
      * @param itemLimit How many results are returned
@@ -37,7 +38,7 @@ public class CategoryClient {
      * @return
      */
     public Observable<String> searchCategories(String filter, int itemLimit, int offset) {
-        return responseToCategoryName(CategoryInterface.searchCategories(filter, itemLimit, offset));
+        return responseToCategoryName(CategoryInterface.searchCategories(filter.toLowerCase(), itemLimit, offset));
 
     }
 
@@ -55,14 +56,15 @@ public class CategoryClient {
 
     /**
      * Searches for categories starting with the specified string.
-     *
+     * prefix passed as lower case to make search case-insensitive
+     * 
      * @param prefix    The prefix to be searched
      * @param itemLimit How many results are returned
      * @param offset    Starts returning items from the nth result. If offset is 9, the response starts with the 9th item of the search result
      * @return
      */
     public Observable<String> searchCategoriesForPrefix(String prefix, int itemLimit, int offset) {
-        return responseToCategoryName(CategoryInterface.searchCategoriesForPrefix(prefix, itemLimit, offset));
+        return responseToCategoryName(CategoryInterface.searchCategoriesForPrefix(prefix.toLowerCase(), itemLimit, offset));
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryItem.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryItem.java
@@ -3,10 +3,7 @@ package fr.free.nrw.commons.category;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-/**
- * Represents a Category Item.
- * Implemented as Parcelable so that its object could be parsed between activity components.
- */
+
 public class CategoryItem implements Parcelable {
     private final String name;
     private boolean selected;
@@ -28,58 +25,36 @@ public class CategoryItem implements Parcelable {
         this.selected = selected;
     }
 
-    /**
-     * Reads from the received Parcel
-     * @param in
-     */
     private CategoryItem(Parcel in) {
         name = in.readString();
         selected = in.readInt() == 1;
     }
 
-    /**
-     * Gets Name
-     * @return
-     */
     public String getName() {
         return name;
     }
 
-    /**
-     * Checks if that Category Item has been selected.
-     * @return
-     */
     public boolean isSelected() {
         return selected;
     }
 
-    /**
-     * Selects the Category Item.
-     * @param selected
-     */
     public void setSelected(boolean selected) {
         this.selected = selected;
     }
 
-    /**
-     * Used by Parcelable
-     * @return
-     */
+    
     @Override
     public int describeContents() {
         return 0;
     }
 
-    /**
-     * Writes to the received Parcel
-     * @param parcel
-     * @param flags
-     */
+
     @Override
     public void writeToParcel(Parcel parcel, int flags) {
         parcel.writeString(name);
         parcel.writeInt(selected ? 1 : 0);
     }
+
 
     @Override
     public boolean equals(Object o) {
@@ -96,17 +71,13 @@ public class CategoryItem implements Parcelable {
 
     }
 
-    /**
-     * Returns hash code for current object
-     */
+    
     @Override
     public int hashCode() {
         return name.hashCode();
     }
 
-    /**
-     * Return String form of current object
-     */
+    
     @Override
     public String toString() {
         return "CategoryItem: '" + name + '\'';

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryItem.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryItem.java
@@ -3,7 +3,6 @@ package fr.free.nrw.commons.category;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-
 public class CategoryItem implements Parcelable {
     private final String name;
     private boolean selected;
@@ -42,19 +41,16 @@ public class CategoryItem implements Parcelable {
         this.selected = selected;
     }
 
-    
     @Override
     public int describeContents() {
         return 0;
     }
-
 
     @Override
     public void writeToParcel(Parcel parcel, int flags) {
         parcel.writeString(name);
         parcel.writeInt(selected ? 1 : 0);
     }
-
 
     @Override
     public boolean equals(Object o) {
@@ -71,13 +67,11 @@ public class CategoryItem implements Parcelable {
 
     }
 
-    
     @Override
     public int hashCode() {
         return name.hashCode();
     }
 
-    
     @Override
     public String toString() {
         return "CategoryItem: '" + name + '\'';

--- a/app/src/test/kotlin/fr/free/nrw/commons/category/CategoriesModelTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/CategoriesModelTest.kt
@@ -1,0 +1,50 @@
+package fr.free.nrw.commons.category
+
+import io.reactivex.Observable
+import junit.framework.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.*
+import org.wikipedia.dataclient.mwapi.MwQueryPage
+import org.wikipedia.dataclient.mwapi.MwQueryResponse
+import org.wikipedia.dataclient.mwapi.MwQueryResult
+
+//class for testing CategoriesModel class
+class CategoriesModelTest {
+    @Mock
+    internal var categoryInterface: CategoryInterface? = null
+
+    @Mock
+    internal var categoryItem: CategoryItem? = null
+
+    @InjectMocks
+    var categoryClient: CategoryClient? = null
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+    }
+
+    // Test Case for verifying that Categories search (MW api calls) are case-insensitive
+    @Test
+    fun searchAllFoundCaseTest() {
+       val mwQueryPage = Mockito.mock(MwQueryPage::class.java)
+        Mockito.`when`(mwQueryPage.title()).thenReturn("Category:Test")
+        val mwQueryResult = Mockito.mock(MwQueryResult::class.java)
+        Mockito.`when`(mwQueryResult.pages()).thenReturn(listOf(mwQueryPage))
+        val mockResponse = Mockito.mock(MwQueryResponse::class.java)
+        Mockito.`when`(mockResponse.query()).thenReturn(mwQueryResult)
+        val categoriesModel: CategoriesModel = CategoriesModel(categoryClient,null,null)
+
+        Mockito.`when`(categoryInterface!!.searchCategoriesForPrefix(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
+                .thenReturn(Observable.just(mockResponse))
+
+        // Checking if both return "Test"
+        val actualCategoryName = categoriesModel!!.searchAll("tes",null).blockingFirst()
+        assertEquals("Test", actualCategoryName.getName())
+        
+        val actualCategoryNameCaps = categoriesModel!!.searchAll("Tes",null).blockingFirst()
+        assertEquals("Test", actualCategoryNameCaps.getName())
+    }
+}

--- a/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryClientTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryClientTest.kt
@@ -68,7 +68,7 @@ class CategoryClientTest {
         val mockResponse = Mockito.mock(MwQueryResponse::class.java)
         Mockito.`when`(mockResponse.query()).thenReturn(mwQueryResult)
 
-        Mockito.`when`(categoryInterface!!.searchCategoriesForPrefix(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
+        Mockito.`when`(categoryInterface!!.searchCategories(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
                 .thenReturn(Observable.just(mockResponse))
 
         val actualCategoryName = categoryClient!!.searchCategories("tes", 10).blockingFirst()
@@ -128,7 +128,7 @@ class CategoryClientTest {
         val mockResponse = Mockito.mock(MwQueryResponse::class.java)
         Mockito.`when`(mockResponse.query()).thenReturn(mwQueryResult)
 
-        Mockito.`when`(categoryInterface!!.getParentCategoryList(ArgumentMatchers.anyString()))
+        Mockito.`when`(categoryInterface!!.searchCategoriesForPrefix(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
                 .thenReturn(Observable.just(mockResponse))
 
         val actualCategoryName = categoryClient!!.searchCategoriesForPrefix("tes", 10).blockingFirst()

--- a/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryClientTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryClientTest.kt
@@ -74,10 +74,14 @@ class CategoryClientTest {
         val actualCategoryName = categoryClient!!.searchCategories("tes", 10).blockingFirst()
         val actualCategoryNameCaps = categoryClient!!.searchCategories("Tes", 10).blockingFirst()
         assertEquals(actualCategoryName, actualCategoryNameCaps)
+        assertEquals("Test", actualCategoryName)
+        assertEquals("Test", actualCategoryNameCaps)
 
         val actualCategoryNameWithOffset = categoryClient!!.searchCategories("tes", 10, 10).blockingFirst()
         val actualCategoryNameWithOffsetCaps = categoryClient!!.searchCategories("Tes", 10, 10).blockingFirst()
         assertEquals(actualCategoryNameWithOffset, actualCategoryNameWithOffsetCaps)
+        assertEquals("Test", actualCategoryNameWithOffset)
+        assertEquals("Test", actualCategoryNameWithOffsetCaps)
     }
 
     @Test
@@ -130,10 +134,14 @@ class CategoryClientTest {
         val actualCategoryName = categoryClient!!.searchCategoriesForPrefix("tes", 10).blockingFirst()
         val actualCategoryNameCaps = categoryClient!!.searchCategoriesForPrefix("Tes", 10).blockingFirst()
         assertEquals(actualCategoryName, actualCategoryNameCaps)
+        assertEquals("Test", actualCategoryName)
+        assertEquals("Test", actualCategoryNameCaps)
 
-        val actualCategoryName = categoryClient!!.searchCategoriesForPrefix("tes", 10, 10).blockingFirst()
-        val actualCategoryNameCaps = categoryClient!!.searchCategoriesForPrefix("Tes", 10, 10).blockingFirst()
-        assertEquals(actualCategoryName, actualCategoryNameCaps)
+        val actualCategoryNameWithOffset = categoryClient!!.searchCategoriesForPrefix("tes", 10, 10).blockingFirst()
+        val actualCategoryNameWithOffsetCaps = categoryClient!!.searchCategoriesForPrefix("Tes", 10, 10).blockingFirst()
+        assertEquals(actualCategoryNameWithOffset, actualCategoryNameWithOffsetCaps)
+        assertEquals("Test", actualCategoryNameWithOffset)
+        assertEquals("Test", actualCategoryNameWithOffsetCaps)
     }
 
     @Test

--- a/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryClientTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryClientTest.kt
@@ -60,31 +60,6 @@ class CategoryClientTest {
     }
 
     @Test
-    fun searchCategoriesCaseTest() {
-        val mwQueryPage = Mockito.mock(MwQueryPage::class.java)
-        Mockito.`when`(mwQueryPage.title()).thenReturn("Category:Test")
-        val mwQueryResult = Mockito.mock(MwQueryResult::class.java)
-        Mockito.`when`(mwQueryResult.pages()).thenReturn(listOf(mwQueryPage))
-        val mockResponse = Mockito.mock(MwQueryResponse::class.java)
-        Mockito.`when`(mockResponse.query()).thenReturn(mwQueryResult)
-
-        Mockito.`when`(categoryInterface!!.searchCategories(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
-                .thenReturn(Observable.just(mockResponse))
-
-        val actualCategoryName = categoryClient!!.searchCategories("tes", 10).blockingFirst()
-        val actualCategoryNameCaps = categoryClient!!.searchCategories("Tes", 10).blockingFirst()
-        assertEquals(actualCategoryName, actualCategoryNameCaps)
-        assertEquals("Test", actualCategoryName)
-        assertEquals("Test", actualCategoryNameCaps)
-
-        val actualCategoryNameWithOffset = categoryClient!!.searchCategories("tes", 10, 10).blockingFirst()
-        val actualCategoryNameWithOffsetCaps = categoryClient!!.searchCategories("Tes", 10, 10).blockingFirst()
-        assertEquals(actualCategoryNameWithOffset, actualCategoryNameWithOffsetCaps)
-        assertEquals("Test", actualCategoryNameWithOffset)
-        assertEquals("Test", actualCategoryNameWithOffsetCaps)
-    }
-
-    @Test
     fun searchCategoriesForPrefixFound() {
         val mwQueryPage = Mockito.mock(MwQueryPage::class.java)
         Mockito.`when`(mwQueryPage.title()).thenReturn("Category:Test")
@@ -117,31 +92,6 @@ class CategoryClientTest {
         categoryClient!!.searchCategoriesForPrefix("tes", 10, 10).subscribe(
                 { fail("SearchCategories returned element when it shouldn't have.") },
                 { s -> throw s })
-    }
-
-    @Test
-    fun searchCategoriesForPrefixCaseTest() {
-        val mwQueryPage = Mockito.mock(MwQueryPage::class.java)
-        Mockito.`when`(mwQueryPage.title()).thenReturn("Category:Test")
-        val mwQueryResult = Mockito.mock(MwQueryResult::class.java)
-        Mockito.`when`(mwQueryResult.pages()).thenReturn(listOf(mwQueryPage))
-        val mockResponse = Mockito.mock(MwQueryResponse::class.java)
-        Mockito.`when`(mockResponse.query()).thenReturn(mwQueryResult)
-
-        Mockito.`when`(categoryInterface!!.searchCategoriesForPrefix(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
-                .thenReturn(Observable.just(mockResponse))
-
-        val actualCategoryName = categoryClient!!.searchCategoriesForPrefix("tes", 10).blockingFirst()
-        val actualCategoryNameCaps = categoryClient!!.searchCategoriesForPrefix("Tes", 10).blockingFirst()
-        assertEquals(actualCategoryName, actualCategoryNameCaps)
-        assertEquals("Test", actualCategoryName)
-        assertEquals("Test", actualCategoryNameCaps)
-
-        val actualCategoryNameWithOffset = categoryClient!!.searchCategoriesForPrefix("tes", 10, 10).blockingFirst()
-        val actualCategoryNameWithOffsetCaps = categoryClient!!.searchCategoriesForPrefix("Tes", 10, 10).blockingFirst()
-        assertEquals(actualCategoryNameWithOffset, actualCategoryNameWithOffsetCaps)
-        assertEquals("Test", actualCategoryNameWithOffset)
-        assertEquals("Test", actualCategoryNameWithOffsetCaps)
     }
 
     @Test

--- a/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryClientTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryClientTest.kt
@@ -58,6 +58,28 @@ class CategoryClientTest {
                 { fail("SearchCategories returned element when it shouldn't have.") },
                 { s -> throw s })
     }
+
+    @Test
+    fun searchCategoriesCaseTest() {
+        val mwQueryPage = Mockito.mock(MwQueryPage::class.java)
+        Mockito.`when`(mwQueryPage.title()).thenReturn("Category:Test")
+        val mwQueryResult = Mockito.mock(MwQueryResult::class.java)
+        Mockito.`when`(mwQueryResult.pages()).thenReturn(listOf(mwQueryPage))
+        val mockResponse = Mockito.mock(MwQueryResponse::class.java)
+        Mockito.`when`(mockResponse.query()).thenReturn(mwQueryResult)
+
+        Mockito.`when`(categoryInterface!!.searchCategoriesForPrefix(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
+                .thenReturn(Observable.just(mockResponse))
+
+        val actualCategoryName = categoryClient!!.searchCategories("tes", 10).blockingFirst()
+        val actualCategoryNameCaps = categoryClient!!.searchCategories("Tes", 10).blockingFirst()
+        assertEquals(actualCategoryName, actualCategoryNameCaps)
+
+        val actualCategoryNameWithOffset = categoryClient!!.searchCategories("tes", 10, 10).blockingFirst()
+        val actualCategoryNameWithOffsetCaps = categoryClient!!.searchCategories("Tes", 10, 10).blockingFirst()
+        assertEquals(actualCategoryNameWithOffset, actualCategoryNameWithOffsetCaps)
+    }
+
     @Test
     fun searchCategoriesForPrefixFound() {
         val mwQueryPage = Mockito.mock(MwQueryPage::class.java)
@@ -92,6 +114,28 @@ class CategoryClientTest {
                 { fail("SearchCategories returned element when it shouldn't have.") },
                 { s -> throw s })
     }
+
+    @Test
+    fun searchCategoriesForPrefixCaseTest() {
+        val mwQueryPage = Mockito.mock(MwQueryPage::class.java)
+        Mockito.`when`(mwQueryPage.title()).thenReturn("Category:Test")
+        val mwQueryResult = Mockito.mock(MwQueryResult::class.java)
+        Mockito.`when`(mwQueryResult.pages()).thenReturn(listOf(mwQueryPage))
+        val mockResponse = Mockito.mock(MwQueryResponse::class.java)
+        Mockito.`when`(mockResponse.query()).thenReturn(mwQueryResult)
+
+        Mockito.`when`(categoryInterface!!.getParentCategoryList(ArgumentMatchers.anyString()))
+                .thenReturn(Observable.just(mockResponse))
+
+        val actualCategoryName = categoryClient!!.searchCategoriesForPrefix("tes", 10).blockingFirst()
+        val actualCategoryNameCaps = categoryClient!!.searchCategoriesForPrefix("Tes", 10).blockingFirst()
+        assertEquals(actualCategoryName, actualCategoryNameCaps)
+
+        val actualCategoryName = categoryClient!!.searchCategoriesForPrefix("tes", 10, 10).blockingFirst()
+        val actualCategoryNameCaps = categoryClient!!.searchCategoriesForPrefix("Tes", 10, 10).blockingFirst()
+        assertEquals(actualCategoryName, actualCategoryNameCaps)
+    }
+
     @Test
     fun getParentCategoryListFound() {
         val mwQueryPage = Mockito.mock(MwQueryPage::class.java)


### PR DESCRIPTION
Fix Category search being case sensitive 

Fixes #3179  Make category search non case-sensitive

Changed the string being sent to the MW api call to lower case.

Tested from the MW api fuzzy search url that the category suggestions would deliver the desired results no matter what case you sent in the api call so to fix the issue api call has been converted to lower case.

Additionally Javadocs have been added to the CategoryItem file.