### PR TITLE
Wiki itemname displaying in toast

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
@@ -68,6 +68,7 @@ public class  Contribution extends Media {
     public String decimalCoords;
     public boolean isMultiple;
     public String wikiDataEntityId;
+    public String wikiItemName;
     private String p18Value;
     public Uri contentProviderUri;
     public String dateCreatedSource;
@@ -262,6 +263,9 @@ public class  Contribution extends Media {
     public String getWikiDataEntityId() {
         return wikiDataEntityId;
     }
+    public String getWikiItemName() {
+        return wikiItemName;
+    }
 
     /**
      * When the corresponding wikidata entity is known as in case of nearby uploads, it can be set
@@ -270,6 +274,10 @@ public class  Contribution extends Media {
      */
     public void setWikiDataEntityId(String wikiDataEntityId) {
         this.wikiDataEntityId = wikiDataEntityId;
+    }
+
+    public void setWikiItemName(String wikiItemName) {
+        this.wikiItemName = wikiItemName;
     }
 
     public String getP18Value() {

--- a/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
@@ -263,6 +263,7 @@ public class  Contribution extends Media {
     public String getWikiDataEntityId() {
         return wikiDataEntityId;
     }
+
     public String getWikiItemName() {
         return wikiItemName;
     }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.java
@@ -113,6 +113,7 @@ public class  Contribution extends Media {
         state = in.readInt();
         transferred = in.readLong();
         isMultiple = in.readInt() == 1;
+        wikiItemName = in.readString();
     }
 
     @Override
@@ -123,6 +124,7 @@ public class  Contribution extends Media {
         parcel.writeInt(state);
         parcel.writeLong(transferred);
         parcel.writeInt(isMultiple ? 1 : 0);
+        parcel.writeString(wikiItemName);
     }
 
     public void setDateCreatedSource(String dateCreatedSource) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
@@ -205,6 +205,7 @@ public class UploadModel {
         UploadItem uploadItem1 = items.get(index);
         uploadItem1.setDescriptions(uploadItem.descriptions);
         uploadItem1.setTitle(uploadItem.title);
+        store.putString("Title", uploadItem.place.getName());
     }
 
     public void useSimilarPictureCoordinates(ImageCoordinates imageCoordinates, int uploadItemIndex) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
@@ -160,6 +160,7 @@ public class UploadModel {
                     CommonsApplication.DEFAULT_EDIT_SUMMARY, item.gpsCoords.getDecimalCoords());
             if (item.place != null) {
                 contribution.setWikiDataEntityId(item.place.getWikiDataEntityId());
+                contribution.setWikiItemName(item.place.getName());
                 // If item already has an image, we need to know it. We don't want to override existing image later
                 contribution.setP18Value(item.place.pic);
             }
@@ -205,7 +206,6 @@ public class UploadModel {
         UploadItem uploadItem1 = items.get(index);
         uploadItem1.setDescriptions(uploadItem.descriptions);
         uploadItem1.setTitle(uploadItem.title);
-        store.putString("Title", uploadItem.place.getName());
     }
 
     public void useSimilarPictureCoordinates(ImageCoordinates imageCoordinates, int uploadItemIndex) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -281,7 +281,7 @@ public class UploadService extends HandlerService<Contribution> {
                         Timber.d("Contribution upload success. Initiating Wikidata edit for"
                                 + " entity id %s if necessary (if P18 is null). P18 value is %s",
                                 contribution.getWikiDataEntityId(), contribution.getP18Value());
-                        wikidataEditService.createClaimWithLogging(contribution.getWikiDataEntityId(), canonicalFilename, contribution.getP18Value());
+                        wikidataEditService.createClaimWithLogging(contribution.getWikiDataEntityId(), contribution.getWikiItemName(), canonicalFilename, contribution.getP18Value());
                         contribution.setFilename(canonicalFilename);
                         contribution.setImageUrl(uploadResult.getImageinfo().getOriginalUrl());
                         contribution.setState(Contribution.STATE_COMPLETED);

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -278,10 +278,11 @@ public class UploadService extends HandlerService<Contribution> {
                         showFailedNotification(contribution);
                     } else {
                         String canonicalFilename = "File:" + uploadResult.getFilename();
+                        String wikiItemName = contribution.getWikiItemName()!=null?contribution.getWikiItemName():"";
                         Timber.d("Contribution upload success. Initiating Wikidata edit for"
                                 + " entity id %s if necessary (if P18 is null). P18 value is %s",
                                 contribution.getWikiDataEntityId(), contribution.getP18Value());
-                        wikidataEditService.createClaimWithLogging(contribution.getWikiDataEntityId(), contribution.getWikiItemName(), canonicalFilename, contribution.getP18Value());
+                        wikidataEditService.createClaimWithLogging(contribution.getWikiDataEntityId(), wikiItemName, canonicalFilename, contribution.getP18Value());
                         contribution.setFilename(canonicalFilename);
                         contribution.setImageUrl(uploadResult.getImageinfo().getOriginalUrl());
                         contribution.setState(Contribution.STATE_COMPLETED);

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -278,11 +278,10 @@ public class UploadService extends HandlerService<Contribution> {
                         showFailedNotification(contribution);
                     } else {
                         String canonicalFilename = "File:" + uploadResult.getFilename();
-                        String wikiItemName = contribution.getWikiItemName()!=null?contribution.getWikiItemName():"";
                         Timber.d("Contribution upload success. Initiating Wikidata edit for"
                                 + " entity id %s if necessary (if P18 is null). P18 value is %s",
                                 contribution.getWikiDataEntityId(), contribution.getP18Value());
-                        wikidataEditService.createClaimWithLogging(contribution.getWikiDataEntityId(), wikiItemName, canonicalFilename, contribution.getP18Value());
+                        wikidataEditService.createClaimWithLogging(contribution.getWikiDataEntityId(), contribution.getWikiItemName(), canonicalFilename, contribution.getP18Value());
                         contribution.setFilename(canonicalFilename);
                         contribution.setImageUrl(uploadResult.getImageinfo().getOriginalUrl());
                         contribution.setState(Contribution.STATE_COMPLETED);

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
@@ -120,9 +120,8 @@ public class WikidataEditService {
      * Show a success toast when the edit is made successfully
      */
     private void showSuccessToast(String wikiItemName) {
-        String title = wikiItemName;
         String successStringTemplate = context.getString(R.string.successful_wikidata_edit);
-        String successMessage = String.format(Locale.getDefault(), successStringTemplate, title);
+        String successMessage = String.format(Locale.getDefault(), successStringTemplate, wikiItemName);
         ViewUtil.showLongToast(context, successMessage);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
@@ -50,7 +50,7 @@ public class WikidataEditService {
      * @param fileName name of the file we will upload
      * @param p18Value pic attribute of Wikidata item
      */
-    public void createClaimWithLogging(String wikidataEntityId, String fileName, @NonNull String p18Value) {
+    public void createClaimWithLogging(String wikidataEntityId, String wikiItemName, String fileName, @NonNull String p18Value) {
         if (wikidataEntityId == null) {
             Timber.d("Skipping creation of claim as Wikidata entity ID is null");
             return;
@@ -71,7 +71,7 @@ public class WikidataEditService {
             return;
         }
 
-        editWikidataProperty(wikidataEntityId, fileName);
+        editWikidataProperty(wikidataEntityId, wikiItemName, fileName);
     }
 
     /**
@@ -82,7 +82,7 @@ public class WikidataEditService {
      * @param fileName
      */
     @SuppressLint("CheckResult")
-    private void editWikidataProperty(String wikidataEntityId, String fileName) {
+    private void editWikidataProperty(String wikidataEntityId, String wikiItemName, String fileName) {
         Timber.d("Upload successful with wiki data entity id as %s", wikidataEntityId);
         Timber.d("Attempting to edit Wikidata property %s", wikidataEntityId);
 
@@ -98,18 +98,18 @@ public class WikidataEditService {
                 })
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(revisionId -> handleClaimResult(wikidataEntityId, String.valueOf(revisionId)), throwable -> {
+                .subscribe(revisionId -> handleClaimResult(wikidataEntityId, wikiItemName, String.valueOf(revisionId)), throwable -> {
                     Timber.e(throwable, "Error occurred while making claim");
                     ViewUtil.showLongToast(context, context.getString(R.string.wikidata_edit_failure));
                 });
     }
 
-    private void handleClaimResult(String wikidataEntityId, String revisionId) {
+    private void handleClaimResult(String wikidataEntityId, String wikiItemName, String revisionId) {
         if (revisionId != null) {
             if (wikidataEditListener != null) {
                 wikidataEditListener.onSuccessfulWikidataEdit();
             }
-            showSuccessToast();
+            showSuccessToast(wikiItemName);
         } else {
             Timber.d("Unable to make wiki data edit for entity %s", wikidataEntityId);
             ViewUtil.showLongToast(context, context.getString(R.string.wikidata_edit_failure));
@@ -119,8 +119,8 @@ public class WikidataEditService {
     /**
      * Show a success toast when the edit is made successfully
      */
-    private void showSuccessToast() {
-        String title = directKvStore.getString("Title", "");
+    private void showSuccessToast(String wikiItemName) {
+        String title = wikiItemName;
         String successStringTemplate = context.getString(R.string.successful_wikidata_edit);
         String successMessage = String.format(Locale.getDefault(), successStringTemplate, title);
         ViewUtil.showLongToast(context, successMessage);

--- a/app/src/test/kotlin/fr/free/nrw/commons/wikidata/WikidataEditServiceTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/wikidata/WikidataEditServiceTest.kt
@@ -34,19 +34,19 @@ class WikidataEditServiceTest {
 
     @Test
     fun noClaimsWhenEntityIdIsNull() {
-        wikidataEditService!!.createClaimWithLogging(null, "Test.jpg","")
+        wikidataEditService!!.createClaimWithLogging(null, null,"Test.jpg","")
         verifyZeroInteractions(wikidataClient!!)
     }
 
     @Test
     fun noClaimsWhenFileNameIsNull() {
-        wikidataEditService!!.createClaimWithLogging("Q1", null,"")
+        wikidataEditService!!.createClaimWithLogging("Q1", "Test", null,"")
         verifyZeroInteractions(wikidataClient!!)
     }
 
     @Test
     fun noClaimsWhenP18IsNotEmpty() {
-        wikidataEditService!!.createClaimWithLogging("Q1", "Test.jpg","Previous.jpg")
+        wikidataEditService!!.createClaimWithLogging("Q1", "Test","Test.jpg","Previous.jpg")
         verifyZeroInteractions(wikidataClient!!)
     }
 
@@ -54,7 +54,7 @@ class WikidataEditServiceTest {
     fun noClaimsWhenLocationIsNotCorrect() {
         `when`(directKvStore!!.getBoolean("Picture_Has_Correct_Location", true))
                 .thenReturn(false)
-        wikidataEditService!!.createClaimWithLogging("Q1", "Test.jpg","")
+        wikidataEditService!!.createClaimWithLogging("Q1", "","Test.jpg","")
         verifyZeroInteractions(wikidataClient!!)
     }
 
@@ -66,7 +66,7 @@ class WikidataEditServiceTest {
                 .thenReturn(Observable.just(1L))
         `when`(wikidataClient!!.addEditTag(anyLong(), ArgumentMatchers.anyString(), ArgumentMatchers.anyString()))
                 .thenReturn(Observable.just(mock(AddEditTagResponse::class.java)))
-        wikidataEditService!!.createClaimWithLogging("Q1", "Test.jpg","")
+        wikidataEditService!!.createClaimWithLogging("Q1", "Test","Test.jpg","")
         verify(wikidataClient!!, times(1))
                 .createClaim(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())
     }


### PR DESCRIPTION
**Description (required)**
Item name was not displayed on toast when an image is uploaded and linked to wikidata entity.

Fixes #2882 Item name not filled in toast

What changes did you make and why?
added the place name which is linked to wikidata item in sharedPreferences in UploadModel class
to display toast in WikiDataEditService class.

**Tests performed (required)**

Tested ProdDebug on OnePlus 5 with API level 28.

**Screenshots (for UI changes only)**
![image](https://user-images.githubusercontent.com/45694892/77305818-b451e800-6d1c-11ea-8c6c-93a113b38bcd.png)

