### PR TITLE
swipe away failed notification

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -217,7 +217,8 @@ public class UploadService extends HandlerService<Contribution> {
         Timber.d("Before execution!");
         curNotification.setContentTitle(getString(R.string.upload_progress_notification_title_start, contribution.getDisplayTitle()))
                 .setContentText(getResources().getQuantityString(R.plurals.uploads_pending_notification_indicator, toUpload, toUpload))
-                .setTicker(getString(R.string.upload_progress_notification_title_in_progress, contribution.getDisplayTitle()));
+                .setTicker(getString(R.string.upload_progress_notification_title_in_progress, contribution.getDisplayTitle()))
+                .setOngoing(true);
         notificationManager
                 .notify(notificationTag, NOTIFICATION_UPLOAD_IN_PROGRESS, curNotification.build());
 
@@ -306,7 +307,8 @@ public class UploadService extends HandlerService<Contribution> {
         curNotification.setTicker(getString(R.string.upload_failed_notification_title, contribution.getDisplayTitle()))
                 .setContentTitle(getString(R.string.upload_failed_notification_title, contribution.getDisplayTitle()))
                 .setContentText(getString(R.string.upload_failed_notification_subtitle))
-                .setProgress(0, 0, false);
+                .setProgress(0, 0, false)
+                .setOngoing(false);
         notificationManager.notify(contribution.getLocalUri().toString(), NOTIFICATION_UPLOAD_FAILED, curNotification.build());
 
         contribution.setState(Contribution.STATE_FAILED);


### PR DESCRIPTION
**Description (required)**
Previously, when an upload fails you cannot swipe away the failed notification as it was ongoing.

Fixes #3596 Sticky notification when upload fails

What changes did you make and why?
when upload fails showfailedNotification is called where ongoing is set to be false and on re-uploading it is again set to be true.

**Tests performed (required)**

Tested ProdDebug on OnePlus 5 with API level 28.
