### PR TITLE
Fixes #3436 and #2881: Media Detail design Overhaul

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -243,9 +243,12 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         compositeDisposable.add(disposable);
     }
 
-    // The imageSpacer is Basically a transparent overlay for the SimpleDraweeView 
-    // which holds the image to be displayed( moreover this image is out of
-    // the scroll view )
+    /**
+     * The imageSpacer is Basically a transparent overlay for the SimpleDraweeView
+     * which holds the image to be displayed( moreover this image is out of
+     * the scroll view )
+     * @param imageInfo used to calculate height of the ImageSpacer
+     */
     private void updateAspectRatio(ImageInfo imageInfo) {
         if (imageInfo != null) {
             int finalHeight = (scrollView.getWidth()*imageInfo.getHeight()) / imageInfo.getWidth();

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -493,7 +493,6 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         final CompatTextView textView = item.findViewById(R.id.mediaDetailCategoryItemText);
 
         textView.setText(catName);
-        textView.setTextColor(getResources().getColor(R.color.enabled_button_text_color_light));
         if (categoriesLoaded && categoriesPresent) {
             textView.setOnClickListener(view -> {
                 // Open Category Details page

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -105,6 +105,8 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
 
     @BindView(R.id.mediaDetailImageView)
     SimpleDraweeView image;
+    @BindView(R.id.mediaDetailImageViewSpacer)
+    LinearLayout imageSpacer;
     @BindView(R.id.mediaDetailTitle)
     TextView title;
     @BindView(R.id.mediaDetailDesc)
@@ -205,7 +207,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         return view;
     }
 
-    @OnClick(R.id.mediaDetailImageView)
+    @OnClick(R.id.mediaDetailImageViewSpacer)
     public void launchZoomActivity(View view) {
         Context ctx = view.getContext();
         ctx.startActivity(
@@ -241,12 +243,18 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         compositeDisposable.add(disposable);
     }
 
+    // The imageSpacer is Basically a transparent overlay for the SimpleDraweeView 
+    // which holds the image to be displayed( moreover this image is out of
+    // the scroll view )
     private void updateAspectRatio(ImageInfo imageInfo) {
         if (imageInfo != null) {
             int finalHeight = (scrollView.getWidth()*imageInfo.getHeight()) / imageInfo.getWidth();
             ViewGroup.LayoutParams params = image.getLayoutParams();
+            ViewGroup.LayoutParams spacerParams = imageSpacer.getLayoutParams();
             params.height = finalHeight;
+            spacerParams.height = finalHeight;
             image.setLayoutParams(params);
+            imageSpacer.setLayoutParams(spacerParams);
         }
     }
 
@@ -485,6 +493,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         final CompatTextView textView = item.findViewById(R.id.mediaDetailCategoryItemText);
 
         textView.setText(catName);
+        textView.setTextColor(getResources().getColor(R.color.enabled_button_text_color_light));
         if (categoriesLoaded && categoriesPresent) {
             textView.setOnClickListener(view -> {
                 // Open Category Details page

--- a/app/src/main/res/drawable/bg_copy_wikitext_button.xml
+++ b/app/src/main/res/drawable/bg_copy_wikitext_button.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid
+        android:color="@color/button_blue" />
+    <corners
+        android:radius="@dimen/progressbar_stroke" />
+</shape>

--- a/app/src/main/res/drawable/bg_delete_button.xml
+++ b/app/src/main/res/drawable/bg_delete_button.xml
@@ -9,12 +9,12 @@
         <shape
             android:shape="rectangle">
             <solid
-                android:color="@color/deleteRed"/>
+                android:color="?attr/mediaDetailNominationBackground"/>
             <corners
                 android:radius="@dimen/progressbar_stroke" />
             <stroke
                 android:width="5px"
-                android:color="@color/deleteRed" />
+                android:color="?attr/mediaDetailNominationBackground" />
         </shape>
     </item>
 

--- a/app/src/main/res/drawable/bg_delete_button.xml
+++ b/app/src/main/res/drawable/bg_delete_button.xml
@@ -12,9 +12,6 @@
                 android:color="?attr/mediaDetailNominationBackground"/>
             <corners
                 android:radius="@dimen/progressbar_stroke" />
-            <stroke
-                android:width="5px"
-                android:color="?attr/mediaDetailNominationBackground" />
         </shape>
     </item>
 

--- a/app/src/main/res/drawable/bg_delete_button.xml
+++ b/app/src/main/res/drawable/bg_delete_button.xml
@@ -9,7 +9,7 @@
         <shape
             android:shape="rectangle">
             <solid
-                android:color="@color/deleteButton"/>
+                android:color="@color/deleteRed"/>
             <corners
                 android:radius="@dimen/progressbar_stroke" />
             <stroke

--- a/app/src/main/res/drawable/ic_info_outline_dark_24dp.xml
+++ b/app/src/main/res/drawable/ic_info_outline_dark_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="@dimen/half_standard_height"
+        android:height="@dimen/half_standard_height"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/button_background_dark"
+        android:pathData="M11,17h2v-6h-2v6zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM11,9h2L13,7h-2v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_map_dark_24dp.xml
+++ b/app/src/main/res/drawable/ic_map_dark_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="@dimen/half_standard_height"
+        android:height="@dimen/half_standard_height"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/button_background_dark"
+        android:pathData="M20.5,3l-0.16,0.03L15,5.1 9,3 3.36,4.9c-0.21,0.07 -0.36,0.25 -0.36,0.48V20.5c0,0.28 0.22,0.5 0.5,0.5l0.16,-0.03L9,18.9l6,2.1 5.64,-1.9c0.21,-0.07 0.36,-0.25 0.36,-0.48V3.5c0,-0.28 -0.22,-0.5 -0.5,-0.5zM15,19l-6,-2.11V5l6,2.11V19z"/>
+</vector>

--- a/app/src/main/res/layout/detail_category_item.xml
+++ b/app/src/main/res/layout/detail_category_item.xml
@@ -18,7 +18,7 @@
         android:textColor="@android:color/white"
         android:textSize="@dimen/description_text_size"
         app:drawablePadding="@dimen/small_gap"
-        app:drawableStart="@drawable/ic_info_outline_24dp"
+        app:drawableStart="@drawable/ic_info_outline_dark_24dp"
         />
 
 </LinearLayout>

--- a/app/src/main/res/layout/detail_category_item.xml
+++ b/app/src/main/res/layout/detail_category_item.xml
@@ -10,7 +10,7 @@
         android:id="@+id/mediaDetailCategoryItemText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/subBackground"
+        android:background="?attr/mainBackground"
         android:foreground="?attr/selectableItemBackground"
         android:gravity="center_vertical"
         android:minHeight="@dimen/overflow_button_dimen"

--- a/app/src/main/res/layout/detail_category_item.xml
+++ b/app/src/main/res/layout/detail_category_item.xml
@@ -14,10 +14,10 @@
         android:foreground="?attr/selectableItemBackground"
         android:gravity="center_vertical"
         android:minHeight="@dimen/overflow_button_dimen"
-        android:padding="@dimen/quarter_standard_height"
+        android:padding="@dimen/small_gap"
         android:textColor="?attr/mediaDetailsText"
         android:textSize="@dimen/description_text_size"
-        app:drawablePadding="@dimen/small_gap"
+        app:drawablePadding="@dimen/tiny_gap"
         app:drawableStart="?attr/iconInfo24"
         />
 

--- a/app/src/main/res/layout/detail_category_item.xml
+++ b/app/src/main/res/layout/detail_category_item.xml
@@ -15,10 +15,10 @@
         android:gravity="center_vertical"
         android:minHeight="@dimen/overflow_button_dimen"
         android:padding="@dimen/quarter_standard_height"
-        android:textColor="@android:color/white"
+        android:textColor="?attr/mediaDetailsText"
         android:textSize="@dimen/description_text_size"
         app:drawablePadding="@dimen/small_gap"
-        app:drawableStart="@drawable/ic_info_outline_dark_24dp"
+        app:drawableStart="?attr/iconInfo24"
         />
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -63,16 +63,10 @@
 
 
                     <TextView
-
+                        style="@style/MediaDetailTextLabelTitle"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
-                        android:layout_weight="30"
-                        android:paddingTop="@dimen/dimen_6"
-                        android:paddingLeft="@dimen/tiny_padding"
-                        android:text="@string/media_detail_title"
-                        android:textColor="@android:color/white"
-                        android:textSize="@dimen/normal_text"
-                        android:textStyle="bold" />
+                        android:text="@string/media_detail_title" />
 
                     <TextView
                         style="@style/MediaDetailTextBody"
@@ -84,14 +78,14 @@
                 </LinearLayout>
 
                 <LinearLayout
-                    style="@style/MediaDetailLinear1"
+                    style="@style/MediaDetailContainer"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:id="@+id/authorLinearLayout"
                     android:orientation="horizontal">
 
                     <TextView
-                        style="@style/MediaDetailTextHeading"
+                        style="@style/MediaDetailTextLabel"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:text="@string/media_detail_author" />
@@ -105,13 +99,13 @@
                 </LinearLayout>
 
                 <LinearLayout
-                    style="@style/MediaDetailLinear1"
+                    style="@style/MediaDetailContainer"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
 
                     <TextView
-                        style="@style/MediaDetailTextHeading"
+                        style="@style/MediaDetailTextLabel"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:text="@string/media_detail_description" />
@@ -134,13 +128,13 @@
                     android:layout_height="@dimen/tiny_gap"/>
 
                 <LinearLayout
-                    style="@style/MediaDetailLinear1"
+                    style="@style/MediaDetailContainer"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
 
                     <TextView
-                        style="@style/MediaDetailTextHeading"
+                        style="@style/MediaDetailTextLabel"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:text="@string/media_detail_license" />
@@ -162,13 +156,13 @@
                 </LinearLayout>
 
                 <LinearLayout
-                    style="@style/MediaDetailLinear1"
+                    style="@style/MediaDetailContainer"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
 
                     <TextView
-                        style="@style/MediaDetailTextHeading"
+                        style="@style/MediaDetailTextLabel"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:text="@string/media_detail_coordinates" />
@@ -190,14 +184,14 @@
                 </LinearLayout>
 
                 <LinearLayout
-                    style="@style/MediaDetailLinear1"
+                    style="@style/MediaDetailContainer"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
                     android:textStyle="bold">
 
                     <TextView
-                        style="@style/MediaDetailTextHeading"
+                        style="@style/MediaDetailTextLabel"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:text="@string/detail_panel_cats_label" />
@@ -211,13 +205,13 @@
                 </LinearLayout>
 
                 <LinearLayout
-                    style="@style/MediaDetailLinear1"
+                    style="@style/MediaDetailContainer"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
 
                     <TextView
-                        style="@style/MediaDetailTextHeading"
+                        style="@style/MediaDetailTextLabel"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:text="@string/media_detail_uploaded_date" />
@@ -260,13 +254,13 @@
                 </LinearLayout>
 
                 <LinearLayout
-                    style="@style/MediaDetailLinear1"
+                    style="@style/MediaDetailContainer"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
 
                     <TextView
-                        style="@style/MediaDetailTextHeading"
+                        style="@style/MediaDetailTextLabel"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:text="@string/media_detail_discussion" />
@@ -283,7 +277,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_margin="@dimen/standard_gap"
-                    android:background="@color/button_blue"
+                    android:background="@drawable/bg_copy_wikitext_button"
                     android:text="@string/copy_wikicode"
                     android:textColor="@color/primaryTextColor" />
 

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -57,7 +57,6 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:weightSum="100"
                     android:background="@color/primaryDarkColor"
                     android:orientation="horizontal"
                     android:padding="@dimen/quarter_standard_height">
@@ -91,7 +90,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:id="@+id/authorLinearLayout"
-                    android:weightSum="100"
                     android:orientation="horizontal"
                     android:paddingLeft="@dimen/quarter_standard_height"
                     android:paddingRight="@dimen/quarter_standard_height"
@@ -124,7 +122,6 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:weightSum="100"
                     android:orientation="horizontal"
                     android:paddingLeft="@dimen/quarter_standard_height"
                     android:paddingRight="@dimen/quarter_standard_height"
@@ -199,7 +196,6 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:weightSum="100"
                     android:orientation="horizontal"
                     android:paddingLeft="@dimen/quarter_standard_height"
                     android:paddingRight="@dimen/quarter_standard_height"
@@ -236,7 +232,6 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:weightSum="100"
                     android:orientation="horizontal"
                     android:paddingLeft="@dimen/quarter_standard_height"
                     android:paddingRight="@dimen/quarter_standard_height"
@@ -267,7 +262,6 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:weightSum="100"
                     android:orientation="horizontal"
                     android:paddingLeft="@dimen/quarter_standard_height"
                     android:paddingRight="@dimen/quarter_standard_height"
@@ -280,6 +274,7 @@
                         android:layout_weight="30"
                         android:paddingLeft="@dimen/tiny_padding"
                         android:paddingTop="@dimen/dimen_6"
+                        android:gravity="center"
                         android:text="@string/media_detail_uploaded_date"
                         android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"
@@ -329,7 +324,6 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:weightSum="100"
                     android:orientation="horizontal"
                     android:paddingLeft="@dimen/quarter_standard_height"
                     android:paddingRight="@dimen/quarter_standard_height"

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -274,7 +274,6 @@
                         android:layout_weight="30"
                         android:paddingLeft="@dimen/tiny_padding"
                         android:paddingTop="@dimen/dimen_6"
-                        android:gravity="center"
                         android:text="@string/media_detail_uploaded_date"
                         android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -75,69 +75,46 @@
                         android:textStyle="bold" />
 
                     <TextView
+                        style="@style/MediaDetailTextBody"
                         android:id="@+id/mediaDetailTitle"
                         android:layout_width="@dimen/widget_margin"
-                        android:layout_height="match_parent"
-                        android:layout_weight="70"
-                        android:layout_gravity="start"
-                        android:padding="@dimen/small_gap"
                         android:textColor="@android:color/white"
-                        android:textSize="@dimen/description_text_size"
+                        android:layout_height="match_parent"
                         tools:text="Title of the media" />
                 </LinearLayout>
 
                 <LinearLayout
+                    style="@style/MediaDetailLinear1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:id="@+id/authorLinearLayout"
-                    android:orientation="horizontal"
-                    android:paddingLeft="@dimen/quarter_standard_height"
-                    android:paddingRight="@dimen/quarter_standard_height"
-                    android:paddingTop="@dimen/tiny_gap"
-                    android:paddingBottom="@dimen/tiny_gap">
+                    android:orientation="horizontal">
 
                     <TextView
+                        style="@style/MediaDetailTextHeading"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
-                        android:layout_weight="30"
-                        android:paddingTop="@dimen/dimen_6"
-                        android:paddingLeft="@dimen/tiny_gap"
-                        android:text="@string/media_detail_author"
-                        android:textColor="?attr/mediaDetailsHeadingText"
-                        android:textSize="@dimen/normal_text"
-                        android:textStyle="bold" />
+                        android:text="@string/media_detail_author" />
 
                     <TextView
+                        style="@style/MediaDetailTextBody"
                         android:id="@+id/mediaDetailAuthor"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
-                        android:layout_weight="70"
-                        android:layout_gravity="start"
-                        android:padding="@dimen/small_gap"
-                        android:textColor="@color/layout_light_grey"
-                        android:textSize="@dimen/description_text_size"
                         tools:text="Media author user name goes here." />
                 </LinearLayout>
 
                 <LinearLayout
+                    style="@style/MediaDetailLinear1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:paddingLeft="@dimen/quarter_standard_height"
-                    android:paddingRight="@dimen/quarter_standard_height"
-                    android:paddingTop="@dimen/tiny_gap"
-                    android:paddingBottom="@dimen/tiny_gap">
+                    android:orientation="horizontal">
 
                     <TextView
+                        style="@style/MediaDetailTextHeading"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
-                        android:layout_weight="30"
-                        android:paddingTop="@dimen/dimen_6"
-                        android:paddingLeft="@dimen/tiny_padding"
-                        android:text="@string/media_detail_description"
-                        android:textColor="?attr/mediaDetailsHeadingText"
-                        android:textSize="@dimen/normal_text"
-                        android:textStyle="bold" />
+                        android:text="@string/media_detail_description" />
 
                     <fr.free.nrw.commons.ui.widget.HtmlTextView
                         android:id="@+id/mediaDetailDesc"
@@ -157,25 +134,16 @@
                     android:layout_height="@dimen/tiny_gap"/>
 
                 <LinearLayout
+                    style="@style/MediaDetailLinear1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_weight="100"
-                    android:orientation="horizontal"
-                    android:paddingLeft="@dimen/quarter_standard_height"
-                    android:paddingRight="@dimen/quarter_standard_height"
-                    android:paddingTop="@dimen/tiny_gap"
-                    android:paddingBottom="@dimen/tiny_gap">
+                    android:orientation="horizontal">
 
                     <TextView
+                        style="@style/MediaDetailTextHeading"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
-                        android:layout_weight="30"
-                        android:paddingLeft="@dimen/tiny_padding"
-                        android:paddingTop="@dimen/dimen_6"
-                        android:text="@string/media_detail_license"
-                        android:textColor="?attr/mediaDetailsHeadingText"
-                        android:textSize="@dimen/normal_text"
-                        android:textStyle="bold" />
+                        android:text="@string/media_detail_license" />
 
                     <fr.free.nrw.commons.ui.widget.CompatTextView
                         android:id="@+id/mediaDetailLicense"
@@ -194,24 +162,16 @@
                 </LinearLayout>
 
                 <LinearLayout
+                    style="@style/MediaDetailLinear1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:paddingLeft="@dimen/quarter_standard_height"
-                    android:paddingRight="@dimen/quarter_standard_height"
-                    android:paddingTop="@dimen/tiny_gap"
-                    android:paddingBottom="@dimen/tiny_gap">
+                    android:orientation="horizontal">
 
                     <TextView
+                        style="@style/MediaDetailTextHeading"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
-                        android:layout_weight="30"
-                        android:paddingLeft="@dimen/tiny_padding"
-                        android:paddingTop="@dimen/dimen_6"
-                        android:text="@string/media_detail_coordinates"
-                        android:textColor="?attr/mediaDetailsHeadingText"
-                        android:textSize="@dimen/normal_text"
-                        android:textStyle="bold" />
+                        android:text="@string/media_detail_coordinates" />
 
                     <fr.free.nrw.commons.ui.widget.CompatTextView
                         android:id="@+id/mediaDetailCoordinates"
@@ -230,26 +190,17 @@
                 </LinearLayout>
 
                 <LinearLayout
+                    style="@style/MediaDetailLinear1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
-                    android:paddingLeft="@dimen/quarter_standard_height"
-                    android:paddingRight="@dimen/quarter_standard_height"
-                    android:paddingTop="@dimen/tiny_gap"
-                    android:paddingBottom="@dimen/tiny_gap"
                     android:textStyle="bold">
 
                     <TextView
+                        style="@style/MediaDetailTextHeading"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
-                        android:layout_weight="30"
-                        android:layout_gravity="start"
-                        android:paddingLeft="@dimen/tiny_padding"
-                        android:paddingTop="@dimen/dimen_6"
-                        android:text="@string/detail_panel_cats_label"
-                        android:textColor="?attr/mediaDetailsHeadingText"
-                        android:textSize="@dimen/normal_text"
-                        android:textStyle="bold" />
+                        android:text="@string/detail_panel_cats_label" />
 
                     <LinearLayout
                         android:id="@+id/mediaDetailCategoryContainer"
@@ -260,34 +211,22 @@
                 </LinearLayout>
 
                 <LinearLayout
+                    style="@style/MediaDetailLinear1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:paddingLeft="@dimen/quarter_standard_height"
-                    android:paddingRight="@dimen/quarter_standard_height"
-                    android:paddingTop="@dimen/tiny_gap"
-                    android:paddingBottom="@dimen/tiny_gap">
+                    android:orientation="horizontal">
 
                     <TextView
+                        style="@style/MediaDetailTextHeading"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
-                        android:layout_weight="30"
-                        android:paddingLeft="@dimen/tiny_padding"
-                        android:paddingTop="@dimen/dimen_6"
-                        android:text="@string/media_detail_uploaded_date"
-                        android:textColor="?attr/mediaDetailsHeadingText"
-                        android:textSize="@dimen/normal_text"
-                        android:textStyle="bold" />
+                        android:text="@string/media_detail_uploaded_date" />
 
                     <TextView
+                        style="@style/MediaDetailTextBody"
                         android:id="@+id/mediaDetailuploadeddate"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
-                        android:layout_weight="70"
-                        android:layout_gravity="start"
-                        android:padding="@dimen/small_gap"
-                        android:textColor="?attr/mediaDetailsText"
-                        android:textSize="@dimen/description_text_size"
                         tools:text="Uploaded date" />
                 </LinearLayout>
 
@@ -321,34 +260,22 @@
                 </LinearLayout>
 
                 <LinearLayout
+                    style="@style/MediaDetailLinear1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:paddingLeft="@dimen/quarter_standard_height"
-                    android:paddingRight="@dimen/quarter_standard_height"
-                    android:paddingTop="@dimen/tiny_gap"
-                    android:paddingBottom="@dimen/tiny_gap">
+                    android:orientation="horizontal">
 
                     <TextView
+                        style="@style/MediaDetailTextHeading"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
-                        android:layout_weight="30"
-                        android:paddingLeft="@dimen/tiny_padding"
-                        android:paddingTop="@dimen/dimen_6"
-                        android:text="@string/media_detail_discussion"
-                        android:textColor="?attr/mediaDetailsHeadingText"
-                        android:textSize="@dimen/normal_text"
-                        android:textStyle="bold" />
+                        android:text="@string/media_detail_discussion" />
 
                     <TextView
+                        style="@style/MediaDetailTextBody"
                         android:id="@+id/mediaDetailDisc"
                         android:layout_width="@dimen/widget_margin"
-                        android:layout_height="match_parent"
-                        android:layout_weight="70"
-                        android:layout_gravity="start"
-                        android:padding="@dimen/small_gap"
-                        android:textColor="?attr/mediaDetailsText"
-                        android:textSize="@dimen/description_text_size" />
+                        android:layout_height="match_parent" />
                 </LinearLayout>
 
                 <Button

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -85,7 +85,7 @@
                     android:orientation="horizontal">
 
                     <TextView
-                        style="@style/MediaDetailTextLabel"
+                        style="@style/MediaDetailTextLabelGeneric"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:text="@string/media_detail_author" />
@@ -105,7 +105,7 @@
                     android:orientation="horizontal">
 
                     <TextView
-                        style="@style/MediaDetailTextLabel"
+                        style="@style/MediaDetailTextLabelGeneric"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:text="@string/media_detail_description" />
@@ -134,7 +134,7 @@
                     android:orientation="horizontal">
 
                     <TextView
-                        style="@style/MediaDetailTextLabel"
+                        style="@style/MediaDetailTextLabelGeneric"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:text="@string/media_detail_license" />
@@ -162,7 +162,7 @@
                     android:orientation="horizontal">
 
                     <TextView
-                        style="@style/MediaDetailTextLabel"
+                        style="@style/MediaDetailTextLabelGeneric"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:text="@string/media_detail_coordinates" />
@@ -191,7 +191,7 @@
                     android:textStyle="bold">
 
                     <TextView
-                        style="@style/MediaDetailTextLabel"
+                        style="@style/MediaDetailTextLabelGeneric"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:text="@string/detail_panel_cats_label" />
@@ -211,7 +211,7 @@
                     android:orientation="horizontal">
 
                     <TextView
-                        style="@style/MediaDetailTextLabel"
+                        style="@style/MediaDetailTextLabelGeneric"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:text="@string/media_detail_uploaded_date" />
@@ -260,7 +260,7 @@
                     android:orientation="horizontal">
 
                     <TextView
-                        style="@style/MediaDetailTextLabel"
+                        style="@style/MediaDetailTextLabelGeneric"
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:text="@string/media_detail_discussion" />

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -5,7 +5,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/white"
+    android:background="?attr/mainBackground"
     >
 
     <ImageView
@@ -34,7 +34,6 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:background="@android:color/transparent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
@@ -52,7 +51,7 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@color/white"
+                android:background="?attr/mainBackground"
                 android:orientation="vertical">
 
                 <LinearLayout

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -62,12 +62,14 @@
                     android:orientation="horizontal"
                     android:padding="@dimen/quarter_standard_height">
 
+
                     <TextView
+
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:layout_weight="30"
-                        android:paddingTop="@dimen/tiny_padding"
-                        android:paddingLeft="@dimen/tiny_gap"
+                        android:paddingTop="@dimen/dimen_6"
+                        android:paddingLeft="@dimen/tiny_padding"
                         android:text="@string/media_detail_title"
                         android:textColor="@android:color/white"
                         android:textSize="@dimen/normal_text"
@@ -91,13 +93,17 @@
                     android:id="@+id/authorLinearLayout"
                     android:weightSum="100"
                     android:orientation="horizontal"
-                    android:padding="@dimen/quarter_standard_height">
+                    android:paddingLeft="@dimen/quarter_standard_height"
+                    android:paddingRight="@dimen/quarter_standard_height"
+                    android:paddingTop="@dimen/tiny_gap"
+                    android:paddingBottom="@dimen/tiny_gap">
 
                     <TextView
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:layout_weight="30"
-                        android:paddingBottom="@dimen/tiny_gap"
+                        android:paddingTop="@dimen/dimen_6"
+                        android:paddingLeft="@dimen/tiny_gap"
                         android:text="@string/media_detail_author"
                         android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"
@@ -120,13 +126,17 @@
                     android:layout_height="wrap_content"
                     android:weightSum="100"
                     android:orientation="horizontal"
-                    android:padding="@dimen/quarter_standard_height">
+                    android:paddingLeft="@dimen/quarter_standard_height"
+                    android:paddingRight="@dimen/quarter_standard_height"
+                    android:paddingTop="@dimen/tiny_gap"
+                    android:paddingBottom="@dimen/tiny_gap">
 
                     <TextView
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:layout_weight="30"
-                        android:padding="@dimen/tiny_gap"
+                        android:paddingTop="@dimen/dimen_6"
+                        android:paddingLeft="@dimen/tiny_padding"
                         android:text="@string/media_detail_description"
                         android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"
@@ -154,13 +164,17 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="100"
                     android:orientation="horizontal"
-                    android:padding="@dimen/quarter_standard_height">
+                    android:paddingLeft="@dimen/quarter_standard_height"
+                    android:paddingRight="@dimen/quarter_standard_height"
+                    android:paddingTop="@dimen/tiny_gap"
+                    android:paddingBottom="@dimen/tiny_gap">
 
                     <TextView
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:layout_weight="30"
-                        android:padding="@dimen/tiny_gap"
+                        android:paddingLeft="@dimen/tiny_padding"
+                        android:paddingTop="@dimen/dimen_6"
                         android:text="@string/media_detail_license"
                         android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"
@@ -187,13 +201,17 @@
                     android:layout_height="wrap_content"
                     android:weightSum="100"
                     android:orientation="horizontal"
-                    android:padding="@dimen/quarter_standard_height">
+                    android:paddingLeft="@dimen/quarter_standard_height"
+                    android:paddingRight="@dimen/quarter_standard_height"
+                    android:paddingTop="@dimen/tiny_gap"
+                    android:paddingBottom="@dimen/tiny_gap">
 
                     <TextView
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:layout_weight="30"
-                        android:padding="@dimen/tiny_gap"
+                        android:paddingLeft="@dimen/tiny_padding"
+                        android:paddingTop="@dimen/dimen_6"
                         android:text="@string/media_detail_coordinates"
                         android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"
@@ -220,7 +238,10 @@
                     android:layout_height="wrap_content"
                     android:weightSum="100"
                     android:orientation="horizontal"
-                    android:padding="@dimen/quarter_standard_height"
+                    android:paddingLeft="@dimen/quarter_standard_height"
+                    android:paddingRight="@dimen/quarter_standard_height"
+                    android:paddingTop="@dimen/tiny_gap"
+                    android:paddingBottom="@dimen/tiny_gap"
                     android:textStyle="bold">
 
                     <TextView
@@ -228,9 +249,8 @@
                         android:layout_height="match_parent"
                         android:layout_weight="30"
                         android:layout_gravity="start"
-                        android:paddingRight="@dimen/tiny_gap"
-                        android:paddingBottom="@dimen/tiny_gap"
-                        android:paddingTop="@dimen/small_height"
+                        android:paddingLeft="@dimen/tiny_padding"
+                        android:paddingTop="@dimen/dimen_6"
                         android:text="@string/detail_panel_cats_label"
                         android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"
@@ -249,13 +269,17 @@
                     android:layout_height="wrap_content"
                     android:weightSum="100"
                     android:orientation="horizontal"
-                    android:padding="@dimen/quarter_standard_height">
+                    android:paddingLeft="@dimen/quarter_standard_height"
+                    android:paddingRight="@dimen/quarter_standard_height"
+                    android:paddingTop="@dimen/tiny_gap"
+                    android:paddingBottom="@dimen/tiny_gap">
 
                     <TextView
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:layout_weight="30"
-                        android:padding="@dimen/tiny_gap"
+                        android:paddingLeft="@dimen/tiny_padding"
+                        android:paddingTop="@dimen/dimen_6"
                         android:text="@string/media_detail_uploaded_date"
                         android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"
@@ -281,6 +305,7 @@
                     android:orientation="vertical"
                     android:padding="@dimen/quarter_standard_height"
                     android:visibility="gone">
+
                     <TextView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -289,6 +314,7 @@
                         android:textColor="@color/primaryTextColor"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold"/>
+
                     <TextView
                         android:id="@+id/seeMore"
                         android:layout_width="match_parent"
@@ -305,13 +331,17 @@
                     android:layout_height="wrap_content"
                     android:weightSum="100"
                     android:orientation="horizontal"
-                    android:padding="@dimen/quarter_standard_height">
+                    android:paddingLeft="@dimen/quarter_standard_height"
+                    android:paddingRight="@dimen/quarter_standard_height"
+                    android:paddingTop="@dimen/tiny_gap"
+                    android:paddingBottom="@dimen/tiny_gap">
 
                     <TextView
                         android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
                         android:layout_weight="30"
-                        android:padding="@dimen/tiny_gap"
+                        android:paddingLeft="@dimen/tiny_padding"
+                        android:paddingTop="@dimen/dimen_6"
                         android:text="@string/media_detail_discussion"
                         android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -197,7 +197,7 @@
                         android:textColor="?attr/mediaDetailsText"
                         android:textSize="@dimen/description_text_size"
                         app:drawablePadding="@dimen/tiny_gap"
-                        app:drawableStart="@drawable/ic_map_dark_24dp"
+                        app:drawableStart="?attr/iconMap24"
                         tools:text="Coordinates link" />
                 </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -5,7 +5,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/mainBackground"
+    android:background="@color/white"
     >
 
     <ImageView
@@ -19,11 +19,10 @@
         />
 
     <com.facebook.drawee.view.SimpleDraweeView
-        android:id="@+id/mediaDetailImage"
+        android:id="@+id/mediaDetailImageView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:actualImageScaleType="centerCrop"
-        />
+        android:layout_height="@dimen/dimen_250"
+        app:actualImageScaleType="none" />
 
     <ScrollView
         android:id="@+id/mediaDetailScrollView"
@@ -35,35 +34,38 @@
 
         <LinearLayout
             android:layout_width="match_parent"
+            android:background="@android:color/transparent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
             <!-- Placeholder. Height gets set at runtime based on container size; the initial value is a hack to keep
                  the detail info offscreen until it's placed properly. May be a better way to do this. -->
-            <com.facebook.drawee.view.SimpleDraweeView
-                android:id="@+id/mediaDetailImageView"
+
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/dimen_250"
-                app:actualImageScaleType="none" />
+                android:orientation="vertical"
+                android:background="@android:color/transparent"
+                android:id="@+id/mediaDetailImageViewSpacer"
+                />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="?attr/fragmentCategorisationBackground"
-                android:orientation="vertical"
-                android:padding="@dimen/standard_gap">
+                android:background="@color/white"
+                android:orientation="vertical">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="?attr/subBackground"
-                    android:orientation="vertical"
+                    android:background="@color/primaryDarkColor"
+                    android:orientation="horizontal"
                     android:padding="@dimen/standard_gap">
 
                     <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:paddingBottom="@dimen/tiny_gap"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_title"
                         android:textColor="@android:color/white"
                         android:textSize="@dimen/normal_text"
@@ -72,220 +74,195 @@
                     <TextView
                         android:id="@+id/mediaDetailTitle"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
+                        android:layout_height="match_parent"
                         android:layout_gravity="start"
-                        android:background="?attr/subBackground"
                         android:padding="@dimen/small_gap"
                         android:textColor="@android:color/white"
                         android:textSize="@dimen/description_text_size"
                         tools:text="Title of the media" />
                 </LinearLayout>
 
-                <fr.free.nrw.commons.media.MediaDetailSpacer
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/small_gap" />
-
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:id="@+id/authorLinearLayout"
-                    android:background="?attr/subBackground"
-                    android:orientation="vertical"
+                    android:background="@color/white"
+                    android:orientation="horizontal"
                     android:padding="@dimen/standard_gap">
 
                     <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
                         android:paddingBottom="@dimen/tiny_gap"
                         android:text="@string/media_detail_author"
-                        android:textColor="@android:color/white"
+                        android:textColor="@color/primaryDarkColor"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold" />
 
                     <TextView
                         android:id="@+id/mediaDetailAuthor"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
+                        android:layout_height="match_parent"
                         android:layout_gravity="start"
-                        android:background="?attr/subBackground"
+
                         android:padding="@dimen/small_gap"
-                        android:textColor="@android:color/white"
+                        android:textColor="@color/layout_light_grey"
                         android:textSize="@dimen/description_text_size"
                         tools:text="Media author user name goes here." />
                 </LinearLayout>
 
-                <fr.free.nrw.commons.media.MediaDetailSpacer
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/small_gap" />
-
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="?attr/subBackground"
-                    android:orientation="vertical"
+                    android:background="@color/white"
+                    android:orientation="horizontal"
                     android:padding="@dimen/standard_gap">
 
                     <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:paddingBottom="@dimen/tiny_gap"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_description"
-                        android:textColor="@android:color/white"
+                        android:textColor="@color/primaryDarkColor"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold" />
 
                     <fr.free.nrw.commons.ui.widget.HtmlTextView
                         android:id="@+id/mediaDetailDesc"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
+                        android:layout_height="match_parent"
                         android:layout_gravity="start"
-                        android:background="?attr/subBackground"
+
                         android:padding="@dimen/small_gap"
-                        android:textColor="@android:color/white"
+                        android:textColor="@color/enabled_button_text_color_light"
                         android:textSize="@dimen/description_text_size"
                         tools:text="Description of the media goes here. This can potentially be fairly long, and will need to wrap across multiple lines. We hope it looks nice though." />
                 </LinearLayout>
 
-                <fr.free.nrw.commons.media.MediaDetailSpacer
+                <View
+                    android:background="@color/divider_grey"
                     android:layout_width="match_parent"
-                    android:layout_height="@dimen/small_gap" />
+                    android:layout_height="@dimen/tiny_gap"/>
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="?attr/subBackground"
-                    android:orientation="vertical"
+                    android:background="@color/white"
+                    android:orientation="horizontal"
                     android:padding="@dimen/standard_gap">
 
                     <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:paddingBottom="@dimen/tiny_gap"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_license"
-                        android:textColor="@android:color/white"
+                        android:textColor="@color/primaryDarkColor"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold" />
 
                     <fr.free.nrw.commons.ui.widget.CompatTextView
                         android:id="@+id/mediaDetailLicense"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
+                        android:layout_height="match_parent"
                         android:layout_gravity="start"
-                        android:background="?attr/subBackground"
                         android:foreground="?attr/selectableItemBackground"
                         android:gravity="center_vertical"
                         android:padding="@dimen/small_gap"
-                        android:textColor="@android:color/white"
+                        android:textColor="@color/enabled_button_text_color_light"
                         android:textSize="@dimen/description_text_size"
                         app:drawablePadding="@dimen/tiny_gap"
-                        app:drawableStart="@drawable/ic_info_outline_24dp"
+                        app:drawableStart="@drawable/ic_info_outline_dark_24dp"
                         tools:text="License link" />
                 </LinearLayout>
-
-                <fr.free.nrw.commons.media.MediaDetailSpacer
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/small_gap" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="?attr/subBackground"
-                    android:orientation="vertical"
+                    android:background="@color/white"
+                    android:orientation="horizontal"
                     android:padding="@dimen/standard_gap">
 
                     <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:paddingBottom="@dimen/tiny_gap"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_coordinates"
-                        android:textColor="@android:color/white"
+                        android:textColor="@color/primaryDarkColor"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold" />
 
                     <fr.free.nrw.commons.ui.widget.CompatTextView
                         android:id="@+id/mediaDetailCoordinates"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
+                        android:layout_height="match_parent"
                         android:layout_gravity="start"
-                        android:background="?attr/subBackground"
                         android:foreground="?attr/selectableItemBackground"
                         android:gravity="center_vertical"
                         android:padding="@dimen/small_gap"
-                        android:textColor="@android:color/white"
+                        android:textColor="@color/enabled_button_text_color_light"
                         android:textSize="@dimen/description_text_size"
                         app:drawablePadding="@dimen/tiny_gap"
-                        app:drawableStart="@drawable/ic_map_white_24dp"
+                        app:drawableStart="@drawable/ic_map_dark_24dp"
                         tools:text="Coordinates link" />
                 </LinearLayout>
-
-                <fr.free.nrw.commons.media.MediaDetailSpacer
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/small_gap" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="?attr/subBackground"
-                    android:orientation="vertical"
+                    android:background="@color/white"
+                    android:orientation="horizontal"
                     android:padding="@dimen/standard_gap"
                     android:textStyle="bold">
 
                     <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
                         android:layout_gravity="start"
+                        android:paddingRight="@dimen/tiny_gap"
                         android:paddingBottom="@dimen/tiny_gap"
+                        android:paddingTop="@dimen/small_height"
                         android:text="@string/detail_panel_cats_label"
-                        android:textColor="@android:color/white"
+                        android:textColor="@color/primaryDarkColor"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold" />
 
                     <LinearLayout
                         android:id="@+id/mediaDetailCategoryContainer"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
+                        android:layout_height="match_parent"
                         android:orientation="vertical" />
                 </LinearLayout>
-
-                <fr.free.nrw.commons.media.MediaDetailSpacer
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/small_gap" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="?attr/subBackground"
-                    android:orientation="vertical"
+                    android:background="@color/white"
+                    android:orientation="horizontal"
                     android:padding="@dimen/standard_gap">
 
                     <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:paddingBottom="@dimen/tiny_gap"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_uploaded_date"
-                        android:textColor="@android:color/white"
+                        android:textColor="@color/primaryDarkColor"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold" />
 
                     <TextView
                         android:id="@+id/mediaDetailuploadeddate"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
+                        android:layout_height="match_parent"
                         android:layout_gravity="start"
-                        android:background="?attr/subBackground"
                         android:padding="@dimen/small_gap"
-                        android:textColor="@android:color/white"
+                        android:textColor="@color/enabled_button_text_color_light"
                         android:textSize="@dimen/description_text_size"
                         tools:text="Uploaded date" />
                 </LinearLayout>
 
-                <fr.free.nrw.commons.media.MediaDetailSpacer
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/small_gap" />
-
                 <LinearLayout
                     android:id="@+id/nominatedDeletionBanner"
-                    android:background="@color/deleteRed"
+                    android:background="@color/swipe_red"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
@@ -310,34 +287,29 @@
                         android:textStyle="bold"/>
                 </LinearLayout>
 
-                <fr.free.nrw.commons.media.MediaDetailSpacer
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/small_gap" />
-
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="?attr/subBackground"
-                    android:orientation="vertical"
+                    android:background="@color/white"
+                    android:orientation="horizontal"
                     android:padding="@dimen/standard_gap">
 
                     <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:paddingBottom="@dimen/tiny_gap"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_discussion"
-                        android:textColor="@android:color/white"
+                        android:textColor="@color/primaryDarkColor"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold" />
 
                     <TextView
                         android:id="@+id/mediaDetailDisc"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
+                        android:layout_height="match_parent"
                         android:layout_gravity="start"
-                        android:background="?attr/subBackground"
                         android:padding="@dimen/small_gap"
-                        android:textColor="@android:color/white"
+                        android:textColor="@color/enabled_button_text_color_light"
                         android:textSize="@dimen/description_text_size" />
                 </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -86,7 +86,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:id="@+id/authorLinearLayout"
-                    android:background="@color/white"
                     android:orientation="horizontal"
                     android:padding="@dimen/standard_gap">
 
@@ -114,7 +113,6 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="@color/white"
                     android:orientation="horizontal"
                     android:padding="@dimen/standard_gap">
 
@@ -147,7 +145,6 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="@color/white"
                     android:orientation="horizontal"
                     android:padding="@dimen/standard_gap">
 
@@ -178,7 +175,6 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="@color/white"
                     android:orientation="horizontal"
                     android:padding="@dimen/standard_gap">
 
@@ -209,7 +205,6 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="@color/white"
                     android:orientation="horizontal"
                     android:padding="@dimen/standard_gap"
                     android:textStyle="bold">
@@ -236,7 +231,6 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="@color/white"
                     android:orientation="horizontal"
                     android:padding="@dimen/standard_gap">
 
@@ -290,7 +284,6 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="@color/white"
                     android:orientation="horizontal"
                     android:padding="@dimen/standard_gap">
 

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -57,14 +57,17 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:weightSum="100"
                     android:background="@color/primaryDarkColor"
                     android:orientation="horizontal"
-                    android:padding="@dimen/standard_gap">
+                    android:padding="@dimen/quarter_standard_height">
 
                     <TextView
-                        android:layout_width="wrap_content"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
-                        android:padding="@dimen/tiny_gap"
+                        android:layout_weight="30"
+                        android:paddingTop="@dimen/tiny_padding"
+                        android:paddingLeft="@dimen/tiny_gap"
                         android:text="@string/media_detail_title"
                         android:textColor="@android:color/white"
                         android:textSize="@dimen/normal_text"
@@ -72,8 +75,9 @@
 
                     <TextView
                         android:id="@+id/mediaDetailTitle"
-                        android:layout_width="match_parent"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
+                        android:layout_weight="70"
                         android:layout_gravity="start"
                         android:padding="@dimen/small_gap"
                         android:textColor="@android:color/white"
@@ -85,12 +89,14 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:id="@+id/authorLinearLayout"
+                    android:weightSum="100"
                     android:orientation="horizontal"
-                    android:padding="@dimen/standard_gap">
+                    android:padding="@dimen/quarter_standard_height">
 
                     <TextView
-                        android:layout_width="wrap_content"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
+                        android:layout_weight="30"
                         android:paddingBottom="@dimen/tiny_gap"
                         android:text="@string/media_detail_author"
                         android:textColor="?attr/mediaDetailsHeadingText"
@@ -99,10 +105,10 @@
 
                     <TextView
                         android:id="@+id/mediaDetailAuthor"
-                        android:layout_width="match_parent"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
+                        android:layout_weight="70"
                         android:layout_gravity="start"
-
                         android:padding="@dimen/small_gap"
                         android:textColor="@color/layout_light_grey"
                         android:textSize="@dimen/description_text_size"
@@ -112,12 +118,14 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:weightSum="100"
                     android:orientation="horizontal"
-                    android:padding="@dimen/standard_gap">
+                    android:padding="@dimen/quarter_standard_height">
 
                     <TextView
-                        android:layout_width="wrap_content"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
+                        android:layout_weight="30"
                         android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_description"
                         android:textColor="?attr/mediaDetailsHeadingText"
@@ -126,10 +134,10 @@
 
                     <fr.free.nrw.commons.ui.widget.HtmlTextView
                         android:id="@+id/mediaDetailDesc"
-                        android:layout_width="match_parent"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
+                        android:layout_weight="70"
                         android:layout_gravity="start"
-
                         android:padding="@dimen/small_gap"
                         android:textColor="?attr/mediaDetailsText"
                         android:textSize="@dimen/description_text_size"
@@ -137,19 +145,21 @@
                 </LinearLayout>
 
                 <View
-                    android:background="@color/divider_grey"
+                    android:background="?attr/mediaDetailSpacerColor"
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/tiny_gap"/>
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_weight="100"
                     android:orientation="horizontal"
-                    android:padding="@dimen/standard_gap">
+                    android:padding="@dimen/quarter_standard_height">
 
                     <TextView
-                        android:layout_width="wrap_content"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
+                        android:layout_weight="30"
                         android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_license"
                         android:textColor="?attr/mediaDetailsHeadingText"
@@ -158,8 +168,9 @@
 
                     <fr.free.nrw.commons.ui.widget.CompatTextView
                         android:id="@+id/mediaDetailLicense"
-                        android:layout_width="match_parent"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
+                        android:layout_weight="70"
                         android:layout_gravity="start"
                         android:foreground="?attr/selectableItemBackground"
                         android:gravity="center_vertical"
@@ -174,12 +185,14 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:weightSum="100"
                     android:orientation="horizontal"
-                    android:padding="@dimen/standard_gap">
+                    android:padding="@dimen/quarter_standard_height">
 
                     <TextView
-                        android:layout_width="wrap_content"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
+                        android:layout_weight="30"
                         android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_coordinates"
                         android:textColor="?attr/mediaDetailsHeadingText"
@@ -188,8 +201,9 @@
 
                     <fr.free.nrw.commons.ui.widget.CompatTextView
                         android:id="@+id/mediaDetailCoordinates"
-                        android:layout_width="match_parent"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
+                        android:layout_weight="70"
                         android:layout_gravity="start"
                         android:foreground="?attr/selectableItemBackground"
                         android:gravity="center_vertical"
@@ -204,13 +218,15 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:weightSum="100"
                     android:orientation="horizontal"
-                    android:padding="@dimen/standard_gap"
+                    android:padding="@dimen/quarter_standard_height"
                     android:textStyle="bold">
 
                     <TextView
-                        android:layout_width="wrap_content"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
+                        android:layout_weight="30"
                         android:layout_gravity="start"
                         android:paddingRight="@dimen/tiny_gap"
                         android:paddingBottom="@dimen/tiny_gap"
@@ -222,20 +238,23 @@
 
                     <LinearLayout
                         android:id="@+id/mediaDetailCategoryContainer"
-                        android:layout_width="match_parent"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
+                        android:layout_weight="70"
                         android:orientation="vertical" />
                 </LinearLayout>
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:weightSum="100"
                     android:orientation="horizontal"
-                    android:padding="@dimen/standard_gap">
+                    android:padding="@dimen/quarter_standard_height">
 
                     <TextView
-                        android:layout_width="wrap_content"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
+                        android:layout_weight="30"
                         android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_uploaded_date"
                         android:textColor="?attr/mediaDetailsHeadingText"
@@ -244,8 +263,9 @@
 
                     <TextView
                         android:id="@+id/mediaDetailuploadeddate"
-                        android:layout_width="match_parent"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
+                        android:layout_weight="70"
                         android:layout_gravity="start"
                         android:padding="@dimen/small_gap"
                         android:textColor="?attr/mediaDetailsText"
@@ -255,11 +275,11 @@
 
                 <LinearLayout
                     android:id="@+id/nominatedDeletionBanner"
-                    android:background="@color/swipe_red"
+                    android:background="?attr/mediaDetailNominationBackground"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:padding="@dimen/standard_gap"
+                    android:padding="@dimen/quarter_standard_height"
                     android:visibility="gone">
                     <TextView
                         android:layout_width="match_parent"
@@ -283,12 +303,14 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:weightSum="100"
                     android:orientation="horizontal"
-                    android:padding="@dimen/standard_gap">
+                    android:padding="@dimen/quarter_standard_height">
 
                     <TextView
-                        android:layout_width="wrap_content"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
+                        android:layout_weight="30"
                         android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_discussion"
                         android:textColor="?attr/mediaDetailsHeadingText"
@@ -297,8 +319,9 @@
 
                     <TextView
                         android:id="@+id/mediaDetailDisc"
-                        android:layout_width="match_parent"
+                        android:layout_width="@dimen/widget_margin"
                         android:layout_height="match_parent"
+                        android:layout_weight="70"
                         android:layout_gravity="start"
                         android:padding="@dimen/small_gap"
                         android:textColor="?attr/mediaDetailsText"

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -93,7 +93,7 @@
                         android:layout_height="match_parent"
                         android:paddingBottom="@dimen/tiny_gap"
                         android:text="@string/media_detail_author"
-                        android:textColor="@color/primaryDarkColor"
+                        android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold" />
 
@@ -120,7 +120,7 @@
                         android:layout_height="match_parent"
                         android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_description"
-                        android:textColor="@color/primaryDarkColor"
+                        android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold" />
 
@@ -131,7 +131,7 @@
                         android:layout_gravity="start"
 
                         android:padding="@dimen/small_gap"
-                        android:textColor="@color/enabled_button_text_color_light"
+                        android:textColor="?attr/mediaDetailsText"
                         android:textSize="@dimen/description_text_size"
                         tools:text="Description of the media goes here. This can potentially be fairly long, and will need to wrap across multiple lines. We hope it looks nice though." />
                 </LinearLayout>
@@ -152,7 +152,7 @@
                         android:layout_height="match_parent"
                         android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_license"
-                        android:textColor="@color/primaryDarkColor"
+                        android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold" />
 
@@ -164,10 +164,10 @@
                         android:foreground="?attr/selectableItemBackground"
                         android:gravity="center_vertical"
                         android:padding="@dimen/small_gap"
-                        android:textColor="@color/enabled_button_text_color_light"
+                        android:textColor="?attr/mediaDetailsText"
                         android:textSize="@dimen/description_text_size"
                         app:drawablePadding="@dimen/tiny_gap"
-                        app:drawableStart="@drawable/ic_info_outline_dark_24dp"
+                        app:drawableStart="?attr/iconInfo24"
                         tools:text="License link" />
                 </LinearLayout>
 
@@ -182,7 +182,7 @@
                         android:layout_height="match_parent"
                         android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_coordinates"
-                        android:textColor="@color/primaryDarkColor"
+                        android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold" />
 
@@ -194,7 +194,7 @@
                         android:foreground="?attr/selectableItemBackground"
                         android:gravity="center_vertical"
                         android:padding="@dimen/small_gap"
-                        android:textColor="@color/enabled_button_text_color_light"
+                        android:textColor="?attr/mediaDetailsText"
                         android:textSize="@dimen/description_text_size"
                         app:drawablePadding="@dimen/tiny_gap"
                         app:drawableStart="@drawable/ic_map_dark_24dp"
@@ -216,7 +216,7 @@
                         android:paddingBottom="@dimen/tiny_gap"
                         android:paddingTop="@dimen/small_height"
                         android:text="@string/detail_panel_cats_label"
-                        android:textColor="@color/primaryDarkColor"
+                        android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold" />
 
@@ -238,7 +238,7 @@
                         android:layout_height="match_parent"
                         android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_uploaded_date"
-                        android:textColor="@color/primaryDarkColor"
+                        android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold" />
 
@@ -248,7 +248,7 @@
                         android:layout_height="match_parent"
                         android:layout_gravity="start"
                         android:padding="@dimen/small_gap"
-                        android:textColor="@color/enabled_button_text_color_light"
+                        android:textColor="?attr/mediaDetailsText"
                         android:textSize="@dimen/description_text_size"
                         tools:text="Uploaded date" />
                 </LinearLayout>
@@ -291,7 +291,7 @@
                         android:layout_height="match_parent"
                         android:padding="@dimen/tiny_gap"
                         android:text="@string/media_detail_discussion"
-                        android:textColor="@color/primaryDarkColor"
+                        android:textColor="?attr/mediaDetailsHeadingText"
                         android:textSize="@dimen/normal_text"
                         android:textStyle="bold" />
 
@@ -301,7 +301,7 @@
                         android:layout_height="match_parent"
                         android:layout_gravity="start"
                         android:padding="@dimen/small_gap"
-                        android:textColor="@color/enabled_button_text_color_light"
+                        android:textColor="?attr/mediaDetailsText"
                         android:textSize="@dimen/description_text_size" />
                 </LinearLayout>
 

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -30,6 +30,8 @@
     <attr name="iconMap24" format="reference" />
     <attr name="mediaDetailsText" format="reference" />
     <attr name="mediaDetailsHeadingText" format="reference" />
+    <attr name="mediaDetailNominationBackground" format="reference" />
+    <attr name="mediaDetailSpacerColor" format="reference" />
     <attr name="icon" format="reference"/>
 
 

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -26,6 +26,10 @@
     <attr name="mainTabBackground" format="reference"/>
     <attr name="mainCardBackground" format="reference"/>
     <attr name="mainScreenNearbyPermissionbutton" format="reference"/>
+    <attr name="iconInfo24" format="reference" />
+    <attr name="iconMap24" format="reference" />
+    <attr name="mediaDetailsText" format="reference" />
+    <attr name="mediaDetailsHeadingText" format="reference" />
     <attr name="icon" format="reference"/>
 
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -25,6 +25,7 @@
     <color name="secondaryTextColor">#000000</color>
 
     <color name="deleteRed">#D32F2F</color>
+    <color name="deleteRedDark">#90960a0a</color>
     <color name="deleteButton">#44000000</color>
     <color name="deleteButtonDark">#88000000</color>
     <color name="deleteButtonLight">#44ffffff</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -24,7 +24,7 @@
     <color name="primaryTextColor">#ffffff</color>
     <color name="secondaryTextColor">#000000</color>
 
-    <color name="deleteRed">#90960a0a</color>
+    <color name="deleteRed">#D32F2F</color>
     <color name="deleteButton">#44000000</color>
     <color name="deleteButtonDark">#88000000</color>
     <color name="deleteButtonLight">#44ffffff</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -139,4 +139,28 @@
         <item name="centerRegion">#906078</item>
     </style>
 
+    <style name="MediaDetailLinear1">
+        <item name="android:paddingLeft">@dimen/quarter_standard_height</item>
+        <item name="android:paddingRight">@dimen/quarter_standard_height</item>
+        <item name="android:paddingTop">@dimen/tiny_gap</item>
+        <item name="android:paddingBottom">@dimen/tiny_gap</item>
+    </style>
+
+    <style name="MediaDetailTextHeading">
+        <item name="android:layout_weight">30</item>
+        <item name="android:paddingTop">@dimen/dimen_6</item>
+        <item name="android:paddingLeft">@dimen/tiny_gap</item>
+        <item name="android:textColor">?attr/mediaDetailsHeadingText</item>
+        <item name="android:textSize">@dimen/normal_text</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="MediaDetailTextBody">
+        <item name="android:layout_weight">70</item>
+        <item name="android:layout_gravity">start</item>
+        <item name="android:padding">@dimen/small_gap</item>
+        <item name="android:textColor">?attr/mediaDetailsText</item>
+        <item name="android:textSize">@dimen/description_text_size</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -77,7 +77,7 @@
         <item name="iconMap24">@drawable/ic_map_dark_24dp</item>
         <item name="mediaDetailsText">@color/enabled_button_text_color_light</item>
         <item name="mediaDetailsHeadingText">@color/primaryDarkColor</item>
-        <item name="mediaDetailNominationBackground">@color/swipe_red</item>
+        <item name="mediaDetailNominationBackground">@color/deleteRed</item>
         <item name="mediaDetailSpacerColor">@color/divider_grey</item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -37,7 +37,7 @@
         <item name="iconMap24" >@drawable/ic_map_white_24dp</item>
         <item name="mediaDetailsText" >@color/white</item>
         <item name="mediaDetailsHeadingText">@color/layout_light_grey</item>
-        <item name="mediaDetailNominationBackground">@color/deleteRed</item>
+        <item name="mediaDetailNominationBackground">@color/deleteRedDark</item>
         <item name="mediaDetailSpacerColor">@color/browser_actions_divider_color</item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -139,20 +139,27 @@
         <item name="centerRegion">#906078</item>
     </style>
 
-    <style name="MediaDetailLinear1">
+    <style name="MediaDetailContainer">
         <item name="android:paddingLeft">@dimen/quarter_standard_height</item>
         <item name="android:paddingRight">@dimen/quarter_standard_height</item>
         <item name="android:paddingTop">@dimen/tiny_gap</item>
         <item name="android:paddingBottom">@dimen/tiny_gap</item>
     </style>
 
-    <style name="MediaDetailTextHeading">
+    <style name="MediaDetailTextLabel">
         <item name="android:layout_weight">30</item>
         <item name="android:paddingTop">@dimen/dimen_6</item>
         <item name="android:paddingLeft">@dimen/tiny_gap</item>
-        <item name="android:textColor">?attr/mediaDetailsHeadingText</item>
         <item name="android:textSize">@dimen/normal_text</item>
         <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="MediaDetailTextLabelTitle" parent="@style/MediaDetailTextLabel">
+        <item name="android:textColor">@android:color/white</item>
+    </style>
+
+    <style name="MediaDetailTextLabelGeneric" parent="@style/MediaDetailTextLabel">
+        <item name="android:textColor">?attr/mediaDetailsHeadingText</item>
     </style>
 
     <style name="MediaDetailTextBody">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -37,6 +37,8 @@
         <item name="iconMap24" >@drawable/ic_map_white_24dp</item>
         <item name="mediaDetailsText" >@color/white</item>
         <item name="mediaDetailsHeadingText">@color/layout_light_grey</item>
+        <item name="mediaDetailNominationBackground">@color/deleteRed</item>
+        <item name="mediaDetailSpacerColor">@color/browser_actions_divider_color</item>
     </style>
 
     <style name="LightAppTheme" parent="Theme.AppCompat.Light.NoActionBar">
@@ -75,6 +77,8 @@
         <item name="iconMap24">@drawable/ic_map_dark_24dp</item>
         <item name="mediaDetailsText">@color/enabled_button_text_color_light</item>
         <item name="mediaDetailsHeadingText">@color/primaryDarkColor</item>
+        <item name="mediaDetailNominationBackground">@color/swipe_red</item>
+        <item name="mediaDetailSpacerColor">@color/divider_grey</item>
     </style>
 
     <style name="WhiteSearchBarTheme" parent="DarkAppTheme">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -33,6 +33,10 @@
         <item name="textEnabled">@color/enabled_button_text_color_dark</item>
         <item name="mainCardBackground">@color/main_background_dark</item>
         <item name="mainScreenNearbyPermissionbutton">@style/DarkFlatNearbyPermissionButton</item>
+        <item name="iconInfo24">@drawable/ic_info_outline_24dp</item>
+        <item name="iconMap24" >@drawable/ic_map_white_24dp</item>
+        <item name="mediaDetailsText" >@color/white</item>
+        <item name="mediaDetailsHeadingText">@color/layout_light_grey</item>
     </style>
 
     <style name="LightAppTheme" parent="Theme.AppCompat.Light.NoActionBar">
@@ -67,6 +71,10 @@
         <item name="textEnabled">@color/enabled_button_text_color_light</item>
         <item name="mainCardBackground">@color/primaryDarkColor</item>
         <item name="mainScreenNearbyPermissionbutton">@style/LightFlatNearbyPermissionButton</item>
+        <item name="iconInfo24">@drawable/ic_info_outline_dark_24dp</item>
+        <item name="iconMap24">@drawable/ic_map_dark_24dp</item>
+        <item name="mediaDetailsText">@color/enabled_button_text_color_light</item>
+        <item name="mediaDetailsHeadingText">@color/primaryDarkColor</item>
     </style>
 
     <style name="WhiteSearchBarTheme" parent="DarkAppTheme">


### PR DESCRIPTION
**Design Overhaul for Media Detail**

Fixes #3436  - Switch to Material Card design for the Media Detail Fragment
and
Fixes #2881 - New Media Details UI

What changes did you make and why?
Changed Media details as per Neslihan's design in #2881 , however the bookmarks and the downloads panel has been kept in the App Bar at the top

**Here is how it looks now**
![GIF-200313_114808 1](https://user-images.githubusercontent.com/44129798/76595062-c368b700-6520-11ea-8521-8ce1dced3067.gif)

