### PR TITLE
fix thumbnail issue 3526

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
@@ -241,7 +241,7 @@ public class OkHttpJsonApiClient {
                 if (binding.getSubclassLabel().getXmlLang() != null) {
                     String label = binding.getSubclassLabel().getValue();
                     String entityId = binding.getSubclass().getValue();
-                    entityId = entityId.substring(entityId.lastIndexOf("/") - 1);
+                    entityId = entityId.substring(entityId.lastIndexOf("/") + 1);
                     subItems.add(new DepictedItem(label, "", "", false,entityId ));
                     Timber.e(label);
                 }


### PR DESCRIPTION
**Description (required)**

Fixes #3526 

What changes did you make and why?
Thumbnail images were not being fetched for child classes due to incorrect entity I'd being sent in the request. This was fixed by taking the substring at the right index.

**Tests performed (required)**

Tested on main variant on Google pixel 3a with API level 10.
