### PR TITLE
Added progress dialog for setting wallpaper

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
@@ -1,5 +1,6 @@
 package fr.free.nrw.commons.utils;
 
+import android.app.ProgressDialog;
 import android.app.WallpaperManager;
 import android.content.Context;
 import android.graphics.Bitmap;
@@ -67,6 +68,8 @@ public class ImageUtils {
     public static final int EMPTY_TITLE = -3;
     public static final int FILE_NAME_EXISTS = -4;
     static final int NO_CATEGORY_SELECTED = -5;
+
+    private static ProgressDialog progressDialog;
 
     @IntDef(
             flag = true,
@@ -188,6 +191,7 @@ public class ImageUtils {
      * @param imageUrl Url of the image
      */
     public static void setWallpaperFromImageUrl(Context context, Uri imageUrl) {
+        showSettingWallpaperProgressBar(context);
         Timber.d("Trying to set wallpaper from url %s", imageUrl.toString());
         ImageRequest imageRequest = ImageRequestBuilder
                 .newBuilderWithSource(imageUrl)
@@ -224,9 +228,21 @@ public class ImageUtils {
         try {
             wallpaperManager.setBitmap(bitmap);
             ViewUtil.showLongToast(context, context.getString(R.string.wallpaper_set_successfully));
+            if (progressDialog.isShowing() && progressDialog != null) {
+                progressDialog.dismiss();
+            }
         } catch (IOException e) {
             Timber.e(e, "Error setting wallpaper");
+            ViewUtil.showLongToast(context, context.getString(R.string.wallpaper_set_unsuccessfully));
+            if (progressDialog != null) {
+                progressDialog.cancel();
+            }
         }
+    }
+
+    private static void showSettingWallpaperProgressBar(Context context) {
+        progressDialog = ProgressDialog.show(context, context.getString(R.string.setting_wallpaper_dialog_title),
+                context.getString(R.string.setting_wallpaper_dialog_message), true);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
@@ -228,7 +228,7 @@ public class ImageUtils {
         try {
             wallpaperManager.setBitmap(bitmap);
             ViewUtil.showLongToast(context, context.getString(R.string.wallpaper_set_successfully));
-            if (progressDialog.isShowing() && progressDialog != null) {
+            if (progressDialog != null && progressDialog.isShowing()) {
                 progressDialog.dismiss();
             }
         } catch (IOException e) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -593,7 +593,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="upload_nearby_place_found_description">Is this a photo of Place %1$s?</string>
   <string name="remove_bookmark">Removed from bookmarks</string>
   <string name="add_bookmark">Added to bookmarks</string>
-  <string name="wallpaper_set_unsuccessfully">Error setting wallpaper</string>
-  <string name="setting_wallpaper_dialog_title">""</string>
+  <string name="wallpaper_set_unsuccessfully">Something went wrong. Could not set the wallpaper</string>
+  <string name="setting_wallpaper_dialog_title">Set as Wallpaper</string>
   <string name="setting_wallpaper_dialog_message">Setting Wallpaper. Please wait…</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -593,4 +593,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="upload_nearby_place_found_description">Is this a photo of Place %1$s?</string>
   <string name="remove_bookmark">Removed from bookmarks</string>
   <string name="add_bookmark">Added to bookmarks</string>
+  <string name="wallpaper_set_unsuccessfully">Error setting wallpaper</string>
+  <string name="setting_wallpaper_dialog_title">""</string>
+  <string name="setting_wallpaper_dialog_message">Setting Wallpaper. Please wait…</string>
 </resources>


### PR DESCRIPTION
**Description**
Added progress dialog for setting wallpaper as per the discussion.

Fixes #3425 "Set as Wallpaper" is not working properly

**What changes did you make and why?**
Setting a new wallpaper takes a lot of time, so a progress dialog will help users to know that the process is going on in the background.

**Tests performed**
Tested betaDebug on Mi A2 Android 10 (stock) with API level 29

**Screenshots showing what changed**
![Screenshot_20200223-190103](https://user-images.githubusercontent.com/30932899/75117271-3abcd080-5670-11ea-9e07-ac9df1b98d32.png)
