### PR TITLE
#3658 Throw exception instead of allowing nullable network models onError - peek response body and throw error

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/OkHttpConnectionFactory.java
+++ b/app/src/main/java/fr/free/nrw/commons/OkHttpConnectionFactory.java
@@ -59,7 +59,7 @@ public final class OkHttpConnectionFactory {
 
     public static class UnsuccessfulResponseInterceptor implements Interceptor {
 
-        private static final String ERRORS_PREFIX = "{\"errors";
+        private static final String ERRORS_PREFIX = "{\"error";
 
         @Override @NonNull public Response intercept(@NonNull final Chain chain) throws IOException {
             final Response rsp = chain.proceed(chain.request());

--- a/app/src/main/java/fr/free/nrw/commons/OkHttpConnectionFactory.java
+++ b/app/src/main/java/fr/free/nrw/commons/OkHttpConnectionFactory.java
@@ -1,19 +1,19 @@
 package fr.free.nrw.commons;
 
 import androidx.annotation.NonNull;
-
-import org.wikipedia.dataclient.SharedPreferenceCookieManager;
-import org.wikipedia.dataclient.okhttp.HttpStatusException;
-
 import java.io.File;
 import java.io.IOException;
-
 import okhttp3.Cache;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import okhttp3.logging.HttpLoggingInterceptor;
+import okhttp3.logging.HttpLoggingInterceptor.Level;
+import org.wikipedia.dataclient.SharedPreferenceCookieManager;
+import org.wikipedia.dataclient.okhttp.HttpStatusException;
+import timber.log.Timber;
 
 public final class OkHttpConnectionFactory {
     private static final String CACHE_DIR_NAME = "okhttp-cache";
@@ -21,7 +21,7 @@ public final class OkHttpConnectionFactory {
     @NonNull private static final Cache NET_CACHE = new Cache(new File(CommonsApplication.getInstance().getCacheDir(),
             CACHE_DIR_NAME), NET_CACHE_SIZE);
 
-    @NonNull private static OkHttpClient CLIENT = createClient();
+    @NonNull private static final OkHttpClient CLIENT = createClient();
 
     @NonNull public static OkHttpClient getClient() {
         return CLIENT;
@@ -39,8 +39,8 @@ public final class OkHttpConnectionFactory {
     }
 
     private static HttpLoggingInterceptor getLoggingInterceptor() {
-        HttpLoggingInterceptor httpLoggingInterceptor = new HttpLoggingInterceptor()
-                .setLevel(HttpLoggingInterceptor.Level.BASIC);
+        final HttpLoggingInterceptor httpLoggingInterceptor = new HttpLoggingInterceptor()
+                .setLevel(Level.BASIC);
 
         httpLoggingInterceptor.redactHeader("Authorization");
         httpLoggingInterceptor.redactHeader("Cookie");
@@ -49,8 +49,8 @@ public final class OkHttpConnectionFactory {
     }
 
     private static class CommonHeaderRequestInterceptor implements Interceptor {
-        @Override @NonNull public Response intercept(@NonNull Chain chain) throws IOException {
-            Request request = chain.request().newBuilder()
+        @Override @NonNull public Response intercept(@NonNull final Chain chain) throws IOException {
+            final Request request = chain.request().newBuilder()
                     .header("User-Agent", CommonsApplication.getInstance().getUserAgent())
                     .build();
             return chain.proceed(request);
@@ -58,9 +58,21 @@ public final class OkHttpConnectionFactory {
     }
 
     public static class UnsuccessfulResponseInterceptor implements Interceptor {
-        @Override @NonNull public Response intercept(@NonNull Chain chain) throws IOException {
-            Response rsp = chain.proceed(chain.request());
+
+        private static final String ERRORS_PREFIX = "{\"errors";
+
+        @Override @NonNull public Response intercept(@NonNull final Chain chain) throws IOException {
+            final Response rsp = chain.proceed(chain.request());
             if (rsp.isSuccessful()) {
+                try (final ResponseBody responseBody = rsp.peekBody(ERRORS_PREFIX.length())) {
+                    if (ERRORS_PREFIX.equals(responseBody.string())){
+                        try (final ResponseBody body = rsp.body()) {
+                            throw new IOException(body.string());
+                        }
+                    }
+                }catch (final IOException e){
+                    Timber.e(e);
+                }
                 return rsp;
             }
             throw new HttpStatusException(rsp);


### PR DESCRIPTION


**Description (required)**

Fixes #3658 

What changes did you make and why?
peek response body and throw error

**Tests performed (required)**

Tested betaDebug on Nexus5x with API level 27