### PR TITLE
Change item background according to the theme

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFilterSearchRecyclerViewAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFilterSearchRecyclerViewAdapter.java
@@ -70,7 +70,7 @@ public class NearbyFilterSearchRecyclerViewAdapter
     @NonNull
     @Override
     public RecyclerViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        View itemView = inflater.inflate(callback.isDarkTheme()?R.layout.nearby_search_list_item_dark:R.layout.nearby_search_list_item, parent, false);
+        View itemView = inflater.inflate(callback.isDarkTheme() ? R.layout.nearby_search_list_item_dark : R.layout.nearby_search_list_item, parent, false);
         return new RecyclerViewHolder(itemView);
     }
 
@@ -80,7 +80,7 @@ public class NearbyFilterSearchRecyclerViewAdapter
         holder.placeTypeIcon.setImageResource(label.getIcon());
         holder.placeTypeLabel.setText(label.toString());
 
-        holder.placeTypeLayout.setBackgroundColor(label.isSelected() ? ContextCompat.getColor(context, R.color.divider_grey) : callback.isDarkTheme()?Color.BLACK:Color.WHITE);
+        holder.placeTypeLayout.setBackgroundColor(label.isSelected() ? ContextCompat.getColor(context, R.color.divider_grey) : callback.isDarkTheme() ? Color.BLACK : Color.WHITE);
         holder.placeTypeLayout.setOnClickListener(view -> {
             callback.setCheckboxUnknown();
             if (label.isSelected()) {
@@ -89,7 +89,7 @@ public class NearbyFilterSearchRecyclerViewAdapter
                 selectedLabels.add(label);
             }
             label.setSelected(!label.isSelected());
-            holder.placeTypeLayout.setBackgroundColor(label.isSelected() ? ContextCompat.getColor(context, R.color.divider_grey) : Color.WHITE);
+            holder.placeTypeLayout.setBackgroundColor(label.isSelected() ? ContextCompat.getColor(context, R.color.divider_grey) : callback.isDarkTheme() ? Color.BLACK : Color.WHITE);
             callback.filterByMarkerType(selectedLabels, 0, false, false);
         });
     }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFilterSearchRecyclerViewAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFilterSearchRecyclerViewAdapter.java
@@ -79,27 +79,19 @@ public class NearbyFilterSearchRecyclerViewAdapter
         Label label = displayedLabels.get(position);
         holder.placeTypeIcon.setImageResource(label.getIcon());
         holder.placeTypeLabel.setText(label.toString());
-
-        if (callback.isDarkTheme()) {
-            holder.placeTypeLayout.setBackgroundColor(label.isSelected() ? ContextCompat.getColor(context, R.color.opak_middle_grey) : ContextCompat.getColor(context, R.color.black));
-        } else {
-            holder.placeTypeLayout.setBackgroundColor(label.isSelected() ? ContextCompat.getColor(context, R.color.divider_grey) : ContextCompat.getColor(context, R.color.white));
-        }
+        holder.placeTypeLayout.setSelected(label.isSelected());
 
         holder.placeTypeLayout.setOnClickListener(view -> {
             callback.setCheckboxUnknown();
+
             if (label.isSelected()) {
                 selectedLabels.remove(label);
             } else {
                 selectedLabels.add(label);
             }
-            label.setSelected(!label.isSelected());
 
-            if (callback.isDarkTheme()) {
-                holder.placeTypeLayout.setBackgroundColor(label.isSelected() ? ContextCompat.getColor(context, R.color.opak_middle_grey) : ContextCompat.getColor(context, R.color.black));
-            } else {
-                holder.placeTypeLayout.setBackgroundColor(label.isSelected() ? ContextCompat.getColor(context, R.color.divider_grey) : ContextCompat.getColor(context, R.color.white));
-            }
+            label.setSelected(!label.isSelected());
+            holder.placeTypeLayout.setSelected(label.isSelected());
 
             callback.filterByMarkerType(selectedLabels, 0, false, false);
         });

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFilterSearchRecyclerViewAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFilterSearchRecyclerViewAdapter.java
@@ -80,7 +80,12 @@ public class NearbyFilterSearchRecyclerViewAdapter
         holder.placeTypeIcon.setImageResource(label.getIcon());
         holder.placeTypeLabel.setText(label.toString());
 
