### PR TITLE
Fix #3191 Make the username along with the rewards icon clickable in the Navigation Drawer

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -13,6 +13,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -136,7 +137,7 @@ public abstract class NavigationBaseActivity extends BaseActivity
         if (allAccounts.length != 0) {
             username.setText(allAccounts[0].name);
         }
-        ImageView userIcon = navHeaderView.findViewById(R.id.user_icon);
+        LinearLayout userIcon = navHeaderView.findViewById(R.id.user_details);
         userIcon.setOnClickListener(v -> {
             drawerLayout.closeDrawer(navigationView);
             AchievementsActivity.startYourself(NavigationBaseActivity.this);

--- a/app/src/main/res/layout/drawer_header.xml
+++ b/app/src/main/res/layout/drawer_header.xml
@@ -19,6 +19,7 @@
         app:srcCompat="@drawable/commons_logo"/>
 
     <LinearLayout
+        android:id="@+id/user_details"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"


### PR DESCRIPTION
**Description (required)**
Made username along with the rewards icon clickable in the navigation drawer. Now achievements section can be opened by clicking the entire linear layout,

Fixes #3191 Make the username along with the rewards icon clickable in the Navigation Drawer

What changes did you make and why?
Made the entire linear layout consisting of the rewards icon and username clickable.

**Tests performed (required)**

Tested betaDebug on Nokia 7 Plus with API level 28.