### PR TITLE
Fix auto zoom issue #3391 Zoom level gets reset at every second.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
@@ -71,6 +71,9 @@ public interface NearbyParentFragmentContract {
         LatLng getLastLocation();
 
         com.mapbox.mapboxsdk.geometry.LatLng getLastFocusLocation();
+
+        boolean isCurrentLocationMarkerVisible();
+        void setProjectorLatLngBounds();
     }
 
     interface NearbyListView {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.java
@@ -8,8 +8,6 @@ import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.List;
 
-import javax.inject.Inject;
-
 import fr.free.nrw.commons.bookmarks.locations.BookmarkLocationsDao;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.location.LatLng;
@@ -21,9 +19,7 @@ import fr.free.nrw.commons.nearby.MarkerPlaceGroup;
 import fr.free.nrw.commons.nearby.NearbyBaseMarker;
 import fr.free.nrw.commons.nearby.NearbyController;
 import fr.free.nrw.commons.nearby.NearbyFilterState;
-import fr.free.nrw.commons.nearby.Place;
 import fr.free.nrw.commons.nearby.contract.NearbyParentFragmentContract;
-import fr.free.nrw.commons.upload.UploadContract;
 import fr.free.nrw.commons.utils.LocationUtils;
 import fr.free.nrw.commons.wikidata.WikidataEditListener;
 import timber.log.Timber;
@@ -194,7 +190,7 @@ public class NearbyParentFragmentPresenter
             nearbyParentFragmentView.populatePlaces(nearbyParentFragmentView.getCameraTarget());
         } else { // Means location changed slightly, ie user is walking or driving.
             Timber.d("Means location changed slightly");
-            if (!nearbyParentFragmentView.isSearchThisAreaButtonVisible()) { // Do not track users position if the user is checking around
+            if (nearbyParentFragmentView.isCurrentLocationMarkerVisible()){ // Means user wants to see their live location
                 nearbyParentFragmentView.recenterMap(curLatLng);
             }
         }
@@ -259,6 +255,7 @@ public class NearbyParentFragmentPresenter
 
     @Override
     public void onCameraMove(com.mapbox.mapboxsdk.geometry.LatLng latLng) {
+        nearbyParentFragmentView.setProjectorLatLngBounds();
             // If our nearby markers are calculated at least once
             if (NearbyController.latestSearchLocation != null) {
                double distance =latLng.distanceTo


### PR DESCRIPTION
**Description (required)**

Fixes #3391 Zoom level gets reset at every second. 


**Tests performed (required)**
Manual tests. Currently if the current location marker (the blue dot indicates users position) is invisible (probably the user tries to explore around), map does not recenter it. If it is visible, we recenter it and thus track users current location.