### PR TITLE
Hide Review for logged out users

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -100,6 +100,7 @@ public abstract class NavigationBaseActivity extends BaseActivity
             nav_Menu.findItem(R.id.action_settings).setVisible(true);
             nav_Menu.findItem(R.id.action_logout).setVisible(false);
             nav_Menu.findItem(R.id.action_bookmarks).setVisible(true);
+            nav_Menu.findItem(R.id.action_review).setVisible(false);
         }else {
             userIcon.setVisibility(View.VISIBLE);
             nav_Menu.findItem(R.id.action_login).setVisible(false);
@@ -107,6 +108,7 @@ public abstract class NavigationBaseActivity extends BaseActivity
             nav_Menu.findItem(R.id.action_settings).setVisible(true);
             nav_Menu.findItem(R.id.action_logout).setVisible(true);
             nav_Menu.findItem(R.id.action_bookmarks).setVisible(true);
+            nav_Menu.findItem(R.id.action_review).setVisible(true);
         }
     }
 


### PR DESCRIPTION
### Description (required)
IMO, it makes sense to not show the review activity for logged
out users for the same reasons that we don't allow users
to upload images.

We're even considering to [limit the review activity to users
with a particular level of achievement]([1]: https://github.com/commons-app/apps-android-commons/issues/2852. So, it's valid to
not show review activity for logged out users who don't
have achievements levels at all.

What changes did you make and why?
Hid the "Review" menu option for logged out users

### Tests performed (required)
Tested betaDebug on Samsung SM-J111F with API level 22

### Screenshots showing what changed (optional - for UI changes)
#### Menu seen by logged out users
![Screenshot_2020-02-08-19-06-58](https://user-images.githubusercontent.com/12448084/74086285-630cd280-4aa7-11ea-80c3-e2193abbbe04.png)

#### Menu seen by logged in users
![Screenshot_2020-02-08-19-06-40](https://user-images.githubusercontent.com/12448084/74086291-6acc7700-4aa7-11ea-9ea5-ff34032fbe81.png)
