### PR TITLE
Fixes: #3327 Trim whitespaces from title on upload

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
@@ -29,7 +29,7 @@ public class  Contribution extends Media {
     private static final String TEMPLATE_DATE_ACC_TO_EXIF = "{{According to EXIF data|%s}}";
 
     //{{date|2009|1|9}} → 9 January 2009
-    private static final String TEMPLATE_DATA_OTHER_SOURCE = "{{date|%d|%d|%d}}";
+    private static final String TEMPLATE_DATA_OTHER_SOURCE = "{{date|%s}}";
 
     public static Creator<Contribution> CREATOR = new Creator<Contribution>() {
         @Override
@@ -201,16 +201,11 @@ public class  Contribution extends Media {
      */
     private String getTemplatizedCreatedDate() {
         if (dateCreated != null) {
+            java.text.SimpleDateFormat dateFormat = new java.text.SimpleDateFormat("yyyy-MM-dd");
             if (UploadableFile.DateTimeWithSource.EXIF_SOURCE.equals(dateCreatedSource)) {
-                return String.format(Locale.ENGLISH, TEMPLATE_DATE_ACC_TO_EXIF, DateUtil.getDateStringWithSkeletonPattern(dateCreated, "yyyy-MM-dd")) + "\n";
+                return String.format(Locale.ENGLISH, TEMPLATE_DATE_ACC_TO_EXIF, dateFormat.format(dateCreated)) + "\n";
             } else {
-                Calendar calendar = Calendar.getInstance();
-                calendar.setTime(dateCreated);
-                calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
-                return String.format(Locale.ENGLISH, TEMPLATE_DATA_OTHER_SOURCE,
-                        calendar.get(Calendar.YEAR),
-                        calendar.get(Calendar.MONTH),
-                        calendar.get(Calendar.DAY_OF_MONTH)) + "\n";
+                return String.format(Locale.ENGLISH, TEMPLATE_DATA_OTHER_SOURCE, dateFormat.format(dateCreated)) + "\n";
             }
         }
         return "";

--- a/app/src/main/java/fr/free/nrw/commons/upload/Title.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/Title.java
@@ -13,7 +13,7 @@ public class Title{
     }
 
     public void setTitleText(String titleText) {
-        this.titleText = titleText;
+        this.titleText = titleText.trim();
 
         if (!TextUtils.isEmpty(titleText)) {
             set = true;


### PR DESCRIPTION
**Description (required)**

Earlier, the branch 2.11-release was having issues #3327 . The white space left at the end of the title should be trimmed, but it wasn't doing so.

Therefore this merge request will rectify the same on the 2.11-release branch.

**Tests performed (required)**

Tested on the prodDebug Build Variant of the app. In the screenshots below both, the pictures were uploaded with one space at the end of each title, the first picture is before the commit and the second one is after the commit.

Before the commit:
https://commons.wikimedia.org/wiki/File%3AEvening_Sky_.jpg

After the commit:
https://commons.wikimedia.org/wiki/File:Lohri_Celebrations_India.jpg

**Screenshots showing what changed (optional - for UI changes)**

**Before the commit:**

Uploaded Picture on WikiMedia:
![Screenshot_1](https://user-images.githubusercontent.com/41429261/72823506-d4701700-3c99-11ea-8ac2-ec70a9df0ca4.PNG)

**After the commit:**

In the App:
![20200121_220002](https://user-images.githubusercontent.com/41429261/72824094-b5be5000-3c9a-11ea-9073-e2e337c719d3.jpg)

Uploaded Picture on WikiMedia:
![Screenshot_2](https://user-images.githubusercontent.com/41429261/72823461-c621fb00-3c99-11ea-81c9-531ba41615c9.PNG)
