### PR TITLE
Add destroyed column to BookmarkLocation table (##3729)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
@@ -164,7 +164,7 @@ public class BookmarkLocationsDao {
                 cursor.getString(cursor.getColumnIndex(Table.COLUMN_CATEGORY)),
                 builder.build(),
                 cursor.getString(cursor.getColumnIndex(Table.COLUMN_PIC)),
-                null
+                cursor.getString(cursor.getColumnIndex(Table.COLUMN_DESTROYED))
         );
     }
 
@@ -181,6 +181,7 @@ public class BookmarkLocationsDao {
         cv.put(BookmarkLocationsDao.Table.COLUMN_LAT, bookmarkLocation.location.getLatitude());
         cv.put(BookmarkLocationsDao.Table.COLUMN_LONG, bookmarkLocation.location.getLongitude());
         cv.put(BookmarkLocationsDao.Table.COLUMN_PIC, bookmarkLocation.pic);
+        cv.put(BookmarkLocationsDao.Table.COLUMN_DESTROYED, bookmarkLocation.destroyed);
         return cv;
     }
 
@@ -199,6 +200,7 @@ public class BookmarkLocationsDao {
         static final String COLUMN_WIKIDATA_LINK = "location_wikidata_link";
         static final String COLUMN_COMMONS_LINK = "location_commons_link";
         static final String COLUMN_PIC = "location_pic";
+        static final String COLUMN_DESTROYED = "location_destroyed";
 
         // NOTE! KEEP IN SAME ORDER AS THEY ARE DEFINED UP THERE. HELPS HARD CODE COLUMN INDICES.
         public static final String[] ALL_FIELDS = {
@@ -213,7 +215,8 @@ public class BookmarkLocationsDao {
                 COLUMN_WIKIPEDIA_LINK,
                 COLUMN_WIKIDATA_LINK,
                 COLUMN_COMMONS_LINK,
-                COLUMN_PIC
+                COLUMN_PIC,
+                COLUMN_DESTROYED
         };
 
         static final String DROP_TABLE_STATEMENT = "DROP TABLE IF EXISTS " + TABLE_NAME;
@@ -230,7 +233,8 @@ public class BookmarkLocationsDao {
                 + COLUMN_WIKIPEDIA_LINK + " STRING,"
                 + COLUMN_WIKIDATA_LINK + " STRING,"
                 + COLUMN_COMMONS_LINK + " STRING,"
-                + COLUMN_PIC + " STRING"
+                + COLUMN_PIC + " STRING,"
+                + COLUMN_DESTROYED + " STRING"
                 + ");";
 
         public static void onCreate(SQLiteDatabase db) {
@@ -271,6 +275,15 @@ public class BookmarkLocationsDao {
                 //We are anyways switching to room, these things won't be nescessary then
                 try {
                     db.execSQL("ALTER TABLE bookmarksLocations ADD COLUMN location_pic STRING;");
+                }catch (SQLiteException exception){
+                    Timber.e(exception);//
+                }
+                return;
+            }
+            if (from == 12 && to == 13) {
+                from++;
+                try {
+                    db.execSQL("ALTER TABLE bookmarksLocations ADD COLUMN location_destroyed STRING;");
                 }catch (SQLiteException exception){
                     Timber.e(exception);//
                 }

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
@@ -248,46 +248,24 @@ public class BookmarkLocationsDao {
 
         public static void onUpdate(SQLiteDatabase db, int from, int to) {
             Timber.d("bookmarksLocations db is updated from:"+from+", to:"+to);
-            if (from == to) {
-                return;
-            }
-            if (from < 7) {
-                // doesn't exist yet
-                from++;
-                onUpdate(db, from, to);
-                return;
-            }
-            if (from == 7) {
-                // table added in version 8
-                onCreate(db);
-                from++;
-                onUpdate(db, from, to);
-                return;
-            }
-            if (from == 8) {
-                from++;
-                onUpdate(db, from, to);
-                return;
-            }
-            if (from == 10 && to == 11) {
-                from++;
-                //This is safe, and can be called clean, as we/I do not remember the appropriate version for this
-                //We are anyways switching to room, these things won't be nescessary then
-                try {
-                    db.execSQL("ALTER TABLE bookmarksLocations ADD COLUMN location_pic STRING;");
-                }catch (SQLiteException exception){
-                    Timber.e(exception);//
-                }
-                return;
-            }
-            if (from == 12 && to == 13) {
-                from++;
-                try {
-                    db.execSQL("ALTER TABLE bookmarksLocations ADD COLUMN location_destroyed STRING;");
-                }catch (SQLiteException exception){
-                    Timber.e(exception);//
-                }
-                return;
+            switch (from) {
+                case 7: onCreate(db);
+                case 8: // No change
+                case 9: // No change
+                case 10:
+                    try {
+                        db.execSQL("ALTER TABLE bookmarksLocations ADD COLUMN location_pic STRING;");
+                    } catch (SQLiteException exception){
+                        Timber.e(exception);
+                    }
+                case 11: // No change
+                case 12:
+                    try {
+                        db.execSQL("ALTER TABLE bookmarksLocations ADD COLUMN location_destroyed STRING;");
+                    }catch (SQLiteException exception){
+                        Timber.e(exception);
+                    }
+                    break;
             }
         }
     }

--- a/app/src/main/java/fr/free/nrw/commons/data/DBOpenHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/data/DBOpenHelper.java
@@ -13,7 +13,7 @@ import fr.free.nrw.commons.explore.recentsearches.RecentSearchesDao;
 public class DBOpenHelper  extends SQLiteOpenHelper {
 
     private static final String DATABASE_NAME = "commons.db";
-    private static final int DATABASE_VERSION = 12;
+    private static final int DATABASE_VERSION = 13;
     public static final String CONTRIBUTIONS_TABLE = "contributions";
     private final String DROP_TABLE_STATEMENT="DROP TABLE IF EXISTS %s";
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/locations/BookMarkLocationDaoTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/locations/BookMarkLocationDaoTest.kt
@@ -36,7 +36,8 @@ class BookMarkLocationDaoTest {
             COLUMN_COMMONS_LINK,
             COLUMN_LAT,
             COLUMN_LONG,
-            COLUMN_PIC)
+            COLUMN_PIC,
+            COLUMN_DESTROYED)
     private val client: ContentProviderClient = mock()
     private val database: SQLiteDatabase = mock()
     private val captor = argumentCaptor<ContentValues>()
@@ -95,6 +96,7 @@ class BookMarkLocationDaoTest {
                 assertEquals(builder.build().wikidataLink, it.siteLinks.wikidataLink)
                 assertEquals(builder.build().commonsLink, it.siteLinks.commonsLink)
                 assertEquals("picName",it.pic)
+                assertEquals("placeDestroyed", it.destroyed)
             }
         }
     }
@@ -147,7 +149,7 @@ class BookMarkLocationDaoTest {
         assertTrue(testObject.updateBookmarkLocation(examplePlaceBookmark))
         verify(client).insert(eq(BASE_URI), captor.capture())
         captor.firstValue.let { cv ->
-            assertEquals(11, cv.size())
+            assertEquals(12, cv.size())
             assertEquals(examplePlaceBookmark.name, cv.getAsString(COLUMN_NAME))
             assertEquals(examplePlaceBookmark.longDescription, cv.getAsString(COLUMN_DESCRIPTION))
             assertEquals(examplePlaceBookmark.label.text, cv.getAsString(COLUMN_LABEL_TEXT))
@@ -158,6 +160,7 @@ class BookMarkLocationDaoTest {
             assertEquals(examplePlaceBookmark.siteLinks.wikidataLink.toString(), cv.getAsString(COLUMN_WIKIDATA_LINK))
             assertEquals(examplePlaceBookmark.siteLinks.commonsLink.toString(), cv.getAsString(COLUMN_COMMONS_LINK))
             assertEquals(examplePlaceBookmark.pic.toString(), cv.getAsString(COLUMN_PIC))
+            assertEquals(examplePlaceBookmark.destroyed.toString(), cv.getAsString(COLUMN_DESTROYED))
         }
     }
 
@@ -253,12 +256,18 @@ class BookMarkLocationDaoTest {
         verify(database).execSQL(CREATE_TABLE_STATEMENT)
     }
 
+    @Test
+    fun migrateTableVersionFrom_v12_to_v13() {
+        onUpdate(database, 12, 13)
+        verify(database).execSQL("ALTER TABLE bookmarksLocations ADD COLUMN location_destroyed STRING;")
+    }
+
     private fun createCursor(rowCount: Int) = MatrixCursor(columns, rowCount).apply {
 
         for (i in 0 until rowCount) {
             addRow(listOf("placeName", "placeDescription","placeCategory", exampleLabel.text, exampleLabel.icon,
                     exampleUri, builder.build().wikipediaLink, builder.build().wikidataLink, builder.build().commonsLink,
-                    exampleLocation.latitude, exampleLocation.longitude, "picName"))
+                    exampleLocation.latitude, exampleLocation.longitude, "picName", "placeDestroyed"))
         }
     }
 }


### PR DESCRIPTION
**Description (required)**
Fixes #3729 

**What changes did you make and why?**
1. Database version changed from **12** to **13**
2. Migration to add column `location_destroyed` to BookmarkLocation table
3. Updated Tests and Dao to reflect the new column 

**Tests performed (required)**
Tested {prodDebug, betaDebug} on {Pixel 2 emulator} with API level {28}.
Checked for successful database migration (on emulator) as well.
