### PR TITLE
Sorting the languages under translate in the about section

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
@@ -16,6 +16,10 @@ import android.widget.LinearLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import java.lang.ref.SoftReference;
+import java.util.Collections;
+import java.util.List;
 import org.wikipedia.util.StringUtil;
 
 import butterknife.BindView;
@@ -136,14 +140,15 @@ public class AboutActivity extends NavigationBaseActivity {
 
     @OnClick(R.id.about_translate)
     public void launchTranslate(View view) {
+        @NonNull List<String> sortedLocalizedNamesRef = CommonsApplication.getInstance().getLanguageLookUpTable().getCanonicalNames();
+        Collections.sort(sortedLocalizedNamesRef);
         final ArrayAdapter<String> languageAdapter = new ArrayAdapter<>(AboutActivity.this,
-                android.R.layout.simple_spinner_dropdown_item, CommonsApplication.getInstance().getLanguageLookUpTable().getLocalizedNames());
+                android.R.layout.simple_spinner_dropdown_item, sortedLocalizedNamesRef);
         final Spinner spinner = new Spinner(AboutActivity.this);
         spinner.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT));
         spinner.setAdapter(languageAdapter);
         spinner.setGravity(17);
         spinner.setPadding(50,0,0,0);
-
         AlertDialog.Builder builder = new AlertDialog.Builder(AboutActivity.this);
         builder.setView(spinner);
         builder.setTitle(R.string.about_translate_title)


### PR DESCRIPTION
**Description (required)**

Fixes #3622 

There were 2 issues combined into one thread:
1. The languages were shown with the characters of the given language (i.e. Mandarin was displayed with Chinese characters).
2. The languages were not sorted

How I fixed them:
1. I changed the list that was called from AppLanguageLookUpTable from localized to cannonical.
2. I imported List and Collections and I sorted said list in lexicographical order.

**Tests performed (required)**

Tested betaDebug on Nexus 5 with API level 29.

**Screenshots (for UI changes only)**

![image](https://user-images.githubusercontent.com/47308920/79023791-0628a980-7b36-11ea-9961-5803247d96a4.png)

