### PR TITLE
Fixed a type in NearbyParentFragment.java where significantly was wri…

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -908,7 +908,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     @Override
     public void onLocationChangedSlightly(fr.free.nrw.commons.location.LatLng latLng) {
-        Timber.d("Location significantly changed");
+        Timber.d("Location slightly changed");
         if (isMapBoxReady && latLng != null &&!isUserBrowsing()) {//If the map has never ever shown the current location, lets do it know
             handleLocationUpdate(latLng,LOCATION_SLIGHTLY_CHANGED);
         }


### PR DESCRIPTION
…tten instead of slightly while adding a log using Timber

**Description (required)**

Fixes #3429 Typo in NearbyParentFragment.java -> onLocationChangedSlightly() method.

What changes did you make and why?
Wrote slightly in place of significantly because otherwise when the location is changed slightly,  it will report as  Location changed **significantly** in the logs which can cause debugging problems in the future.

**Tests performed (required)**
None

