### PR TITLE
Adds a Test for Method A categories search

### DIFF
--- a/app/src/test/kotlin/fr/free/nrw/commons/category/CategoriesModelTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/CategoriesModelTest.kt
@@ -24,7 +24,7 @@ class CategoriesModelTest {
     internal lateinit var gson: Gson
 
     @Spy
-    internal lateinit var categoryItemForMethodA: CategoryItem
+    internal lateinit var categoryItemForSubstringSearch: CategoryItem
 
     @Mock
     internal var categoryDao: CategoryDao? = null
@@ -39,7 +39,7 @@ class CategoriesModelTest {
     @Throws(Exception::class)
     fun setUp() {
         gson = Gson()
-        categoryItemForMethodA = CategoryItem("",false)
+        categoryItemForSubstringSearch = CategoryItem("",false)
         MockitoAnnotations.initMocks(this)
     }
 
@@ -67,12 +67,13 @@ class CategoriesModelTest {
 
     /**
     * For testing the substring search algorithm for Categories search
-    * To be more precise it tests the Method A which has been described 
+    * To be more precise it tests the In Between substring( ex: searching `atte` 
+    * will give search suggestions: `Latte`, `Iced latte` e.t.c) which has been described 
     * on github repo wiki: 
     * https://github.com/commons-app/apps-android-commons/wiki/Category-suggestions-(readme)#user-content-3-category-search-when-typing-in-the-search-field-has-been-made-more-flexible
     */
     @Test
-    fun searchAllFoundCaseTestForMethodA() {
+    fun searchAllFoundCaseTestForSubstringSearch() {
         val mockDaoList = mutableListOf<String>("")
         val mwQueryPage = Mockito.mock(MwQueryPage::class.java)
         Mockito.`when`(mwQueryPage.title()).thenReturn("Category:Test")
@@ -83,8 +84,8 @@ class CategoriesModelTest {
         Mockito.`when`(context!!.getSharedPreferences("",0))
                 .thenReturn(null)
         val directKvStore = Mockito.spy(JsonKvStore(context,"",gson))
-        val categoriesModelForMethodA = Mockito.spy(CategoriesModel(categoryClient,categoryDao,directKvStore))
-        Mockito.doReturn(Observable.just(categoryItemForMethodA)).`when`(categoriesModelForMethodA).gpsCategories()
+        val categoriesModelForSubstringSearch = Mockito.spy(CategoriesModel(categoryClient,categoryDao,directKvStore))
+        Mockito.doReturn(Observable.just(categoryItemForSubstringSearch)).`when`(categoriesModelForSubstringSearch).gpsCategories()
         Mockito.`when`(context!!.getSharedPreferences("",0))
                 .thenReturn(null)
         Mockito.`when`(categoryInterface!!.searchCategories(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
@@ -95,10 +96,10 @@ class CategoriesModelTest {
                 .thenReturn(Observable.just(mockResponse))
 
         // Checking if both return "Test"
-        val actualCategoryName = categoriesModelForMethodA!!.searchAll(null, listOf<String>("tes")).blockingLast()
+        val actualCategoryName = categoriesModelForSubstringSearch!!.searchAll(null, listOf<String>("tes")).blockingLast()
         assertEquals("Test",actualCategoryName.getName())
 
-        val actualCategoryNameCaps = categoriesModelForMethodA!!.searchAll(null, listOf<String>("Tes")).blockingLast()
+        val actualCategoryNameCaps = categoriesModelForSubstringSearch!!.searchAll(null, listOf<String>("Tes")).blockingLast()
         assertEquals("Test",actualCategoryNameCaps.getName())
     }
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/category/CategoriesModelTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/CategoriesModelTest.kt
@@ -21,10 +21,10 @@ class CategoriesModelTest {
     internal var categoryItem: CategoryItem? = null
 
     @Spy
-    internal var gson: Gson? = Gson()
+    internal lateinit var gson: Gson
 
     @Spy
-    internal var categoryItemForMethodA: CategoryItem? = CategoryItem("",false)
+    internal lateinit var categoryItemForMethodA: CategoryItem
 
     @Mock
     internal var categoryDao: CategoryDao? = null
@@ -38,6 +38,8 @@ class CategoriesModelTest {
     @Before
     @Throws(Exception::class)
     fun setUp() {
+        gson = Gson()
+        categoryItemForMethodA = CategoryItem("",false)
         MockitoAnnotations.initMocks(this)
     }
 


### PR DESCRIPTION
**Adds a Test for Method A categories search**

What changes did you make and why?

There were tests for prefix category search but no such method for Method_A/substring search for the categories serch function

Here the Method A search which i am reffering to is given in wiki:
https://github.com/commons-app/apps-android-commons/wiki/Category-suggestions-(readme)#user-content-3-category-search-when-typing-in-the-search-field-has-been-made-more-flexible

