### PR TITLE
Fixes #3295: Ultimate achievement: Too many contributions

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -238,18 +238,18 @@ public class AchievementsActivity extends NavigationBaseActivity {
                                         // achievements calculator to fail in some cases, for more details
                                         // refer Issue: #3295
                                         if (numberOfEdits <= 150000) {
-                                            showSnackBarWithRetry();
+                                            showSnackBarWithRetry(false);
                                         } else {
-                                            showSnackBarUltimateAchievementWithRetry();
+                                            showSnackBarWithRetry(true);
                                         }
                                     }
                                 },
                                 t -> {
                                     Timber.e(t, "Fetching achievements statistics failed");
                                     if (numberOfEdits <= 150000) {
-                                        showSnackBarWithRetry();
+                                        showSnackBarWithRetry(false);
                                     } else {
-                                        showSnackBarUltimateAchievementWithRetry();
+                                        showSnackBarWithRetry(true);
                                     }
                                 }
                         ));
@@ -275,7 +275,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(edits -> {
-                    numberOfEdits += edits;
+                    numberOfEdits = edits;
                     wikidataEditsText.setText(String.valueOf(edits));
                 }, e -> {
                     Timber.e("Error:" + e);
@@ -285,22 +285,20 @@ public class AchievementsActivity extends NavigationBaseActivity {
     /**
      * Shows a snack bar which has an action button which on click dismisses the snackbar and invokes the
      * listener passed
+     * @param tooManyAchievements if this value is true it means that the number of achievements of the 
+     * user are so high that it wrecks havoc with the Achievements calculator due to which request may time 
+     * out. Well this is the Ultimate Achievement
      */
-    private void showSnackBarWithRetry() {
-        progressBar.setVisibility(View.GONE);
-        ViewUtil.showDismissibleSnackBar(findViewById(android.R.id.content),
-                R.string.achievements_fetch_failed, R.string.retry, view -> setAchievements());
-    }
-
-    /**
-     * Shows a snack bar which tells the users that their wiki edit count is so high that it (in some cases)
-     * wreks havoc with the Achievements calculator due to which request may time out
-     * Well this is the Ultimate Achievement 
-     */
-    private void showSnackBarUltimateAchievementWithRetry() {
-        progressBar.setVisibility(View.GONE);
-        ViewUtil.showDismissibleSnackBar(findViewById(android.R.id.content),
-                R.string.achievements_fetch_failed_ultimate_achievement, R.string.retry, view -> setAchievements());
+    private void showSnackBarWithRetry(boolean tooManyAchievements) {
+        if (tooManyAchievements) {
+            progressBar.setVisibility(View.GONE);
+            ViewUtil.showDismissibleSnackBar(findViewById(android.R.id.content),
+                    R.string.achievements_fetch_failed_ultimate_achievement, R.string.retry, view -> setAchievements());
+        } else {
+            progressBar.setVisibility(View.GONE);
+            ViewUtil.showDismissibleSnackBar(findViewById(android.R.id.content),
+                    R.string.achievements_fetch_failed, R.string.retry, view -> setAchievements());
+        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -110,6 +110,9 @@ public class AchievementsActivity extends NavigationBaseActivity {
 
     private CompositeDisposable compositeDisposable = new CompositeDisposable();
 
+    // To keep track of the number of wiki edits made by a user
+    private int numberOfEdits = 0;
+
     /**
      * This method helps in the creation Achievement screen and
      * dynamically set the size of imageView
@@ -140,8 +143,8 @@ public class AchievementsActivity extends NavigationBaseActivity {
         progressBar.setVisibility(View.VISIBLE);
 
         hideLayouts();
-        setAchievements();
         setWikidataEditCount();
+        setAchievements();
         initDrawer();
     }
 
@@ -230,12 +233,24 @@ public class AchievementsActivity extends NavigationBaseActivity {
                                         Timber.d("success");
                                         layoutImageReverts.setVisibility(View.INVISIBLE);
                                         imageView.setVisibility(View.INVISIBLE);
-                                        showSnackBarWithRetry();
+                                        // If the number of edits made by the user are more than 150,000
+                                        // in some cases such high number of wiki edit counts cause the 
+                                        // achievements calculator to fail in some cases, for more details
+                                        // refer Issue: #3295
+                                        if (numberOfEdits <= 150000) {
+                                            showSnackBarWithRetry();
+                                        } else {
+                                            showSnackBarUltimateAchievementWithRetry();
+                                        }
                                     }
                                 },
                                 t -> {
                                     Timber.e(t, "Fetching achievements statistics failed");
-                                    showSnackBarWithRetry();
+                                    if (numberOfEdits <= 150000) {
+                                        showSnackBarWithRetry();
+                                    } else {
+                                        showSnackBarUltimateAchievementWithRetry();
+                                    }
                                 }
                         ));
             }
@@ -259,7 +274,10 @@ public class AchievementsActivity extends NavigationBaseActivity {
                 .getWikidataEdits(userName)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(edits -> wikidataEditsText.setText(String.valueOf(edits)), e -> {
+                .subscribe(edits -> {
+                    numberOfEdits += edits;
+                    wikidataEditsText.setText(String.valueOf(edits));
+                }, e -> {
                     Timber.e("Error:" + e);
                 }));
     }
@@ -272,6 +290,17 @@ public class AchievementsActivity extends NavigationBaseActivity {
         progressBar.setVisibility(View.GONE);
         ViewUtil.showDismissibleSnackBar(findViewById(android.R.id.content),
                 R.string.achievements_fetch_failed, R.string.retry, view -> setAchievements());
+    }
+
+    /**
+     * Shows a snack bar which tells the users that their wiki edit count is so high that it (in some cases)
+     * wreks havoc with the Achievements calculator due to which request may time out
+     * Well this is the Ultimate Achievement 
+     */
+    private void showSnackBarUltimateAchievementWithRetry() {
+        progressBar.setVisibility(View.GONE);
+        ViewUtil.showDismissibleSnackBar(findViewById(android.R.id.content),
+                R.string.achievements_fetch_failed_ultimate_achievement, R.string.retry, view -> setAchievements());
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -458,6 +458,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="display_location_permission_title">Display location permission</string>
   <string name="display_location_permission_explanation">Ask for location permission when needed for nearby notification card view feature.</string>
   <string name="achievements_fetch_failed">Something went wrong, We could not fetch your achievements</string>
+  <string name="achievements_fetch_failed_ultimate_achievement">You\'ve made so many contributions our achievements calculation system can\'t cope. This is the ultimate achievement.</string>
   <string name="ends_on">Ends on:</string>
   <string name="display_campaigns">Display campaigns</string>
   <string name="display_campaigns_explanation">See the ongoing campaigns</string>


### PR DESCRIPTION
**Fixes: Ultimate achievement: Too many contributions**

Fixes #3295 Ultimate achievement: Too many contributions (making our script time out)

What changes did you make and why?
Made changes to Achievements activity as follows:
 - Do nothing If The request for achievement calculation succeeds 
 - If the response for number of achievements is null and edit count>150,000 then display Ultimate achievement message ( since the high number edits would have created problem with achievement calculation)
 - If request for achievements times out and edit count > 150,000 then too display the ultimate achievement message (since the high number of edits might have caused request to time out ) 

**Tests performed**

Tested ProdDebug on pixel 3a with API level 28.


