### PR TITLE
Achievements: fix nearby count invisible

### DIFF
--- a/app/src/androidTest/java/fr/free/nrw/commons/AchievementsActivityTest.kt
+++ b/app/src/androidTest/java/fr/free/nrw/commons/AchievementsActivityTest.kt
@@ -2,11 +2,13 @@ package fr.free.nrw.commons
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.DrawerActions
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.filters.MediumTest
 import androidx.test.runner.AndroidJUnit4
 import fr.free.nrw.commons.achievements.AchievementsActivity
@@ -33,5 +35,15 @@ class AchievementsActivityTest {
         onView(withId(R.id.user_icon)).perform(click())
 
         Intents.intended(hasComponent(AchievementsActivity::class.java.name))
+    }
+
+    @Test
+    fun testInitialCounterState() {
+        onView(withId(R.id.drawer_layout)).perform(DrawerActions.open())
+        onView(withId(R.id.user_icon)).perform(click())
+
+        Intents.intended(hasComponent(AchievementsActivity::class.java.name))
+
+        onView(withId(R.id.wikidata_edits)).check(matches(withText("0")))
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -270,7 +270,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
         if (StringUtils.isBlank(userName)) {
             return;
         }
-        wikidataEditsText.setText(String.valueOf(0));
+        wikidataEditsText.setText("0");
         compositeDisposable.add(okHttpJsonApiClient
                 .getWikidataEdits(userName)
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -142,6 +142,9 @@ public class AchievementsActivity extends NavigationBaseActivity {
         setSupportActionBar(toolbar);
         progressBar.setVisibility(View.VISIBLE);
 
+        // Set the initial value of wikidata_edits to 0
+        wikidataEditsText.setText("0");
+
         hideLayouts();
         setWikidataEditCount();
         setAchievements();
@@ -270,7 +273,6 @@ public class AchievementsActivity extends NavigationBaseActivity {
         if (StringUtils.isBlank(userName)) {
             return;
         }
-        wikidataEditsText.setText("0");
         compositeDisposable.add(okHttpJsonApiClient
                 .getWikidataEdits(userName)
                 .subscribeOn(Schedulers.io())
@@ -279,7 +281,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
                     numberOfEdits = edits;
                     wikidataEditsText.setText(String.valueOf(edits));
                 }, e -> {
-                    Timber.e("Error:" + e);
+                    Timber.e("Error: " + e);
                 }));
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -270,6 +270,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
         if (StringUtils.isBlank(userName)) {
             return;
         }
+        wikidataEditsText.setText(String.valueOf(0));
         compositeDisposable.add(okHttpJsonApiClient
                 .getWikidataEdits(userName)
                 .subscribeOn(Schedulers.io())


### PR DESCRIPTION
Fixes #3767

What changes did you make and why?

Nearby count was invisible before getting a response from the API.
Set a default value of 0 to avoid invisibility, before calling the API.

![SS archievements](https://user-images.githubusercontent.com/42658489/84066295-8faff880-a97a-11ea-8e90-0a2b397ddcb4.jpeg)
