### PR TITLE
#3816 Update Android Gradle Plugin to 4.0.0 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ android:
   components:
   - tools
   - platform-tools
-  - build-tools-28.0.3
+  - build-tools-29.0.2
   - extra-google-m2repository
   - extra-android-m2repository
   - android-22

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -134,7 +134,6 @@ dependencies {
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         //applicationId 'fr.free.nrw.commons'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -151,7 +151,6 @@ android {
         testOptions {
             execution 'ANDROIDX_TEST_ORCHESTRATOR'
         }
-        multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "com.hiya:jacoco-android:0.2"
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"


### PR DESCRIPTION


**Description (required)**

Fixes #3816 

What changes did you make and why?
- upgrade AGP 
- remove explicit buildToolsVersion

**Tests performed (required)**

TestedProdDebug on Nexus5x with API level 27
