### PR TITLE
Revert "Fixes: #3179 Make category search non case-sensitive (#3326)"

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.java
@@ -123,9 +123,8 @@ public class CategoriesModel{
         }
 
         //otherwise, search API for matching categories
-        //term passed as lower case to make search case-insensitive(taking only lower case for everything)
         return categoryClient
-                .searchCategoriesForPrefix(term.toLowerCase(), SEARCH_CATS_LIMIT)
+                .searchCategoriesForPrefix(term, SEARCH_CATS_LIMIT)
                 .map(name -> new CategoryItem(name, false));
     }
 
@@ -184,12 +183,11 @@ public class CategoriesModel{
 
     /**
      * Return category for single title
-     * title is converted to lower case to make search case-insensitive
      * @param title
      * @return
      */
     private Observable<CategoryItem> getTitleCategories(String title) {
-        return categoryClient.searchCategories(title.toLowerCase(), SEARCH_CATS_LIMIT)
+        return categoryClient.searchCategories(title, SEARCH_CATS_LIMIT)
                 .map(name -> new CategoryItem(name, false));
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryClient.java
@@ -55,7 +55,7 @@ public class CategoryClient {
 
     /**
      * Searches for categories starting with the specified string.
-     * 
+     *
      * @param prefix    The prefix to be searched
      * @param itemLimit How many results are returned
      * @param offset    Starts returning items from the nth result. If offset is 9, the response starts with the 9th item of the search result

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryItem.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryItem.java
@@ -3,6 +3,10 @@ package fr.free.nrw.commons.category;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+/**
+ * Represents a Category Item.
+ * Implemented as Parcelable so that its object could be parsed between activity components.
+ */
 public class CategoryItem implements Parcelable {
     private final String name;
     private boolean selected;
@@ -24,28 +28,53 @@ public class CategoryItem implements Parcelable {
         this.selected = selected;
     }
 
+    /**
+     * Reads from the received Parcel
+     * @param in
+     */
     private CategoryItem(Parcel in) {
         name = in.readString();
         selected = in.readInt() == 1;
     }
 
+    /**
+     * Gets Name
+     * @return
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Checks if that Category Item has been selected.
+     * @return
+     */
     public boolean isSelected() {
         return selected;
     }
 
+    /**
+     * Selects the Category Item.
+     * @param selected
+     */
     public void setSelected(boolean selected) {
         this.selected = selected;
     }
 
+    /**
+     * Used by Parcelable
+     * @return
+     */
     @Override
     public int describeContents() {
         return 0;
     }
 
+    /**
+     * Writes to the received Parcel
+     * @param parcel
+     * @param flags
+     */
     @Override
     public void writeToParcel(Parcel parcel, int flags) {
         parcel.writeString(name);
@@ -67,11 +96,17 @@ public class CategoryItem implements Parcelable {
 
     }
 
+    /**
+     * Returns hash code for current object
+     */
     @Override
     public int hashCode() {
         return name.hashCode();
     }
 
+    /**
+     * Return String form of current object
+     */
     @Override
     public String toString() {
         return "CategoryItem: '" + name + '\'';

--- a/app/src/test/kotlin/fr/free/nrw/commons/category/CategoriesModelTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/CategoriesModelTest.kt
@@ -17,9 +17,6 @@ class CategoriesModelTest {
     @Mock
     internal var categoryInterface: CategoryInterface? = null
 
-    @Mock
-    internal var categoryItem: CategoryItem? = null
-
     @Spy
     internal lateinit var gson: Gson
 
@@ -41,28 +38,6 @@ class CategoriesModelTest {
         gson = Gson()
         categoryItemForSubstringSearch = CategoryItem("",false)
         MockitoAnnotations.initMocks(this)
-    }
-
-    // Test Case for verifying that Categories search (MW api calls) are case-insensitive
-    @Test
-    fun searchAllFoundCaseTest() {
-       val mwQueryPage = Mockito.mock(MwQueryPage::class.java)
-        Mockito.`when`(mwQueryPage.title()).thenReturn("Category:Test")
-        val mwQueryResult = Mockito.mock(MwQueryResult::class.java)
-        Mockito.`when`(mwQueryResult.pages()).thenReturn(listOf(mwQueryPage))
-        val mockResponse = Mockito.mock(MwQueryResponse::class.java)
-        Mockito.`when`(mockResponse.query()).thenReturn(mwQueryResult)
-        val categoriesModel: CategoriesModel = CategoriesModel(categoryClient,null,null)
-
-        Mockito.`when`(categoryInterface!!.searchCategoriesForPrefix(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
-                .thenReturn(Observable.just(mockResponse))
-
-        // Checking if both return "Test"
-        val actualCategoryName = categoriesModel!!.searchAll("tes",null).blockingFirst()
-        assertEquals("Test", actualCategoryName.getName())
-        
-        val actualCategoryNameCaps = categoriesModel!!.searchAll("Tes",null).blockingFirst()
-        assertEquals("Test", actualCategoryNameCaps.getName())
     }
 
     /**

--- a/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryClientTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryClientTest.kt
@@ -58,7 +58,6 @@ class CategoryClientTest {
                 { fail("SearchCategories returned element when it shouldn't have.") },
                 { s -> throw s })
     }
-
     @Test
     fun searchCategoriesForPrefixFound() {
         val mwQueryPage = Mockito.mock(MwQueryPage::class.java)
@@ -93,7 +92,6 @@ class CategoryClientTest {
                 { fail("SearchCategories returned element when it shouldn't have.") },
                 { s -> throw s })
     }
-
     @Test
     fun getParentCategoryListFound() {
         val mwQueryPage = Mockito.mock(MwQueryPage::class.java)


### PR DESCRIPTION
**Description (required)**
Simply lower casing the name of the category sent to the server doesn't result in the server doing a case insensitive category search. In fact, it reduces the category search space as only categories that has a lower case character is searched even if the search text contains upper case characters.

The test case did not catch this issue as the first character of the title is case insensitive[[ref 1](https://www.mediawiki.org/wiki/Manual:Page_title)].

So, revert the changes done in commit afdeaae0757d4d7773921169eb65d3ba9916834a (#3326).

See further discussion in the issue thread of #3179 starting from https://github.com/commons-app/apps-android-commons/issues/3179#issuecomment-605462140
