### PR TITLE
Fixes #3371

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -894,7 +894,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     }
 
     private boolean isUserBrowsing() {
-        boolean isUserBrowsing = !presenter.areLocationsClose(getCameraTarget(), lastKnownLocation);
+        boolean isUserBrowsing = lastKnownLocation!=null && !presenter.areLocationsClose(getCameraTarget(), lastKnownLocation);
         return isUserBrowsing;
     }
 


### PR DESCRIPTION


**Description (required)**

Fixes App Crashes when LastKnownLocation is null #3371

What changes did you make and why?
* Is UserBrowsing should first check if last known location is non-null before checking if last location and current locations are close
**Tests performed (required)**

Tested betaDebug on Samsung S7 Api 27.

