### PR TITLE
Rephrase the screenshot requirement in the PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ What changes did you make and why?
 
 Tested {build variant, e.g. ProdDebug} on {name of device or emulator} with API level {API level}.
 
-**Screenshots showing what changed (optional - for UI changes)**
+**Screenshots (for UI changes only)**
 
 Need help? See https://support.google.com/android/answer/9075928
 


### PR DESCRIPTION
**Description (required)**

The requirement for screenshots in the PR template was confusing and many new contributors end up attaching unnecessary screenshots. To prevent this confusion, I have rephrased the screenshot requirement to be more clear and concise.

Fixes #3544 Rephrase the requirement asking for screenshots in the pull request template

**What changes did you make and why?**

Modified the pull request template to rephrase the screenshots requirement.