### PR TITLE
Fixed invisible username clickable after logout bug

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/NavigationBaseActivity.java
@@ -90,7 +90,6 @@ public abstract class NavigationBaseActivity extends BaseActivity
         drawerLayout.addDrawerListener(toggle);
         toggle.setDrawerIndicatorEnabled(true);
         toggle.syncState();
-        setUserName();
         Menu nav_Menu = navigationView.getMenu();
         View headerLayout = navigationView.getHeaderView(0);
         ImageView userIcon = headerLayout.findViewById(R.id.user_icon);
@@ -102,7 +101,8 @@ public abstract class NavigationBaseActivity extends BaseActivity
             nav_Menu.findItem(R.id.action_logout).setVisible(false);
             nav_Menu.findItem(R.id.action_bookmarks).setVisible(true);
             nav_Menu.findItem(R.id.action_review).setVisible(false);
-        }else {
+        } else {
+            setUserName();
             userIcon.setVisibility(View.VISIBLE);
             nav_Menu.findItem(R.id.action_login).setVisible(false);
             nav_Menu.findItem(R.id.action_home).setVisible(true);


### PR DESCRIPTION
**Description**
Username is now not clickable to logged-in users.
Fixes #3652

**Tests performed**
Tested prodDebug on Google Pixel 2 with API level 29

**Screenshots**
![Screenshot_1586717685](https://user-images.githubusercontent.com/30932899/79077219-299f5000-7d00-11ea-8420-37dfaf96039f.png)
