### PR TITLE
PULL_REQUEST_TEMPLATE: clarify that issue number needs to be replaced

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 **Description (required)**
 
-Fixes #{GitHub issue number}
+Fixes #INSERT_ISSUE_NUMBER_HERE
 
 What changes did you make and why?
 


### PR DESCRIPTION
**Description (required)**
Some contributors seem to be missing the fact that they have to mention
the issue number right after `Fixes ` to ensure the [corresponding issue
gets closed](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when the PR gets merged.

Clarify this by using a better phrase that clearly states that they
have to replace the placeholder text with the issue number.
