### PR TITLE
PULL_REQUEST_TEMPLATE: request only issue number

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 **Description (required)**
 
-Fixes #{GitHub issue number} {Github issue title}
+Fixes #{GitHub issue number}
 
 What changes did you make and why?
 


### PR DESCRIPTION
**Description (required)**
For some time now, GitHub is showing cards when we hover over an issue
number which gives us a quick summary of the issue. The issue title is
shown in the card among other things.

Given that and the fact that we already require the issue number to be
specified in the pull request description, it's now moot to
ask the contributors to include the issue title in the pull request
description. So, let's remove this unnecessary burden from them.

Fixes #3540

**What changes did you make and why?**
Updated the Pull request template to remove the requirement of mentioning issue title.
