### PR TITLE
Change {{According to Exif data}} template character case

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
@@ -23,8 +23,8 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 public class  Contribution extends Media {
 
-    //{{According to EXIF data|2009-01-09}}
-    private static final String TEMPLATE_DATE_ACC_TO_EXIF = "{{According to EXIF data|%s}}";
+    //{{According to Exif data|2009-01-09}}
+    private static final String TEMPLATE_DATE_ACC_TO_EXIF = "{{According to Exif data|%s}}";
 
     //2009-01-09 → 9 January 2009
     private static final String TEMPLATE_DATA_OTHER_SOURCE = "%s";


### PR DESCRIPTION
**Description (required)**

Changes `EXIF` to `Exif` in the {{According to Exif data}} template.  Resolves #3328 

"According to Exif data" template documentation: https://commons.wikimedia.org/wiki/Template:According_to_Exif_data



**Tests performed (required)**

Only Github's Travis CI.

