### PR TITLE
Added Support for System Wide Dark Theme

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -145,7 +145,7 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     }
 
     // Return true is system wide dark theme is enabled else false
-    public boolean getSystemDefaultThemeBool(String theme) {
+    private boolean getSystemDefaultThemeBool(String theme) {
         switch (theme) {
             case "Dark":
                 return true;
@@ -157,7 +157,7 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     }
 
     // Returns the default system wide theme
-    public String getSystemDefaultTheme() {
+    private String getSystemDefaultTheme() {
         if ((getResources().getConfiguration().uiMode &
                 Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
             return "Dark";

--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -146,23 +146,21 @@ public class LoginActivity extends AccountAuthenticatorActivity {
 
     // Return true is system wide dark theme is enabled else false
     private boolean getSystemDefaultThemeBool(String theme) {
-        switch (theme) {
-            case "Dark":
-                return true;
-            case "Default":
-                return getSystemDefaultThemeBool(getSystemDefaultTheme());
-            default:
-                return false;
+        if (getString(R.string.theme_dark_name).equals(theme)) {
+            return true;
+        } else if (getString(R.string.theme_default_name).equals(theme)) {
+            return getSystemDefaultThemeBool(getSystemDefaultTheme());
         }
+        return false;
     }
 
     // Returns the default system wide theme
     private String getSystemDefaultTheme() {
         if ((getResources().getConfiguration().uiMode &
                 Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
-            return "Dark";
+            return getString(R.string.theme_dark_name);
         }
-        return "Light";
+        return getString(R.string.theme_light_name);
     }
 
     @OnFocusChange(R.id.login_username)

--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -4,7 +4,6 @@ import android.accounts.AccountAuthenticatorActivity;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
@@ -54,9 +53,9 @@ import fr.free.nrw.commons.contributions.MainActivity;
 import fr.free.nrw.commons.di.ApplicationlessInjection;
 import fr.free.nrw.commons.explore.categories.ExploreActivity;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
-import fr.free.nrw.commons.settings.Prefs;
 import fr.free.nrw.commons.theme.NavigationBaseActivity;
 import fr.free.nrw.commons.utils.ConfigUtils;
+import fr.free.nrw.commons.utils.SystemThemeUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
 import io.reactivex.disposables.CompositeDisposable;
 import retrofit2.Call;
@@ -84,6 +83,9 @@ public class LoginActivity extends AccountAuthenticatorActivity {
 
     @Inject
     LoginClient loginClient;
+
+    @Inject
+    SystemThemeUtils systemThemeUtils;
 
     @BindView(R.id.login_button)
     Button loginButton;
@@ -123,8 +125,7 @@ public class LoginActivity extends AccountAuthenticatorActivity {
                 .getCommonsApplicationComponent()
                 .inject(this);
 
-        boolean isDarkTheme = getSystemDefaultThemeBool(
-                applicationKvStore.getString(Prefs.KEY_THEME_VALUE, getSystemDefaultTheme()));
+        boolean isDarkTheme = systemThemeUtils.isDeviceInNightMode();
         setTheme(isDarkTheme ? R.style.DarkAppTheme : R.style.LightAppTheme);
         getDelegate().installViewFactory();
         getDelegate().onCreate(savedInstanceState);
@@ -142,25 +143,6 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         } else {
             loginCredentials.setVisibility(View.GONE);
         }
-    }
-
-    // Return true is system wide dark theme is enabled else false
-    private boolean getSystemDefaultThemeBool(String theme) {
-        if (getString(R.string.theme_dark_name).equals(theme)) {
-            return true;
-        } else if (getString(R.string.theme_default_name).equals(theme)) {
-            return getSystemDefaultThemeBool(getSystemDefaultTheme());
-        }
-        return false;
-    }
-
-    // Returns the default system wide theme
-    private String getSystemDefaultTheme() {
-        if ((getResources().getConfiguration().uiMode &
-                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
-            return getString(R.string.theme_dark_name);
-        }
-        return getString(R.string.theme_light_name);
     }
 
     @OnFocusChange(R.id.login_username)

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -244,23 +244,21 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     // Return true is system wide dark theme is enabled else false
     private boolean getSystemDefaultThemeBool(String theme) {
-        switch (theme) {
-            case "Dark":
-                return true;
-            case "Default":
-                return getSystemDefaultThemeBool(getSystemDefaultTheme());
-            default:
-                return false;
+        if (getString(R.string.theme_dark_name).equals(theme)) {
+            return true;
+        } else if (getString(R.string.theme_default_name).equals(theme)) {
+            return getSystemDefaultThemeBool(getSystemDefaultTheme());
         }
+        return false;
     }
 
     // Returns the default system wide theme
     private String getSystemDefaultTheme() {
         if ((getResources().getConfiguration().uiMode &
                 Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
-            return "Dark";
+            return getString(R.string.theme_dark_name);
         }
-        return "Light";
+        return getString(R.string.theme_light_name);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -86,13 +86,13 @@ import fr.free.nrw.commons.nearby.NearbyMarker;
 import fr.free.nrw.commons.nearby.Place;
 import fr.free.nrw.commons.nearby.contract.NearbyParentFragmentContract;
 import fr.free.nrw.commons.nearby.presenter.NearbyParentFragmentPresenter;
-import fr.free.nrw.commons.settings.Prefs;
 import fr.free.nrw.commons.utils.ExecutorUtils;
 import fr.free.nrw.commons.utils.LayoutUtils;
 import fr.free.nrw.commons.utils.LocationUtils;
 import fr.free.nrw.commons.utils.NearbyFABUtils;
 import fr.free.nrw.commons.utils.NetworkUtils;
 import fr.free.nrw.commons.utils.PermissionUtils;
+import fr.free.nrw.commons.utils.SystemThemeUtils;
 import fr.free.nrw.commons.utils.UiUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
 import fr.free.nrw.commons.wikidata.WikidataEditListener;
@@ -156,6 +156,9 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     @Inject ContributionController controller;
     @Inject WikidataEditListener wikidataEditListener;
 
+    @Inject
+    SystemThemeUtils systemThemeUtils;
+
     private NearbyFilterSearchRecyclerViewAdapter nearbyFilterSearchRecyclerViewAdapter;
 
     private BottomSheetBehavior bottomSheetListBehavior;
@@ -210,8 +213,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        isDarkTheme = getSystemDefaultThemeBool(
-                applicationKvStore.getString(Prefs.KEY_THEME_VALUE, getSystemDefaultTheme()));
+        isDarkTheme = systemThemeUtils.isDeviceInNightMode();
         cameraMoveListener= () -> presenter.onCameraMove(mapBox.getCameraPosition().target);
         addCheckBoxCallback();
         presenter.attachView(this);
@@ -240,25 +242,6 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             });
 
         });
-    }
-
-    // Return true is system wide dark theme is enabled else false
-    private boolean getSystemDefaultThemeBool(String theme) {
-        if (getString(R.string.theme_dark_name).equals(theme)) {
-            return true;
-        } else if (getString(R.string.theme_default_name).equals(theme)) {
-            return getSystemDefaultThemeBool(getSystemDefaultTheme());
-        }
-        return false;
-    }
-
-    // Returns the default system wide theme
-    private String getSystemDefaultTheme() {
-        if ((getResources().getConfiguration().uiMode &
-                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
-            return getString(R.string.theme_dark_name);
-        }
-        return getString(R.string.theme_light_name);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -9,7 +9,6 @@ import android.content.IntentFilter;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.os.Bundle;
-import android.text.TextUtils;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -87,6 +86,7 @@ import fr.free.nrw.commons.nearby.NearbyMarker;
 import fr.free.nrw.commons.nearby.Place;
 import fr.free.nrw.commons.nearby.contract.NearbyParentFragmentContract;
 import fr.free.nrw.commons.nearby.presenter.NearbyParentFragmentPresenter;
+import fr.free.nrw.commons.settings.Prefs;
 import fr.free.nrw.commons.utils.ExecutorUtils;
 import fr.free.nrw.commons.utils.LayoutUtils;
 import fr.free.nrw.commons.utils.LocationUtils;
@@ -210,7 +210,8 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        isDarkTheme = applicationKvStore.getBoolean("theme", false);
+        isDarkTheme = getSystemDefaultThemeBool(
+                applicationKvStore.getString(Prefs.KEY_THEME_VALUE, getSystemDefaultTheme()));
         cameraMoveListener= () -> presenter.onCameraMove(mapBox.getCameraPosition().target);
         addCheckBoxCallback();
         presenter.attachView(this);
@@ -239,6 +240,27 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             });
 
         });
+    }
+
+    // Return true is system wide dark theme is enabled else false
+    public boolean getSystemDefaultThemeBool(String theme) {
+        switch (theme) {
+            case "Dark":
+                return true;
+            case "Default":
+                return getSystemDefaultThemeBool(getSystemDefaultTheme());
+            default:
+                return false;
+        }
+    }
+
+    // Returns the default system wide theme
+    public String getSystemDefaultTheme() {
+        if ((getResources().getConfiguration().uiMode &
+                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
+            return "Dark";
+        }
+        return "Light";
     }
 
     /**
@@ -821,10 +843,10 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     }
 
     private void showFABs() {
-            NearbyFABUtils.addAnchorToBigFABs(fabPlus, bottomSheetDetails.getId());
-            fabPlus.show();
-            NearbyFABUtils.addAnchorToSmallFABs(fabGallery, getView().findViewById(R.id.empty_view).getId());
-            NearbyFABUtils.addAnchorToSmallFABs(fabCamera, getView().findViewById(R.id.empty_view1).getId());
+        NearbyFABUtils.addAnchorToBigFABs(fabPlus, bottomSheetDetails.getId());
+        fabPlus.show();
+        NearbyFABUtils.addAnchorToSmallFABs(fabGallery, getView().findViewById(R.id.empty_view).getId());
+        NearbyFABUtils.addAnchorToSmallFABs(fabCamera, getView().findViewById(R.id.empty_view1).getId());
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -243,7 +243,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     }
 
     // Return true is system wide dark theme is enabled else false
-    public boolean getSystemDefaultThemeBool(String theme) {
+    private boolean getSystemDefaultThemeBool(String theme) {
         switch (theme) {
             case "Dark":
                 return true;
@@ -255,7 +255,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     }
 
     // Returns the default system wide theme
-    public String getSystemDefaultTheme() {
+    private String getSystemDefaultTheme() {
         if ((getResources().getConfiguration().uiMode &
                 Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
             return "Dark";

--- a/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
@@ -9,6 +9,7 @@ public class Prefs {
     public static final String IS_CONTRIBUTION_COUNT_CHANGED = "ccontributionCountChanged";
     public static final String MANAGED_EXIF_TAGS = "managed_exif_tags";
     public static final String KEY_LANGUAGE_VALUE = "languageDescription";
+    public static final String KEY_THEME_VALUE = "theme";
 
     public static class Licenses {
         public static final String CC_BY_SA_3 = "CC BY-SA 3.0";

--- a/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
@@ -9,7 +9,7 @@ public class Prefs {
     public static final String IS_CONTRIBUTION_COUNT_CHANGED = "ccontributionCountChanged";
     public static final String MANAGED_EXIF_TAGS = "managed_exif_tags";
     public static final String KEY_LANGUAGE_VALUE = "languageDescription";
-    public static final String KEY_THEME_VALUE = "theme";
+    public static final String KEY_THEME_VALUE = "themePref";
 
     public static class Licenses {
         public static final String CC_BY_SA_3 = "CC BY-SA 3.0";

--- a/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
@@ -9,7 +9,7 @@ public class Prefs {
     public static final String IS_CONTRIBUTION_COUNT_CHANGED = "ccontributionCountChanged";
     public static final String MANAGED_EXIF_TAGS = "managed_exif_tags";
     public static final String KEY_LANGUAGE_VALUE = "languageDescription";
-    public static final String KEY_THEME_VALUE = "themePref";
+    public static final String KEY_THEME_VALUE = "appThemePref";
 
     public static class Licenses {
         public static final String CC_BY_SA_3 = "CC BY-SA 3.0";

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -146,18 +146,14 @@ public class SettingsFragment extends PreferenceFragment {
     }
 
     /**
-     * Prepares themes list and adds them to list preference as pairs.
      * Uses previously saved theme if there is any, if not then uses default.
-     * Adds preference theme listener and saves value choosen by user to shared preferences
+     * Adds preference theme listener and saves value chosen by user to shared preferences
      * to remember later
      */
     private void prepareTheme() {
 
         String[] themeOptionsNames = {getString(R.string.theme_default_name),
                 getString(R.string.theme_dark_name), getString(R.string.theme_light_name)};
-
-        themeListPreference.setEntries(themeOptionsNames);
-        themeListPreference.setEntryValues(themeOptionsNames);
 
         String currentTheme = getCurrentTheme();
         if (currentTheme.equals("")){
@@ -193,7 +189,7 @@ public class SettingsFragment extends PreferenceFragment {
     /**
      * Prepares language summary and language codes list and adds them to list preference as pairs.
      * Uses previously saved language if there is any, if not uses phone local as initial language.
-     * Adds preference changed listener and saves value choosen by user to shared preferences
+     * Adds preference changed listener and saves value chosen by user to shared preferences
      * to remember later
      */
     private void prepareLanguages() {

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -32,7 +32,6 @@ import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.logging.CommonsLogSender;
 import fr.free.nrw.commons.upload.Language;
 import fr.free.nrw.commons.utils.PermissionUtils;
-import fr.free.nrw.commons.utils.SystemThemeUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
 
 public class SettingsFragment extends PreferenceFragment {
@@ -43,9 +42,6 @@ public class SettingsFragment extends PreferenceFragment {
 
     @Inject
     CommonsLogSender commonsLogSender;
-
-    @Inject
-    SystemThemeUtils systemThemeUtils;
 
     private ListPreference themeListPreference;
     private ListPreference langListPreference;
@@ -61,7 +57,7 @@ public class SettingsFragment extends PreferenceFragment {
         // Load the preferences from an XML resource
         addPreferencesFromResource(R.xml.preferences);
 
-        themeListPreference = (ListPreference) findPreference("themePref");
+        themeListPreference = (ListPreference) findPreference(Prefs.KEY_THEME_VALUE);
         prepareTheme();
 
         //Check if the Author Name switch is enabled and appropriately handle the author name usage
@@ -152,14 +148,11 @@ public class SettingsFragment extends PreferenceFragment {
      */
     private void prepareTheme() {
 
-        String[] themeOptionsNames = {getString(R.string.theme_default_name),
-                getString(R.string.theme_dark_name), getString(R.string.theme_light_name)};
-
         String currentTheme = getCurrentTheme();
         if (currentTheme.equals("")){
             // If current theme code is empty, means none selected by user yet so use default
-            themeListPreference.setSummary(themeOptionsNames[0]);
-            themeListPreference.setValue(themeOptionsNames[0]);
+            themeListPreference.setSummary(getString(R.string.theme_default_name));
+            themeListPreference.setValue(getString(R.string.theme_default_value));
         } else {
             // If any theme is selected by user previously, use it
             int prefIndex = themeListPreference.findIndexOfValue(currentTheme);
@@ -171,15 +164,9 @@ public class SettingsFragment extends PreferenceFragment {
             String userSelectedValue = (String) newValue;
             int prefIndex = themeListPreference.findIndexOfValue(userSelectedValue);
             themeListPreference.setSummary(themeListPreference.getEntries()[prefIndex]);
-
-            saveThemeValue(userSelectedValue);
             getActivity().recreate();
             return true;
         });
-    }
-
-    private void saveThemeValue(String userSelectedValue) {
-        defaultKvStore.putString(Prefs.KEY_THEME_VALUE, userSelectedValue);
     }
 
     private String getCurrentTheme() {

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -149,28 +149,25 @@ public class SettingsFragment extends PreferenceFragment {
     private void prepareTheme() {
 
         String currentTheme = getCurrentTheme();
-        if (currentTheme.equals("")){
-            // If current theme code is empty, means none selected by user yet so use default
-            themeListPreference.setSummary(getString(R.string.theme_default_name));
-            themeListPreference.setValue(getString(R.string.theme_default_value));
-        } else {
-            // If any theme is selected by user previously, use it
-            int prefIndex = themeListPreference.findIndexOfValue(currentTheme);
-            themeListPreference.setSummary(themeListPreference.getEntries()[prefIndex]);
-            themeListPreference.setValue(currentTheme);
-        }
+
+        themeListPreference.setSummary(getThemeSummary(currentTheme));
+        themeListPreference.setValue(currentTheme);
 
         themeListPreference.setOnPreferenceChangeListener((preference, newValue) -> {
             String userSelectedValue = (String) newValue;
-            int prefIndex = themeListPreference.findIndexOfValue(userSelectedValue);
-            themeListPreference.setSummary(themeListPreference.getEntries()[prefIndex]);
+            themeListPreference.setSummary(getThemeSummary(userSelectedValue));
             getActivity().recreate();
             return true;
         });
     }
 
+    private CharSequence getThemeSummary(String value) {
+        int prefIndex = themeListPreference.findIndexOfValue(value);
+        return themeListPreference.getEntries()[prefIndex];
+    }
+
     private String getCurrentTheme() {
-        return defaultKvStore.getString(Prefs.KEY_THEME_VALUE, getString(R.string.theme_default_name));
+        return defaultKvStore.getString(Prefs.KEY_THEME_VALUE, "0");
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -1,7 +1,6 @@
 package fr.free.nrw.commons.settings;
 
 import android.Manifest;
-import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.EditTextPreference;
@@ -33,6 +32,7 @@ import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.logging.CommonsLogSender;
 import fr.free.nrw.commons.upload.Language;
 import fr.free.nrw.commons.utils.PermissionUtils;
+import fr.free.nrw.commons.utils.SystemThemeUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
 
 public class SettingsFragment extends PreferenceFragment {
@@ -40,8 +40,12 @@ public class SettingsFragment extends PreferenceFragment {
     @Inject
     @Named("default_preferences")
     JsonKvStore defaultKvStore;
+
     @Inject
     CommonsLogSender commonsLogSender;
+
+    @Inject
+    SystemThemeUtils systemThemeUtils;
 
     private ListPreference themeListPreference;
     private ListPreference langListPreference;
@@ -139,25 +143,6 @@ public class SettingsFragment extends PreferenceFragment {
             displayLocationPermissionForCardView.setEnabled(false);
             displayCampaignsCardView.setEnabled(false);
         }
-    }
-
-    // Return true is system wide dark theme is enabled else false
-    private boolean getSystemDefaultThemeBool(String theme) {
-        if (getString(R.string.theme_dark_name).equals(theme)) {
-            return true;
-        } else if (getString(R.string.theme_default_name).equals(theme)) {
-            return getSystemDefaultThemeBool(getSystemDefaultTheme());
-        }
-        return false;
-    }
-
-    // Returns the default system wide theme
-    private String getSystemDefaultTheme() {
-        if ((getResources().getConfiguration().uiMode &
-                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
-            return getString(R.string.theme_dark_name);
-        }
-        return getString(R.string.theme_light_name);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -148,10 +148,7 @@ public class SettingsFragment extends PreferenceFragment {
      */
     private void prepareTheme() {
 
-        String currentTheme = getCurrentTheme();
-
-        themeListPreference.setSummary(getThemeSummary(currentTheme));
-        themeListPreference.setValue(currentTheme);
+        themeListPreference.setSummary(getThemeSummary(getCurrentTheme()));
 
         themeListPreference.setOnPreferenceChangeListener((preference, newValue) -> {
             getActivity().recreate();

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -32,8 +32,9 @@ import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.logging.CommonsLogSender;
 import fr.free.nrw.commons.upload.Language;
 import fr.free.nrw.commons.utils.PermissionUtils;
-import fr.free.nrw.commons.utils.SystemThemeUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
+
+import static fr.free.nrw.commons.utils.SystemThemeUtils.THEME_MODE_DEFAULT;
 
 public class SettingsFragment extends PreferenceFragment {
 
@@ -43,9 +44,6 @@ public class SettingsFragment extends PreferenceFragment {
 
     @Inject
     CommonsLogSender commonsLogSender;
-
-    @Inject
-    SystemThemeUtils systemThemeUtils;
 
     private ListPreference themeListPreference;
     private ListPreference langListPreference;
@@ -167,7 +165,7 @@ public class SettingsFragment extends PreferenceFragment {
     }
 
     private String getCurrentTheme() {
-        return defaultKvStore.getString(Prefs.KEY_THEME_VALUE, systemThemeUtils.THEME_MODE_DEFAULT);
+        return defaultKvStore.getString(Prefs.KEY_THEME_VALUE, THEME_MODE_DEFAULT);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -32,6 +32,7 @@ import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.logging.CommonsLogSender;
 import fr.free.nrw.commons.upload.Language;
 import fr.free.nrw.commons.utils.PermissionUtils;
+import fr.free.nrw.commons.utils.SystemThemeUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
 
 public class SettingsFragment extends PreferenceFragment {
@@ -42,6 +43,9 @@ public class SettingsFragment extends PreferenceFragment {
 
     @Inject
     CommonsLogSender commonsLogSender;
+
+    @Inject
+    SystemThemeUtils systemThemeUtils;
 
     private ListPreference themeListPreference;
     private ListPreference langListPreference;
@@ -143,8 +147,6 @@ public class SettingsFragment extends PreferenceFragment {
 
     /**
      * Uses previously saved theme if there is any, if not then uses default.
-     * Adds preference theme listener and saves value chosen by user to shared preferences
-     * to remember later
      */
     private void prepareTheme() {
 
@@ -154,8 +156,6 @@ public class SettingsFragment extends PreferenceFragment {
         themeListPreference.setValue(currentTheme);
 
         themeListPreference.setOnPreferenceChangeListener((preference, newValue) -> {
-            String userSelectedValue = (String) newValue;
-            themeListPreference.setSummary(getThemeSummary(userSelectedValue));
             getActivity().recreate();
             return true;
         });
@@ -167,7 +167,7 @@ public class SettingsFragment extends PreferenceFragment {
     }
 
     private String getCurrentTheme() {
-        return defaultKvStore.getString(Prefs.KEY_THEME_VALUE, "0");
+        return defaultKvStore.getString(Prefs.KEY_THEME_VALUE, systemThemeUtils.THEME_MODE_DEFAULT);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.settings;
 
 import android.Manifest;
+import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.EditTextPreference;
@@ -12,18 +13,15 @@ import android.preference.SwitchPreference;
 import android.text.Editable;
 import android.text.TextWatcher;
 
-import com.google.gson.reflect.TypeToken;
 import com.karumi.dexter.Dexter;
 import com.karumi.dexter.listener.PermissionGrantedResponse;
 import com.karumi.dexter.listener.single.BasePermissionListener;
 
-import java.lang.reflect.Type;
-import java.util.Collections;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -44,7 +42,9 @@ public class SettingsFragment extends PreferenceFragment {
     JsonKvStore defaultKvStore;
     @Inject
     CommonsLogSender commonsLogSender;
-    private ListPreference listPreference;
+
+    private ListPreference themeListPreference;
+    private ListPreference langListPreference;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -57,11 +57,8 @@ public class SettingsFragment extends PreferenceFragment {
         // Load the preferences from an XML resource
         addPreferencesFromResource(R.xml.preferences);
 
-        SwitchPreference themePreference = (SwitchPreference) findPreference("theme");
-        themePreference.setOnPreferenceChangeListener((preference, newValue) -> {
-            getActivity().recreate();
-            return true;
-        });
+        themeListPreference = (ListPreference) findPreference("themePref");
+        prepareTheme();
 
         //Check if the Author Name switch is enabled and appropriately handle the author name usage
         SwitchPreference useAuthorName = (SwitchPreference) findPreference("useAuthorName");
@@ -117,7 +114,7 @@ public class SettingsFragment extends PreferenceFragment {
             }
         });
 
-        listPreference = (ListPreference) findPreference("descriptionDefaultLanguagePref");
+        langListPreference = (ListPreference) findPreference("descriptionDefaultLanguagePref");
         prepareLanguages();
         Preference betaTesterPreference = findPreference("becomeBetaTester");
         betaTesterPreference.setOnPreferenceClickListener(preference -> {
@@ -144,6 +141,71 @@ public class SettingsFragment extends PreferenceFragment {
         }
     }
 
+    // Return true is system wide dark theme is enabled else false
+    public boolean getSystemDefaultThemeBool(String theme) {
+        switch (theme) {
+            case "Dark":
+                return true;
+            case "Default":
+                return getSystemDefaultThemeBool(getSystemDefaultTheme());
+            default:
+                return false;
+        }
+    }
+
+    // Returns the default system wide theme
+    public String getSystemDefaultTheme() {
+        if ((getResources().getConfiguration().uiMode &
+                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
+            return "Dark";
+        }
+        return "Light";
+    }
+
+    /**
+     * Prepares themes list and adds them to list preference as pairs.
+     * Uses previously saved theme if there is any, if not then uses default.
+     * Adds preference theme listener and saves value choosen by user to shared preferences
+     * to remember later
+     */
+    private void prepareTheme() {
+
+        String[] themeOptionsNames = {"Default", "Dark", "Light"};
+
+        themeListPreference.setEntries(themeOptionsNames);
+        themeListPreference.setEntryValues(themeOptionsNames);
+
+        String currentTheme = getCurrentTheme();
+        if (currentTheme.equals("")){
+            // If current theme code is empty, means none selected by user yet so use default
+            themeListPreference.setSummary(themeOptionsNames[0]);
+            themeListPreference.setValue(themeOptionsNames[0]);
+        } else {
+            // If any theme is selected by user previously, use it
+            int prefIndex = themeListPreference.findIndexOfValue(currentTheme);
+            themeListPreference.setSummary(themeListPreference.getEntries()[prefIndex]);
+            themeListPreference.setValue(currentTheme);
+        }
+
+        themeListPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+            String userSelectedValue = (String) newValue;
+            int prefIndex = themeListPreference.findIndexOfValue(userSelectedValue);
+            themeListPreference.setSummary(themeListPreference.getEntries()[prefIndex]);
+
+            saveThemeValue(userSelectedValue);
+            getActivity().recreate();
+            return true;
+        });
+    }
+
+    private void saveThemeValue(String userSelectedValue) {
+        defaultKvStore.putString(Prefs.KEY_THEME_VALUE, userSelectedValue);
+    }
+
+    private String getCurrentTheme() {
+        return defaultKvStore.getString(Prefs.KEY_THEME_VALUE, "Default");
+    }
+
     /**
      * Prepares language summary and language codes list and adds them to list preference as pairs.
      * Uses previously saved language if there is any, if not uses phone local as initial language.
@@ -167,26 +229,26 @@ public class SettingsFragment extends PreferenceFragment {
         CharSequence[] languageNames = languageNamesList.toArray(new CharSequence[0]);
         CharSequence[] languageCodes = languageCodesList.toArray(new CharSequence[0]);
         // Add all languages and languages codes to lists preference as pair
-        listPreference.setEntries(languageNames);
-        listPreference.setEntryValues(languageCodes);
+        langListPreference.setEntries(languageNames);
+        langListPreference.setEntryValues(languageCodes);
 
         // Gets current language code from shared preferences
         String languageCode = getCurrentLanguageCode();
-        if(languageCode.equals("")){
+        if (languageCode.equals("")){
             // If current language code is empty, means none selected by user yet so use phone local
-            listPreference.setSummary(Locale.getDefault().getDisplayLanguage());
-            listPreference.setValue(Locale.getDefault().getLanguage());
+            langListPreference.setSummary(Locale.getDefault().getDisplayLanguage());
+            langListPreference.setValue(Locale.getDefault().getLanguage());
         } else {
             // If any language is selected by user previously, use it
-            int prefIndex = listPreference.findIndexOfValue(languageCode);
-            listPreference.setSummary(listPreference.getEntries()[prefIndex]);
-            listPreference.setValue(languageCode);
+            int prefIndex = langListPreference.findIndexOfValue(languageCode);
+            langListPreference.setSummary(langListPreference.getEntries()[prefIndex]);
+            langListPreference.setValue(languageCode);
         }
 
-        listPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+        langListPreference.setOnPreferenceChangeListener((preference, newValue) -> {
             String userSelectedValue = (String) newValue;
-            int prefIndex = listPreference.findIndexOfValue(userSelectedValue);
-            listPreference.setSummary(listPreference.getEntries()[prefIndex]);
+            int prefIndex = langListPreference.findIndexOfValue(userSelectedValue);
+            langListPreference.setSummary(langListPreference.getEntries()[prefIndex]);
             saveLanguageValue(userSelectedValue);
             return true;
         });

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -142,7 +142,7 @@ public class SettingsFragment extends PreferenceFragment {
     }
 
     // Return true is system wide dark theme is enabled else false
-    public boolean getSystemDefaultThemeBool(String theme) {
+    private boolean getSystemDefaultThemeBool(String theme) {
         switch (theme) {
             case "Dark":
                 return true;
@@ -154,7 +154,7 @@ public class SettingsFragment extends PreferenceFragment {
     }
 
     // Returns the default system wide theme
-    public String getSystemDefaultTheme() {
+    private String getSystemDefaultTheme() {
         if ((getResources().getConfiguration().uiMode &
                 Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
             return "Dark";

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -143,23 +143,21 @@ public class SettingsFragment extends PreferenceFragment {
 
     // Return true is system wide dark theme is enabled else false
     private boolean getSystemDefaultThemeBool(String theme) {
-        switch (theme) {
-            case "Dark":
-                return true;
-            case "Default":
-                return getSystemDefaultThemeBool(getSystemDefaultTheme());
-            default:
-                return false;
+        if (getString(R.string.theme_dark_name).equals(theme)) {
+            return true;
+        } else if (getString(R.string.theme_default_name).equals(theme)) {
+            return getSystemDefaultThemeBool(getSystemDefaultTheme());
         }
+        return false;
     }
 
     // Returns the default system wide theme
     private String getSystemDefaultTheme() {
         if ((getResources().getConfiguration().uiMode &
                 Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
-            return "Dark";
+            return getString(R.string.theme_dark_name);
         }
-        return "Light";
+        return getString(R.string.theme_light_name);
     }
 
     /**
@@ -170,7 +168,8 @@ public class SettingsFragment extends PreferenceFragment {
      */
     private void prepareTheme() {
 
-        String[] themeOptionsNames = {"Default", "Dark", "Light"};
+        String[] themeOptionsNames = {getString(R.string.theme_default_name),
+                getString(R.string.theme_dark_name), getString(R.string.theme_light_name)};
 
         themeListPreference.setEntries(themeOptionsNames);
         themeListPreference.setEntryValues(themeOptionsNames);
@@ -203,7 +202,7 @@ public class SettingsFragment extends PreferenceFragment {
     }
 
     private String getCurrentTheme() {
-        return defaultKvStore.getString(Prefs.KEY_THEME_VALUE, "Default");
+        return defaultKvStore.getString(Prefs.KEY_THEME_VALUE, getString(R.string.theme_default_name));
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
@@ -1,5 +1,6 @@
 package fr.free.nrw.commons.theme;
 
+import android.content.res.Configuration;
 import android.os.Bundle;
 
 import javax.inject.Inject;
@@ -8,6 +9,7 @@ import javax.inject.Named;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.di.CommonsDaggerAppCompatActivity;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
+import fr.free.nrw.commons.settings.Prefs;
 import io.reactivex.disposables.CompositeDisposable;
 
 public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
@@ -21,14 +23,16 @@ public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        wasPreviouslyDarkTheme = defaultKvStore.getBoolean("theme", false);
+        wasPreviouslyDarkTheme = getSystemDefaultThemeBool(
+                defaultKvStore.getString(Prefs.KEY_THEME_VALUE, getSystemDefaultTheme()));
         setTheme(wasPreviouslyDarkTheme ? R.style.DarkAppTheme : R.style.LightAppTheme);
     }
 
     @Override
     protected void onResume() {
         // Restart activity if theme is changed
-        if (wasPreviouslyDarkTheme != defaultKvStore.getBoolean("theme", false)) {
+        if (wasPreviouslyDarkTheme != getSystemDefaultThemeBool(
+                defaultKvStore.getString(Prefs.KEY_THEME_VALUE, getSystemDefaultTheme()))) {
             recreate();
         }
 
@@ -40,4 +44,26 @@ public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
         super.onDestroy();
         compositeDisposable.clear();
     }
+
+    // Return true is system wide dark theme is enabled else false
+    public boolean getSystemDefaultThemeBool(String theme) {
+        switch (theme) {
+            case "Dark":
+                return true;
+            case "Default":
+                return getSystemDefaultThemeBool(getSystemDefaultTheme());
+            default:
+                return false;
+        }
+    }
+
+    // Returns the default system wide theme
+    public String getSystemDefaultTheme() {
+        if ((getResources().getConfiguration().uiMode &
+                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
+            return "Dark";
+        }
+        return "Light";
+    }
+
 }

--- a/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
@@ -46,7 +46,7 @@ public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
     }
 
     // Return true is system wide dark theme is enabled else false
-    public boolean getSystemDefaultThemeBool(String theme) {
+    private boolean getSystemDefaultThemeBool(String theme) {
         switch (theme) {
             case "Dark":
                 return true;
@@ -58,7 +58,7 @@ public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
     }
 
     // Returns the default system wide theme
-    public String getSystemDefaultTheme() {
+    private String getSystemDefaultTheme() {
         if ((getResources().getConfiguration().uiMode &
                 Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
             return "Dark";

--- a/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
@@ -47,23 +47,21 @@ public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
 
     // Return true is system wide dark theme is enabled else false
     private boolean getSystemDefaultThemeBool(String theme) {
-        switch (theme) {
-            case "Dark":
-                return true;
-            case "Default":
-                return getSystemDefaultThemeBool(getSystemDefaultTheme());
-            default:
-                return false;
+        if (getString(R.string.theme_dark_name).equals(theme)) {
+            return true;
+        } else if (getString(R.string.theme_default_name).equals(theme)) {
+            return getSystemDefaultThemeBool(getSystemDefaultTheme());
         }
+        return false;
     }
 
     // Returns the default system wide theme
     private String getSystemDefaultTheme() {
         if ((getResources().getConfiguration().uiMode &
                 Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
-            return "Dark";
+            return getString(R.string.theme_dark_name);
         }
-        return "Light";
+        return getString(R.string.theme_light_name);
     }
 
 }

--- a/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.theme;
 
-import android.content.res.Configuration;
 import android.os.Bundle;
 
 import javax.inject.Inject;
@@ -9,7 +8,7 @@ import javax.inject.Named;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.di.CommonsDaggerAppCompatActivity;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
-import fr.free.nrw.commons.settings.Prefs;
+import fr.free.nrw.commons.utils.SystemThemeUtils;
 import io.reactivex.disposables.CompositeDisposable;
 
 public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
@@ -17,22 +16,23 @@ public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
     @Named("default_preferences")
     public JsonKvStore defaultKvStore;
 
+    @Inject
+    SystemThemeUtils systemThemeUtils;
+
     protected CompositeDisposable compositeDisposable = new CompositeDisposable();
     protected boolean wasPreviouslyDarkTheme;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        wasPreviouslyDarkTheme = getSystemDefaultThemeBool(
-                defaultKvStore.getString(Prefs.KEY_THEME_VALUE, getSystemDefaultTheme()));
+        wasPreviouslyDarkTheme = systemThemeUtils.isDeviceInNightMode();
         setTheme(wasPreviouslyDarkTheme ? R.style.DarkAppTheme : R.style.LightAppTheme);
     }
 
     @Override
     protected void onResume() {
         // Restart activity if theme is changed
-        if (wasPreviouslyDarkTheme != getSystemDefaultThemeBool(
-                defaultKvStore.getString(Prefs.KEY_THEME_VALUE, getSystemDefaultTheme()))) {
+        if (wasPreviouslyDarkTheme != systemThemeUtils.isDeviceInNightMode()) {
             recreate();
         }
 
@@ -44,24 +44,4 @@ public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
         super.onDestroy();
         compositeDisposable.clear();
     }
-
-    // Return true is system wide dark theme is enabled else false
-    private boolean getSystemDefaultThemeBool(String theme) {
-        if (getString(R.string.theme_dark_name).equals(theme)) {
-            return true;
-        } else if (getString(R.string.theme_default_name).equals(theme)) {
-            return getSystemDefaultThemeBool(getSystemDefaultTheme());
-        }
-        return false;
-    }
-
-    // Returns the default system wide theme
-    private String getSystemDefaultTheme() {
-        if ((getResources().getConfiguration().uiMode &
-                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
-            return getString(R.string.theme_dark_name);
-        }
-        return getString(R.string.theme_light_name);
-    }
-
 }

--- a/app/src/main/java/fr/free/nrw/commons/utils/SystemThemeUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/SystemThemeUtils.java
@@ -14,9 +14,9 @@ public class SystemThemeUtils {
     private Context context;
     private JsonKvStore applicationKvStore;
 
-    public final String THEME_MODE_DEFAULT = "0";
-    public final String THEME_MODE_DARK = "1";
-    public final String THEME_MODE_LIGHT = "2";
+    public static final String THEME_MODE_DEFAULT = "0";
+    public static final String THEME_MODE_DARK = "1";
+    public static final String THEME_MODE_LIGHT = "2";
 
     @Inject
     public SystemThemeUtils(Context context, @Named("default_preferences") JsonKvStore applicationKvStore) {

--- a/app/src/main/java/fr/free/nrw/commons/utils/SystemThemeUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/SystemThemeUtils.java
@@ -23,9 +23,9 @@ public class SystemThemeUtils {
 
     // Return true is system wide dark theme is enabled else false
     public boolean getSystemDefaultThemeBool(String theme) {
-        if (context.getResources().getString(R.string.theme_dark_name).equals(theme)) {
+        if (theme.equals(context.getString(R.string.theme_dark_value))) {
             return true;
-        } else if (context.getResources().getString(R.string.theme_default_name).equals(theme)) {
+        } else if (theme.equals(context.getString(R.string.theme_default_value))) {
             return getSystemDefaultThemeBool(getSystemDefaultTheme());
         }
         return false;
@@ -35,9 +35,9 @@ public class SystemThemeUtils {
     public String getSystemDefaultTheme() {
         if ((context.getResources().getConfiguration().uiMode &
                 Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
-            return context.getResources().getString(R.string.theme_dark_name);
+            return context.getString(R.string.theme_dark_value);
         }
-        return context.getResources().getString(R.string.theme_light_name);
+        return context.getString(R.string.theme_light_value);
     }
 
     // Returns true if the device is in night mode or false otherwise

--- a/app/src/main/java/fr/free/nrw/commons/utils/SystemThemeUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/SystemThemeUtils.java
@@ -6,7 +6,6 @@ import android.content.res.Configuration;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.settings.Prefs;
 
@@ -23,9 +22,9 @@ public class SystemThemeUtils {
 
     // Return true is system wide dark theme is enabled else false
     public boolean getSystemDefaultThemeBool(String theme) {
-        if (theme.equals(context.getString(R.string.theme_dark_value))) {
+        if (theme.equals("1")) {
             return true;
-        } else if (theme.equals(context.getString(R.string.theme_default_value))) {
+        } else if (theme.equals("0")) {
             return getSystemDefaultThemeBool(getSystemDefaultTheme());
         }
         return false;
@@ -33,11 +32,8 @@ public class SystemThemeUtils {
 
     // Returns the default system wide theme
     public String getSystemDefaultTheme() {
-        if ((context.getResources().getConfiguration().uiMode &
-                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
-            return context.getString(R.string.theme_dark_value);
-        }
-        return context.getString(R.string.theme_light_value);
+        return (context.getResources().getConfiguration().uiMode &
+                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES ? "1" : "2";
     }
 
     // Returns true if the device is in night mode or false otherwise

--- a/app/src/main/java/fr/free/nrw/commons/utils/SystemThemeUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/SystemThemeUtils.java
@@ -1,0 +1,51 @@
+package fr.free.nrw.commons.utils;
+
+import android.content.Context;
+import android.content.res.Configuration;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.kvstore.JsonKvStore;
+import fr.free.nrw.commons.settings.Prefs;
+
+public class SystemThemeUtils {
+
+    private Context context;
+
+    @Inject
+    @Named("default_preferences")
+    JsonKvStore applicationKvStore;
+
+    @Inject
+    public SystemThemeUtils(Context context) {
+        this.context = context;
+    }
+
+    // Return true is system wide dark theme is enabled else false
+    public boolean getSystemDefaultThemeBool(String theme) {
+        if (context.getResources().getString(R.string.theme_dark_name).equals(theme)) {
+            return true;
+        } else if (context.getResources().getString(R.string.theme_default_name).equals(theme)) {
+            return getSystemDefaultThemeBool(getSystemDefaultTheme());
+        }
+        return false;
+    }
+
+    // Returns the default system wide theme
+    public String getSystemDefaultTheme() {
+        if ((context.getResources().getConfiguration().uiMode &
+                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
+            return context.getResources().getString(R.string.theme_dark_name);
+        }
+        return context.getResources().getString(R.string.theme_light_name);
+    }
+
+    // Returns true if the device is in night mode or false otherwise
+    public boolean isDeviceInNightMode() {
+        return getSystemDefaultThemeBool(
+                applicationKvStore.getString(Prefs.KEY_THEME_VALUE, getSystemDefaultTheme()));
+    }
+
+}

--- a/app/src/main/java/fr/free/nrw/commons/utils/SystemThemeUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/SystemThemeUtils.java
@@ -14,6 +14,10 @@ public class SystemThemeUtils {
     private Context context;
     private JsonKvStore applicationKvStore;
 
+    public final String THEME_MODE_DEFAULT = "0";
+    public final String THEME_MODE_DARK = "1";
+    public final String THEME_MODE_LIGHT = "2";
+
     @Inject
     public SystemThemeUtils(Context context, @Named("default_preferences") JsonKvStore applicationKvStore) {
         this.context = context;
@@ -22,9 +26,9 @@ public class SystemThemeUtils {
 
     // Return true is system wide dark theme is enabled else false
     public boolean getSystemDefaultThemeBool(String theme) {
-        if (theme.equals("1")) {
+        if (theme.equals(THEME_MODE_DARK)) {
             return true;
-        } else if (theme.equals("0")) {
+        } else if (theme.equals(THEME_MODE_DEFAULT)) {
             return getSystemDefaultThemeBool(getSystemDefaultTheme());
         }
         return false;
@@ -33,7 +37,7 @@ public class SystemThemeUtils {
     // Returns the default system wide theme
     public String getSystemDefaultTheme() {
         return (context.getResources().getConfiguration().uiMode &
-                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES ? "1" : "2";
+                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES ? THEME_MODE_DARK : THEME_MODE_LIGHT;
     }
 
     // Returns true if the device is in night mode or false otherwise

--- a/app/src/main/java/fr/free/nrw/commons/utils/SystemThemeUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/SystemThemeUtils.java
@@ -13,14 +13,12 @@ import fr.free.nrw.commons.settings.Prefs;
 public class SystemThemeUtils {
 
     private Context context;
+    private JsonKvStore applicationKvStore;
 
     @Inject
-    @Named("default_preferences")
-    JsonKvStore applicationKvStore;
-
-    @Inject
-    public SystemThemeUtils(Context context) {
+    public SystemThemeUtils(Context context, @Named("default_preferences") JsonKvStore applicationKvStore) {
         this.context = context;
+        this.applicationKvStore = applicationKvStore;
     }
 
     // Return true is system wide dark theme is enabled else false

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -41,9 +41,9 @@
         <item>@string/theme_light_name</item>
     </array>
 
-    <array name="pref_theme_entries_values">
-        <item>@string/theme_default_value</item>
-        <item>@string/theme_dark_value</item>
-        <item>@string/theme_light_value</item>
-    </array>
+    <string-array name="pref_theme_entries_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -40,4 +40,10 @@
         <item>@string/theme_dark_name</item>
         <item>@string/theme_light_name</item>
     </array>
+
+    <array name="pref_theme_entries_values">
+        <item>@string/theme_default_value</item>
+        <item>@string/theme_dark_value</item>
+        <item>@string/theme_light_value</item>
+    </array>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -35,4 +35,9 @@
         <item>@string/exif_tag_software</item>
     </array>
 
+    <array name="pref_theme_entries">
+        <item>@string/theme_default_name</item>
+        <item>@string/theme_dark_name</item>
+        <item>@string/theme_light_name</item>
+    </array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -599,4 +599,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="wallpaper_set_unsuccessfully">Something went wrong. Could not set the wallpaper</string>
   <string name="setting_wallpaper_dialog_title">Set as Wallpaper</string>
   <string name="setting_wallpaper_dialog_message">Setting Wallpaper. Please wait…</string>
+  <string name="theme_default_name">Default</string>
+  <string name="theme_dark_name">Dark</string>
+  <string name="theme_light_name">Light</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,7 +114,6 @@
   <string name="allow_gps">Automatically get current location</string>
   <string name="allow_gps_summary">Retrieves current location if image is not geotagged, and geotags image with it. Warning: This will reveal your current location.</string>
   <string name="preference_theme">Theme</string>
-  <string name="preference_theme_summary">Default</string>
   <string name="license_name_cc_by_sa_four"> Attribution-ShareAlike 4.0</string>
   <string name="license_name_cc_by_four"> Attribution 4.0</string>
   <string name="license_name_cc_by_sa"> Attribution-ShareAlike 3.0</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -601,4 +601,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="theme_default_name">Default</string>
   <string name="theme_dark_name">Dark</string>
   <string name="theme_light_name">Light</string>
+  <string name="theme_default_value">0</string>
+  <string name="theme_dark_value">1</string>
+  <string name="theme_light_value">2</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -601,7 +601,4 @@ Upload your first media by tapping on the add button.</string>
   <string name="theme_default_name">Default</string>
   <string name="theme_dark_name">Dark</string>
   <string name="theme_light_name">Light</string>
-  <string name="theme_default_value">0</string>
-  <string name="theme_dark_value">1</string>
-  <string name="theme_light_value">2</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,8 +113,8 @@
   <string name="use_previous">Use previous title and description</string>
   <string name="allow_gps">Automatically get current location</string>
   <string name="allow_gps_summary">Retrieves current location if image is not geotagged, and geotags image with it. Warning: This will reveal your current location.</string>
-  <string name="preference_theme">Night mode</string>
-  <string name="preference_theme_summary">Use dark theme</string>
+  <string name="preference_theme">Theme</string>
+  <string name="preference_theme_summary">Default</string>
   <string name="license_name_cc_by_sa_four"> Attribution-ShareAlike 4.0</string>
   <string name="license_name_cc_by_four"> Attribution 4.0</string>
   <string name="license_name_cc_by_sa"> Attribution-ShareAlike 3.0</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -8,7 +8,10 @@
         <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleListPreference
             android:key="themePref"
             android:title= "@string/preference_theme"
-            android:summary="@string/preference_theme_summary" />
+            android:defaultValue="@string/theme_default_name"
+            android:entries="@array/pref_theme_entries"
+            android:entryValues="@array/pref_theme_entries"
+            android:summary="@string/theme_default_name" />
 
     </fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreferenceCategory>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -10,6 +10,7 @@
             android:title= "@string/preference_theme"
             android:entries="@array/pref_theme_entries"
             android:entryValues="@array/pref_theme_entries_values"
+            android:defaultValue="0"
             android:summary="@string/theme_default_name" />
 
     </fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreferenceCategory>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -6,11 +6,11 @@
         android:title="@string/preference_category_appearance">
 
         <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleListPreference
-            android:key="themePref"
+            android:key="appThemePref"
             android:title= "@string/preference_theme"
             android:defaultValue="@string/theme_default_name"
             android:entries="@array/pref_theme_entries"
-            android:entryValues="@array/pref_theme_entries"
+            android:entryValues="@array/pref_theme_entries_values"
             android:summary="@string/theme_default_name" />
 
     </fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreferenceCategory>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -5,11 +5,10 @@
     <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreferenceCategory
         android:title="@string/preference_category_appearance">
 
-        <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleSwitchPreference
-            android:title="@string/preference_theme"
-            android:defaultValue="false"
-            android:summary="@string/preference_theme_summary"
-            android:key="theme" />
+        <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleListPreference
+            android:key="themePref"
+            android:title= "@string/preference_theme"
+            android:summary="@string/preference_theme_summary" />
 
     </fr.free.nrw.commons.ui.LongTitlePreferences.LongTitlePreferenceCategory>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -8,7 +8,6 @@
         <fr.free.nrw.commons.ui.LongTitlePreferences.LongTitleListPreference
             android:key="appThemePref"
             android:title= "@string/preference_theme"
-            android:defaultValue="@string/theme_default_name"
             android:entries="@array/pref_theme_entries"
             android:entryValues="@array/pref_theme_entries_values"
             android:summary="@string/theme_default_name" />


### PR DESCRIPTION
**Description**

Fixes #3377 

What changes did you make and why?
I added the support for system-wide dark theme, so if you have a system-wide dark theme enabled in your phone then the app will automatically switch to dark mode. In case you prefer the light mode for app or dark mode app (irrespective of the system-wide setting) the app will retain the theme.

**Tests performed**

Tested betaDebug on Xiaomi Mi A2 with API level 29.

**Screenshots showing what changed**
![Screenshot_20200304-014250](https://user-images.githubusercontent.com/30932899/75833536-a235f700-5db9-11ea-87ec-8c95e7dd55eb.png)
