### PR TITLE
Fast scroll issue fixed

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
@@ -183,6 +183,7 @@ public class CategoryImagesListFragment extends DaggerFragment {
         gridView.setOnScrollListener(new AbsListView.OnScrollListener() {
             @Override
             public void onScrollStateChanged(AbsListView view, int scrollState) {
+                view.setFastScrollEnabled(scrollState!=SCROLL_STATE_IDLE);
             }
 
             @Override

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
@@ -183,7 +183,7 @@ public class CategoryImagesListFragment extends DaggerFragment {
         gridView.setOnScrollListener(new AbsListView.OnScrollListener() {
             @Override
             public void onScrollStateChanged(AbsListView view, int scrollState) {
-                view.setFastScrollEnabled(scrollState!=SCROLL_STATE_IDLE);
+                view.setFastScrollEnabled(scrollState != SCROLL_STATE_IDLE);
             }
 
             @Override

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryImagesListFragment.java
@@ -183,7 +183,6 @@ public class CategoryImagesListFragment extends DaggerFragment {
         gridView.setOnScrollListener(new AbsListView.OnScrollListener() {
             @Override
             public void onScrollStateChanged(AbsListView view, int scrollState) {
-                view.setFastScrollEnabled(scrollState != SCROLL_STATE_IDLE);
             }
 
             @Override

--- a/app/src/main/res/layout/fragment_category_images.xml
+++ b/app/src/main/res/layout/fragment_category_images.xml
@@ -36,7 +36,6 @@
         android:numColumns="auto_fit"
         android:listSelector="@null"
         android:fadingEdge="none"
-        android:fastScrollEnabled="true"
         />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_category_images.xml
+++ b/app/src/main/res/layout/fragment_category_images.xml
@@ -36,6 +36,7 @@
         android:numColumns="auto_fit"
         android:listSelector="@null"
         android:fadingEdge="none"
+        android:scrollbars="none"
         />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_category_images.xml
+++ b/app/src/main/res/layout/fragment_category_images.xml
@@ -36,7 +36,6 @@
         android:numColumns="auto_fit"
         android:listSelector="@null"
         android:fadingEdge="none"
-        android:scrollbars="none"
         />
 
 </RelativeLayout>


### PR DESCRIPTION
**Description (required)**
Earlier, accidental touch on right side of screen would lead to abrupt jump to images in explore activity due to fast scroll enabled.

Fixes #3316 Enabled Fast Scroll disrupts normal scroll flow

What changes did you make and why?
Enabled fast scroll only when state is changed(user scrolls) so normal scroll flow isn't disrupted. 
Also scrollbar is hidden so isn't visible for normal scroll this is done to prevent overlapping which wasn't looking nice

**Tests performed (required)**

Tested ProdDebug on OnePlus 5 with API level 28.
