### PR TITLE
Fixes #3466  No crash information in crash email (Gmail)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -72,8 +72,7 @@ import static org.acra.ReportField.USER_COMMENT;
 )
 
 @AcraMailSender(
-        mailTo = "commons-app-android-private@googlegroups.com",
-        reportAsFile = true
+        mailTo = "commons-app-android-private@googlegroups.com"
 )
 
 @AcraDialog(

--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -73,7 +73,7 @@ import static org.acra.ReportField.USER_COMMENT;
 
 @AcraMailSender(
         mailTo = "commons-app-android-private@googlegroups.com",
-        reportAsFile = false
+        reportAsFile = true
 )
 
 @AcraDialog(


### PR DESCRIPTION
**Description (required)**

Fixes #3466  No crash information in crash email (Gmail).

I changed our acra mail sender confiuration to send info as a file. This does not provides a complete solution (If we insist to get them as plain text, we need some other solutions) but at least makes us possible to get logs.