### PR TITLE
#3469 Update Gradle Play Publisher to resolve issues with travis build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,13 @@
 plugins {
-    id 'com.github.triplet.play' version '2.2.1' apply false
+    id 'com.github.triplet.play' version '2.7.2' apply false
 }
 apply from: '../gitutils.gradle'
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'jacoco-android'
+apply plugin: "com.hiya.jacoco-android"
 apply from: 'quality.gradle'
+
 
 def isRunningOnTravisAndIsNotPRBuild = System.getenv("CI") == "true" && file('../play.p12').exists()
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,6 @@ apply plugin: 'kotlin-kapt'
 apply plugin: "com.hiya.jacoco-android"
 apply from: 'quality.gradle'
 
-
 def isRunningOnTravisAndIsNotPRBuild = System.getenv("CI") == "true" && file('../play.p12').exists()
 
 if(isRunningOnTravisAndIsNotPRBuild) {

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,11 @@ buildscript {
         google()
         jcenter()
         mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.1'
-        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
+        classpath "com.hiya:jacoco-android:0.2"
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
         classpath 'org.codehaus.groovy:groovy-all:2.4.15'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip


### PR DESCRIPTION
**Description (required)**

Fixes #3469 Update Gradle Play Publisher to resolve issues with travis build

update GPP/Gradle and use jacoco-android fork with gradle 6.0 support