### PR TITLE
Fixes #2909: "Requesting category check" notification even though I did not mark as such

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewController.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewController.java
@@ -148,7 +148,6 @@ public class ReviewController {
                 .inject(this);
         ViewUtil.showShortToast(context, context.getString(R.string.send_thank_toast, media.getDisplayTitle()));
 
-        publishProgress(context, 0);
         if (firstRevision == null) {
             return;
         }
@@ -157,7 +156,6 @@ public class ReviewController {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe((result) -> {
-                    publishProgress(context, 2);
                     String message;
                     String title;
                     if (result) {


### PR DESCRIPTION

**Requesting category check" notification even though I did not mark as such**

Fixes #2909 

What changes did you make and why?
The sendThanks function was building a notification for requesting category check which was completely unnecessary 

**Tests performed (required)**

Tested ProdDebug on Honor Play with API level 29.


