### PR TITLE
Fixes: #3343 TextUtils.isEmpty creates problems when unit testing with Mockito

### DIFF
--- a/app/src/test/java/android/text/TextUtils.java
+++ b/app/src/test/java/android/text/TextUtils.java
@@ -58,4 +58,25 @@ public class TextUtils {
         return type == Character.PARAGRAPH_SEPARATOR || type == Character.LINE_SEPARATOR
                 || codePoint == 10;
     }
+
+    /**
+     * Returns whether the given CharSequence contains any printable characters.
+     */
+    public static boolean isGraphic(CharSequence str) {
+        final int len = str.length();
+        for (int cp, i=0; i<len; i+=Character.charCount(cp)) {
+            cp = Character.codePointAt(str, i);
+            int gc = Character.getType(cp);
+            if (gc != Character.CONTROL
+                    && gc != Character.FORMAT
+                    && gc != Character.SURROGATE
+                    && gc != Character.UNASSIGNED
+                    && gc != Character.LINE_SEPARATOR
+                    && gc != Character.PARAGRAPH_SEPARATOR
+                    && gc != Character.SPACE_SEPARATOR) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/app/src/test/java/android/text/TextUtils.java
+++ b/app/src/test/java/android/text/TextUtils.java
@@ -1,0 +1,61 @@
+package android.text;
+
+
+import androidx.annotation.Nullable;
+
+/**
+ * This Class Mocks TextUtils for the purpose of testing.
+ * NOTE: This class would not change the function of the TextUtils used in app
+ * it onlt mocks it for the unit tests
+ *
+ */
+public class TextUtils {
+    /**
+     * mocks TextUtils.isEmpty
+     */
+    public static boolean isEmpty(@Nullable CharSequence str) {
+        return str == null || str.length() == 0;
+    }
+
+    /**
+     * mocks TextUtils.equals
+     */
+    public static boolean equals(CharSequence a, CharSequence b) {
+        if (a == b) return true;
+        int length;
+        if (a != null && b != null && (length = a.length()) == b.length()) {
+            if (a instanceof String && b instanceof String) {
+                return a.equals(b);
+            } else {
+                for (int i = 0; i < length; i++) {
+                    if (a.charAt(i) != b.charAt(i)) return false;
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * mocks TextUtils.isDigitsOnly
+     */
+    public static boolean isDigitsOnly(CharSequence str) {
+        final int len = str.length();
+        for (int cp, i = 0; i < len; i += Character.charCount(cp)) {
+            cp = Character.codePointAt(str, i);
+            if (!Character.isDigit(cp)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * mocks TextUtils.isNewline
+     */
+    private static boolean isNewline(int codePoint) {
+        int type = Character.getType(codePoint);
+        return type == Character.PARAGRAPH_SEPARATOR || type == Character.LINE_SEPARATOR
+                || codePoint == 10;
+    }
+}

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadControllerTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadControllerTest.kt
@@ -49,6 +49,7 @@ class UploadControllerTest {
     @Test
     fun startUpload() {
         val contribution = mock(Contribution::class.java)
+        `when`(contribution.getCreator()).thenReturn("Creator")
         uploadController!!.startUpload(contribution)
     }
 }


### PR DESCRIPTION
**TextUtils.isEmpty creates problems when unit testing with Mockito**

Fixes #3343  TextUtils.isEmpty creates problems when unit testing with Mockito

Added a mock `TextUtils` class for making Unit testing of boolean returning TextUtils methods unit testable using Mockito. Moreover TextUtils.isEmpty has been used in nearly 50 instances in the codebase, with this we can efficiently test them with mockito

**The Changes would not interfere with the working of app, as the changes made are under test/ directory so as to mock its use while testing**

**Tests performed (required)**

It is meant to make unit testing easier 
