### PR TITLE
Change "Archived" notifications to "Read" notifications

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -186,7 +186,7 @@ public class NotificationActivity extends NavigationBaseActivity {
         // Handle item selection
         switch (item.getItemId()) {
             case R.id.archived:
-                if (item.getTitle().equals(getString(R.string.menu_option_archived))) {
+                if (item.getTitle().equals(getString(R.string.menu_option_read))) {
                     NotificationActivity.startYourself(NotificationActivity.this, "read");
                 }else if (item.getTitle().equals(getString(R.string.menu_option_unread))) {
                     onBackPressed();
@@ -252,7 +252,7 @@ public class NotificationActivity extends NavigationBaseActivity {
     private void setPageTitle() {
         if (getSupportActionBar() != null) {
             if (getIntent().getStringExtra("title").equals("read")) {
-                getSupportActionBar().setTitle(R.string.archived_notifications);
+                getSupportActionBar().setTitle(R.string.read_notifications);
             } else {
                 getSupportActionBar().setTitle(R.string.notifications);
             }
@@ -261,7 +261,7 @@ public class NotificationActivity extends NavigationBaseActivity {
 
     private void setEmptyView() {
         if (getIntent().getStringExtra("title").equals("read")) {
-            noNotificationText.setText(R.string.no_archived_notification);
+            noNotificationText.setText(R.string.no_read_notification);
         }else {
             noNotificationText.setText(R.string.no_notification);
         }
@@ -272,7 +272,7 @@ public class NotificationActivity extends NavigationBaseActivity {
             notificationMenuItem.setTitle(R.string.menu_option_unread);
 
         }else {
-            notificationMenuItem.setTitle(R.string.menu_option_archived);
+            notificationMenuItem.setTitle(R.string.menu_option_read);
 
         }
     }

--- a/app/src/main/res/menu/menu_notifications.xml
+++ b/app/src/main/res/menu/menu_notifications.xml
@@ -6,5 +6,5 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:icon="@drawable/ic_more_vert_white_24dp"
-        android:title="@string/menu_option_archived" />
+        android:title="@string/menu_option_read" />
 </menu>

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -372,7 +372,7 @@
   <string name="contributions_fragment">bydraes</string>
   <string name="nearby_fragment">Naby</string>
   <string name="notifications">Kennisgewings</string>
-  <string name="archived_notifications">Kennisgewings (geargiveer)</string>
+  <string name="read_notifications">Kennisgewings (geargiveer)</string>
   <string name="display_nearby_notification">Vertoon kennisgewing in die buurt</string>
   <string name="display_nearby_notification_summary">Tik hier om die naaste plek te sien waar u foto\'s benodig</string>
   <string name="no_close_nearby">Geen nabygeleë plekke gevind nie</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -390,7 +390,7 @@
   <string name="contributions_fragment">مساهمات</string>
   <string name="nearby_fragment">مجاور</string>
   <string name="notifications">الإشعارات</string>
-  <string name="archived_notifications">الإخطارات (مؤرشفة)</string>
+  <string name="read_notifications">الإخطارات (مؤرشفة)</string>
   <string name="display_nearby_notification">عرض الإخطار القريب</string>
   <string name="display_nearby_notification_summary">انقر هنا لرؤية أقرب مكان يحتاج إلى صور</string>
   <string name="no_close_nearby">لم يتم العثور على أماكن قريبة بالقرب منك</string>
@@ -504,9 +504,9 @@
   <string name="no_image_reverted">لم يتم إرجاع أية صور</string>
   <string name="no_image_uploaded">لا توجد صور مرفوعة</string>
   <string name="no_notification">ليست لديك إشعارات غير مقروءة</string>
-  <string name="no_archived_notification">ليست لديك إشعارات مؤرشفة</string>
+  <string name="no_read_notification">ليست لديك إشعارات مؤرشفة</string>
   <string name="share_logs_using">مشاركة السجلات باستخدام</string>
-  <string name="menu_option_archived">عرض المؤرشفة</string>
+  <string name="menu_option_read">عرض المؤرشفة</string>
   <string name="menu_option_unread">عرض غير المقروءة</string>
   <string name="error_occurred_in_picking_images">حدث خطأ أثناء التقاط الصور</string>
   <string name="image_chooser_title">اختيار الصور للرفع</string>

--- a/app/src/main/res/values-ast/strings.xml
+++ b/app/src/main/res/values-ast/strings.xml
@@ -379,7 +379,7 @@
   <string name="contributions_fragment">Collaboraciones</string>
   <string name="nearby_fragment">Cercanu</string>
   <string name="notifications">Avisos</string>
-  <string name="archived_notifications">Avisos (archivaos)</string>
+  <string name="read_notifications">Avisos (archivaos)</string>
   <string name="display_nearby_notification">Amosar notificaciones de cercanía</string>
   <string name="display_nearby_notification_summary">Toca equí para ver el llugar más cercanu que precisa semeyes</string>
   <string name="no_close_nearby">Nun s\'atoparon llugares cercanos nos alredores</string>
@@ -492,9 +492,9 @@
   <string name="no_image_reverted">Nun se revertió nenguna imaxe</string>
   <string name="no_image_uploaded">Nun se xubió nenguna imaxe</string>
   <string name="no_notification">Nun tienes avisos ensin lleer</string>
-  <string name="no_archived_notification">Nun tienes avisos archivaos</string>
+  <string name="no_read_notification">Nun tienes avisos archivaos</string>
   <string name="share_logs_using">Compartir rexistros usando</string>
-  <string name="menu_option_archived">Ver los archivaos</string>
+  <string name="menu_option_read">Ver los archivaos</string>
   <string name="menu_option_unread">Ver los nun lleíos</string>
   <string name="error_occurred_in_picking_images">Asocedió un error al escoyer les imaxes</string>
   <string name="image_chooser_title">Escueyi les imaxes pa xubir</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -214,7 +214,7 @@
   <string name="preference_author_name_toggle">Използване на персонализирано авторско име</string>
   <string name="preference_author_name_toggle_summary">При качването използвайте персонализирано авторско име вместо потребителското си име</string>
   <string name="preference_author_name">Персонализирано авторско име</string>
-  <string name="archived_notifications">Известия (архивирани)</string>
+  <string name="read_notifications">Известия (архивирани)</string>
   <string name="list_sheet">Списък</string>
   <string name="next">Следваща</string>
   <string name="submit">Изпращане</string>
@@ -244,9 +244,9 @@
   <string name="no_image_reverted">Няма върнати изображения</string>
   <string name="no_image_uploaded">Няма качени изображения</string>
   <string name="no_notification">Нямате непрочетени известия</string>
-  <string name="no_archived_notification">Нямате архивирани известия</string>
+  <string name="no_read_notification">Нямате архивирани известия</string>
   <string name="share_logs_using">Споделяне на дневници, използвайки</string>
-  <string name="menu_option_archived">Преглеждане на архивирани</string>
+  <string name="menu_option_read">Преглеждане на архивирани</string>
   <string name="menu_option_unread">Преглеждане на непрочетени</string>
   <string name="error_occurred_in_picking_images">Възникна грешка при избирането на изображенията</string>
   <string name="image_chooser_title">Изберете изображения за качване</string>

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -319,7 +319,7 @@
   <string name="error_occurred">Ur fazi zo bet !</string>
   <string name="preference_author_name_toggle">Implijit un anv aozer personelaet</string>
   <string name="nearby_fragment">Nepell</string>
-  <string name="archived_notifications">Kemennoù(diellaouet)</string>
+  <string name="read_notifications">Kemennoù(diellaouet)</string>
   <string name="next">War-lerc\'h</string>
   <string name="previous">Kent</string>
   <string name="submit">Kas</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -356,7 +356,7 @@
   <string name="contributions_fragment">Contribucions</string>
   <string name="nearby_fragment">A prop</string>
   <string name="notifications">Notificacions</string>
-  <string name="archived_notifications">Notificacions (arxivades)</string>
+  <string name="read_notifications">Notificacions (arxivades)</string>
   <string name="display_nearby_notification">Mostra notificacions properes</string>
   <string name="display_nearby_notification_summary">Feu un toc aquí per a veure el lloc més proper que necessiti fotos</string>
   <string name="no_close_nearby">No s\'han trobat llocs propers prop vostre</string>
@@ -437,9 +437,9 @@
   <string name="no_image_reverted">No s\'ha revertit cap imatge</string>
   <string name="no_image_uploaded">No s\'ha carregat cap imatge</string>
   <string name="no_notification">No teniu cap notificació sense llegir</string>
-  <string name="no_archived_notification">No teniu cap notificació arxivada</string>
+  <string name="no_read_notification">No teniu cap notificació arxivada</string>
   <string name="share_logs_using">Comparteix els registres utilitzant</string>
-  <string name="menu_option_archived">Mostra els arxivats</string>
+  <string name="menu_option_read">Mostra els arxivats</string>
   <string name="menu_option_unread">Mostra aquelles per llegir</string>
   <string name="error_occurred_in_picking_images">S\'ha produït un error en escollir les imatges</string>
   <string name="image_chooser_title">Trieu les imatges per carregar</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -395,7 +395,7 @@
   <string name="contributions_fragment">Příspěvky</string>
   <string name="nearby_fragment">Poblíž</string>
   <string name="notifications">Upozornění</string>
-  <string name="archived_notifications">Upozornění (přečtená)</string>
+  <string name="read_notifications">Upozornění (přečtená)</string>
   <string name="display_nearby_notification">Zobrazit upozornění v okolí</string>
   <string name="display_nearby_notification_summary">Klepnutím sem zobrazíte nejbližší místo, které potřebuje obrázky</string>
   <string name="no_close_nearby">Nebyla nalezena žádná místa v okolí</string>
@@ -508,9 +508,9 @@
   <string name="no_image_reverted">Žádné revertované obrázky</string>
   <string name="no_image_uploaded">Žádné nahrané obrázky</string>
   <string name="no_notification">Nemáte žádná nepřečtená upozornění</string>
-  <string name="no_archived_notification">Nemáte nepřečtená upozornění</string>
+  <string name="no_read_notification">Nemáte nepřečtená upozornění</string>
   <string name="share_logs_using">Sdílet logy pomocí</string>
-  <string name="menu_option_archived">Zobrazit přečtené</string>
+  <string name="menu_option_read">Zobrazit přečtené</string>
   <string name="menu_option_unread">Zobrazit nepřečtené</string>
   <string name="error_occurred_in_picking_images">Nastala chyba při vybírání obrázků</string>
   <string name="image_chooser_title">Vyberte obrázky, které chcete nahrát</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -366,7 +366,7 @@
   <string name="review_thanks_no_button_text">Næste billede</string>
   <string name="no_image">Ingen billeder brugt</string>
   <string name="share_logs_using">Del logs ved hjælp af</string>
-  <string name="menu_option_archived">Vis arkiverede</string>
+  <string name="menu_option_read">Vis arkiverede</string>
   <string name="menu_option_unread">Vis ulæste</string>
   <string name="error_occurred_in_picking_images">Der opstod en fejl under udvælgelse af billeder</string>
   <string name="please_wait">Vent venligst…</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -388,7 +388,7 @@
   <string name="contributions_fragment">Beiträge</string>
   <string name="nearby_fragment">In der Nähe</string>
   <string name="notifications">Benachrichtigungen</string>
-  <string name="archived_notifications">Benachrichtigungen (archiviert)</string>
+  <string name="read_notifications">Benachrichtigungen (archiviert)</string>
   <string name="display_nearby_notification">Benachrichtigungen in der Nähe anzeigen</string>
   <string name="display_nearby_notification_summary">Hier tippen, um Orte in der Nähe anzusehen, die Bilder benötigen.</string>
   <string name="no_close_nearby">Keine Orte in deiner Umgebung gefunden.</string>
@@ -501,9 +501,9 @@
   <string name="no_image_reverted">Keine Bilder zurückgesetzt</string>
   <string name="no_image_uploaded">Keine Bilder hochgeladen</string>
   <string name="no_notification">Du hast keine ungelesenen Benachrichtigungen</string>
-  <string name="no_archived_notification">Du hast keine archivierten Benachrichtigungen</string>
+  <string name="no_read_notification">Du hast keine archivierten Benachrichtigungen</string>
   <string name="share_logs_using">Lognutzung teilen</string>
-  <string name="menu_option_archived">Archivierte ansehen</string>
+  <string name="menu_option_read">Archivierte ansehen</string>
   <string name="menu_option_unread">Ungelesene ansehen</string>
   <string name="error_occurred_in_picking_images">Beim Auswählen der Bilder ist ein Fehler aufgetreten</string>
   <string name="image_chooser_title">Hochzuladende Bilder auswählen</string>

--- a/app/src/main/res/values-diq/strings.xml
+++ b/app/src/main/res/values-diq/strings.xml
@@ -232,7 +232,7 @@
   <string name="preference_author_name_toggle">Nameyê nuştekariyo xısusiyi bıgurene</string>
   <string name="preference_author_name">Nameyê nuştekariyo xısusi</string>
   <string name="contributions_fragment">İştıraki</string>
-  <string name="archived_notifications">Xeberi (arşifkerdeyi)</string>
+  <string name="read_notifications">Xeberi (arşifkerdeyi)</string>
   <string name="list_sheet">Liste</string>
   <string name="next">Bahdoyên</string>
   <string name="previous">Verên</string>
@@ -256,8 +256,8 @@
   <string name="nominate_for_deletion_done">Temam</string>
   <string name="review_thanks_yes_button_text">Eya, çıra mebo</string>
   <string name="no_notification">Beyanatên şımayê nêwendeyi çıniyê</string>
-  <string name="no_archived_notification">Beyanatên şımayê arçivkerdeyi çıniyê</string>
-  <string name="menu_option_archived">Arşivkerdeyan bıvêne</string>
+  <string name="no_read_notification">Beyanatên şımayê arçivkerdeyi çıniyê</string>
+  <string name="menu_option_read">Arşivkerdeyan bıvêne</string>
   <string name="menu_option_unread">Nêwendeyan bıvêne</string>
   <string name="please_wait">Kerem kerên, bıpawên...</string>
   <string name="skip_image" fuzzy="true">NÊ RESIMİ RAVİYARNE</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -406,7 +406,7 @@
   <string name="no_image">Δεν χρησιμοποιούνται εικόνες</string>
   <string name="no_image_uploaded">Δεν έχουν ανεβεί εικόνες</string>
   <string name="no_notification">Δεν έχετε αδιάβαστες ενημερώσεις</string>
-  <string name="no_archived_notification">Δεν έχετε αρχειοθετημένες ενημερώσεις</string>
+  <string name="no_read_notification">Δεν έχετε αρχειοθετημένες ενημερώσεις</string>
   <string name="please_wait">Παρακαλούμε περιμένετε…</string>
   <string name="exif_tag_name_author">Δημιουργός</string>
   <string name="exif_tag_name_copyright">Πνευματικά δικαιώματα</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -381,7 +381,7 @@
   <string name="contributions_fragment">Kontribuoj</string>
   <string name="nearby_fragment">Apude</string>
   <string name="notifications">Sciigoj</string>
-  <string name="archived_notifications">Sciigoj (enarkivigitaj)</string>
+  <string name="read_notifications">Sciigoj (enarkivigitaj)</string>
   <string name="display_nearby_notification">Montri sciigojn pri apudaĵoj</string>
   <string name="display_nearby_notification_summary">Tuŝetu ĉi tie por vidi apudan lokon kiu bezonas bildojn</string>
   <string name="no_close_nearby">Neniu proksima loko trovita ĉe vi.</string>
@@ -494,9 +494,9 @@
   <string name="no_image_reverted">Neniu bildo estis malfarita</string>
   <string name="no_image_uploaded">Neniu alŝutita bildo</string>
   <string name="no_notification">Vi ne havas nelegitajn sciigojn</string>
-  <string name="no_archived_notification">Vi ne havas enarkivigitajn sciigojn</string>
+  <string name="no_read_notification">Vi ne havas enarkivigitajn sciigojn</string>
   <string name="share_logs_using">Konigi protokolojn per</string>
-  <string name="menu_option_archived">Vidi enarkivigitojn</string>
+  <string name="menu_option_read">Vidi enarkivigitojn</string>
   <string name="menu_option_unread">Vidi nelegitojn</string>
   <string name="error_occurred_in_picking_images">Eraro okazis dum elektado de bildoj</string>
   <string name="image_chooser_title">Elekti alŝutotajn bildojn</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -404,7 +404,7 @@
   <string name="contributions_fragment">Contribuciones</string>
   <string name="nearby_fragment">Cercanos</string>
   <string name="notifications">Notificaciones</string>
-  <string name="archived_notifications">Notificaciones (archivadas)</string>
+  <string name="read_notifications">Notificaciones (archivadas)</string>
   <string name="display_nearby_notification">Mostrar notificaciones de cercanía</string>
   <string name="display_nearby_notification_summary">Toca aquí para ver el lugar más cercano que necesita fotos</string>
   <string name="no_close_nearby">No se encontraron lugares cercanos cerca de ti</string>
@@ -517,9 +517,9 @@
   <string name="no_image_reverted">Ninguna imagen revertida</string>
   <string name="no_image_uploaded">Ninguna imagen subida</string>
   <string name="no_notification">No tienes notificaciones sin leer</string>
-  <string name="no_archived_notification">No tienes notificaciones archivadas</string>
+  <string name="no_read_notification">No tienes notificaciones archivadas</string>
   <string name="share_logs_using">Compartir registros usando</string>
-  <string name="menu_option_archived">Ver archivados</string>
+  <string name="menu_option_read">Ver archivados</string>
   <string name="menu_option_unread">Ver no leidas</string>
   <string name="error_occurred_in_picking_images">Ocurrió un error mientras se elegían imagenes</string>
   <string name="image_chooser_title">Elige imágenes para cargar</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -376,7 +376,7 @@
   <string name="contributions_fragment">مشارکت‌ها</string>
   <string name="nearby_fragment">در نزدیکی</string>
   <string name="notifications">آگاه‌سازی‌ها</string>
-  <string name="archived_notifications">اعلان‌ها (بایگانی‌شده)</string>
+  <string name="read_notifications">اعلان‌ها (بایگانی‌شده)</string>
   <string name="display_nearby_notification">نمایش اعلان اطراف</string>
   <string name="no_close_nearby">هیچ‌ مکان نزدیکی به شما یافته نشد</string>
   <string name="list_sheet">فهرست</string>
@@ -453,8 +453,8 @@
   <string name="no_image_reverted">تصویر برگردانده نشد</string>
   <string name="no_image_uploaded">هیچ تصویری بارگذاری نشد</string>
   <string name="no_notification">شما هیچ اعلان خوانده‌نشده‌ای ندارید</string>
-  <string name="no_archived_notification">شما هیچ پیغام بایگانی شده‌ای ندارید</string>
-  <string name="menu_option_archived">نمایش بایگانی‌شده</string>
+  <string name="no_read_notification">شما هیچ پیغام بایگانی شده‌ای ندارید</string>
+  <string name="menu_option_read">نمایش بایگانی‌شده</string>
   <string name="menu_option_unread">مشاهده خوانده نشده ها</string>
   <string name="image_chooser_title">انتخاب تصویر برای بارگذاری</string>
   <string name="please_wait">لطفاً صبر کنید...</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -366,7 +366,7 @@
   <string name="contributions_fragment">Muokkaukset</string>
   <string name="nearby_fragment">Lähistöllä</string>
   <string name="notifications">Ilmoitukset</string>
-  <string name="archived_notifications">Ilmoitukset (arkistoidut)</string>
+  <string name="read_notifications">Ilmoitukset (arkistoidut)</string>
   <string name="display_nearby_notification">Näytä lähistöllä-ilmoitus</string>
   <string name="list_sheet">Lista</string>
   <string name="step_count">Vaihe %1$d/%2$d</string>
@@ -420,7 +420,7 @@
   <string name="review_copyright_no_button_text">Näyttää hyvälle</string>
   <string name="review_thanks_yes_button_text">Kyllä, miksi ei</string>
   <string name="review_thanks_no_button_text">Seuraava kuva</string>
-  <string name="menu_option_archived">Näytä arkistoidut</string>
+  <string name="menu_option_read">Näytä arkistoidut</string>
   <string name="menu_option_unread">Näytä lukemattomat</string>
   <string name="image_chooser_title">Valitse tallennettavat tiedostot</string>
   <string name="please_wait">Odota…</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -403,7 +403,7 @@
   <string name="contributions_fragment">Contributions</string>
   <string name="nearby_fragment">Proche</string>
   <string name="notifications">Notifications</string>
-  <string name="archived_notifications">Notifications (archivées)</string>
+  <string name="read_notifications">Notifications (archivées)</string>
   <string name="display_nearby_notification">Afficher la notification de proximité</string>
   <string name="display_nearby_notification_summary">Taper ici pour voir l’endroit le plus proche qui a besoin d’images</string>
   <string name="no_close_nearby">Aucun endroit à proximité trouvé près de chez vous</string>
@@ -517,9 +517,9 @@
   <string name="no_image_reverted">Aucune image retournée</string>
   <string name="no_image_uploaded">Aucune image téléversée</string>
   <string name="no_notification">Vous n\'avez aucune notification non lue</string>
-  <string name="no_archived_notification">Vous n’avez pas de notification archivée</string>
+  <string name="no_read_notification">Vous n’avez pas de notification archivée</string>
   <string name="share_logs_using">Partager les journaux en utilisant</string>
-  <string name="menu_option_archived">Afficher les archivés</string>
+  <string name="menu_option_read">Afficher les archivés</string>
   <string name="menu_option_unread">Afficher les non lus</string>
   <string name="error_occurred_in_picking_images">Erreur lors de la sélection des images</string>
   <string name="image_chooser_title">Choisir les images à téléverser</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -385,7 +385,7 @@
   <string name="contributions_fragment">Contribucións</string>
   <string name="nearby_fragment">Preto</string>
   <string name="notifications">Notificacións</string>
-  <string name="archived_notifications">Notificacións (arquivadas)</string>
+  <string name="read_notifications">Notificacións (arquivadas)</string>
   <string name="display_nearby_notification">Amosar notificacións de proximidade</string>
   <string name="display_nearby_notification_summary">Prema aquí para ver o lugar máis preto que necesita fotos</string>
   <string name="no_close_nearby">Non se atoparon lugares preto de ti</string>
@@ -482,9 +482,9 @@
   <string name="no_image_reverted">Ningunha imaxe revertida</string>
   <string name="no_image_uploaded">Ningunha imaxe subida</string>
   <string name="no_notification">Non ten ningunha notificación sen ler</string>
-  <string name="no_archived_notification">Non ten notificacións arquivadas</string>
+  <string name="no_read_notification">Non ten notificacións arquivadas</string>
   <string name="share_logs_using">Compartir os rexistros usando</string>
-  <string name="menu_option_archived">Ver arquivadas</string>
+  <string name="menu_option_read">Ver arquivadas</string>
   <string name="menu_option_unread">Ver as non lidas</string>
   <string name="error_occurred_in_picking_images">Houbo un erro ó escoller as imaxes</string>
   <string name="image_chooser_title">Escoller imaxes a subir</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -351,7 +351,7 @@
   <string name="contributions_fragment">योगदान</string>
   <string name="nearby_fragment">निकट</string>
   <string name="notifications">सूचनायें</string>
-  <string name="archived_notifications">सूचनाएँ (पुरालेखित)</string>
+  <string name="read_notifications">सूचनाएँ (पुरालेखित)</string>
   <string name="list_sheet">सूची</string>
   <string name="storage_permission">स्टोरेज अनुमति</string>
   <string name="next">अगला</string>
@@ -395,7 +395,7 @@
   <string name="no_image_reverted">कोई चित्र वापस नहीं लाया</string>
   <string name="no_image_uploaded">कोई चित्र अपलोड नहीं किया</string>
   <string name="no_notification" fuzzy="true">आपके पास कोई अपठित सूचना नहीं है</string>
-  <string name="no_archived_notification" fuzzy="true">आपकी कोई सूचना पुरालेखित नहीं है</string>
-  <string name="menu_option_archived">पुरालेखित देखें</string>
+  <string name="no_read_notification" fuzzy="true">आपकी कोई सूचना पुरालेखित नहीं है</string>
+  <string name="menu_option_read">पुरालेखित देखें</string>
   <string name="menu_option_unread">अपठित देखें</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -385,7 +385,7 @@
   <string name="contributions_fragment">Közreműködések</string>
   <string name="nearby_fragment">Közelben</string>
   <string name="notifications">Értesítések</string>
-  <string name="archived_notifications">Archivált értesítések</string>
+  <string name="read_notifications">Archivált értesítések</string>
   <string name="display_nearby_notification">Közeli értesítések megjelenítése</string>
   <string name="no_close_nearby">Nem található közeli hely</string>
   <string name="list_sheet">Lista</string>
@@ -494,8 +494,8 @@
   <string name="no_image_reverted">Nincs visszavont kép</string>
   <string name="no_image_uploaded">Nincs feltöltött kép</string>
   <string name="no_notification">Nincs olvasatlan üzenet</string>
-  <string name="no_archived_notification">Nincs archivált üzenet</string>
-  <string name="menu_option_archived">Archiváltak megtekintése</string>
+  <string name="no_read_notification">Nincs archivált üzenet</string>
+  <string name="menu_option_read">Archiváltak megtekintése</string>
   <string name="menu_option_unread">Olvasatlanok megtekintése</string>
   <string name="error_occurred_in_picking_images">Hiba történt a képek betöltése során</string>
   <string name="image_chooser_title">Feltöltendő képek kiválasztása</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -377,7 +377,7 @@
   <string name="contributions_fragment">Kontribusi</string>
   <string name="nearby_fragment">Sekitar</string>
   <string name="notifications">Pemberitahuan</string>
-  <string name="archived_notifications">Pemberitahuan (diarsipkan)</string>
+  <string name="read_notifications">Pemberitahuan (diarsipkan)</string>
   <string name="display_nearby_notification">Tampilkan pemberitahuan sekitar</string>
   <string name="display_nearby_notification_summary">Tekan di sini untuk melihat tempat terdekat yang membutuhkan gambar</string>
   <string name="no_close_nearby">Tidak ada tempat sekitaran yang ditemukan di dekat Anda</string>
@@ -430,7 +430,7 @@
   <string name="never_ask_again">Jangan pernah menanyakan ini lagi</string>
   <string name="display_location_permission_title">Tampilkan izin lokasi</string>
   <string name="display_campaigns">Sinahang penyobyahan</string>
-  <string name="menu_option_archived">Lihat arsip</string>
+  <string name="menu_option_read">Lihat arsip</string>
   <string name="menu_option_unread">Lihat yang belum terbaca</string>
   <string name="error_occurred_in_picking_images">Terjadi kesalahan ketika memilih gambar</string>
   <string name="image_chooser_title">Pilih Gambar untuk diunggah</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -372,7 +372,7 @@
   <string name="contributions_fragment">Framlög</string>
   <string name="nearby_fragment">Nálægt</string>
   <string name="notifications">Tilkynningar</string>
-  <string name="archived_notifications">Tilkynningar (í geymslu)</string>
+  <string name="read_notifications">Tilkynningar (í geymslu)</string>
   <string name="display_nearby_notification">Birta tilkynningu um nágrenni</string>
   <string name="display_nearby_notification_summary">Ýttu hér til að sjá nálægasta staðinn sem þarfnast mynda</string>
   <string name="no_close_nearby">Engir staðir fundust í nágrenninu</string>
@@ -448,7 +448,7 @@
   <string name="no_image_reverted">Engar myndir endurstilltar</string>
   <string name="no_image_uploaded">Engar myndir sendar inn</string>
   <string name="no_notification">Þú ert ekki með neinar ólesnar tilkynningar</string>
-  <string name="menu_option_archived">Skoða í geymslu</string>
+  <string name="menu_option_read">Skoða í geymslu</string>
   <string name="menu_option_unread">Skoða ólesið</string>
   <string name="error_occurred_in_picking_images">Villa kom upp við að velja myndir</string>
   <string name="image_chooser_title">Veldu myndir til að senda inn</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -384,7 +384,7 @@
   <string name="contributions_fragment">Contributi</string>
   <string name="nearby_fragment">Nelle vicinanze</string>
   <string name="notifications">Notifiche</string>
-  <string name="archived_notifications">Notifiche (archiviate)</string>
+  <string name="read_notifications">Notifiche (archiviate)</string>
   <string name="display_nearby_notification">Mostra notifica nelle vicinanze</string>
   <string name="display_nearby_notification_summary">Tocca qui per vedere il luogo più vicino che ha bisogno di immagini</string>
   <string name="no_close_nearby">Nessun posto nelle vicinanze trovato vicino a te</string>
@@ -464,9 +464,9 @@
   <string name="no_image_reverted">Nessuna immagine ripristinata</string>
   <string name="no_image_uploaded">Nessuna immagine caricata</string>
   <string name="no_notification">Non hai alcuna notifica non letta</string>
-  <string name="no_archived_notification">Non hai notifiche archiviate</string>
+  <string name="no_read_notification">Non hai notifiche archiviate</string>
   <string name="share_logs_using">Condividi i registri usando</string>
-  <string name="menu_option_archived">Vedi archiviate</string>
+  <string name="menu_option_read">Vedi archiviate</string>
   <string name="menu_option_unread">Vedi non lette</string>
   <string name="error_occurred_in_picking_images">Si è verificato un errore durante la selezione delle immagini</string>
   <string name="image_chooser_title">Scegli le immagini da caricare</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -393,7 +393,7 @@
   <string name="contributions_fragment">תרומות</string>
   <string name="nearby_fragment">בסביבה</string>
   <string name="notifications">התראות</string>
-  <string name="archived_notifications">התראות (בארכיון)</string>
+  <string name="read_notifications">התראות (בארכיון)</string>
   <string name="display_nearby_notification">הצגת התראות סמוכות</string>
   <string name="display_nearby_notification_summary">יש לגעת כאן כדי לצפות במקום הקרוב ביותר שדורש תמונות</string>
   <string name="no_close_nearby">לא נמצאו מקומות בסביבתך</string>
@@ -507,9 +507,9 @@
   <string name="no_image_reverted">לא שוחזרו תמונות</string>
   <string name="no_image_uploaded">לא הועלו תמונות</string>
   <string name="no_notification">אין לך התראות שלא נקראו</string>
-  <string name="no_archived_notification">אין לך התראות בארכיון</string>
+  <string name="no_read_notification">אין לך התראות בארכיון</string>
   <string name="share_logs_using">שיתוף יומנים בעזרת</string>
-  <string name="menu_option_archived">הצגת ארכיון</string>
+  <string name="menu_option_read">הצגת ארכיון</string>
   <string name="menu_option_unread">הצגת התראות שלא נקראו</string>
   <string name="error_occurred_in_picking_images">אירעה שגיאה בעת בחירת תמונות</string>
   <string name="image_chooser_title">נא לבחור תמונות להעלאה</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -389,7 +389,7 @@
   <string name="contributions_fragment">投稿記録</string>
   <string name="nearby_fragment">付近</string>
   <string name="notifications">お知らせ</string>
-  <string name="archived_notifications">お知らせ（過去ログ）</string>
+  <string name="read_notifications">お知らせ（過去ログ）</string>
   <string name="display_nearby_notification">近くの場所のお知らせを表示する</string>
   <string name="display_nearby_notification_summary">ここをタップして、近くで画像を募集中の場所を表示</string>
   <string name="no_close_nearby">現在地の近くに該当する場所が見つかりません</string>
@@ -501,9 +501,9 @@
   <string name="no_image_reverted">却下された画像はありません</string>
   <string name="no_image_uploaded">投稿した画像はありません</string>
   <string name="no_notification">未読のお知らせはありません</string>
-  <string name="no_archived_notification">過去ログ化したお知らせはありません</string>
+  <string name="no_read_notification">過去ログ化したお知らせはありません</string>
   <string name="share_logs_using">ログの共有に使うアプリ</string>
-  <string name="menu_option_archived">アーカイブ済みを表示</string>
+  <string name="menu_option_read">アーカイブ済みを表示</string>
   <string name="menu_option_unread">未読を見る</string>
   <string name="error_occurred_in_picking_images">画像の選択中にエラーが発生しました</string>
   <string name="image_chooser_title">アップロードする画像を選ぶ</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -306,7 +306,7 @@
   <string name="contributions_fragment">წვლილი</string>
   <string name="nearby_fragment">ახლოს</string>
   <string name="notifications">შეტყობინებები</string>
-  <string name="archived_notifications">შეტყობინებები (არქივი)</string>
+  <string name="read_notifications">შეტყობინებები (არქივი)</string>
   <string name="list_sheet">სია</string>
   <string name="storage_permission">მეხსიერების ნებართვა</string>
   <string name="step_count">ნაბიჯი %1$d %2$d-დან</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -374,7 +374,7 @@
   <string name="contributions_fragment">기여</string>
   <string name="nearby_fragment">근처</string>
   <string name="notifications">알림</string>
-  <string name="archived_notifications">알림 (보관됨)</string>
+  <string name="read_notifications">알림 (보관됨)</string>
   <string name="display_nearby_notification">주변 알림 표시</string>
   <string name="display_nearby_notification_summary">사진이 필요한 주변 장소를 보려면 여기를 탭하세요</string>
   <string name="no_close_nearby">당신에게 가까운 주변 장소를 찾지 못했습니다</string>
@@ -446,8 +446,8 @@
   <string name="skip_image_explanation">이 버튼을 클릭하면 위키미디어 공용으로부터 최근 업로드된 다른 이미지를 제공합니다</string>
   <string name="review_image_explanation">이미지를 검토하고 위키미디어 공용의 품질을 개선할 수 있습니다.\n 4가지 검토 변수가 있습니다:\n - 이 이미지가 범위 내에 있는가? \n - 이 이미지가 저작권 규정을 준수하고 있는가? \n - 이 이미지가 올바르게 분류되어 있는가? \n - 모든 것이 문제 없다면 기여자에게 감사를 표할 수도 있습니다.</string>
   <string name="no_notification">읽지 않은 알림이 없습니다</string>
-  <string name="no_archived_notification">보관된 알림이 없습니다</string>
-  <string name="menu_option_archived">보관한 항목 보기</string>
+  <string name="no_read_notification">보관된 알림이 없습니다</string>
+  <string name="menu_option_read">보관한 항목 보기</string>
   <string name="menu_option_unread">읽지 않은 항목 보기</string>
   <string name="error_occurred_in_picking_images">이미지 선택 도중 오류가 발생했습니다</string>
   <string name="image_chooser_title">업로드할 이미지 선택</string>

--- a/app/src/main/res/values-lb/strings.xml
+++ b/app/src/main/res/values-lb/strings.xml
@@ -337,7 +337,7 @@
   <string name="review_thanks_no_button_text">Nächst BILD</string>
   <string name="no_image">Keng Biller benotzt</string>
   <string name="no_image_uploaded">Keng Biller eropgelueden</string>
-  <string name="no_archived_notification">Dir hutt keng archivéier Notifikatiounen</string>
+  <string name="no_read_notification">Dir hutt keng archivéier Notifikatiounen</string>
   <string name="error_occurred_in_picking_images">Feeler beim Eraussiche vun de Biller</string>
   <string name="image_chooser_title">Sicht Biller eraus fir eropzelueden</string>
   <string name="please_wait">Waart wgl. ...</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -188,7 +188,7 @@
   <string name="send_thank_send">Sūta pateicību</string>
   <string name="send_thank_notification_title">Sūta pateicību</string>
   <string name="review_thanks_no_button_text">Nākamais attēls</string>
-  <string name="menu_option_archived">Skatīt arhivētos</string>
+  <string name="menu_option_read">Skatīt arhivētos</string>
   <string name="menu_option_unread">Skatīt nelasītos</string>
   <string name="please_wait">Lūdzu, uzgaidiet...</string>
   <string name="skip_image">Izlaist šo attēlu</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -380,7 +380,7 @@
   <string name="contributions_fragment">Придонеси</string>
   <string name="nearby_fragment">Во близина</string>
   <string name="notifications">Известувања</string>
-  <string name="archived_notifications">Известувања (архивирани)</string>
+  <string name="read_notifications">Известувања (архивирани)</string>
   <string name="display_nearby_notification">Известувај ме за места во близина</string>
   <string name="display_nearby_notification_summary">Допрете тука за да го видите најблиското место без слика</string>
   <string name="no_close_nearby">Не најдов места во ваша близина</string>
@@ -494,9 +494,9 @@
   <string name="no_image_reverted">Нема вратени слики</string>
   <string name="no_image_uploaded">Нема подигнати слики</string>
   <string name="no_notification">Немате непрочитани известувања</string>
-  <string name="no_archived_notification">Немате архивирани известувања</string>
+  <string name="no_read_notification">Немате архивирани известувања</string>
   <string name="share_logs_using">Споделувај дневници користејќи</string>
-  <string name="menu_option_archived">Погл. архивирани</string>
+  <string name="menu_option_read">Погл. архивирани</string>
   <string name="menu_option_unread">Погл. непрочитани</string>
   <string name="error_occurred_in_picking_images">Се јави грешка при избирањето на сликите</string>
   <string name="image_chooser_title">Изберете слики за подигање</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -287,7 +287,7 @@
   <string name="contributions_fragment">ဆောင်ရွက်ချက်များ</string>
   <string name="nearby_fragment">အနီးအနား</string>
   <string name="notifications">အသိပေးချက်များ</string>
-  <string name="archived_notifications">အသိပေးချက်များ (မော်ကွန်းတင်ပြီး)</string>
+  <string name="read_notifications">အသိပေးချက်များ (မော်ကွန်းတင်ပြီး)</string>
   <string name="display_nearby_notification">အနီးအနားအသိပေးချက်ကို ပြသရန်</string>
   <string name="list_sheet">စာရင်း</string>
   <string name="storage_permission">သိုလှောင်ခန်း ခွင်ပြုချက်</string>
@@ -348,7 +348,7 @@
   <string name="review_copyright_no_button_text">အဆင်ပြေပုံပေါက်ပါသည်</string>
   <string name="review_thanks_no_button_text">နောက်ရုပ်ပုံ</string>
   <string name="no_notification">မဖတ်ရသေးသော အသိပေးချက်များ မရှိပါ</string>
-  <string name="no_archived_notification">မော်ကွန်းတင်ပြီးသော အသိပေးချက်များ မရှိပါ</string>
+  <string name="no_read_notification">မော်ကွန်းတင်ပြီးသော အသိပေးချက်များ မရှိပါ</string>
   <string name="please_wait">ကျေးဇူးပြု၍ ခဏစောင့်ပါ...</string>
   <string name="previous_image_title_description">ယခင် ခေါင်းစဉ်/ဖော်ပြချက် မိတ္တူကူးရန်</string>
   <string name="welcome_dont_upload_content_description">နမူနာရုပ်ပုံများ အက်ပလုပ်တင်ရန် မဟုတ်ပါ</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -387,7 +387,7 @@
   <string name="contributions_fragment">Bidrag</string>
   <string name="nearby_fragment">I nærheten</string>
   <string name="notifications">Varsler</string>
-  <string name="archived_notifications">Varsler (arkivert)</string>
+  <string name="read_notifications">Varsler (arkivert)</string>
   <string name="display_nearby_notification">Vis varsel for steder i nærheten</string>
   <string name="display_nearby_notification_summary">Trykk her for å se det nærmeste stedet som trenger bilder</string>
   <string name="no_close_nearby">Ingen steder funnet i nærheten av deg</string>
@@ -500,9 +500,9 @@
   <string name="no_image_reverted">Ingen bilder tilbakestilt</string>
   <string name="no_image_uploaded">Ingen bilder lastet opp</string>
   <string name="no_notification">Du har uleste varsler</string>
-  <string name="no_archived_notification">Du har ingen arkiverte varsler</string>
+  <string name="no_read_notification">Du har ingen arkiverte varsler</string>
   <string name="share_logs_using">Del logger ved hjelp av</string>
-  <string name="menu_option_archived">Vis arkiverte</string>
+  <string name="menu_option_read">Vis arkiverte</string>
   <string name="menu_option_unread">Vis uleste</string>
   <string name="error_occurred_in_picking_images">Feil under utvalg av bilder</string>
   <string name="image_chooser_title">Velg bilder å laste opp</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -254,7 +254,7 @@
   <string name="contributions_fragment">योगदानहरू</string>
   <string name="nearby_fragment">नजिकैको</string>
   <string name="notifications">सूचनाहरू</string>
-  <string name="archived_notifications">सूचनाहरू (अभिलेख)</string>
+  <string name="read_notifications">सूचनाहरू (अभिलेख)</string>
   <string name="list_sheet">सूची</string>
   <string name="storage_permission">भण्डारण अनुमति</string>
   <string name="next">अर्को</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -288,7 +288,7 @@
   <string name="contributions_fragment">Bijdragen</string>
   <string name="nearby_fragment">Dichtbij</string>
   <string name="notifications">Meldingen</string>
-  <string name="archived_notifications">Meldingen (in het archief)</string>
+  <string name="read_notifications">Meldingen (in het archief)</string>
   <string name="display_nearby_notification">Meldingen dichtbij weergeven</string>
   <string name="list_sheet">Lijst</string>
   <string name="storage_permission">Toestemming om op te slaan</string>
@@ -305,9 +305,9 @@
   <string name="display_location_permission_title">Machtiging voor locatie weergeven</string>
   <string name="display_location_permission_explanation">Naar machtiging voor locatie vragen als dat nodig is voor de functie meldingskaart dichtbij weergeven.</string>
   <string name="no_image_uploaded">Geen afbeeldingen geüpload</string>
-  <string name="no_archived_notification" fuzzy="true">U hebt geen gearchiveerde melding</string>
+  <string name="no_read_notification" fuzzy="true">U hebt geen gearchiveerde melding</string>
   <string name="share_logs_using">Logboeken delen via</string>
-  <string name="menu_option_archived">Gearchiveerd bekijken</string>
+  <string name="menu_option_read">Gearchiveerd bekijken</string>
   <string name="menu_option_unread">Ongelezen bekijken</string>
   <string name="image_chooser_title">Kies de afbeeldingen die u wilt plaatsen</string>
   <string name="please_wait">Een ogenblik geduld…</string>

--- a/app/src/main/res/values-pms/strings.xml
+++ b/app/src/main/res/values-pms/strings.xml
@@ -378,7 +378,7 @@
   <string name="contributions_fragment">Contribussion</string>
   <string name="nearby_fragment">Davzin</string>
   <string name="notifications">Notìfiche</string>
-  <string name="archived_notifications">Notìfiche (archivià)</string>
+  <string name="read_notifications">Notìfiche (archivià)</string>
   <string name="display_nearby_notification">Smon-e la notìfica ëd prossimità</string>
   <string name="display_nearby_notification_summary">Sgnaché sì për vëdde ël pòst pi davzin ch\'a l\'ha damanca ëd plance</string>
   <string name="no_close_nearby">Gnun pòst trovà davzin a chiel</string>
@@ -492,9 +492,9 @@
   <string name="no_image_reverted">Gnun-e plance anvertìe</string>
   <string name="no_image_uploaded">Gnun-e plance carià</string>
   <string name="no_notification">A l\'ha gnun-e notìfiche nen lesùe</string>
-  <string name="no_archived_notification">A l\'ha gnun-e notìfiche archivià</string>
+  <string name="no_read_notification">A l\'ha gnun-e notìfiche archivià</string>
   <string name="share_logs_using">Partagé j\'argistr dovrand</string>
-  <string name="menu_option_archived">Vëdde l\'archivi</string>
+  <string name="menu_option_read">Vëdde l\'archivi</string>
   <string name="menu_option_unread">Vëdde lòn ch\'a l\'é ancor nen ëstàit lesù</string>
   <string name="error_occurred_in_picking_images">A-i é staje n\'eror an selessionand le plance</string>
   <string name="image_chooser_title">Serne le plance da carié</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -392,7 +392,7 @@
   <string name="contributions_fragment">Contribuições</string>
   <string name="nearby_fragment">Próximo</string>
   <string name="notifications">Notificações</string>
-  <string name="archived_notifications">Notificações (arquivadas)</string>
+  <string name="read_notifications">Notificações (arquivadas)</string>
   <string name="display_nearby_notification">Exibir notificação próxima</string>
   <string name="display_nearby_notification_summary">Toque aqui para ver o local mais próximo que precisa de fotos</string>
   <string name="no_close_nearby">Nenhum lugar próximo encontrado perto de você</string>
@@ -506,9 +506,9 @@
   <string name="no_image_reverted">Nenhuma imagem revertida</string>
   <string name="no_image_uploaded">Nenhuma imagem enviada</string>
   <string name="no_notification">Não tem nenhuma notificação por ler</string>
-  <string name="no_archived_notification">Não tem nenhuma notificação arquivada</string>
+  <string name="no_read_notification">Não tem nenhuma notificação arquivada</string>
   <string name="share_logs_using">Compartilhar registros usando</string>
-  <string name="menu_option_archived">Ver arquivadas</string>
+  <string name="menu_option_read">Ver arquivadas</string>
   <string name="menu_option_unread">Ver não lidas</string>
   <string name="error_occurred_in_picking_images">Ocorreu um erro ao escolher imagens</string>
   <string name="image_chooser_title">Escolha imagens para fazer o carregamento</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -392,7 +392,7 @@
   <string name="contributions_fragment">Contribuições</string>
   <string name="nearby_fragment">Aqui perto</string>
   <string name="notifications">Notificações</string>
-  <string name="archived_notifications">Notificações (arquivadas)</string>
+  <string name="read_notifications">Notificações (arquivadas)</string>
   <string name="display_nearby_notification">Apresentar notificação de proximidade</string>
   <string name="display_nearby_notification_summary">Toque aqui para ver o local mais próximo que precisa de fotos</string>
   <string name="no_close_nearby">Não foi encontrado nenhum local próximo</string>
@@ -505,9 +505,9 @@
   <string name="no_image_reverted">Não foi revertida nenhuma imagem</string>
   <string name="no_image_uploaded">Não foi carregada nenhuma imagem</string>
   <string name="no_notification">Não tem nenhuma notificação por ler</string>
-  <string name="no_archived_notification">Não tem nenhuma notificação arquivada</string>
+  <string name="no_read_notification">Não tem nenhuma notificação arquivada</string>
   <string name="share_logs_using">Partilhar os registos usando</string>
-  <string name="menu_option_archived">Ver arquivadas</string>
+  <string name="menu_option_read">Ver arquivadas</string>
   <string name="menu_option_unread">Ver não lidas</string>
   <string name="error_occurred_in_picking_images">Ocorreu um erro ao escolher imagens</string>
   <string name="image_chooser_title">Escolher imagens a carregar</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -378,7 +378,7 @@
   <string name="contributions_fragment">Contribuții</string>
   <string name="nearby_fragment">În apropiere</string>
   <string name="notifications">Notificări</string>
-  <string name="archived_notifications">Notificări (arhivate)</string>
+  <string name="read_notifications">Notificări (arhivate)</string>
   <string name="display_nearby_notification">Afișați notificarea din apropiere</string>
   <string name="display_nearby_notification_summary">Apăsați aici pentru a vedea cel mai apropiat loc care are nevoie de imagini</string>
   <string name="no_close_nearby">Nu există locuri apropiate găsite în apropierea dvs.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -400,7 +400,7 @@
   <string name="contributions_fragment">Вклад</string>
   <string name="nearby_fragment">Поблизости</string>
   <string name="notifications">Уведомления</string>
-  <string name="archived_notifications">Уведомления (архивированные)</string>
+  <string name="read_notifications">Уведомления (архивированные)</string>
   <string name="display_nearby_notification">Уведомлять меня о местах поблизости</string>
   <string name="display_nearby_notification_summary">Нажмите здесь, чтобы увидеть ближайшее место без изображений</string>
   <string name="no_close_nearby">Не найдено мест поблизости</string>
@@ -515,9 +515,9 @@
   <string name="no_image_reverted">Нет откаченых изображений</string>
   <string name="no_image_uploaded">Нет загруженных изображений</string>
   <string name="no_notification">У вас нет непрочитанных уведомлений</string>
-  <string name="no_archived_notification">Нет архивированных уведомлений</string>
+  <string name="no_read_notification">Нет архивированных уведомлений</string>
   <string name="share_logs_using">Поделиться лог-файлами</string>
-  <string name="menu_option_archived">См. архивированные</string>
+  <string name="menu_option_read">См. архивированные</string>
   <string name="menu_option_unread">См. непрочитанные</string>
   <string name="error_occurred_in_picking_images">Произошла ошибка при загрузке изображений</string>
   <string name="image_chooser_title">Выберите изображения для загрузки</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -381,7 +381,7 @@
   <string name="contributions_fragment">Príspevky</string>
   <string name="nearby_fragment">V okolí</string>
   <string name="notifications">Upozornenia</string>
-  <string name="archived_notifications">Upozornenia (prečítané)</string>
+  <string name="read_notifications">Upozornenia (prečítané)</string>
   <string name="display_nearby_notification">Zobraziť notifikáciu o miestach v okolí</string>
   <string name="display_nearby_notification_summary">Kliknutím sem sa zobrazí najbližšie miesto, ktoré potrebuje obrázky</string>
   <string name="no_close_nearby">Vo vašej blízkosti neboli nájdené žiadne miesta</string>
@@ -495,9 +495,9 @@
   <string name="no_image_reverted">Žiadne revertované obrázky</string>
   <string name="no_image_uploaded">Žiadne nahrané obrázky</string>
   <string name="no_notification">Nemáte žiadne neprečítané upozornenia</string>
-  <string name="no_archived_notification">Nemáte žiadne prečítané upozornenia</string>
+  <string name="no_read_notification">Nemáte žiadne prečítané upozornenia</string>
   <string name="share_logs_using">Zdieľať log pomocou</string>
-  <string name="menu_option_archived">Zobraziť prečítané</string>
+  <string name="menu_option_read">Zobraziť prečítané</string>
   <string name="menu_option_unread">Zobraziť neprečítané</string>
   <string name="error_occurred_in_picking_images">Nastala chyba pri vyberaní obrázkov</string>
   <string name="image_chooser_title">Vyberte obrázky, ktoré chcete nahrať</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -379,7 +379,7 @@
   <string name="contributions_fragment">Доприноси</string>
   <string name="nearby_fragment">У близини</string>
   <string name="notifications">Обавештења</string>
-  <string name="archived_notifications">Обавештења (архивирана)</string>
+  <string name="read_notifications">Обавештења (архивирана)</string>
   <string name="display_nearby_notification">Прикажи обавештење у близини</string>
   <string name="display_nearby_notification_summary">Притисните овде да бисте видели најближе место којем треба слика</string>
   <string name="no_close_nearby">Нису пронађена места у близини близу вас</string>
@@ -475,9 +475,9 @@
   <string name="no_image_reverted">Нема враћених слика</string>
   <string name="no_image_uploaded">Нема отпремљених слика</string>
   <string name="no_notification">Немате непрочитаних обавештења.</string>
-  <string name="no_archived_notification">Немате архивираних обавештења</string>
+  <string name="no_read_notification">Немате архивираних обавештења</string>
   <string name="share_logs_using">Подели дневнике користећи</string>
-  <string name="menu_option_archived">Прикажи архивирано</string>
+  <string name="menu_option_read">Прикажи архивирано</string>
   <string name="menu_option_unread">Прикажи непрочитано</string>
   <string name="error_occurred_in_picking_images">Дошло је до грешке при избору слика</string>
   <string name="image_chooser_title">Одабир слика за отпремање</string>

--- a/app/src/main/res/values-su/strings.xml
+++ b/app/src/main/res/values-su/strings.xml
@@ -369,7 +369,7 @@
   <string name="contributions_fragment">Kontribusi</string>
   <string name="nearby_fragment">Sabudeureun</string>
   <string name="notifications">Iber</string>
-  <string name="archived_notifications">Iber (arsip)</string>
+  <string name="read_notifications">Iber (arsip)</string>
   <string name="display_nearby_notification">Témbongkeun iber sabudeureun</string>
   <string name="no_close_nearby">Taya tempat sabudeureun nu kairong jang anjeun</string>
   <string name="list_sheet">Daptar</string>
@@ -445,9 +445,9 @@
   <string name="no_image_reverted">Taya gambar nu dibalikkeun</string>
   <string name="no_image_uploaded">Taya gambar diunjal</string>
   <string name="no_notification">Anjeun teu boga iber nu can dibaca</string>
-  <string name="no_archived_notification">Anjeun teu boga iber arsip</string>
+  <string name="no_read_notification">Anjeun teu boga iber arsip</string>
   <string name="share_logs_using">Bagikeun log pamakéan</string>
-  <string name="menu_option_archived">Tempo arsip</string>
+  <string name="menu_option_read">Tempo arsip</string>
   <string name="menu_option_unread">Tempo nu can dibaca</string>
   <string name="error_occurred_in_picking_images">Éror pas keur nyomot gambar</string>
   <string name="image_chooser_title">Pilih Gambar unjalkeuneun</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -384,7 +384,7 @@
   <string name="contributions_fragment">Bidrag</string>
   <string name="nearby_fragment">I närheten</string>
   <string name="notifications">Aviseringar</string>
-  <string name="archived_notifications">Aviseringar (arkiverade)</string>
+  <string name="read_notifications">Aviseringar (arkiverade)</string>
   <string name="display_nearby_notification">Visa avisering för i närheten</string>
   <string name="display_nearby_notification_summary">Tryck här för att se den närmaste platsen som behöver bilder</string>
   <string name="no_close_nearby">Inga platser i närheten hittades som är nära dig</string>
@@ -498,9 +498,9 @@
   <string name="no_image_reverted">Inga bilder återställdes</string>
   <string name="no_image_uploaded">Inga bilder laddades upp</string>
   <string name="no_notification">Du har inga olästa aviseringar</string>
-  <string name="no_archived_notification">Du har inga arkiverade aviseringar</string>
+  <string name="no_read_notification">Du har inga arkiverade aviseringar</string>
   <string name="share_logs_using">Dela loggar med</string>
-  <string name="menu_option_archived">Visa arkiverade</string>
+  <string name="menu_option_read">Visa arkiverade</string>
   <string name="menu_option_unread">Visa olästa</string>
   <string name="error_occurred_in_picking_images">Fel uppstod när bilder valdes ut</string>
   <string name="image_chooser_title">Välj bilder att ladda upp</string>

--- a/app/src/main/res/values-tcy/strings.xml
+++ b/app/src/main/res/values-tcy/strings.xml
@@ -365,7 +365,7 @@
   <string name="contributions_fragment">ಕಾಣಿಕೆಲು</string>
   <string name="nearby_fragment">ಕೈತಲ್‍ದ</string>
   <string name="notifications">ಅಧಿಸೂಚನೆಲು</string>
-  <string name="archived_notifications" fuzzy="true">ಅಧಿಸೂಚನೆಲು(ಅನುರಕ್ಷಿತ)</string>
+  <string name="read_notifications" fuzzy="true">ಅಧಿಸೂಚನೆಲು(ಅನುರಕ್ಷಿತ)</string>
   <string name="display_nearby_notification">ಕೈತಲ್ದ ಅಧಿಸೂಚನೆ ತೋಜಾಲೆ</string>
   <string name="display_nearby_notification_summary">ಚಿತ್ರ ಬೋಡಾಯಿನ ಕೈತಲ್ದ ಜಾಗ ತೂವರೆ ಮುಲ್ಪ ತಟ್ಟ್\'ಲೆ</string>
   <string name="no_close_nearby">ಇರೆನ ಮುಟ್ಟೊಡು ಕೈತಲ್ದ ಜಾಗೊಲು ತಿಕ್ಕುಜಾ.</string>
@@ -395,8 +395,8 @@
   <string name="deletion_reason_uploaded_by_mistake">ಯಾನ್ ಅವೆನ್ ತತ್ತ್\'ದ್ ಮಿತೇರಾಯೆ.</string>
   <string name="deletion_reason_publicly_visible">ಅವು ಸಾರ್ವತ್ರಿಕವಾದ್ ತೋಜುಂಡು ಇಂದ್ ಎಂಕ್ ಗೊತ್ತಿತ್ತಿಜಿ.</string>
   <string name="deletion_reason_bad_for_my_privacy">ಅವು ಎನ್ನ ಖಾಸಗಿತೆನೊಕು ಹಾಳ್ಂದ್ ಎಂಕ್ ತೆರಿಂಡ್.</string>
-  <string name="no_archived_notification" fuzzy="true">ಇರೆಗ್ ಅನುರಕ್ಷಿತ ಅಧಿಸೂಚನೆ ಇಜ್ಜಿ</string>
-  <string name="menu_option_archived">ಅನುರಕ್ಷಿತ ತೂಲೆ</string>
+  <string name="no_read_notification" fuzzy="true">ಇರೆಗ್ ಅನುರಕ್ಷಿತ ಅಧಿಸೂಚನೆ ಇಜ್ಜಿ</string>
+  <string name="menu_option_read">ಅನುರಕ್ಷಿತ ತೂಲೆ</string>
   <string name="menu_option_unread">ಓದಂದಿನ ತೂಲೆ</string>
   <string name="error_occurred_in_picking_images">ಆಕೃತಿಲೆನ್ ಪೆಜ್ಜಿನಗ ದೋಷ ಆಂಡ್</string>
   <string name="image_chooser_title">ಮಿತರಾರೆ ಆಕೃತಿಲೆನ್ ಆಯುಲೆ</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -377,7 +377,7 @@
   <string name="contributions_fragment">తోడ్పాటు</string>
   <string name="nearby_fragment">చుట్టుపక్కల</string>
   <string name="notifications">గమనింపులు</string>
-  <string name="archived_notifications">గమనింపులు (ఆర్కైవు చేసినవి)</string>
+  <string name="read_notifications">గమనింపులు (ఆర్కైవు చేసినవి)</string>
   <string name="display_nearby_notification">చుట్టుపక్కల గమనింపును చూపించు</string>
   <string name="display_nearby_notification_summary">బొమ్మలు అవసరమైన చుట్టుపక్కల స్థలాన్ని చూసేందుకు ఇక్కడ నొక్కండి</string>
   <string name="no_close_nearby">మీ చుట్టుపక్కల స్థలాలేమీ కనబడలేదు</string>
@@ -490,9 +490,9 @@
   <string name="no_image_reverted">బొమ్మలు వేటినీ వెనక్కి తిరక్కొట్టలేదు</string>
   <string name="no_image_uploaded">బొమ్మలేమీ ఎక్కించలేదు</string>
   <string name="no_notification">మీకు చదవని గమనింపులేమీ లేవు</string>
-  <string name="no_archived_notification">మీకు ఆర్కైవు చేసిన గమనింపులేమీ లేవు</string>
+  <string name="no_read_notification">మీకు ఆర్కైవు చేసిన గమనింపులేమీ లేవు</string>
   <string name="share_logs_using">దీన్ని వాడి లాగ్‌లను పంచుకోండి</string>
-  <string name="menu_option_archived">ఆర్కైవులను చూడండి</string>
+  <string name="menu_option_read">ఆర్కైవులను చూడండి</string>
   <string name="menu_option_unread">చదవని వాటిని చూడండి</string>
   <string name="error_occurred_in_picking_images">బొమ్మలను ఎంచుకునేటపుడు లోపం దొర్లింది</string>
   <string name="image_chooser_title">ఎక్కించేందుకు బొమ్మలను ఎంచుకోండి</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -396,7 +396,7 @@
   <string name="contributions_fragment">Katkılar</string>
   <string name="nearby_fragment">Yakınındakiler</string>
   <string name="notifications">Bildirimler</string>
-  <string name="archived_notifications">Bildirimler (arşivlenmiş)</string>
+  <string name="read_notifications">Bildirimler (arşivlenmiş)</string>
   <string name="display_nearby_notification">Yakındaki bildirimi görüntüle</string>
   <string name="display_nearby_notification_summary">Resimlere en yakın yeri görmek için buraya dokunun</string>
   <string name="no_close_nearby">Size yakın bir yer bulunamadı</string>
@@ -510,9 +510,9 @@
   <string name="no_image_reverted">Resim döndürülmedi</string>
   <string name="no_image_uploaded">Resim yüklenmedi</string>
   <string name="no_notification">Okunmamış bildirimleriniz yok</string>
-  <string name="no_archived_notification">Arşivlenmiş bildiriminiz yok</string>
+  <string name="no_read_notification">Arşivlenmiş bildiriminiz yok</string>
   <string name="share_logs_using">Kullanarak günlükleri paylaş</string>
-  <string name="menu_option_archived">Arşivlenmişleri görüntüle</string>
+  <string name="menu_option_read">Arşivlenmişleri görüntüle</string>
   <string name="menu_option_unread">Okunmamışları görüntüle</string>
   <string name="error_occurred_in_picking_images">Resimler toplanırken hata oluştu</string>
   <string name="image_chooser_title">Yüklenecek Görüntüleri Seçin</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -397,7 +397,7 @@
   <string name="contributions_fragment">Внесок</string>
   <string name="nearby_fragment">Поблизу</string>
   <string name="notifications">Сповіщення</string>
-  <string name="archived_notifications">Сповіщення (архівовані)</string>
+  <string name="read_notifications">Сповіщення (архівовані)</string>
   <string name="display_nearby_notification">Повідомляти мене про місця поблизу</string>
   <string name="display_nearby_notification_summary">Торкніться тут, щоб побачити найближчі місця, які ще не мають зображень</string>
   <string name="no_close_nearby">Не знайдено місць поблизу Вас</string>
@@ -513,9 +513,9 @@
   <string name="no_image_reverted">Відхилених зображень немає</string>
   <string name="no_image_uploaded">Завантажених зображень немає</string>
   <string name="no_notification">У вас немає непрочитаних сповіщень</string>
-  <string name="no_archived_notification">Немає архівованих сповіщень</string>
+  <string name="no_read_notification">Немає архівованих сповіщень</string>
   <string name="share_logs_using">Поширення журналів</string>
-  <string name="menu_option_archived">Перегляд архівованих</string>
+  <string name="menu_option_read">Перегляд архівованих</string>
   <string name="menu_option_unread">Перегляд непрочитаних</string>
   <string name="error_occurred_in_picking_images">Сталася помилка при завантаженні зображень</string>
   <string name="image_chooser_title">Оберіть зображення для завантаження</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -389,7 +389,7 @@
   <string name="contributions_fragment">貢獻</string>
   <string name="nearby_fragment">附近</string>
   <string name="notifications">通知</string>
-  <string name="archived_notifications">通知（已存檔）</string>
+  <string name="read_notifications">通知（已存檔）</string>
   <string name="display_nearby_notification">顯示附近地點通知</string>
   <string name="display_nearby_notification_summary">在此輕觸來查看缺少圖片的最近地點</string>
   <string name="no_close_nearby">查無靠近您的附近地點</string>
@@ -503,9 +503,9 @@
   <string name="no_image_reverted">沒有圖片被還原回復</string>
   <string name="no_image_uploaded">沒有圖片被上傳</string>
   <string name="no_notification">您有尚未讀取的通知</string>
-  <string name="no_archived_notification">您沒有已存檔通知</string>
+  <string name="no_read_notification">您沒有已存檔通知</string>
   <string name="share_logs_using">分享日誌使用</string>
-  <string name="menu_option_archived">檢視已存檔</string>
+  <string name="menu_option_read">檢視已存檔</string>
   <string name="menu_option_unread">檢視未讀</string>
   <string name="error_occurred_in_picking_images">當挑選圖片時發生錯誤</string>
   <string name="image_chooser_title">選擇要上傳的圖片</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -400,7 +400,7 @@
   <string name="contributions_fragment">贡献</string>
   <string name="nearby_fragment">附近</string>
   <string name="notifications">通知</string>
-  <string name="archived_notifications">通知（已存档）</string>
+  <string name="read_notifications">通知（已存档）</string>
   <string name="display_nearby_notification">显示附近通知</string>
   <string name="display_nearby_notification_summary">点击此处查看最近需要图片的地方</string>
   <string name="no_close_nearby">附近找不到靠近您的地方</string>
@@ -513,9 +513,9 @@
   <string name="no_image_reverted">没有被撤回的图片</string>
   <string name="no_image_uploaded">还没有上传图片</string>
   <string name="no_notification">您没有任何未读通知</string>
-  <string name="no_archived_notification">您没有已存档的通知</string>
+  <string name="no_read_notification">您没有已存档的通知</string>
   <string name="share_logs_using">分享日志于</string>
-  <string name="menu_option_archived">查看已存档</string>
+  <string name="menu_option_read">查看已存档</string>
   <string name="menu_option_unread">查看未读</string>
   <string name="error_occurred_in_picking_images">选择图片时出错</string>
   <string name="image_chooser_title">选择要上传的图片</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -393,7 +393,7 @@
   <string name="contributions_fragment">Contributions</string>
   <string name="nearby_fragment">Nearby</string>
   <string name="notifications">Notifications</string>
-  <string name="archived_notifications">Notifications (read)</string>
+  <string name="read_notifications">Notifications (read)</string>
   <string name="display_nearby_notification">Display nearby notification</string>
   <string name="display_nearby_notification_summary">Tap here to see the nearest place that needs pictures</string>
   <string name="no_close_nearby">No nearby places found close to you</string>
@@ -521,9 +521,9 @@ Upload your first media by tapping on the add button.</string>
   <string name="no_image_uploaded">No images uploaded</string>
 
   <string name="no_notification">You have no unread notifications</string>
-  <string name="no_archived_notification">You have no read notifications</string>
+  <string name="no_read_notification">You have no read notifications</string>
   <string name="share_logs_using">Share logs using</string>
-  <string name="menu_option_archived">View read</string>
+  <string name="menu_option_read">View read</string>
   <string name="menu_option_unread">View unread</string>
 
   <string name="error_occurred_in_picking_images">Error occurred while picking images</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -393,7 +393,7 @@
   <string name="contributions_fragment">Contributions</string>
   <string name="nearby_fragment">Nearby</string>
   <string name="notifications">Notifications</string>
-  <string name="archived_notifications">Notifications (archived)</string>
+  <string name="archived_notifications">Notifications (read)</string>
   <string name="display_nearby_notification">Display nearby notification</string>
   <string name="display_nearby_notification_summary">Tap here to see the nearest place that needs pictures</string>
   <string name="no_close_nearby">No nearby places found close to you</string>
@@ -521,9 +521,9 @@ Upload your first media by tapping on the add button.</string>
   <string name="no_image_uploaded">No images uploaded</string>
 
   <string name="no_notification">You have no unread notifications</string>
-  <string name="no_archived_notification">You have no archived notifications</string>
+  <string name="no_archived_notification">You have no read notifications</string>
   <string name="share_logs_using">Share logs using</string>
-  <string name="menu_option_archived">View archived</string>
+  <string name="menu_option_archived">View read</string>
   <string name="menu_option_unread">View unread</string>
 
   <string name="error_occurred_in_picking_images">Error occurred while picking images</string>


### PR DESCRIPTION
**Description (required)**

Fixes #3426 - "Archived" notifications should be referred to as "Read"

_What changes did you make and why?_

I replaced the word _archived_ in strings with _read_. However, I did not change the string names, e.g., `menu_option_archived` was not changed to `menu_option_read`. Doing this would require changes in many files, so I'm not sure if it's necessary. In case it is better to change the string names too, please let me know and I will make those changes.

**Screenshots (for UI changes only)**

![image](https://user-images.githubusercontent.com/44764339/77163398-ff2cef00-6ad3-11ea-96dd-6fb2215e652c.png)