### PR TITLE
#3624 DateTimeFormat wrong - match pattern returned from servers

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/utils/CommonsDateUtil.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/CommonsDateUtil.java
@@ -25,9 +25,10 @@ public class CommonsDateUtil {
      * Gets the timestamp pattern for a date
      * @return timestamp
      */
-    public static SimpleDateFormat getIso8601DateFormatTimestamp() {
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ROOT);
-        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return simpleDateFormat;
+        public static SimpleDateFormat getIso8601DateFormatTimestamp() {
+            final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX",
+                Locale.ROOT);
+            simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+            return simpleDateFormat;
     }
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/utils/CommonsDateUtilTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/utils/CommonsDateUtilTest.kt
@@ -1,0 +1,20 @@
+package fr.free.nrw.commons.utils
+
+import org.hamcrest.core.IsEqual.equalTo
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+class CommonsDateUtilTest {
+
+    @Test
+    fun `Iso8601DateFormatTimestamp parses legal date`() {
+        val iso8601DateFormatTimestamp = CommonsDateUtil
+            .getIso8601DateFormatTimestamp()
+        val parsedDate = iso8601DateFormatTimestamp
+            .parse("2020-04-07T14:21:57Z")
+        assertThat(
+            "2020-04-07T14:21:57Z",
+            equalTo(iso8601DateFormatTimestamp.format(parsedDate))
+        )
+    }
+}


### PR DESCRIPTION
Fixes #3624 

What changes did you make and why?

Used the right format

**Tests performed (required)**

getting timeouts but wrote unit test, if anyone can test that'd be great

