### PR TITLE
Fixes #3705

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -224,6 +224,14 @@ public class ContributionsFragment
                 Timber.d("Fetching thumbnail for %s", contribution.filename);
                 contributionsPresenter.fetchMediaDetails(contribution);
             }
+
+            @Override
+            public void onContributionsUpdated() {
+                //If the contributions are updated, let the pager fragment know
+                if (null != mediaDetailPagerFragment) {
+                    mediaDetailPagerFragment.notifyDataSetChanged();
+                }
+            }
         });
 
         if(null==mediaDetailPagerFragment){

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListAdapter.java
@@ -77,5 +77,7 @@ public class ContributionsListAdapter extends RecyclerView.Adapter<ContributionV
         Contribution getContributionForPosition(int position);
 
         void fetchMediaUriFor(Contribution contribution);
+
+        void onContributionsUpdated();
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -188,6 +188,7 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment {
         this.contributions.clear();
         this.contributions.addAll(contributionList);
         adapter.setContributions(contributions);
+        callback.onContributionsUpdated();
     }
 
     public interface SourceRefresher {


### PR DESCRIPTION
**Description (required)**
Due to data inconsistency between MediaDetailsPagerFragment's provider and its adapter, the app used to throw illegalstateexception
Fixes #3705

What changes did you make and why?
* Let the MediaDetailsFragment know the contributions have been updated
**Tests performed (required)**

Tested betaDebug with API 27

