### PR TITLE
Fixes #3412 Add option to not show the dialog again

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -4,9 +4,11 @@ import android.accounts.Account;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.util.DisplayMetrics;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
@@ -109,6 +111,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
     MenuItem item;
 
     private CompositeDisposable compositeDisposable = new CompositeDisposable();
+    private SharedPreferences prefs;
 
     /**
      * This method helps in the creation Achievement screen and
@@ -315,7 +318,8 @@ public class AchievementsActivity extends NavigationBaseActivity {
      * @param uploadCount
      */
     private void setUploadProgress(int uploadCount){
-        if (uploadCount==0){
+        prefs = this.getSharedPreferences(getString(R.string.achievements_activity), Context.MODE_PRIVATE);
+        if (uploadCount==0 && !prefs.getBoolean(getString(R.string.no_contributions_dialog), false)){
             setZeroAchievements();
         }else {
 
@@ -331,6 +335,12 @@ public class AchievementsActivity extends NavigationBaseActivity {
         AlertDialog.Builder builder=new AlertDialog.Builder(this)
                 .setMessage(getString(R.string.no_achievements_yet))
                 .setPositiveButton(getString(R.string.ok), (dialog, which) -> {
+                })
+                .setNegativeButton(getString(R.string.no_show), (dialog, which) -> {
+                    prefs = this.getSharedPreferences(getString(R.string.achievements_activity), Context.MODE_PRIVATE);
+                    SharedPreferences.Editor edit = prefs.edit();
+                    edit.putBoolean(getString(R.string.no_contributions_dialog), true);
+                    edit.apply();
                 });
         AlertDialog dialog = builder.create();
         dialog.show();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -591,4 +591,7 @@ Upload your first media by tapping on the add button.</string>
 
   <string name="upload_nearby_place_found_title">Nearby Place Found</string>
   <string name="upload_nearby_place_found_description">Is this a photo of Place %1$s?</string>
+  <string name="achievements_activity">Achievements Activity</string>
+  <string name="no_show">Don\'t show again</string>
+  <string name="no_contributions_dialog">Show no contributions dialog</string>
 </resources>


### PR DESCRIPTION
**Description (required)**

Fixes #3412 No contributions dialog keeps popping repeatedly.

What changes did you make and why?

Added an option to not show the no contributions dialog repeatedly. Now it's up to the user to choose whether to be shown this dialog again and again or not. This improves the UX of the app. Otherwise, it gets very tiresome for a user to keep canceling this dialog every time the achievements activity is opened. 

**Tests performed (required)**

Tested ProdDebug on Nokia 7 Plus with API level 29.