### PR TITLE
Fixes #3639 (Fix Save State implementation of CheckBoxTriState )

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/app/src/main/java/fr/free/nrw/commons/nearby/CheckBoxTriStates.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/CheckBoxTriStates.java
@@ -1,9 +1,6 @@
 package fr.free.nrw.commons.nearby;
 
 import android.content.Context;
-import android.os.Bundle;
-import android.os.Parcel;
-import android.os.Parcelable;
 import android.util.AttributeSet;
 import android.widget.CompoundButton;
 
@@ -13,7 +10,6 @@ import androidx.appcompat.widget.AppCompatCheckBox;
 import java.util.List;
 
 import fr.free.nrw.commons.R;
-import fr.free.nrw.commons.nearby.presenter.NearbyParentFragmentPresenter;
 
 /**
  * Base on https://stackoverflow.com/a/40939367/3950497 answer.

--- a/app/src/main/java/fr/free/nrw/commons/nearby/CheckBoxTriStates.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/CheckBoxTriStates.java
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.nearby;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.AttributeSet;
@@ -64,12 +65,6 @@ public class CheckBoxTriStates extends AppCompatCheckBox {
      */
     private OnCheckedChangeListener clientListener;
 
-    /**
-     * This flag is needed to avoid accidentally changing the current {@link #state} when
-     * {@link #onRestoreInstanceState(Parcelable)} calls {@link #setChecked(boolean)}
-     * evoking our {@link #privateListener} and therefore changing the real state.
-     */
-    private boolean restoring;
 
     public CheckBoxTriStates(Context context) {
         super(context);
@@ -91,7 +86,7 @@ public class CheckBoxTriStates extends AppCompatCheckBox {
     }
 
     public void setState(int state) {
-        if(!this.restoring && this.state != state) {
+        if(this.state != state) {
             this.state = state;
 
             if(this.clientListener != null) {
@@ -118,27 +113,6 @@ public class CheckBoxTriStates extends AppCompatCheckBox {
         super.setOnCheckedChangeListener(privateListener);
     }
 
-    @Override
-    public Parcelable onSaveInstanceState() {
-        Parcelable superState = super.onSaveInstanceState();
-
-        SavedState ss = new SavedState(superState);
-
-        ss.state = state;
-
-        return ss;
-    }
-
-    @Override
-    public void onRestoreInstanceState(Parcelable state) {
-        this.restoring = true; // indicates that the ui is restoring its state
-        SavedState ss = (SavedState) state;
-        super.onRestoreInstanceState(ss.getSuperState());
-        setState(ss.state);
-        requestLayout();
-        this.restoring = false;
-    }
-
     private void init() {
         state = UNKNOWN;
         updateBtn();
@@ -163,45 +137,5 @@ public class CheckBoxTriStates extends AppCompatCheckBox {
         }
         setButtonDrawable(btnDrawable);
 
-    }
-
-    static class SavedState extends BaseSavedState {
-        int state;
-
-        SavedState(Parcelable superState) {
-            super(superState);
-        }
-
-        private SavedState(Parcel in) {
-            super(in);
-            state = in.readInt();
-        }
-
-        @Override
-        public void writeToParcel(Parcel out, int flags) {
-            super.writeToParcel(out, flags);
-            out.writeValue(state);
-        }
-
-        @Override
-        public String toString() {
-            return "CheckboxTriState.SavedState{"
-                    + Integer.toHexString(System.identityHashCode(this))
-                    + " state=" + state + "}";
-        }
-
-        @SuppressWarnings("hiding")
-        public static final Parcelable.Creator<SavedState> CREATOR =
-                new Parcelable.Creator<SavedState>() {
-                    @Override
-                    public SavedState createFromParcel(Parcel in) {
-                        return new SavedState(in);
-                    }
-
-                    @Override
-                    public SavedState[] newArray(int size) {
-                        return new SavedState[size];
-                    }
-                };
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/CheckBoxTriStates.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/CheckBoxTriStates.java
@@ -22,7 +22,7 @@ public class CheckBoxTriStates extends AppCompatCheckBox {
 
     static public final int CHECKED = 1;
 
-    private int state;
+    private int state=UNKNOWN;
 
     private Callback callback;
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -118,7 +118,7 @@ import static fr.free.nrw.commons.wikidata.WikidataConstants.PLACE_OBJECT;
 
 public class NearbyParentFragment extends CommonsDaggerSupportFragment
         implements NearbyParentFragmentContract.View,
-        WikidataEditListener.WikidataP18EditListener, LocationUpdateListener {
+        WikidataEditListener.WikidataP18EditListener, LocationUpdateListener ,CheckBoxTriStates.Callback{
 
     private static final String CHECKBOX_STATE = "checkbox_state";
     @BindView(R.id.bottom_sheet) RelativeLayout rlBottomSheet;
@@ -229,7 +229,6 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         }
         isDarkTheme = systemThemeUtils.isDeviceInNightMode();
         cameraMoveListener= () -> presenter.onCameraMove(mapBox.getCameraPosition().target);
-        addCheckBoxCallback();
         presenter.attachView(this);
         initRvNearbyList();
         initThemePreferences();
@@ -290,10 +289,6 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         rvNearbyList.setLayoutManager(new LinearLayoutManager(getContext()));
         adapterFactory = new NearbyAdapterFactory(this, controller);
         rvNearbyList.setAdapter(adapterFactory.create(null));
-    }
-
-    private void addCheckBoxCallback() {
-        checkBoxTriStates.setCallback((o, state, b, b1) -> presenter.filterByMarkerType(o,state,b,b1));
     }
 
     private void performMapReadyActions() {
@@ -644,7 +639,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     @Override
     public boolean isCurrentLocationMarkerVisible() {
-        if (latLngBounds == null) {
+        if (latLngBounds == null || currentLocationMarker==null) {
             Timber.d("Map projection bounds are null");
             return false;
         } else {
@@ -968,6 +963,12 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     public void backButtonClicked() {
         presenter.backButtonClicked();
+    }
+
+    @Override
+    public void filterByMarkerType(@Nullable List<Label> selectedLabels, int state, boolean b,
+        boolean b1) {
+        presenter.filterByMarkerType(selectedLabels,state,b,b1);
     }
 
     /**
@@ -1509,5 +1510,11 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private void startTheMap() {
         mapView.onStart();
         performMapReadyActions();
+    }
+
+    @Override
+    public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
+        super.onViewStateRestored(savedInstanceState);
+        checkBoxTriStates.setCallback(this);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -204,6 +204,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private MapboxMap.OnCameraMoveListener cameraMoveListener;
     private fr.free.nrw.commons.location.LatLng lastFocusLocation;
     private LatLngBounds latLngBounds;
+    private int restoredCheckBoxState=CheckBoxTriStates.UNKNOWN;
 
 
     @Override
@@ -222,12 +223,6 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         checkBoxTriStates.setCallback(this);
-        //Restore checkbox's state
-        if (null != savedInstanceState) {
-            int checkBoxSavedState = savedInstanceState.getInt(CHECKBOX_STATE,
-                CheckBoxTriStates.UNKNOWN);
-            checkBoxTriStates.setState(checkBoxSavedState);
-        }
         isDarkTheme = systemThemeUtils.isDeviceInNightMode();
         cameraMoveListener= () -> presenter.onCameraMove(mapBox.getCameraPosition().target);
         presenter.attachView(this);
@@ -238,6 +233,9 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             this.mapBox=mapBoxMap;
             initViews();
             presenter.setActionListeners(applicationKvStore);
+            if (restoredCheckBoxState != CheckBoxTriStates.UNKNOWN) {//The default state is UNKNOWN
+                checkBoxTriStates.setState(restoredCheckBoxState);
+            }
             initNearbyFilter();
             mapBoxMap.setStyle(isDarkTheme?Style.DARK:Style.OUTDOORS, style -> {
                 UiSettings uiSettings = mapBoxMap.getUiSettings();
@@ -457,7 +455,6 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     @Override
     public void setCheckBoxAction() {
         checkBoxTriStates.addAction();
-        checkBoxTriStates.setState(CheckBoxTriStates.UNKNOWN);
     }
 
     @Override
@@ -1517,5 +1514,14 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
         super.onViewStateRestored(savedInstanceState);
         checkBoxTriStates.setCallback(this);
+        if (null != savedInstanceState) {
+            int checkBoxSavedState = savedInstanceState.getInt(CHECKBOX_STATE,
+                CheckBoxTriStates.UNKNOWN);
+            if(mapBox!=null && isMapBoxReady) {
+                checkBoxTriStates.setState(checkBoxSavedState);
+            }else{
+                restoredCheckBoxState =checkBoxSavedState;
+            }
+        }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -221,6 +221,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        checkBoxTriStates.setCallback(this);
         //Restore checkbox's state
         if (null != savedInstanceState) {
             int checkBoxSavedState = savedInstanceState.getInt(CHECKBOX_STATE,

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -204,7 +204,6 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private MapboxMap.OnCameraMoveListener cameraMoveListener;
     private fr.free.nrw.commons.location.LatLng lastFocusLocation;
     private LatLngBounds latLngBounds;
-    private int restoredCheckBoxState=CheckBoxTriStates.UNKNOWN;
 
 
     @Override
@@ -233,9 +232,6 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             this.mapBox=mapBoxMap;
             initViews();
             presenter.setActionListeners(applicationKvStore);
-            if (restoredCheckBoxState != CheckBoxTriStates.UNKNOWN) {//The default state is UNKNOWN
-                checkBoxTriStates.setState(restoredCheckBoxState);
-            }
             initNearbyFilter();
             mapBoxMap.setStyle(isDarkTheme?Style.DARK:Style.OUTDOORS, style -> {
                 UiSettings uiSettings = mapBoxMap.getUiSettings();
@@ -1514,14 +1510,5 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
         super.onViewStateRestored(savedInstanceState);
         checkBoxTriStates.setCallback(this);
-        if (null != savedInstanceState) {
-            int checkBoxSavedState = savedInstanceState.getInt(CHECKBOX_STATE,
-                CheckBoxTriStates.UNKNOWN);
-            if(mapBox!=null && isMapBoxReady) {
-                checkBoxTriStates.setState(checkBoxSavedState);
-            }else{
-                restoredCheckBoxState =checkBoxSavedState;
-            }
-        }
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -118,9 +118,8 @@ import static fr.free.nrw.commons.wikidata.WikidataConstants.PLACE_OBJECT;
 
 public class NearbyParentFragment extends CommonsDaggerSupportFragment
         implements NearbyParentFragmentContract.View,
-        WikidataEditListener.WikidataP18EditListener, LocationUpdateListener ,CheckBoxTriStates.Callback{
+        WikidataEditListener.WikidataP18EditListener, LocationUpdateListener {
 
-    private static final String CHECKBOX_STATE = "checkbox_state";
     @BindView(R.id.bottom_sheet) RelativeLayout rlBottomSheet;
     @BindView(R.id.bottom_sheet_details) View bottomSheetDetails;
     @BindView(R.id.transparentView) View transparentView;
@@ -221,9 +220,9 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        checkBoxTriStates.setCallback(this);
         isDarkTheme = systemThemeUtils.isDeviceInNightMode();
         cameraMoveListener= () -> presenter.onCameraMove(mapBox.getCameraPosition().target);
+        addCheckBoxCallback();
         presenter.attachView(this);
         initRvNearbyList();
         initThemePreferences();
@@ -284,6 +283,10 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         rvNearbyList.setLayoutManager(new LinearLayoutManager(getContext()));
         adapterFactory = new NearbyAdapterFactory(this, controller);
         rvNearbyList.setAdapter(adapterFactory.create(null));
+    }
+
+    private void addCheckBoxCallback() {
+        checkBoxTriStates.setCallback((o, state, b, b1) -> presenter.filterByMarkerType(o,state,b,b1));
     }
 
     private void performMapReadyActions() {
@@ -450,6 +453,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     @Override
     public void setCheckBoxAction() {
         checkBoxTriStates.addAction();
+        checkBoxTriStates.setState(CheckBoxTriStates.UNKNOWN);
     }
 
     @Override
@@ -956,12 +960,6 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     public void backButtonClicked() {
         presenter.backButtonClicked();
-    }
-
-    @Override
-    public void filterByMarkerType(@Nullable List<Label> selectedLabels, int state, boolean b,
-        boolean b1) {
-        presenter.filterByMarkerType(selectedLabels,state,b,b1);
     }
 
     /**
@@ -1503,11 +1501,5 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private void startTheMap() {
         mapView.onStart();
         performMapReadyActions();
-    }
-
-    @Override
-    public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
-        super.onViewStateRestored(savedInstanceState);
-        checkBoxTriStates.setCallback(this);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -360,7 +360,6 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        outState.putInt(CHECKBOX_STATE,checkBoxTriStates.getState());
         super.onSaveInstanceState(outState);
         mapView.onSaveInstanceState(outState);
     }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -120,6 +120,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         implements NearbyParentFragmentContract.View,
         WikidataEditListener.WikidataP18EditListener, LocationUpdateListener {
 
+    private static final String CHECKBOX_STATE = "checkbox_state";
     @BindView(R.id.bottom_sheet) RelativeLayout rlBottomSheet;
     @BindView(R.id.bottom_sheet_details) View bottomSheetDetails;
     @BindView(R.id.transparentView) View transparentView;
@@ -220,6 +221,12 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        //Restore checkbox's state
+        if (null != savedInstanceState) {
+            int checkBoxSavedState = savedInstanceState.getInt(CHECKBOX_STATE,
+                CheckBoxTriStates.UNKNOWN);
+            checkBoxTriStates.setState(checkBoxSavedState);
+        }
         isDarkTheme = systemThemeUtils.isDeviceInNightMode();
         cameraMoveListener= () -> presenter.onCameraMove(mapBox.getCameraPosition().target);
         addCheckBoxCallback();
@@ -363,6 +370,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
+        outState.putInt(CHECKBOX_STATE,checkBoxTriStates.getState());
         super.onSaveInstanceState(outState);
         mapView.onSaveInstanceState(outState);
     }


### PR DESCRIPTION


**Description (required)**

Fixes #3639 

What changes did you make and why?
CheckBox's custom saved state was not being Parcealized properly
* Removed custom save state implementation of CheckBoxTriState
* Save/Restore CheckBox state in NearbyParentFragment

**Tests performed (required)**

Tested betaDebug on Samsung S7 with "Don't Keep Activities" enabled in developer mode with the steps mentioned in the issue

