### PR TITLE
Copy place name on long click

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -580,7 +580,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private void addActionToTitle() {
         title.setOnLongClickListener(view -> {
                 Utils.copy("place", title.getText().toString(), getContext());
-                Toast.makeText(getContext(), "Text copied to clipboard", Toast.LENGTH_SHORT).show();
+                Toast.makeText(getContext(), R.string.text_copy, Toast.LENGTH_SHORT).show();
                 return true;
             });
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -578,9 +578,13 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
      *
      */
     private void addActionToTitle() {
+        title.setOnLongClickListener(view -> {
+                Utils.copy("place", title.getText().toString(), getContext());
+                Toast.makeText(getContext(), "Text copied to clipboard", Toast.LENGTH_SHORT).show();
+                return true;
+            });
+
         title.setOnClickListener(view -> {
-            Utils.copy("place", title.getText().toString(), getContext());
-            Toast.makeText(getContext(), "Text copied to clipboard", Toast.LENGTH_SHORT).show();
             bottomSheetListBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
             if (bottomSheetDetailsBehavior.getState() == BottomSheetBehavior.STATE_COLLAPSED) {
                 bottomSheetDetailsBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);


### PR DESCRIPTION
**Description (required)**

Fixes #3558

**What changes did you make and why?**

The place name is copied on a long click now instead of a normal click.

**Tests performed (required)**

Tested betaDebug 