### PR TITLE
Fix p18 issue For an item with P18 item, do not add another one

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
@@ -68,7 +68,7 @@ public class  Contribution extends Media {
     public String decimalCoords;
     public boolean isMultiple;
     public String wikiDataEntityId;
-    public String p18Value;
+    private String p18Value;
     public Uri contentProviderUri;
     public String dateCreatedSource;
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
@@ -68,6 +68,7 @@ public class  Contribution extends Media {
     public String decimalCoords;
     public boolean isMultiple;
     public String wikiDataEntityId;
+    public String p18Value;
     public Uri contentProviderUri;
     public String dateCreatedSource;
 
@@ -269,6 +270,19 @@ public class  Contribution extends Media {
      */
     public void setWikiDataEntityId(String wikiDataEntityId) {
         this.wikiDataEntityId = wikiDataEntityId;
+    }
+
+    public String getP18Value() {
+        return p18Value;
+    }
+
+    /**
+     * When the corresponding image property of wiki entity is known as in case of nearby uploads,
+     * it can be set using the setter method
+     * @param p18Value p18 value, image property of the wikidata item
+     */
+    public void setP18Value(String p18Value) {
+        this.p18Value = p18Value;
     }
 
     public void setContentProviderUri(Uri contentProviderUri) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
@@ -198,7 +198,8 @@ public class UploadModel {
             if (item.place != null) {
                 contribution.setWikiDataEntityId(item.place.getWikiDataEntityId());
                 // If item already has an image, we need to know it. We don't want to override existing image later
-                contribution.setP18Value(item.place.pic);            }
+                contribution.setP18Value(item.place.pic);
+            }
             if (null == selectedCategories) {//Just a fail safe, this should never be null
                 selectedCategories = new ArrayList<>();
             }

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
@@ -197,7 +197,8 @@ public class UploadModel {
                     CommonsApplication.DEFAULT_EDIT_SUMMARY, item.gpsCoords.getCoords());
             if (item.place != null) {
                 contribution.setWikiDataEntityId(item.place.getWikiDataEntityId());
-            }
+                // If item already has an image, we need to know it. We don't want to override existing image later
+                contribution.setP18Value(item.place.pic);            }
             if (null == selectedCategories) {//Just a fail safe, this should never be null
                 selectedCategories = new ArrayList<>();
             }

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -278,9 +278,10 @@ public class UploadService extends HandlerService<Contribution> {
                         showFailedNotification(contribution);
                     } else {
                         String canonicalFilename = "File:" + uploadResult.getFilename();
-                        Timber.d("Contribution upload success. Initiating Wikidata edit for entity id %s",
-                                contribution.getWikiDataEntityId());
-                        wikidataEditService.createClaimWithLogging(contribution.getWikiDataEntityId(), canonicalFilename);
+                        Timber.d("Contribution upload success. Initiating Wikidata edit for"
+                                + " entity id %s if necessary (if P18 is null). P18 value is %s",
+                                contribution.getWikiDataEntityId(), contribution.getP18Value());
+                        wikidataEditService.createClaimWithLogging(contribution.getWikiDataEntityId(), canonicalFilename, contribution.getP18Value());
                         contribution.setFilename(canonicalFilename);
                         contribution.setImageUrl(uploadResult.getImageinfo().getOriginalUrl());
                         contribution.setState(Contribution.STATE_COMPLETED);

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
@@ -54,11 +54,6 @@ public class WikidataEditService {
             return;
         }
 
-        if (!p18Value.trim().isEmpty()) {
-            Timber.d("Skipping creation of claim as p18Value is not null, we won't override existing image");
-            return;
-        }
-
         if (fileName == null) {
             Timber.d("Skipping creation of claim as fileName entity ID is null");
             return;
@@ -66,6 +61,11 @@ public class WikidataEditService {
 
         if (!(directKvStore.getBoolean("Picture_Has_Correct_Location", true))) {
             Timber.d("Image location and nearby place location mismatched, so Wikidata item won't be edited");
+            return;
+        }
+
+        if (!p18Value.trim().isEmpty()) {
+            Timber.d("Skipping creation of claim as p18Value is not null, we won't override existing image");
             return;
         }
 

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.wikidata;
 import android.annotation.SuppressLint;
 import android.content.Context;
 
+import androidx.annotation.NonNull;
 import java.util.Locale;
 
 import javax.inject.Inject;
@@ -45,10 +46,11 @@ public class WikidataEditService {
 
     /**
      * Create a P18 claim and log the edit with custom tag
-     * @param wikidataEntityId
-     * @param fileName
+     * @param wikidataEntityId a unique id of each Wikidata items
+     * @param fileName name of the file we will upload
+     * @param p18Value pic attribute of Wikidata item
      */
-    public void createClaimWithLogging(String wikidataEntityId, String fileName, String p18Value) {
+    public void createClaimWithLogging(String wikidataEntityId, String fileName, @NonNull String p18Value) {
         if (wikidataEntityId == null) {
             Timber.d("Skipping creation of claim as Wikidata entity ID is null");
             return;

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
@@ -48,9 +48,14 @@ public class WikidataEditService {
      * @param wikidataEntityId
      * @param fileName
      */
-    public void createClaimWithLogging(String wikidataEntityId, String fileName) {
+    public void createClaimWithLogging(String wikidataEntityId, String fileName, String p18Value) {
         if (wikidataEntityId == null) {
             Timber.d("Skipping creation of claim as Wikidata entity ID is null");
+            return;
+        }
+
+        if (!p18Value.trim().isEmpty()) {
+            Timber.d("Skipping creation of claim as p18Value is not null, we won't override existing image");
             return;
         }
 

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
@@ -65,7 +65,7 @@ public class WikidataEditService {
         }
 
         if (!p18Value.trim().isEmpty()) {
-            Timber.d("Skipping creation of claim as p18Value is not null, we won't override existing image");
+            Timber.d("Skipping creation of claim as p18Value is not empty, we won't override existing image");
             return;
         }
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/wikidata/WikidataEditServiceTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/wikidata/WikidataEditServiceTest.kt
@@ -45,6 +45,12 @@ class WikidataEditServiceTest {
     }
 
     @Test
+    fun noClaimsWhenP18IsNotEmpty() {
+        wikidataEditService!!.createClaimWithLogging("Q1", "Test.jpg","Previous.jpg")
+        verifyZeroInteractions(wikidataClient!!)
+    }
+
+    @Test
     fun noClaimsWhenLocationIsNotCorrect() {
         `when`(directKvStore!!.getBoolean("Picture_Has_Correct_Location", true))
                 .thenReturn(false)

--- a/app/src/test/kotlin/fr/free/nrw/commons/wikidata/WikidataEditServiceTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/wikidata/WikidataEditServiceTest.kt
@@ -34,13 +34,13 @@ class WikidataEditServiceTest {
 
     @Test
     fun noClaimsWhenEntityIdIsNull() {
-        wikidataEditService!!.createClaimWithLogging(null, "Test.jpg")
+        wikidataEditService!!.createClaimWithLogging(null, "Test.jpg","")
         verifyZeroInteractions(wikidataClient!!)
     }
 
     @Test
     fun noClaimsWhenFileNameIsNull() {
-        wikidataEditService!!.createClaimWithLogging("Q1", null)
+        wikidataEditService!!.createClaimWithLogging("Q1", null,"")
         verifyZeroInteractions(wikidataClient!!)
     }
 
@@ -48,7 +48,7 @@ class WikidataEditServiceTest {
     fun noClaimsWhenLocationIsNotCorrect() {
         `when`(directKvStore!!.getBoolean("Picture_Has_Correct_Location", true))
                 .thenReturn(false)
-        wikidataEditService!!.createClaimWithLogging("Q1", "Test.jpg")
+        wikidataEditService!!.createClaimWithLogging("Q1", "Test.jpg","")
         verifyZeroInteractions(wikidataClient!!)
     }
 
@@ -60,7 +60,7 @@ class WikidataEditServiceTest {
                 .thenReturn(Observable.just(1L))
         `when`(wikidataClient!!.addEditTag(anyLong(), ArgumentMatchers.anyString(), ArgumentMatchers.anyString()))
                 .thenReturn(Observable.just(mock(AddEditTagResponse::class.java)))
-        wikidataEditService!!.createClaimWithLogging("Q1", "Test.jpg")
+        wikidataEditService!!.createClaimWithLogging("Q1", "Test.jpg","")
         verify(wikidataClient!!, times(1))
                 .createClaim(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())
     }


### PR DESCRIPTION
**Description (required)**

Fixes #3333 For an item with P18 item, do not add another one.
It checks if an item has image or not. If it has an image (green dots on the map) then even if we upload from the map, our upload is a regular commons upload (does not edit wikidata image property). If the wikidata item doesnt have the image, then our upload form map will fill the image property.

**Tests
Tested on a real device, wit android 9. Both cases are tested with upload flows, they worked as expected.