### PR TITLE
Fixes #3382 Fixed Notification Message Icon Background

### DIFF
--- a/app/src/main/res/layout/item_notification.xml
+++ b/app/src/main/res/layout/item_notification.xml
@@ -14,7 +14,6 @@
         android:layout_marginLeft="16dp"
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
-        android:background="@android:color/white"
         android:scaleType="centerCrop"
         app:srcCompat="@drawable/ic_message_black_24dp"
         app:tint="@color/primaryDarkColor"


### PR DESCRIPTION
**Description**
Fixed Notification Message Icon Background which was set to white.

Fixes #3382 Notification message icon's background stays white in night mode

**Tests performed**

Tested betaDebug on Google Pixel 2 Virtual Device with API level 28 Android 10.

**Screenshots showing what changed**
![Screenshot_1581057663](https://user-images.githubusercontent.com/30932899/74006994-41c2be00-49a3-11ea-9873-e06c01b8f57b.png)

