### PR TITLE
#3457 Permissions in Manifest only granted to system apps 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,9 +15,7 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
-    <uses-permission android:name="android.permission.MANAGE_DOCUMENTS" />
     <uses-permission android:name="com.google.android.apps.photos.permission.GOOGLE_PHOTOS" />
-    <uses-permission android:name="android.permission.READ_LOGS" />
     <uses-permission android:name="android.permission.SET_WALLPAPER"/>
 
 


### PR DESCRIPTION

**Description (required)**

Fixes #3457 

What changes did you make and why?
- remove system app only permissions

**Tests performed (required)**

Tested ProdDebug on Nexus5X with API level 27

**Screenshots (for UI changes only)**

One of the removed permissions and associated warning
![image](https://user-images.githubusercontent.com/3358282/80213380-fb3f4000-8630-11ea-8edb-0ff3422674c7.png)

