### PR TITLE
Fixes #3506: Image height remains zero for some time on bad network

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -9,14 +9,11 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.DisplayMetrics;
-import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
-import android.view.WindowManager;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
@@ -36,7 +33,6 @@ import com.facebook.imagepipeline.request.ImageRequest;
 
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.util.DateUtil;
-import org.wikipedia.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -67,7 +63,6 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 import timber.log.Timber;
 
-import static android.content.Context.WINDOW_SERVICE;
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -258,8 +258,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
         DisplayMetrics dm = new DisplayMetrics();
         WindowManager windowManager = (WindowManager) context.getSystemService(WINDOW_SERVICE);
         windowManager.getDefaultDisplay().getMetrics(dm);
-        int width = dm.widthPixels;
-        return width;
+        return dm.widthPixels;
     }
 
     private final ControllerListener aspectRatioListener = new BaseControllerListener<ImageInfo>() {

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -227,7 +227,13 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
                     .setVisibility(View.GONE);
         }
         media = detailProvider.getMediaAtPosition(index);
-        displayMediaDetails();
+
+        scrollView.post(new Runnable() {
+            @Override
+            public void run() {
+                displayMediaDetails();
+            }
+        });
     }
 
     private void displayMediaDetails() {
@@ -246,19 +252,12 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
 
     private void updateAspectRatio(ImageInfo imageInfo) {
         if (imageInfo != null) {
-            int screenWidth = getScreenWidth(getContext());
+            int screenWidth = scrollView.getWidth();
             int finalHeight = (screenWidth*imageInfo.getHeight()) / imageInfo.getWidth();
             ViewGroup.LayoutParams params = image.getLayoutParams();
             params.height = finalHeight;
             image.setLayoutParams(params);
         }
-    }
-
-    private int getScreenWidth(Context context) {
-        DisplayMetrics dm = new DisplayMetrics();
-        WindowManager windowManager = (WindowManager) context.getSystemService(WINDOW_SERVICE);
-        windowManager.getDefaultDisplay().getMetrics(dm);
-        return dm.widthPixels;
     }
 
     private final ControllerListener aspectRatioListener = new BaseControllerListener<ImageInfo>() {

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -15,6 +15,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
+import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import android.view.WindowManager;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -227,13 +228,15 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
                     .setVisibility(View.GONE);
         }
         media = detailProvider.getMediaAtPosition(index);
-
-        scrollView.post(new Runnable() {
-            @Override
-            public void run() {
-                displayMediaDetails();
+        scrollView.getViewTreeObserver().addOnGlobalLayoutListener(
+            new OnGlobalLayoutListener() {
+                @Override
+                public void onGlobalLayout() {
+                    scrollView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                    displayMediaDetails();
+                }
             }
-        });
+        );
     }
 
     private void displayMediaDetails() {

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -9,11 +9,13 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
+import android.view.WindowManager;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
@@ -64,6 +66,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 import timber.log.Timber;
 
+import static android.content.Context.WINDOW_SERVICE;
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 
@@ -243,11 +246,20 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
 
     private void updateAspectRatio(ImageInfo imageInfo) {
         if (imageInfo != null) {
-            int finalHeight = (scrollView.getWidth()*imageInfo.getHeight()) / imageInfo.getWidth();
+            int screenWidth = getScreenWidth(getContext());
+            int finalHeight = (screenWidth*imageInfo.getHeight()) / imageInfo.getWidth();
             ViewGroup.LayoutParams params = image.getLayoutParams();
             params.height = finalHeight;
             image.setLayoutParams(params);
         }
+    }
+
+    private int getScreenWidth(Context context) {
+        DisplayMetrics dm = new DisplayMetrics();
+        WindowManager windowManager = (WindowManager) context.getSystemService(WINDOW_SERVICE);
+        windowManager.getDefaultDisplay().getMetrics(dm);
+        int width = dm.widthPixels;
+        return width;
     }
 
     private final ControllerListener aspectRatioListener = new BaseControllerListener<ImageInfo>() {


### PR DESCRIPTION
**Optimised Width loading**

Fixes #3506 Image View Height remains zero for some time on a bad network

What changes did you make and why?
The calculation of image height used the width of scroll view which took time to inflate, now the width is retrieved from context which has almost no latency
