### PR TITLE
changing background color of conditions in nearby as uniform

### DIFF
--- a/app/src/main/res/color/bg_chip_state.xml
+++ b/app/src/main/res/color/bg_chip_state.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/current_marker_stroke" android:state_checked="true" />
+    <item android:color="@color/cardview_light_background" android:state_checked="true" />
     <item android:color="@color/cardview_light_background" />
 </selector>


### PR DESCRIPTION
Signed-off-by: Mudit Jain <ciphereck@gmail.com>

**Description (required)**
Fixed #3235 Color of conditions in Nearby

What changes did you make and why?
Changed the color of true state of nearby conditions (background color of chip state)

**Tests performed (required)**
Tested prodDebug and betaDebug on One Plus 7T with API level 28.


**Screenshots showing what changed (optional - for UI changes)**
![Screenshot (Feb 2, 2020 2_54_25 PM)](https://user-images.githubusercontent.com/24265219/73606113-dfe20d00-45cc-11ea-8fda-d68b5c2e4eae.jpg)

Dark Mode
![Screenshot (Feb 2, 2020 2_57_24 PM)](https://user-images.githubusercontent.com/24265219/73606133-fc7e4500-45cc-11ea-8dfb-b1994325281a.jpg)

