### PR TITLE
Fixes #3704: Green pins seen on initial "Nearby" map, despite "Needs …

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1224,9 +1224,6 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
      * since grey icon may lead the users to believe that it is disabled or prohibited contribution
      */
     private void hideAllMArkers() {
-        if(currentLocationMarker==null){
-            return;
-        }
         VectorDrawableCompat vectorDrawable;
         vectorDrawable = VectorDrawableCompat.create(
                 getContext().getResources(), R.drawable.ic_custom_greyed_out_marker, getContext().getTheme());


### PR DESCRIPTION
…Photos" selected

**Description (required)**
Fixes initialization of markers when Nearby map tapped for the first time.

Fixes #3704 

**What changes did you make and why?**
Removed `currentLocationMarker` check for null, which prevented markers to hide in `NearbyParentFragment.hideAllMArkers()`  

**Tests performed (required)**
Tested betaDebug on emulator with API level 28.