### PR TITLE
Fixes #3336 Hotfix: Coordinates of picture are not uploaded

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -27,6 +27,8 @@ import org.wikipedia.AppAdapter;
 import org.wikipedia.language.AppLanguageLookUpTable;
 
 import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -43,6 +45,7 @@ import fr.free.nrw.commons.di.ApplicationlessInjection;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.logging.FileLoggingTree;
 import fr.free.nrw.commons.logging.LogUtils;
+import fr.free.nrw.commons.settings.Prefs;
 import fr.free.nrw.commons.upload.FileUtils;
 import fr.free.nrw.commons.utils.ConfigUtils;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -132,6 +135,16 @@ public class CommonsApplication extends Application {
         AppAdapter.set(new CommonsAppAdapter(sessionManager, defaultPrefs));
 
         initTimber();
+
+
+        if (!defaultPrefs.getBoolean("has_user_manually_removed_location")) {
+            Set<String> defaultExifTagsSet = defaultPrefs.getStringSet(Prefs.MANAGED_EXIF_TAGS);
+            if (null == defaultExifTagsSet) {
+                defaultExifTagsSet = new HashSet<>();
+            }
+            defaultExifTagsSet.add(getString(R.string.exif_tag_location));
+            defaultPrefs.putStringSet(Prefs.MANAGED_EXIF_TAGS, defaultExifTagsSet);
+        }
 
 //        Set DownsampleEnabled to True to downsample the image in case it's heavy
         ImagePipelineConfig config = ImagePipelineConfig.newBuilder(this)

--- a/app/src/main/java/fr/free/nrw/commons/kvstore/BasicKvStore.java
+++ b/app/src/main/java/fr/free/nrw/commons/kvstore/BasicKvStore.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 import androidx.annotation.Nullable;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -203,4 +204,11 @@ public class BasicKvStore implements KeyValueStore {
         _store.unregisterOnSharedPreferenceChangeListener(l);
     }
 
+    public Set<String> getStringSet(String key){
+        return _store.getStringSet(key, new HashSet<>());
+    }
+
+    public void putStringSet(String key,Set<String> value){
+        _store.edit().putStringSet(key,value).apply();
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
@@ -7,7 +7,7 @@ public class Prefs {
     public static final String DEFAULT_LICENSE = "defaultLicense";
     public static final String UPLOADS_SHOWING = "uploadsshowing";
     public static final String IS_CONTRIBUTION_COUNT_CHANGED = "ccontributionCountChanged";
-    public static final String MANAGED_EXIF_TAGS = "managedExifTags";
+    public static final String MANAGED_EXIF_TAGS = "managed_exif_tags";
     public static final String KEY_LANGUAGE_VALUE = "languageDescription";
 
     public static class Licenses {

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -74,20 +74,9 @@ public class SettingsFragment extends PreferenceFragment {
             return true;
         });
 
-        if (!defaultKvStore.getBoolean("has_user_manually_removed_location")) {
-            Type setType = new TypeToken<Set<String>>() {
-            }.getType();
-            Set<String> defaultExifTagsSet = defaultKvStore.getJson(Prefs.MANAGED_EXIF_TAGS, setType);
-            if (null == defaultExifTagsSet) {
-                defaultExifTagsSet = new HashSet<>();
-            }
-            defaultExifTagsSet.add(getString(R.string.exif_tag_location));
-            defaultKvStore.putJson(Prefs.MANAGED_EXIF_TAGS, defaultExifTagsSet);
-        }
-        MultiSelectListPreference multiSelectListPref = (MultiSelectListPreference) findPreference("manageExifTags");
+        MultiSelectListPreference multiSelectListPref = (MultiSelectListPreference) findPreference(Prefs.MANAGED_EXIF_TAGS);
         if (multiSelectListPref != null) {
             multiSelectListPref.setOnPreferenceChangeListener((preference, newValue) -> {
-                defaultKvStore.putJson(Prefs.MANAGED_EXIF_TAGS, newValue);
                 if (newValue instanceof HashSet && !((HashSet) newValue).contains(getString(R.string.exif_tag_location))) {
                     defaultKvStore.putBoolean("has_user_manually_removed_location", true);
                 }

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -74,7 +74,7 @@ public class SettingsFragment extends PreferenceFragment {
             return true;
         });
 
-        if (defaultKvStore.getBoolean("has_user_manually_removed_location")) {
+        if (!defaultKvStore.getBoolean("has_user_manually_removed_location")) {
             Type setType = new TypeToken<Set<String>>() {
             }.getType();
             Set<String> defaultExifTagsSet = defaultKvStore.getJson(Prefs.MANAGED_EXIF_TAGS, setType);

--- a/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.java
@@ -105,7 +105,7 @@ public class FileProcessor implements Callback {
      */
     private Set<String> getExifTagsToRedact(Context context) {
         Type setType = new TypeToken<Set<String>>() {}.getType();
-        Set<String> prefManageEXIFTags = defaultKvStore.getJson(Prefs.MANAGED_EXIF_TAGS, setType);
+        Set<String> prefManageEXIFTags = defaultKvStore.getStringSet(Prefs.MANAGED_EXIF_TAGS);
 
         Set<String> redactTags = new HashSet<>(Arrays.asList(
                 context.getResources().getStringArray(R.array.pref_exifTag_values)));

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -70,7 +70,7 @@
         <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleMultiSelectListPreference
             android:entries="@array/pref_exifTag_entries"
             android:entryValues="@array/pref_exifTag_values"
-            android:key="manageExifTags"
+            android:key="managedExifTags"
             android:title="@string/manage_exif_tags"
             android:summary="@string/manage_exif_tags_summary"/>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -70,7 +70,7 @@
         <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleMultiSelectListPreference
             android:entries="@array/pref_exifTag_entries"
             android:entryValues="@array/pref_exifTag_values"
-            android:key="managedExifTags"
+            android:key="managed_exif_tags"
             android:title="@string/manage_exif_tags"
             android:summary="@string/manage_exif_tags_summary"/>
 


### PR DESCRIPTION
**Description (required)**
Add the value of location in managedExif tags so that location is not redacted by default (unless the user has manually chosen that)
Fixes #3336 Hotfix: Coordinates of picture are not uploaded

What changes did you make and why?
* Do not redact location by default
**Tests performed (required)**

Tested betaDebug on Samsung S7