### PR TITLE
Issue #3428: Swapped text in dialog buttons 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -442,8 +442,8 @@ public class ContributionsFragment
         DialogUtil.showAlertDialog(getActivity(),
                 getString(R.string.nearby_card_permission_title),
                 getString(R.string.nearby_card_permission_explanation),
-                this::displayYouWontSeeNearbyMessage,
                 this::requestLocationPermission,
+                this::displayYouWontSeeNearbyMessage,
                 checkBoxView,
                 false);
     }

--- a/app/src/main/java/fr/free/nrw/commons/quiz/QuizChecker.java
+++ b/app/src/main/java/fr/free/nrw/commons/quiz/QuizChecker.java
@@ -151,7 +151,8 @@ public class QuizChecker {
                 activity.getString(R.string.quiz_alert_message, REVERT_PERCENTAGE_FOR_MESSAGE),
                 activity.getString(R.string.about_translate_proceed),
                 activity.getString(android.R.string.cancel),
-                () -> startQuizActivity(activity), null);
+                () -> startQuizActivity(activity),
+                null);
     }
 
     private void startQuizActivity(Activity activity) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.java
@@ -167,10 +167,11 @@ public class UploadCategoriesFragment extends UploadBaseFragment implements Cate
         DialogUtil.showAlertDialog(getActivity(),
                 getString(R.string.no_categories_selected),
                 getString(R.string.no_categories_selected_warning_desc),
-                getString(R.string.no_go_back),
                 getString(R.string.yes_submit),
-                null,
-                () -> goToNextScreen());
+                getString(R.string.no_go_back),
+                () -> goToNextScreen(),
+                null);
+
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -355,11 +355,11 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
                         uploadTitleFormat,
                         uploadItem.getFileName()),
                 () -> {
-
-                },
-                () -> {
                     uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
                     onNextButtonClicked();
+                },
+                () -> {
+
                 });
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -357,10 +357,8 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
                 () -> {
                     uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
                     onNextButtonClicked();
-                },
-                () -> {
+                }, null);
 
-                });
     }
 
     @Override
@@ -370,10 +368,11 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
             DialogUtil.showAlertDialog(getActivity(),
                     getString(R.string.warning),
                     errorMessageForResult,
-                    () -> deleteThisPicture(),
-                    () -> {
-                        uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
+                    () -> { uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
                         onNextButtonClicked();
+                    },
+                    () -> {
+                        deleteThisPicture();
                     });
         }
         //If the error message is null, we will probably not show anything

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -368,12 +368,12 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
             DialogUtil.showAlertDialog(getActivity(),
                     getString(R.string.warning),
                     errorMessageForResult,
-                    () -> { uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
+                    () -> {
+                        uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
                         onNextButtonClicked();
                     },
-                    () -> {
-                        deleteThisPicture();
-                    });
+                    () -> deleteThisPicture()
+        );
         }
         //If the error message is null, we will probably not show anything
     }

--- a/app/src/main/java/fr/free/nrw/commons/utils/DialogUtil.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/DialogUtil.java
@@ -44,8 +44,8 @@ public class DialogUtil {
         showAlertDialog(activity,
                 title,
                 message,
-                activity.getString(R.string.no),
                 activity.getString(R.string.yes),
+                activity.getString(R.string.no),
                 onPositiveBtnClick,
                 onNegativeBtnClick);
     }
@@ -96,8 +96,8 @@ public class DialogUtil {
         showAlertDialog(activity,
                 title,
                 message,
-                activity.getString(R.string.no),
                 activity.getString(R.string.yes),
+                activity.getString(R.string.no),
                 onPositiveBtnClick,
                 onNegativeBtnClick,
                 customView,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -552,7 +552,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="exif_tag_name_software">Software</string>
 
   <string name="share_text">Upload photos to Wikimedia Commons directly from your phone. Download the Commons App now: %1$s</string>
-  <string name="share_via">Share app via…</string>
+  <string name="share_via">Share app via...</string>
   <string name="image_info">Image Info</string>
   <string name="no_categories_found">No Categories found</string>
   <string name="upload_cancelled">Cancelled Upload</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -552,7 +552,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="exif_tag_name_software">Software</string>
 
   <string name="share_text">Upload photos to Wikimedia Commons directly from your phone. Download the Commons App now: %1$s</string>
-  <string name="share_via">Share app via...</string>
+  <string name="share_via">Share app via…</string>
   <string name="image_info">Image Info</string>
   <string name="no_categories_found">No Categories found</string>
   <string name="upload_cancelled">Cancelled Upload</string>


### PR DESCRIPTION
because, according to Android Convention, they were opposite each other

**Description**

Fixes #3428 Dialog buttons set as opposite to Android design conventions 

What changes did you make and why?
In DialogUtil.java, I replaced R.string.no with R.string.yes making it the text for the positiveButton, and I replaced R.string.yes with R.string.no making it the text for the negativeButton. I did this inside both of the TWO times that showAlertDialog method occurs inside the java file. 

**Tests performed (required)**

Forgive me if I'm wrong, but according to the developer documentation, it mentions that tests are not required if the issue is not labeled with an 'enhancement' tag. So, I did not perform any tests.

**Screenshots showing what changed (optional - for UI changes)**
BEFORE:
![image](https://user-images.githubusercontent.com/20774412/76452654-dc019180-63a7-11ea-8e17-939d3a12e126.png)

AFTER: 
![image](https://user-images.githubusercontent.com/20774412/76452799-166b2e80-63a8-11ea-962c-7becd7106fe5.png)
---
