### PR TITLE
Nearby: make list resize and display message when empty

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -154,7 +154,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     MapView mapView;
     @BindView(R.id.rv_nearby_list)
     RecyclerView rvNearbyList;
-    @BindView(R.id.statusMessage) TextView statusTextView;
+    @BindView(R.id.no_results_message) TextView noResultsView;
 
     @Inject LocationServiceManager locationManager;
     @Inject NearbyController nearbyController;
@@ -628,10 +628,9 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     public void updateListFragment(List<Place> placeList) {
         adapterFactory.updateAdapterData(placeList, (RVRendererAdapter<Place>) rvNearbyList.getAdapter());
         if (placeList.size() <= 0) {
-            statusTextView.setText(R.string.nearby_empty);
-            statusTextView.setVisibility(View.VISIBLE);
+            noResultsView.setVisibility(View.VISIBLE);
         } else {
-            statusTextView.setVisibility(View.GONE);
+            noResultsView.setVisibility(View.GONE);
         }
     }
 
@@ -642,10 +641,9 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     public void updateNearbyList() {
         adapterFactory.update((RVRendererAdapter<Place>) rvNearbyList.getAdapter());
         if (rvNearbyList.getAdapter().getItemCount() <= 0) {
-            statusTextView.setText(R.string.nearby_empty);
-            statusTextView.setVisibility(View.VISIBLE);
+            noResultsView.setVisibility(View.VISIBLE);
         } else {
-            statusTextView.setVisibility(View.GONE);
+            noResultsView.setVisibility(View.GONE);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -154,6 +154,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     MapView mapView;
     @BindView(R.id.rv_nearby_list)
     RecyclerView rvNearbyList;
+    @BindView(R.id.statusMessage) TextView statusTextView;
 
     @Inject LocationServiceManager locationManager;
     @Inject NearbyController nearbyController;
@@ -626,6 +627,12 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     @Override
     public void updateListFragment(List<Place> placeList) {
         adapterFactory.updateAdapterData(placeList, (RVRendererAdapter<Place>) rvNearbyList.getAdapter());
+        if (placeList.size() <= 0) {
+            statusTextView.setText(R.string.nearby_empty);
+            statusTextView.setVisibility(View.VISIBLE);
+        } else {
+            statusTextView.setVisibility(View.GONE);
+        }
     }
 
     public void clearNearbyList() {
@@ -634,6 +641,12 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     public void updateNearbyList() {
         adapterFactory.update((RVRendererAdapter<Place>) rvNearbyList.getAdapter());
+        if (rvNearbyList.getAdapter().getItemCount() <= 0) {
+            statusTextView.setText(R.string.nearby_empty);
+            statusTextView.setVisibility(View.VISIBLE);
+        } else {
+            statusTextView.setVisibility(View.GONE);
+        }
     }
 
     public void addPlaceToNearbyList(Place place) {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -627,11 +627,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     @Override
     public void updateListFragment(List<Place> placeList) {
         adapterFactory.updateAdapterData(placeList, (RVRendererAdapter<Place>) rvNearbyList.getAdapter());
-        if (placeList.size() <= 0) {
-            noResultsView.setVisibility(View.VISIBLE);
-        } else {
-            noResultsView.setVisibility(View.GONE);
-        }
+        noResultsView.setVisibility(placeList.size() <= 0 ? View.VISIBLE : View.GONE);
     }
 
     public void clearNearbyList() {
@@ -640,11 +636,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     public void updateNearbyList() {
         adapterFactory.update((RVRendererAdapter<Place>) rvNearbyList.getAdapter());
-        if (rvNearbyList.getAdapter().getItemCount() <= 0) {
-            noResultsView.setVisibility(View.VISIBLE);
-        } else {
-            noResultsView.setVisibility(View.GONE);
-        }
+        noResultsView.setVisibility(rvNearbyList.getAdapter().getItemCount() <= 0 ? View.VISIBLE : View.GONE);
     }
 
     public void addPlaceToNearbyList(Place place) {

--- a/app/src/main/res/layout/bottom_sheet_nearby.xml
+++ b/app/src/main/res/layout/bottom_sheet_nearby.xml
@@ -4,13 +4,32 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
+    android:gravity="bottom"
     app:behavior_hideable="true"
     android:visibility="visible"
     app:layout_behavior="@string/bottom_sheet_behavior"
-    android:background="@android:color/white">
+    android:background="@android:color/transparent">
+
+    <RelativeLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      android:background="@android:color/white">
+
+    <TextView
+      android:id="@+id/statusMessage"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:paddingVertical="50dp"
+      android:paddingHorizontal="50dp"
+      android:layout_centerHorizontal="true"
+      android:layout_centerVertical="true"
+      android:layout_gravity="center"
+      android:visibility="gone" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_nearby_list"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="wrap_content"/>
+    </RelativeLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/bottom_sheet_nearby.xml
+++ b/app/src/main/res/layout/bottom_sheet_nearby.xml
@@ -3,7 +3,6 @@
     android:id="@+id/bottom_sheet"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     android:gravity="bottom"
     app:behavior_hideable="true"
     android:visibility="visible"
@@ -20,11 +19,8 @@
       android:id="@+id/no_results_message"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:paddingVertical="50dp"
-      android:paddingHorizontal="50dp"
-      android:layout_centerHorizontal="true"
-      android:layout_centerVertical="true"
-      android:layout_gravity="center"
+      android:padding="50dp"
+      android:layout_centerInParent="true"
       android:visibility="gone"
       android:text="@string/nearby_no_results"/>
 

--- a/app/src/main/res/layout/bottom_sheet_nearby.xml
+++ b/app/src/main/res/layout/bottom_sheet_nearby.xml
@@ -17,7 +17,7 @@
       android:background="@android:color/white">
 
     <TextView
-      android:id="@+id/statusMessage"
+      android:id="@+id/no_results_message"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:paddingVertical="50dp"
@@ -25,7 +25,8 @@
       android:layout_centerHorizontal="true"
       android:layout_centerVertical="true"
       android:layout_gravity="center"
-      android:visibility="gone" />
+      android:visibility="gone"
+      android:text="@string/nearby_no_results"/>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_nearby_list"

--- a/app/src/main/res/layout/bottom_sheet_nearby.xml
+++ b/app/src/main/res/layout/bottom_sheet_nearby.xml
@@ -12,7 +12,6 @@
     <RelativeLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:orientation="vertical"
       android:background="@android:color/white">
 
     <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -628,5 +628,6 @@ Upload your first media by tapping on the add button.</string>
   <string name="ask_to_turn_location_on">Turn on location?</string>
   <string name="nearby_needs_location">Nearby needs location enabled to work properly</string>
   <string name="use_location_from_similar_image">Did you shoot these two pictures at the same place? Do you want to use the latitude/longitude of the picture on the right?</string>
+  <string name="nearby_empty">No places found, try changing your search criteria.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -628,6 +628,6 @@ Upload your first media by tapping on the add button.</string>
   <string name="ask_to_turn_location_on">Turn on location?</string>
   <string name="nearby_needs_location">Nearby needs location enabled to work properly</string>
   <string name="use_location_from_similar_image">Did you shoot these two pictures at the same place? Do you want to use the latitude/longitude of the picture on the right?</string>
-  <string name="nearby_empty">No places found, try changing your search criteria.</string>
+  <string name="nearby_no_results">No places found, try changing your search criteria.</string>
 
 </resources>


### PR DESCRIPTION
**Description**
Make the list of nearby places resize up to its old size, depending on the content. Handle the empty case by displaying a message. 

Fixes #3727 

What changes did you make and why?
- Made the list wrap-content and wrapped it in a transparent layout of fixed size (the old size).
- Added a textview with a message to be displayed when the list is empty.

**Tests performed**

Tested betaDebug on Pixel XL with API level 29.

**Screenshots**
List at full size
![image](https://user-images.githubusercontent.com/29753876/81708488-27e4bb80-9469-11ea-8126-884617982eed.png)

List resized 
![image](https://user-images.githubusercontent.com/29753876/81708685-4d71c500-9469-11ea-8955-3327a9b0d152.png)

Message displayed when list is empty
![image](https://user-images.githubusercontent.com/29753876/81708889-71350b00-9469-11ea-9d24-3995e36101f7.png)


