### PR TITLE
Fixes #3109 "No Wikidata item matching" message remains despite items loaded

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/depictions/SubClass/SubDepictionListContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/depictions/SubClass/SubDepictionListContract.java
@@ -19,6 +19,8 @@ public interface SubDepictionListContract {
 
         void initErrorView();
 
+        void setNoSubDepiction();
+
         void showSnackbar();
 
         void setIsLastPage(boolean b);

--- a/app/src/main/java/fr/free/nrw/commons/depictions/SubClass/SubDepictionListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/depictions/SubClass/SubDepictionListFragment.java
@@ -168,10 +168,13 @@ public class SubDepictionListFragment extends DaggerFragment implements SubDepic
         hasMoreImages = false;
         progressBar.setVisibility(GONE);
         bottomProgressBar.setVisibility(GONE);
+    }
+
+    @Override
+    public void setNoSubDepiction() {
         depictionNotFound.setVisibility(VISIBLE);
         String no_depiction = getString(isParentClass? R.string.no_parent_classes: R.string.no_child_classes);
         depictionNotFound.setText(String.format(Locale.getDefault(), no_depiction, depictsName));
-
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/depictions/SubClass/SubDepictionListPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/depictions/SubClass/SubDepictionListPresenter.java
@@ -134,6 +134,7 @@ public class SubDepictionListPresenter implements SubDepictionListContract.UserA
         if (mediaList == null || mediaList.isEmpty()) {
             if(queryList.isEmpty()){
                 view.initErrorView();
+                view.setNoSubDepiction();
             }else{
                 view.setIsLastPage(true);
             }

--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -203,7 +203,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
     private void handleError(Throwable throwable) {
         Timber.e(throwable, "Error occurred while loading queried categories");
         try {
-            initErrorView();
+            bottomProgressBar.setVisibility(View.GONE);
             ViewUtil.showShortSnackbar(categoriesRecyclerView, R.string.error_loading_categories);
         }catch (Exception e){
             e.printStackTrace();
@@ -216,6 +216,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
      */
     private void initErrorView() {
         progressBar.setVisibility(GONE);
+        bottomProgressBar.setVisibility(View.GONE);
         categoriesNotFoundView.setVisibility(VISIBLE);
         categoriesNotFoundView.setText(getString(R.string.categories_not_found,query));
     }

--- a/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragment.java
@@ -150,6 +150,13 @@ public class SearchDepictionsFragment extends CommonsDaggerSupportFragment imple
         isLoading = false;
         progressBar.setVisibility(GONE);
         bottomProgressBar.setVisibility(GONE);
+    }
+
+    /**
+     * Sets view when no depiction found for a query
+     */
+    @Override
+    public void setNoDepictionFound(){
         depictionNotFound.setVisibility(VISIBLE);
         String no_depiction = getString(R.string.depictions_not_found);
         depictionNotFound.setText(String.format(Locale.getDefault(), no_depiction, presenter.getQuery()));

--- a/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragmentContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragmentContract.java
@@ -19,6 +19,11 @@ public interface SearchDepictionsFragmentContract {
         void initErrorView();
 
         /**
+         * Sets view when no depiction found for a query
+         */
+        void setNoDepictionFound();
+
+        /**
          * Handles the UI updates for no internet scenario
          */
         void handleNoInternet();

--- a/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragmentPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/depictions/SearchDepictionsFragmentPresenter.java
@@ -150,6 +150,7 @@ public class SearchDepictionsFragmentPresenter extends CommonsDaggerSupportFragm
         if (mediaList == null || mediaList.isEmpty()) {
             if(queryList.isEmpty()){
                 view.initErrorView();
+                view.setNoDepictionFound();
             }else{
                 view.setIsLastPage(true);
             }


### PR DESCRIPTION
**Description (required)**
In Explore, No Wikidata item matching" message displays despite items loaded.

Fixes #3109 

What changes did you make and why?
created a separate method for setting view visible only when query list is empty.
Similar changes were made for category and sub-depictions

**Tests performed (required)**

Tested ProdDebug on OnePlus 5 with API level 28.


