### PR TITLE
Fixes #3606: cancel in translate goes back to about screen

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
@@ -152,7 +152,7 @@ public class AboutActivity extends NavigationBaseActivity {
                     String langCode = CommonsApplication.getInstance().getLanguageLookUpTable().getCodes().get(spinner.getSelectedItemPosition());
                     Utils.handleWebUrl(AboutActivity.this, Uri.parse(Urls.TRANSLATE_WIKI_URL + langCode));
                 });
-        builder.setNegativeButton(R.string.about_translate_cancel, (dialog, which) -> finish());
+        builder.setNegativeButton(R.string.about_translate_cancel, (dialog, which) -> dialog.cancel());
         builder.create().show();
 
     }


### PR DESCRIPTION
**Description (required)**

Fixes #3606 

What changes did you make and why?
Changed dismissing of the dialog with finish to dialog.cancel.

**Tests performed (required)**

Tested {build variant, e.g. ProdDebug} on {name of device or emulator} with API level {API level}.

**Screenshots (for UI changes only)**
![canceltranslate](https://user-images.githubusercontent.com/10153512/77987305-c255c900-7319-11ea-9d72-8b705e6d32f5.gif)


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