-        holder.placeTypeLayout.setBackgroundColor(label.isSelected() ? ContextCompat.getColor(context, R.color.divider_grey) : callback.isDarkTheme() ? Color.BLACK : Color.WHITE);
+        if (callback.isDarkTheme()) {
+            holder.placeTypeLayout.setBackgroundColor(label.isSelected() ? ContextCompat.getColor(context, R.color.opak_middle_grey) : ContextCompat.getColor(context, R.color.black));
+        } else {
+            holder.placeTypeLayout.setBackgroundColor(label.isSelected() ? ContextCompat.getColor(context, R.color.divider_grey) : ContextCompat.getColor(context, R.color.white));
+        }
+
         holder.placeTypeLayout.setOnClickListener(view -> {
             callback.setCheckboxUnknown();
             if (label.isSelected()) {
@@ -89,7 +94,13 @@ public class NearbyFilterSearchRecyclerViewAdapter
                 selectedLabels.add(label);
             }
             label.setSelected(!label.isSelected());
-            holder.placeTypeLayout.setBackgroundColor(label.isSelected() ? ContextCompat.getColor(context, R.color.divider_grey) : callback.isDarkTheme() ? Color.BLACK : Color.WHITE);
+
+            if (callback.isDarkTheme()) {
+                holder.placeTypeLayout.setBackgroundColor(label.isSelected() ? ContextCompat.getColor(context, R.color.opak_middle_grey) : ContextCompat.getColor(context, R.color.black));
+            } else {
+                holder.placeTypeLayout.setBackgroundColor(label.isSelected() ? ContextCompat.getColor(context, R.color.divider_grey) : ContextCompat.getColor(context, R.color.white));
+            }
+
             callback.filterByMarkerType(selectedLabels, 0, false, false);
         });
     }
@@ -165,7 +176,7 @@ public class NearbyFilterSearchRecyclerViewAdapter
         notifyDataSetChanged();
     }
 
-    public interface  Callback{
+    public interface  Callback {
 
         void setCheckboxUnknown();
 

--- a/app/src/main/res/drawable/linearlayout_color_dark_selector.xml
+++ b/app/src/main/res/drawable/linearlayout_color_dark_selector.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true"
+        android:drawable="@color/opak_middle_grey" />
+    <item android:drawable="@color/black" />
+</selector>

--- a/app/src/main/res/drawable/linearlayout_color_selector.xml
+++ b/app/src/main/res/drawable/linearlayout_color_selector.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true"
+        android:drawable="@color/divider_grey" />
+    <item android:drawable="@color/white" />
+</selector>

--- a/app/src/main/res/layout/nearby_search_list_item.xml
+++ b/app/src/main/res/layout/nearby_search_list_item.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/search_list_item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
-    android:padding="@dimen/tiny_margin">
+    android:padding="@dimen/tiny_margin"
+    android:background="@drawable/linearlayout_color_selector">
 
     <ImageView
         android:id="@+id/place_icon"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"/>
 
     <TextView
         android:id="@+id/place_text"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"></TextView>
+        android:layout_height="wrap_content"/>
 </LinearLayout>

--- a/app/src/main/res/layout/nearby_search_list_item_dark.xml
+++ b/app/src/main/res/layout/nearby_search_list_item_dark.xml
@@ -4,16 +4,17 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="@dimen/tiny_margin"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    android:background="@drawable/linearlayout_color_dark_selector">
 
     <ImageView
         android:id="@+id/place_icon"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"/>
 
     <TextView
         android:id="@+id/place_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textColor="@color/white"></TextView>
+        android:textColor="@color/white"/>
 </LinearLayout>


### PR DESCRIPTION
**Description (required)**

Fixes #3474 - Items in Place type list in Nearby become unreadable on unselecting

**What changes did you make and why?**

Added a conditional operator that sets the background colour of the item based on the theme.

**Tests performed (required)**

Tested betaDebug on Redmi Note 5 Pro with API level 28.

**Screenshot**

_The item background is highlighted on selecting and becomes black on unselecting._

![gif1](https://user-images.githubusercontent.com/44764339/76286330-e0567d80-62c7-11ea-96c0-449dfd1901d8.gif)