### PR TITLE
#3801 SPARQL responses can return greater than 50 results breaking wbGetEntities

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.category
 
 import android.text.TextUtils
+import fr.free.nrw.commons.explore.depictions.combineLatest
 import fr.free.nrw.commons.upload.GpsCategoryModel
 import fr.free.nrw.commons.upload.structure.depictions.DepictedItem
 import fr.free.nrw.commons.utils.StringSortingUtils
@@ -112,12 +113,7 @@ class CategoriesModel @Inject constructor(
      * @return
      */
     private fun titleCategories(titleList: List<String>) =
-        if (titleList.isNotEmpty())
-            Observable.combineLatest(titleList.map { getTitleCategories(it) }) { searchResults ->
-                searchResults.map { it as List<String> }.flatten()
-            }
-        else
-            Observable.just(emptyList())
+        titleList.map { getTitleCategories(it) }.combineLatest().map { it.flatten() }
 
     /**
      * Return category for single title


### PR DESCRIPTION


**Description (required)**

Fixes #3801 

What changes did you make and why?
 - chunk ids by max size and combine requests

**Tests performed (required)**

Tested ProdDebug on Nexus5X with API level 27


