### PR TITLE
Fix issue 3137

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragment.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import javax.inject.Inject;
+import timber.log.Timber;
 
 /**
  * Display depictions in search fragment
@@ -147,6 +148,7 @@ public class SearchDepictionsFragment extends CommonsDaggerSupportFragment imple
      */
     @Override
     public void initErrorView() {
+        isLoading = false;
         progressBar.setVisibility(GONE);
         bottomProgressBar.setVisibility(GONE);
         depictionNotFound.setVisibility(VISIBLE);
@@ -195,10 +197,11 @@ public class SearchDepictionsFragment extends CommonsDaggerSupportFragment imple
     }
 
     @Override
-    public void loadingDepictions() {
+    public void loadingDepictions(boolean isLoading) {
         depictionNotFound.setVisibility(GONE);
         bottomProgressBar.setVisibility(View.VISIBLE);
         progressBar.setVisibility(GONE);
+        this.isLoading = isLoading;
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragment.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import javax.inject.Inject;
-import timber.log.Timber;
 
 /**
  * Display depictions in search fragment

--- a/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragmentContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragmentContract.java
@@ -32,7 +32,7 @@ public interface SearchDepictionsFragmentContract {
         /**
          * load depictions
          */
-        void loadingDepictions();
+        void loadingDepictions(boolean isLoading);
 
         /**
          * clear adapter

--- a/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragmentPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragmentPresenter.java
@@ -82,19 +82,20 @@ public class SearchDepictionsFragmentPresenter extends CommonsDaggerSupportFragm
      */
     @Override
     public void updateDepictionList(String query, int pageSize, boolean reInitialise) {
-        this.query = query;
-        view.loadingDepictions();
-        if (reInitialise) {
-            size = 0;
-        }
-        saveQuery();
-        compositeDisposable.add(depictsClient.searchForDepictions(query, 25, offset)
-                .subscribeOn(ioScheduler)
-                .observeOn(mainThreadScheduler)
-                .timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .doOnSubscribe(disposable -> saveQuery())
-                .collect(ArrayList<DepictedItem>::new, ArrayList::add)
-                .subscribe(this::handleSuccess, this::handleError));
+      this.query = query;
+      view.loadingDepictions(true);
+      if (reInitialise) {
+        size = 0;
+      }
+      saveQuery();
+
+      compositeDisposable.add(depictsClient.searchForDepictions(query, 25, offset)
+            .subscribeOn(ioScheduler)
+            .observeOn(mainThreadScheduler)
+            .timeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .doOnSubscribe(disposable -> saveQuery())
+            .collect(ArrayList<DepictedItem>::new, ArrayList::add)
+            .subscribe(this::handleSuccess, this::handleError));
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragmentPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragmentPresenter.java
@@ -88,7 +88,6 @@ public class SearchDepictionsFragmentPresenter extends CommonsDaggerSupportFragm
         size = 0;
       }
       saveQuery();
-
       compositeDisposable.add(depictsClient.searchForDepictions(query, 25, offset)
             .subscribeOn(ioScheduler)
             .observeOn(mainThreadScheduler)


### PR DESCRIPTION
**Description (required)**

Fixes #3137 

What changes did you make and why?
There were repeating items due to isLoading variable not being set to true when there is a server call in progress. This led to multiple calls with the same offset values thereby leading to addition of repeated items in the list. This has been corrected by updating the variable to true whenever a call is in progress so as to avoid duplicates.

**Tests performed (required)**

Tested app on Google Pixel 3A with API level 10