### PR TITLE
achievements: adding help links to popups [fixes #3433]

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -60,6 +60,13 @@ public class AchievementsActivity extends NavigationBaseActivity {
     private static final double BADGE_IMAGE_WIDTH_RATIO = 0.4;
     private static final double BADGE_IMAGE_HEIGHT_RATIO = 0.3;
 
+    private static final String IMAGES_UPLOADED_URL = "https://commons.wikimedia.org/wiki/Commons:Project_scope";
+    private static final String IMAGE_REVERTS_URL = "https://commons.wikimedia.org/wiki/Commons:Deletion_policy#Reasons_for_deletion";
+    private static final String IMAGES_USED_BY_WIKI_URL = "https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Images";
+    private static final String STATISTICS_WIKIDATA_EDITS_URL = "https://www.wikidata.org/wiki/Property:P18";
+    private static final String STATISTICS_FEATURED_URL = "https://commons.wikimedia.org/wiki/Commons:Featured_pictures";
+    private static final String STATISTICS_THANKS_URL = "https://www.mediawiki.org/wiki/Extension:Thanks";
+
     private LevelController.LevelInfo levelInfo;
 
     @BindView(R.id.achievement_badge_image)
@@ -469,7 +476,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
     public void showUploadInfo(){
         launchAlertWithLink(getResources().getString(R.string.images_uploaded)
                 ,getResources().getString(R.string.images_uploaded_explanation)
-                , "https://commons.wikimedia.org/wiki/Commons:Project_scope"
+                , IMAGES_UPLOADED_URL
                 , getResources().getString(R.string.read_more));
     }
 
@@ -477,7 +484,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
     public void showRevertedInfo(){
         launchAlertWithLink(getResources().getString(R.string.image_reverts)
                 ,getResources().getString(R.string.images_reverted_explanation)
-                , "https://commons.wikimedia.org/wiki/Commons:Deletion_policy#Reasons_for_deletion"
+                , IMAGE_REVERTS_URL
                 , getResources().getString(R.string.read_more));
     }
 
@@ -485,7 +492,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
     public void showUsedByWikiInfo(){
         launchAlertWithLink(getResources().getString(R.string.images_used_by_wiki)
                 ,getResources().getString(R.string.images_used_explanation)
-                , "https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Images"
+                , IMAGES_USED_BY_WIKI_URL
                 , getResources().getString(R.string.read_more));
     }
 
@@ -493,7 +500,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
     public void showImagesViaNearbyInfo(){
         launchAlertWithLink(getResources().getString(R.string.statistics_wikidata_edits)
                 ,getResources().getString(R.string.images_via_nearby_explanation)
-                , "https://www.wikidata.org/wiki/Property:P18"
+                , STATISTICS_WIKIDATA_EDITS_URL
                 , getResources().getString(R.string.read_more));
     }
 
@@ -501,7 +508,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
     public void showFeaturedImagesInfo(){
         launchAlertWithLink(getResources().getString(R.string.statistics_featured)
                 ,getResources().getString(R.string.images_featured_explanation)
-                , "https://commons.wikimedia.org/wiki/Commons:Featured_pictures"
+                , STATISTICS_FEATURED_URL
                 , getResources().getString(R.string.read_more));
     }
 
@@ -509,7 +516,7 @@ public class AchievementsActivity extends NavigationBaseActivity {
     public void showThanksReceivedInfo(){
         launchAlertWithLink(getResources().getString(R.string.statistics_thanks)
                 ,getResources().getString(R.string.thanks_received_explanation)
-                , "https://www.mediawiki.org/wiki/Extension:Thanks"
+                , STATISTICS_THANKS_URL
                 , getResources().getString(R.string.read_more));
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -19,6 +19,7 @@ import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import android.widget.Toast;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 import androidx.constraintlayout.widget.ConstraintLayout;
@@ -467,38 +468,50 @@ public class AchievementsActivity extends NavigationBaseActivity {
 
     @OnClick(R.id.images_upload_info)
     public void showUploadInfo(){
-        launchAlert(getResources().getString(R.string.images_uploaded)
-                ,getResources().getString(R.string.images_uploaded_explanation));
+        launchAlertWithLink(getResources().getString(R.string.images_uploaded)
+                ,getResources().getString(R.string.images_uploaded_explanation)
+                , "https://commons.wikimedia.org/wiki/Commons:Project_scope"
+                , getResources().getString(R.string.read_more));
     }
 
     @OnClick(R.id.images_reverted_info)
     public void showRevertedInfo(){
-        launchAlert(getResources().getString(R.string.image_reverts)
-                ,getResources().getString(R.string.images_reverted_explanation));
+        launchAlertWithLink(getResources().getString(R.string.image_reverts)
+                ,getResources().getString(R.string.images_reverted_explanation)
+                , "https://commons.wikimedia.org/wiki/Commons:Deletion_policy#Reasons_for_deletion"
+                , getResources().getString(R.string.read_more));
     }
 
     @OnClick(R.id.images_used_by_wiki_info)
     public void showUsedByWikiInfo(){
-        launchAlert(getResources().getString(R.string.images_used_by_wiki)
-                ,getResources().getString(R.string.images_used_explanation));
+        launchAlertWithLink(getResources().getString(R.string.images_used_by_wiki)
+                ,getResources().getString(R.string.images_used_explanation)
+                , "https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Images"
+                , getResources().getString(R.string.read_more));
     }
 
     @OnClick(R.id.images_nearby_info)
     public void showImagesViaNearbyInfo(){
-        launchAlert(getResources().getString(R.string.statistics_wikidata_edits)
-                ,getResources().getString(R.string.images_via_nearby_explanation));
+        launchAlertWithLink(getResources().getString(R.string.statistics_wikidata_edits)
+                ,getResources().getString(R.string.images_via_nearby_explanation)
+                , "https://www.wikidata.org/wiki/Property:P18"
+                , getResources().getString(R.string.read_more));
     }
 
     @OnClick(R.id.images_featured_info)
     public void showFeaturedImagesInfo(){
-        launchAlert(getResources().getString(R.string.statistics_featured)
-                ,getResources().getString(R.string.images_featured_explanation));
+        launchAlertWithLink(getResources().getString(R.string.statistics_featured)
+                ,getResources().getString(R.string.images_featured_explanation)
+                , "https://commons.wikimedia.org/wiki/Commons:Featured_pictures"
+                , getResources().getString(R.string.read_more));
     }
 
     @OnClick(R.id.thanks_received_info)
     public void showThanksReceivedInfo(){
-        launchAlert(getResources().getString(R.string.statistics_thanks)
-                ,getResources().getString(R.string.thanks_received_explanation));
+        launchAlertWithLink(getResources().getString(R.string.statistics_thanks)
+                ,getResources().getString(R.string.thanks_received_explanation)
+                , "https://www.mediawiki.org/wiki/Extension:Thanks"
+                , getResources().getString(R.string.read_more));
     }
 
     /**
@@ -508,12 +521,33 @@ public class AchievementsActivity extends NavigationBaseActivity {
      */
     private void launchAlert(String title, String message){
         new AlertDialog.Builder(AchievementsActivity.this)
-                .setTitle(title)
-                .setMessage(message)
-                .setCancelable(true)
-                .setPositiveButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
-                .create()
-                .show();
+            .setTitle(title)
+            .setMessage(message)
+            .setCancelable(true)
+            .setPositiveButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
+            .create()
+            .show();
+    }
+
+    /**
+     * takes title, message, url and alertButtonText as input to display alerts with links
+     * @param title
+     * @param message
+     * @param url
+     * @param alertButtonText
+     */
+    private void launchAlertWithLink(String title, String message, String url, String alertButtonText){
+        new AlertDialog.Builder(AchievementsActivity.this)
+            .setTitle(title)
+            .setMessage(message)
+            .setCancelable(true)
+            .setPositiveButton(alertButtonText, (dialog, id) -> {
+                Intent i = new Intent(Intent.ACTION_VIEW);
+                i.setData(Uri.parse(url));
+                startActivity(i);
+            })
+            .create()
+            .show();
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/achievements/AchievementsActivity.java
@@ -19,7 +19,6 @@ import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import android.widget.Toast;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 import androidx.constraintlayout.widget.ConstraintLayout;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -387,6 +387,7 @@
 
   <string name="Achievements">Achievements</string>
   <string name="statistics">Statistics</string>
+  <string name="read_more">Read more</string>
   <string name="statistics_thanks">Thanks Received</string>
   <string name="statistics_featured">Featured Images</string>
   <string name="statistics_wikidata_edits">Images via \"Nearby Places\"</string>


### PR DESCRIPTION
**Description (required)**
achievements: adding links to popups for extra information

Fixes #3433 

What changes did you make and why?
- New string added for "Read more" string in strings.xml
- New method added for lauchAlertWithLink to open link using an intent
- Associate this new method for the existing popups that requires extra info

**Tests performed (required)**

Tested with ProdDebug on Redmi Note 7 with API level 28 and Nexus 5X API level 28 (emulator).

**Screenshots (for UI changes only)**
![image](https://user-images.githubusercontent.com/20119298/84215926-8794ad80-aa8d-11ea-971f-b174bea54877.png)


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
