### PR TITLE
Fix NullPointer when clicking on image in MediaDetailFragment (#3730)…

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -209,10 +209,12 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
 
     @OnClick(R.id.mediaDetailImageViewSpacer)
     public void launchZoomActivity(View view) {
-        Context ctx = view.getContext();
-        ctx.startActivity(
-                new Intent(ctx,ZoomableActivity.class).setData(Uri.parse(media.getImageUrl()))
-        );
+        if (media.getImageUrl() != null) {
+            Context ctx = view.getContext();
+            ctx.startActivity(
+                new Intent(ctx, ZoomableActivity.class).setData(Uri.parse(media.getImageUrl()))
+            );
+        }
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1090,7 +1090,6 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     @Override
     public void filterOutAllMarkers() {
-        hideAllMarkers();
         updateNearbyList();
     }
 
@@ -1119,9 +1118,6 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         boolean displayNeedsPhoto,
         boolean filterForPlaceState,
         boolean filterForAllNoneType) {
-
-        // Remove the previous markers before updating them
-        hideAllMarkers();
 
         for (MarkerPlaceGroup markerPlaceGroup : NearbyController.markerLabelList) {
             Place place = markerPlaceGroup.getPlace();

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1090,6 +1090,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     @Override
     public void filterOutAllMarkers() {
+        hideAllMarkers();
         updateNearbyList();
     }
 
@@ -1119,6 +1120,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         boolean filterForPlaceState,
         boolean filterForAllNoneType) {
 
+        hideAllMarkers();
         for (MarkerPlaceGroup markerPlaceGroup : NearbyController.markerLabelList) {
             Place place = markerPlaceGroup.getPlace();
 
@@ -1213,7 +1215,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
      * since grey icon may lead the users to believe that it is disabled or prohibited contribution
      */
 
-    private void hideAllMArkers() {
+    private void hideAllMarkers() {
         VectorDrawableCompat vectorDrawable;
         vectorDrawable = VectorDrawableCompat.create(
                 getContext().getResources(), R.drawable.ic_custom_greyed_out_marker, getContext().getTheme());


### PR DESCRIPTION
**Description (required)**
Uri.parse would throw NullPointerException if the image in MediaDetailFragment was clicked before the image URL is available


**Tests performed (required)**

Tested betaDebug on S7

