### PR TITLE
Fixes #3327: Trim whitespaces from title on upload

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/Title.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/Title.kt
@@ -14,14 +14,7 @@ class Title {
     }
 
     fun setTitleText(titleText: String?) {
-
-        if(titleText != null){
-            this.titleText = titleText.trim()
-        }
-        else{
-            this.titleText = titleText
-        }
-        this.titleText = titleText
+        this.titleText=titleText?.trim()
         if (!TextUtils.isEmpty(titleText)) {
             isSet = true
         }

--- a/app/src/main/java/fr/free/nrw/commons/upload/Title.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/Title.kt
@@ -14,6 +14,13 @@ class Title {
     }
 
     fun setTitleText(titleText: String?) {
+
+        if(titleText != null){
+            this.titleText = titleText.trim()
+        }
+        else{
+            this.titleText = titleText
+        }
         this.titleText = titleText
         if (!TextUtils.isEmpty(titleText)) {
             isSet = true


### PR DESCRIPTION
**Description (required)**

Branch - master
Fixes #3327: Trim whitespaces from title on upload.

**What changes were made?**

If the input text is not null then the white space will be trimmed from both ends of the string. If the input text is null, then set the title text as it is. 

Kotlin doesn't not allow to implement trim() function if the default value of String variable is null. Therefore, an if-else statement will check whether the title text is null or not.

