### PR TITLE
Removed `onFocusChange` listener of `username` Edittext since on focus change to `password`, it was hiding the keyboard.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -145,13 +145,6 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         }
     }
 
-    @OnFocusChange(R.id.login_username)
-    void onUsernameFocusChanged(View view, boolean hasFocus) {
-        if (!hasFocus) {
-            ViewUtil.hideKeyboard(view);
-        }
-    }
-
     @OnFocusChange(R.id.login_password)
     void onPasswordFocusChanged(View view, boolean hasFocus) {
         if (!hasFocus) {


### PR DESCRIPTION
**Description (required)**

Fixes #3453 "LoginActivity Hides the keyboard if I try to advance focus from Username to Password"

What changes did you make and why?
Removed `onFocusChange` listener of `username` Edittext since on focus change to `password`, it was hiding the keyboard.

**Tests performed (required)**

Tested betaDebug on Redmi Note 5 Pro with API level 28.

