### PR TITLE
#3380 "Nearby Place found" despite already Nearby upload 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
@@ -1,29 +1,25 @@
 package fr.free.nrw.commons.bookmarks.locations;
 
+import static fr.free.nrw.commons.bookmarks.locations.BookmarkLocationsContentProvider.BASE_URI;
+
 import android.content.ContentProviderClient;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.os.RemoteException;
-
 import androidx.annotation.NonNull;
-
+import fr.free.nrw.commons.location.LatLng;
+import fr.free.nrw.commons.nearby.Label;
 import fr.free.nrw.commons.nearby.NearbyController;
+import fr.free.nrw.commons.nearby.Place;
+import fr.free.nrw.commons.nearby.Sitelinks;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
-
-import fr.free.nrw.commons.location.LatLng;
-import fr.free.nrw.commons.nearby.Label;
-import fr.free.nrw.commons.nearby.Place;
-import fr.free.nrw.commons.nearby.Sitelinks;
 import timber.log.Timber;
-
-import static fr.free.nrw.commons.bookmarks.locations.BookmarkLocationsContentProvider.BASE_URI;
 
 public class BookmarkLocationsDao {
 
@@ -107,7 +103,7 @@ public class BookmarkLocationsDao {
     private void deleteBookmarkLocation(Place bookmarkLocation) {
         ContentProviderClient db = clientProvider.get();
         try {
-            db.delete(BookmarkLocationsContentProvider.uriForName(bookmarkLocation.name), null, null);
+            db.delete(BookmarkLocationsContentProvider.uriForName(bookmarkLocation.getName()), null, null);
         } catch (RemoteException e) {
             throw new RuntimeException(e);
         } finally {
@@ -129,7 +125,7 @@ public class BookmarkLocationsDao {
                     BookmarkLocationsContentProvider.BASE_URI,
                     Table.ALL_FIELDS,
                     Table.COLUMN_NAME + "=?",
-                    new String[]{bookmarkLocation.name},
+                    new String[]{bookmarkLocation.getName()},
                     null);
             if (cursor != null && cursor.moveToFirst()) {
                 return true;
@@ -175,13 +171,13 @@ public class BookmarkLocationsDao {
         cv.put(BookmarkLocationsDao.Table.COLUMN_CATEGORY, bookmarkLocation.getCategory());
         cv.put(BookmarkLocationsDao.Table.COLUMN_LABEL_TEXT, bookmarkLocation.getLabel().getText());
         cv.put(BookmarkLocationsDao.Table.COLUMN_LABEL_ICON, bookmarkLocation.getLabel().getIcon());
-        cv.put(BookmarkLocationsDao.Table.COLUMN_WIKIPEDIA_LINK, bookmarkLocation.siteLinks.getWikipediaLink().toString());
-        cv.put(BookmarkLocationsDao.Table.COLUMN_WIKIDATA_LINK, bookmarkLocation.siteLinks.getWikidataLink().toString());
-        cv.put(BookmarkLocationsDao.Table.COLUMN_COMMONS_LINK, bookmarkLocation.siteLinks.getCommonsLink().toString());
-        cv.put(BookmarkLocationsDao.Table.COLUMN_LAT, bookmarkLocation.location.getLatitude());
-        cv.put(BookmarkLocationsDao.Table.COLUMN_LONG, bookmarkLocation.location.getLongitude());
-        cv.put(BookmarkLocationsDao.Table.COLUMN_PIC, bookmarkLocation.pic);
-        cv.put(BookmarkLocationsDao.Table.COLUMN_DESTROYED, bookmarkLocation.destroyed);
+        cv.put(BookmarkLocationsDao.Table.COLUMN_WIKIPEDIA_LINK, bookmarkLocation.getSiteLinks().getWikipediaLink().toString());
+        cv.put(BookmarkLocationsDao.Table.COLUMN_WIKIDATA_LINK, bookmarkLocation.getSiteLinks().getWikidataLink().toString());
+        cv.put(BookmarkLocationsDao.Table.COLUMN_COMMONS_LINK, bookmarkLocation.getSiteLinks().getCommonsLink().toString());
+        cv.put(BookmarkLocationsDao.Table.COLUMN_LAT, bookmarkLocation.getLocation().getLatitude());
+        cv.put(BookmarkLocationsDao.Table.COLUMN_LONG, bookmarkLocation.getLocation().getLongitude());
+        cv.put(BookmarkLocationsDao.Table.COLUMN_PIC, bookmarkLocation.getPic());
+        cv.put(BookmarkLocationsDao.Table.COLUMN_DESTROYED, bookmarkLocation.getDestroyed());
         return cv;
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -41,7 +41,6 @@ import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient;
 import fr.free.nrw.commons.nearby.NearbyController;
 import fr.free.nrw.commons.nearby.NearbyNotificationCardView;
 import fr.free.nrw.commons.nearby.Place;
-import fr.free.nrw.commons.settings.Prefs;
 import fr.free.nrw.commons.upload.UploadService;
 import fr.free.nrw.commons.utils.ConfigUtils;
 import fr.free.nrw.commons.utils.DialogUtil;
@@ -365,7 +364,7 @@ public class ContributionsFragment
     private void updateNearbyNotification(@Nullable NearbyController.NearbyPlacesInfo nearbyPlacesInfo) {
         if (nearbyPlacesInfo != null && nearbyPlacesInfo.placeList != null && nearbyPlacesInfo.placeList.size() > 0) {
             Place closestNearbyPlace = nearbyPlacesInfo.placeList.get(0);
-            String distance = formatDistanceBetween(curLatLng, closestNearbyPlace.location);
+            String distance = formatDistanceBetween(curLatLng, closestNearbyPlace.getLocation());
             closestNearbyPlace.setDistance(distance);
             nearbyNotificationCardView.updateContent(closestNearbyPlace);
         } else {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyController.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyController.java
@@ -1,15 +1,18 @@
 package fr.free.nrw.commons.nearby;
 
+import static fr.free.nrw.commons.utils.LengthUtils.computeDistanceBetween;
+import static fr.free.nrw.commons.utils.LengthUtils.formatDistanceBetween;
+
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
-
 import androidx.annotation.MainThread;
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
-
 import com.mapbox.mapboxsdk.annotations.IconFactory;
 import com.mapbox.mapboxsdk.annotations.Marker;
-
+import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.location.LatLng;
+import fr.free.nrw.commons.utils.UiUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -18,16 +21,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
-
 import javax.inject.Inject;
-
-import fr.free.nrw.commons.R;
-import fr.free.nrw.commons.location.LatLng;
-import fr.free.nrw.commons.utils.UiUtils;
 import timber.log.Timber;
-
-import static fr.free.nrw.commons.utils.LengthUtils.computeDistanceBetween;
-import static fr.free.nrw.commons.utils.LengthUtils.formatDistanceBetween;
 
 public class NearbyController {
     private static final int MAX_RESULTS = 1000;
@@ -68,29 +63,29 @@ public class NearbyController {
         List<Place> places = nearbyPlaces.radiusExpander(searchLatLng, Locale.getDefault().getLanguage(), returnClosestResult);
 
         if (null != places && places.size() > 0) {
-            LatLng[] boundaryCoordinates = {places.get(0).location,   // south
-                    places.get(0).location, // north
-                    places.get(0).location, // west
-                    places.get(0).location};// east, init with a random location
+            LatLng[] boundaryCoordinates = {places.get(0).getLocation(),   // south
+                    places.get(0).getLocation(), // north
+                    places.get(0).getLocation(), // west
+                    places.get(0).getLocation()};// east, init with a random location
 
 
             if (curLatLng != null) {
                 Timber.d("Sorting places by distance...");
                 final Map<Place, Double> distances = new HashMap<>();
                 for (Place place : places) {
-                    distances.put(place, computeDistanceBetween(place.location, curLatLng));
+                    distances.put(place, computeDistanceBetween(place.getLocation(), curLatLng));
                     // Find boundaries with basic find max approach
-                    if (place.location.getLatitude() < boundaryCoordinates[0].getLatitude()) {
-                        boundaryCoordinates[0] = place.location;
+                    if (place.getLocation().getLatitude() < boundaryCoordinates[0].getLatitude()) {
+                        boundaryCoordinates[0] = place.getLocation();
                     }
-                    if (place.location.getLatitude() > boundaryCoordinates[1].getLatitude()) {
-                        boundaryCoordinates[1] = place.location;
+                    if (place.getLocation().getLatitude() > boundaryCoordinates[1].getLatitude()) {
+                        boundaryCoordinates[1] = place.getLocation();
                     }
-                    if (place.location.getLongitude() < boundaryCoordinates[2].getLongitude()) {
-                        boundaryCoordinates[2] = place.location;
+                    if (place.getLocation().getLongitude() < boundaryCoordinates[2].getLongitude()) {
+                        boundaryCoordinates[2] = place.getLocation();
                     }
-                    if (place.location.getLongitude() > boundaryCoordinates[3].getLongitude()) {
-                        boundaryCoordinates[3] = place.location;
+                    if (place.getLocation().getLongitude() > boundaryCoordinates[3].getLongitude()) {
+                        boundaryCoordinates[3] = place.getLocation();
                     }
                 }
                 Collections.sort(places,
@@ -139,7 +134,7 @@ public class NearbyController {
             List<Place> placeList) {
         placeList = placeList.subList(0, Math.min(placeList.size(), MAX_RESULTS));
         for (Place place : placeList) {
-            String distance = formatDistanceBetween(curLatLng, place.location);
+            String distance = formatDistanceBetween(curLatLng, place.getLocation());
             place.setDistance(distance);
         }
         return placeList;
@@ -185,23 +180,23 @@ public class NearbyController {
             Bitmap iconGrey = UiUtils.getBitmap(vectorDrawableGrey);
 
             for (Place place : placeList) {
-                String distance = formatDistanceBetween(curLatLng, place.location);
+                String distance = formatDistanceBetween(curLatLng, place.getLocation());
                 place.setDistance(distance);
 
                 NearbyBaseMarker nearbyBaseMarker = new NearbyBaseMarker();
-                nearbyBaseMarker.title(place.name);
+                nearbyBaseMarker.title(place.getName());
                 nearbyBaseMarker.position(
                         new com.mapbox.mapboxsdk.geometry.LatLng(
-                                place.location.getLatitude(),
-                                place.location.getLongitude()));
+                                place.getLocation().getLatitude(),
+                                place.getLocation().getLongitude()));
                 nearbyBaseMarker.place(place);
                 // Check if string is only spaces or empty, if so place doesn't have any picture
-                if (!place.pic.trim().isEmpty()) {
+                if (!place.getPic().trim().isEmpty()) {
                     if (iconGreen != null) {
                         nearbyBaseMarker.icon(IconFactory.getInstance(context)
                                 .fromBitmap(iconGreen));
                     }
-                } else if (!place.destroyed.trim().isEmpty()) { // Means place is destroyed
+                } else if (!place.getDestroyed().trim().isEmpty()) { // Means place is destroyed
                     if (iconGrey != null) {
                         nearbyBaseMarker.icon(IconFactory.getInstance(context)
                                 .fromBitmap(iconGrey));

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyNotificationCardView.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyNotificationCardView.java
@@ -1,5 +1,7 @@
 package fr.free.nrw.commons.nearby;
 
+import static fr.free.nrw.commons.contributions.MainActivity.NEARBY_TAB_POSITION;
+
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
@@ -8,18 +10,14 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.contributions.MainActivity;
 import fr.free.nrw.commons.nearby.fragments.NearbyParentFragment;
 import fr.free.nrw.commons.utils.SwipableCardView;
 import fr.free.nrw.commons.utils.ViewUtil;
 import timber.log.Timber;
-
-import static fr.free.nrw.commons.contributions.MainActivity.NEARBY_TAB_POSITION;
 
 /**
  * Custom card view for nearby notification card view on main screen, above contributions list
@@ -136,8 +134,8 @@ public class NearbyNotificationCardView extends SwipableCardView {
         notificationTitle.setVisibility(VISIBLE);
         notificationDistance.setVisibility(VISIBLE);
         notificationIcon.setVisibility(VISIBLE);
-        notificationTitle.setText(place.name);
-        notificationDistance.setText(place.distance);
+        notificationTitle.setText(place.getName());
+        notificationDistance.setText(place.getDistance());
 
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
@@ -18,16 +18,16 @@ import timber.log.Timber;
  */
 public class Place implements Parcelable {
 
-    public final String name;
+    private final String name;
     private final Label label;
     private final String longDescription;
-    public final LatLng location;
+    private final LatLng location;
     private final String category;
-    public final String pic;
-    public final String destroyed;
+    private final String pic;
+    private final String destroyed;
 
-    public String distance;
-    public final Sitelinks siteLinks;
+    private String distance;
+    private final Sitelinks siteLinks;
 
 
     public Place(String name, Label label, String longDescription, LatLng location, String category, Sitelinks siteLinks, String pic, String destroyed) {
@@ -151,6 +151,22 @@ public class Place implements Parcelable {
      */
     public boolean hasCommonsLink() {
         return !(siteLinks == null || Uri.EMPTY.equals(siteLinks.getCommonsLink()));
+    }
+
+    public String getPic() {
+        return pic;
+    }
+
+    public String getDestroyed() {
+        return destroyed;
+    }
+
+    public String getDistance() {
+        return distance;
+    }
+
+    public Sitelinks getSiteLinks() {
+        return siteLinks;
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.java
@@ -1,15 +1,16 @@
 package fr.free.nrw.commons.nearby.presenter;
 
-import android.util.Log;
-import android.view.View;
+import static fr.free.nrw.commons.location.LocationServiceManager.LocationChangeType.LOCATION_SIGNIFICANTLY_CHANGED;
+import static fr.free.nrw.commons.location.LocationServiceManager.LocationChangeType.LOCATION_SLIGHTLY_CHANGED;
+import static fr.free.nrw.commons.location.LocationServiceManager.LocationChangeType.MAP_UPDATED;
+import static fr.free.nrw.commons.location.LocationServiceManager.LocationChangeType.SEARCH_CUSTOM_AREA;
+import static fr.free.nrw.commons.nearby.CheckBoxTriStates.CHECKED;
+import static fr.free.nrw.commons.nearby.CheckBoxTriStates.UNCHECKED;
+import static fr.free.nrw.commons.nearby.CheckBoxTriStates.UNKNOWN;
 
+import android.view.View;
 import androidx.annotation.MainThread;
 import com.mapbox.mapboxsdk.annotations.Marker;
-
-import java.lang.reflect.Proxy;
-import java.util.HashMap;
-import java.util.List;
-
 import fr.free.nrw.commons.bookmarks.locations.BookmarkLocationsDao;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.location.LatLng;
@@ -24,15 +25,10 @@ import fr.free.nrw.commons.nearby.NearbyFilterState;
 import fr.free.nrw.commons.nearby.contract.NearbyParentFragmentContract;
 import fr.free.nrw.commons.utils.LocationUtils;
 import fr.free.nrw.commons.wikidata.WikidataEditListener;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.List;
 import timber.log.Timber;
-
-import static fr.free.nrw.commons.location.LocationServiceManager.LocationChangeType.LOCATION_SIGNIFICANTLY_CHANGED;
-import static fr.free.nrw.commons.location.LocationServiceManager.LocationChangeType.LOCATION_SLIGHTLY_CHANGED;
-import static fr.free.nrw.commons.location.LocationServiceManager.LocationChangeType.MAP_UPDATED;
-import static fr.free.nrw.commons.location.LocationServiceManager.LocationChangeType.SEARCH_CUSTOM_AREA;
-import static fr.free.nrw.commons.nearby.CheckBoxTriStates.CHECKED;
-import static fr.free.nrw.commons.nearby.CheckBoxTriStates.UNCHECKED;
-import static fr.free.nrw.commons.nearby.CheckBoxTriStates.UNKNOWN;
 
 public class NearbyParentFragmentPresenter
         implements NearbyParentFragmentContract.UserActions,
@@ -314,7 +310,7 @@ public class NearbyParentFragmentPresenter
                     new MarkerPlaceGroup(nearbyBaseMarker.getMarker(), bookmarkLocationDao.findBookmarkLocation(nearbyBaseMarker.getPlace()), nearbyBaseMarker.getPlace()));
             //TODO: fix bookmark location
             NearbyController.markerExistsMap.put((nearbyBaseMarkers.get(i).getPlace().hasWikidataLink()), nearbyBaseMarkers.get(i).getMarker());
-            NearbyController.markerNeedPicMap.put(((nearbyBaseMarkers.get(i).getPlace().pic == null) ? true : false), nearbyBaseMarkers.get(i).getMarker());
+            NearbyController.markerNeedPicMap.put(((nearbyBaseMarkers.get(i).getPlace().getPic() == null) ? true : false), nearbyBaseMarkers.get(i).getMarker());
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadItem.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadItem.java
@@ -18,7 +18,7 @@ public class UploadItem {
   private final String mimeType;
   private ImageCoordinates gpsCoords;
   private List<UploadMediaDetail> uploadMediaDetails;
-  private final Place place;
+  private Place place;
   private final long createdTimestamp;
   private final String createdTimestampSource;
   private final BehaviorSubject<Integer> imageQuality;
@@ -103,4 +103,7 @@ public class UploadItem {
     this.gpsCoords = gpsCoords;
   }
 
+  public void setPlace(Place place) {
+    this.place = place;
+  }
 }

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -35,8 +35,6 @@ import fr.free.nrw.commons.upload.UploadItem;
 import fr.free.nrw.commons.utils.DialogUtil;
 import fr.free.nrw.commons.utils.ImageUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import javax.inject.Inject;
@@ -214,7 +212,7 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
     }
 
     @Override
-    public void onImageProcessed(UploadItem uploadItem, Place place) {
+    public void onImageProcessed(UploadItem uploadItem) {
         photoViewBackgroundImage.setImageURI(uploadItem.getMediaUri());
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailsContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailsContract.java
@@ -16,7 +16,7 @@ public interface UploadMediaDetailsContract {
 
     interface View extends SimilarImageInterface {
 
-        void onImageProcessed(UploadItem uploadItem, Place place);
+        void onImageProcessed(UploadItem uploadItem);
 
         void onNearbyPlaceFound(UploadItem uploadItem, Place place);
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -85,14 +85,14 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
                 .observeOn(mainThreadScheduler)
                 .subscribe(uploadItem ->
                     {
-                        view.onImageProcessed(uploadItem, place);
+                        view.onImageProcessed(uploadItem);
                         view.updateMediaDetails(uploadItem.getUploadMediaDetails());
                         ImageCoordinates gpsCoords = uploadItem.getGpsCoords();
                         final boolean hasImageCoordinates =
                           gpsCoords != null && gpsCoords.getImageCoordsExists();
                         view.showMapWithImageCoordinates(hasImageCoordinates);
                         view.showProgress(false);
-                        if (hasImageCoordinates) {
+                        if (hasImageCoordinates && uploadItem.getPlace() == null) {
                             checkNearbyPlaces(uploadItem);
                         }
                     },
@@ -184,9 +184,11 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
 
   @Override
   public void onUserConfirmedUploadIsOfPlace(Place place, int uploadItemPosition) {
-    final List<UploadMediaDetail> uploadMediaDetails = repository.getUploads()
-        .get(uploadItemPosition)
+    final UploadItem uploadItem = repository.getUploads()
+        .get(uploadItemPosition);
+    final List<UploadMediaDetail> uploadMediaDetails = uploadItem
         .getUploadMediaDetails();
+    uploadItem.setPlace(place);
     uploadMediaDetails.set(0, new UploadMediaDetail(place));
     view.updateMediaDetails(uploadMediaDetails);
   }

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaPresenterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaPresenterTest.kt
@@ -86,8 +86,7 @@ class UploadMediaPresenterTest {
         verify(view).showProgress(true)
         testScheduler.triggerActions()
         verify(view).onImageProcessed(
-            ArgumentMatchers.any(UploadItem::class.java),
-            ArgumentMatchers.any(Place::class.java)
+            ArgumentMatchers.any(UploadItem::class.java)
         )
         verify(view).showProgress(false)
     }

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaPresenterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaPresenterTest.kt
@@ -21,6 +21,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 import java.util.*
+import kotlin.collections.ArrayList
 
 
 /**
@@ -65,8 +66,10 @@ class UploadMediaPresenterTest {
         testObservableUploadItem = Observable.just(uploadItem)
         testSingleImageResult = Single.just(1)
         testScheduler = TestScheduler()
-        uploadMediaPresenter = UploadMediaPresenter(repository,
-            jsonKvStore,testScheduler, testScheduler)
+        uploadMediaPresenter = UploadMediaPresenter(
+            repository,
+            jsonKvStore, testScheduler, testScheduler
+        )
         uploadMediaPresenter.onAttachView(view)
     }
 
@@ -226,4 +229,18 @@ class UploadMediaPresenterTest {
         verify(view).showSimilarImageFragment("original", "possible", similar)
     }
 
+    @Test
+    fun `when user confirms place update details and upload item`() {
+        val item = mock<UploadItem>()
+        whenever(repository.uploads).thenReturn(listOf(item))
+        val place = mock<Place>()
+        whenever(place.longDescription).thenReturn("desc")
+        whenever(place.name).thenReturn("capt")
+        val mediaDetails = mock<ArrayList<UploadMediaDetail>>()
+        whenever(item.uploadMediaDetails).thenReturn(mediaDetails)
+        uploadMediaPresenter.onUserConfirmedUploadIsOfPlace(place, 0)
+        verify(item).place = place
+        verify(mediaDetails)[0] = UploadMediaDetail("en", "desc", "capt")
+        verify(view).updateMediaDetails(mediaDetails)
+    }
 }


### PR DESCRIPTION


**Description (required)**

Fixes #3380 

What changes did you make and why?
- Don't try to find a nearby place if it is already a nearby upload
- when a nearby upload is detected update the place so it will attempt to attach upload to p18 of nearby item

**Tests performed (required)**

@nicolas-raoul this one is quite hard to test for me as I don't think this works on `beta` and I do not have `prod` quality photos of things nearby myself. If you can spare the time to test this I would be grateful.
