### PR TITLE
openStreetMap attribution enabled

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -229,8 +229,8 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
                 UiSettings uiSettings = mapBoxMap.getUiSettings();
                 uiSettings.setCompassGravity(Gravity.BOTTOM | Gravity.LEFT);
                 uiSettings.setCompassMargins(12, 0, 0, 24);
-                uiSettings.setLogoEnabled(false);
-                uiSettings.setAttributionEnabled(false);
+                uiSettings.setLogoEnabled(true);
+                uiSettings.setAttributionEnabled(true);
                 uiSettings.setRotateGesturesEnabled(false);
                 NearbyParentFragment.this.isMapBoxReady=true;
                 performMapReadyActions();


### PR DESCRIPTION
Enabled openStreetMap Attribution 

Fixes #2911 No OpenStreetMap attribution

What changes did you make and why?
I just made the attribution enabled and logo true on mapboxMap

**Tests performed (required)**

Tested logo on Lenovo K8plus



![WhatsApp Image 2020-03-11 at 9 17 25 AM](https://user-images.githubusercontent.com/37452934/76401007-3bab6d00-63a7-11ea-9727-423669ca3d3d.jpeg)
