### PR TITLE
Fix NullPointer when clicking on image in MediaDetailFragment (#3730)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -222,10 +222,12 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
 
     @OnClick(R.id.mediaDetailImageViewSpacer)
     public void launchZoomActivity(View view) {
-        Context ctx = view.getContext();
-        ctx.startActivity(
-                new Intent(ctx,ZoomableActivity.class).setData(Uri.parse(media.getImageUrl()))
-        );
+        if (media.getImageUrl() != null) {
+            Context ctx = view.getContext();
+            ctx.startActivity(
+                new Intent(ctx, ZoomableActivity.class).setData(Uri.parse(media.getImageUrl()))
+            );
+        }
     }
 
     @Override


### PR DESCRIPTION
**Description**
Fixes #3730

**What changes did you make and why?**
Added a null check to prevent Null Pointer Exception when user clicks on image in MediaDetailFragment.

**Tests performed (required)**
Tested on {prodDebug, betaDebug} on {Pixel 2 emulator} with API level {28}.
