### PR TITLE
Fix: Issue #3367 Bug: SoftKeyboard showing even after switching from nearby tab to contribution tab

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -42,6 +42,7 @@ import fr.free.nrw.commons.notification.NotificationController;
 import fr.free.nrw.commons.quiz.QuizChecker;
 import fr.free.nrw.commons.theme.NavigationBaseActivity;
 import fr.free.nrw.commons.upload.UploadService;
+import fr.free.nrw.commons.utils.ViewUtil;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 import timber.log.Timber;
@@ -179,7 +180,7 @@ public class MainActivity extends NavigationBaseActivity implements FragmentMana
                         Timber.d("Contributions tab selected");
                         tabLayout.getTabAt(CONTRIBUTIONS_TAB_POSITION).select();
                         isContributionsFragmentVisible = true;
-                        ((NearbyParentFragment)contributionsActivityPagerAdapter.getItem(NEARBY_TAB_POSITION)).hideKeyboard();
+                        ViewUtil.hideKeyboard(tabLayout.getRootView());
                         updateMenuItem();
                         break;
                     case NEARBY_TAB_POSITION:

--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -179,6 +179,7 @@ public class MainActivity extends NavigationBaseActivity implements FragmentMana
                         Timber.d("Contributions tab selected");
                         tabLayout.getTabAt(CONTRIBUTIONS_TAB_POSITION).select();
                         isContributionsFragmentVisible = true;
+                        ((NearbyParentFragment)contributionsActivityPagerAdapter.getItem(NEARBY_TAB_POSITION)).hideKeyboard();
                         updateMenuItem();
                         break;
                     case NEARBY_TAB_POSITION:

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.nearby.fragments;
 
 import android.Manifest;
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -8,6 +9,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.res.Configuration;
 import android.os.Bundle;
+import android.os.IBinder;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -15,6 +17,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
@@ -488,6 +491,20 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             nearbyParentFragmentPresenter.centerMapToPlace(place,
                     getActivity().getResources().getConfiguration().orientation ==
                             Configuration.ORIENTATION_PORTRAIT);
+        }
+    }
+
+    /**
+     * Hides the keyboard in case the tab is switched
+     */
+    public void hideKeyboard(){
+        if(!searchView.isIconified()) {
+            searchView.clearFocus();
+            InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(Activity.INPUT_METHOD_SERVICE);
+            final IBinder windowToken = this.getView().getRootView().getWindowToken();
+            if (view != null) {
+                imm.hideSoftInputFromWindow(windowToken, InputMethodManager.HIDE_NOT_ALWAYS);
+            }
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1,7 +1,6 @@
 package fr.free.nrw.commons.nearby.fragments;
 
 import android.Manifest;
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -9,7 +8,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.res.Configuration;
 import android.os.Bundle;
-import android.os.IBinder;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -17,7 +15,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
@@ -491,20 +488,6 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             nearbyParentFragmentPresenter.centerMapToPlace(place,
                     getActivity().getResources().getConfiguration().orientation ==
                             Configuration.ORIENTATION_PORTRAIT);
-        }
-    }
-
-    /**
-     * Hides the keyboard in case the tab is switched
-     */
-    public void hideKeyboard(){
-        if(!searchView.isIconified()) {
-            searchView.clearFocus();
-            InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(Activity.INPUT_METHOD_SERVICE);
-            final IBinder windowToken = this.getView().getRootView().getWindowToken();
-            if (view != null) {
-                imm.hideSoftInputFromWindow(windowToken, InputMethodManager.HIDE_NOT_ALWAYS);
-            }
         }
     }
 


### PR DESCRIPTION
**Description (required)**

Fixes #3367 Bug: SoftKeyboard showing even after switching from nearby tab to contribution tab

What changes did you make and why?
Made the Soft Keyboard disappear on shifting across tabs
**Tests performed (required)**

Tested 2.12.3-debug on Redmi Note7 Pro with API level 27.

**Screenshots showing what changed (optional - for UI changes)**
Before:
<img src="https://user-images.githubusercontent.com/32506591/73610406-dcff1080-45fc-11ea-815e-59778945aa7a.gif" width="400">

After:
<img src="https://user-images.githubusercontent.com/32506591/73610397-b9d46100-45fc-11ea-8c40-319284cf1cdc.gif" width="400">




---
