### PR TITLE
Fixes the issue about Oversized and UnderSized text in Explorer & Hom…

### DIFF
--- a/app/src/main/res/layout/activity_contributions.xml
+++ b/app/src/main/res/layout/activity_contributions.xml
@@ -15,15 +15,17 @@
         <include layout="@layout/toolbar"/>
 
         <com.google.android.material.tabs.TabLayout
-            android:id="@+id/tab_layout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?attr/tabBackground"
-            app:tabIndicatorColor="?attr/tabIndicatorColor"
-            app:tabSelectedTextColor="?attr/tabSelectedTextColor"
-            app:tabTextColor="?attr/tabTextColor"
-            android:layout_below="@id/toolbar"
-            app:tabMode="fixed" />
+          android:id="@+id/tab_layout"
+          style="@style/CustomTabLayoutStyle"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_below="@id/toolbar"
+          android:background="?attr/tabBackground"
+          app:tabIndicatorColor="?attr/tabIndicatorColor"
+          app:tabMode="fixed"
+          app:tabSelectedTextColor="?attr/tabSelectedTextColor"
+          app:tabTextAppearance="@style/CustomTabLayoutStyle"
+          app:tabTextColor="?attr/tabTextColor" />
 
         <FrameLayout android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_explore.xml
+++ b/app/src/main/res/layout/activity_explore.xml
@@ -18,15 +18,17 @@
             <include layout="@layout/toolbar"/>
 
             <com.google.android.material.tabs.TabLayout
-                android:id="@+id/tab_layout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_below="@id/toolbar"
-                android:background="?attr/tabBackground"
-                app:tabIndicatorColor="?attr/tabIndicatorColor"
-                app:tabMode="fixed"
-                app:tabSelectedTextColor="?attr/tabSelectedTextColor"
-                app:tabTextColor="?attr/tabTextColor" />
+              android:id="@+id/tab_layout"
+              style="@style/CustomTabLayoutStyle"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_below="@id/toolbar"
+              android:background="?attr/tabBackground"
+              app:tabIndicatorColor="?attr/tabIndicatorColor"
+              app:tabMode="fixed"
+              app:tabSelectedTextColor="?attr/tabSelectedTextColor"
+              app:tabTextAppearance="@style/CustomTabLayoutStyle"
+              app:tabTextColor="?attr/tabTextColor" />
         </com.google.android.material.appbar.AppBarLayout>
 
         <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout/custom_nearby_tab_layout.xml
+++ b/app/src/main/res/layout/custom_nearby_tab_layout.xml
@@ -6,14 +6,16 @@
     android:orientation="horizontal"
     android:gravity="center">
     <TextView
-        android:id="@+id/tabContent"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textAlignment="center"
-        android:textColor="@android:color/white"
-        android:text="@string/nearby_fragment"
-        android:textAllCaps="true"
-        android:gravity="center"/>
+      android:id="@+id/tabContent"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:gravity="center"
+      android:text="@string/nearby_fragment"
+      android:textAlignment="center"
+      android:textAllCaps="true"
+      android:textColor="@android:color/white"
+      android:textSize="@dimen/description_text_size"
+      app:autoSizeTextType="uniform" />
     <ImageView
         android:layout_width="@dimen/normal_height"
         android:layout_height="@dimen/normal_height"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -172,4 +172,10 @@
         <item name="android:textSize">@dimen/description_text_size</item>
     </style>
 
+    <style name="CustomTabLayoutStyle" parent="@android:style/TextAppearance.Widget.TabWidget" >
+        <item name="android:textSize">@dimen/description_text_size</item>
+        <item name="textAllCaps">true</item>
+
+    </style>
+
 </resources>


### PR DESCRIPTION

**Description (required)**

Fixes #3711

By changing the TabCustom Layout into an 'sp' dimension ( to allow app to adapt textSize ) , and adapt the Nearby Custom Layout .

Changed files :

Layout/activity_contributions.xml
Layout/activity_explore.xml
Layout/custom_nearby_tab_layout.xml

Values/styles.xml

**Tests performed (required)**

Tested App on Samsung A7 / Samsung S9 with API level 28/29.

work done with @paul-tra.

**Screenshots (for UI changes only)**

With previous text size :
![min1](https://user-images.githubusercontent.com/33942038/80805502-8764e080-8bb8-11ea-92d7-5ba449e45b0b.jpg)
![min2](https://user-images.githubusercontent.com/33942038/80805508-8b90fe00-8bb8-11ea-8f1d-e5303a54bcd0.jpg)

With over-sized text :

![normal1](https://user-images.githubusercontent.com/33942038/80805562-a9f6f980-8bb8-11ea-9408-303949c4e800.jpg)
![normal2](https://user-images.githubusercontent.com/33942038/80805564-aa8f9000-8bb8-11ea-905a-4f162f40a302.jpg)

