### PR TITLE
Fixes #3403 Add padding between privacy policy button and bottom of the screen

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -245,6 +245,7 @@
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
         android:layout_marginBottom="@dimen/normal_text"
+        android:paddingBottom="@dimen/login_padding"
         android:textColor="@color/status_bar_blue"
         android:text="@string/about_privacy_policy" />
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -9,6 +9,7 @@
     <dimen name="medium_width">12dp</dimen>
 
     <!-- Standard margins / padding -->
+    <dimen name="login_padding">30dp</dimen>
     <dimen name="tiny_height">1dp</dimen>
     <dimen name="miniscule_margin">2dp</dimen>
     <dimen name="tiny_margin">4dp</dimen>


### PR DESCRIPTION
**Description (required)**

Fixes #3403 Position of privacy policy on the login screen

What changes did you make and why?

Added padding between the privacy policy and the bottom of the screen.

**Tests performed (required)**

Tested betaDebug on Nokia 7 Plus with API level 28.

**Screenshots showing what changed (optional - for UI changes)**

![screencap](https://user-images.githubusercontent.com/41234408/74332435-b50d6b00-4dbb-11ea-9748-785d019eced0.png)
