### PR TITLE
exit app on back pressed in tutorial

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.java
@@ -86,7 +86,11 @@ public class WelcomeActivity extends BaseActivity {
         if (pager.getCurrentItem() != 0) {
             pager.setCurrentItem(pager.getCurrentItem() - 1, true);
         } else {
-            finishAffinity();
+            if(defaultKvStore.getBoolean("firstrun",true)){
+                finishAffinity();
+            } else{
+                finish();
+            }
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.java
@@ -86,7 +86,7 @@ public class WelcomeActivity extends BaseActivity {
         if (pager.getCurrentItem() != 0) {
             pager.setCurrentItem(pager.getCurrentItem() - 1, true);
         } else {
-            finish();
+            finishAffinity();
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.java
@@ -86,10 +86,10 @@ public class WelcomeActivity extends BaseActivity {
         if (pager.getCurrentItem() != 0) {
             pager.setCurrentItem(pager.getCurrentItem() - 1, true);
         } else {
-            if(defaultKvStore.getBoolean("firstrun",true)){
+            if (defaultKvStore.getBoolean("firstrun", true)) {
                 finishAffinity();
-            } else{
-                finish();
+            } else {
+                super.onBackPressed();
             }
         }
     }


### PR DESCRIPTION
**Description (required)**
On a fresh install, user was not able to exit from app during tutorial when back is pressed. This happens because we were using finish() which goes to the previous activity in stack instead of exiting the app.

Fixes #3590 Unable to exit the app from onbarding tutorial

What changes did you make and why?
used finishAffinity() instead in onBackPressed() method

**Tests performed (required)**

Tested ProdDebug on OnePlus 5 with API level 28.
