### PR TITLE
#3675 Rename buttons of the dialog box shown when no depiction is selected - remove "yes, submit" and "no, go back"

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.java
@@ -151,8 +151,8 @@ public class UploadCategoriesFragment extends UploadBaseFragment implements Cate
         DialogUtil.showAlertDialog(getActivity(),
                 getString(R.string.no_categories_selected),
                 getString(R.string.no_categories_selected_warning_desc),
-                getString(R.string.yes_submit),
-                getString(R.string.no_go_back),
+                getString(R.string.continue_message),
+                getString(R.string.cancel),
                 () -> goToNextScreen(),
                 null);
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
@@ -104,8 +104,8 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
         DialogUtil.showAlertDialog(getActivity(),
             getString(R.string.no_depictions_selected),
             getString(R.string.no_depictions_selected_warning_desc),
-            getString(R.string.yes_submit),
-            getString(R.string.no_go_back),
+            getString(R.string.continue_message),
+            getString(R.string.cancel),
             this::goToNextScreen,
             null
         );

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -460,13 +460,10 @@ Upload your first media by tapping on the add button.</string>
   <string name="desc_language_Pacific">Pacific</string>
 
   <string name="no_categories_selected">No Categories Selected</string>
-  <string name="no_categories_selected_warning_desc">Images without categories are rarely usable. Are you sure you want to submit without selecting categories?</string>
+  <string name="no_categories_selected_warning_desc">Images without categories are rarely usable. Are you sure you want to continue without selecting categories?</string>
 
   <string name="no_depictions_selected">No Depictions Selected</string>
-  <string name="no_depictions_selected_warning_desc">Depictions help when searching for images. Are you sure you want to submit without selecting depictions?</string>
-
-  <string name="yes_submit">Yes, Submit</string>
-  <string name="no_go_back">No, Go Back</string>
+  <string name="no_depictions_selected_warning_desc">Images with depictions are more easily found and more likely to be used. Are you sure you want to continue without selecting depictions?</string>
 
   <string name="upload_flow_all_images_in_set">(For all images in set)</string>
   <string name="search_this_area">Search this area</string>


### PR DESCRIPTION


**Description (required)**

Fixes #3675

What changes did you make and why?
replace "yes, submit" and "no, go back" with "continue" + "cancel"
alter dialog body text to reflect change in buttons

**Tests performed (required)**

Tested {betaDebug on Nexus5X with API level 27.

**Screenshots (for UI changes only)**

![image](https://user-images.githubusercontent.com/3358282/79860011-d85f2280-83c9-11ea-9f6e-7ccce4899a56.png)

![image](https://user-images.githubusercontent.com/3358282/79860034-e14ff400-83c9-11ea-9eda-40736ee91ff0.png)

