### PR TITLE
Fix compilation errors while trying to run instrumentation tests

### DIFF
--- a/app/src/androidTest/java/fr/free/nrw/commons/AboutActivityTest.kt
+++ b/app/src/androidTest/java/fr/free/nrw/commons/AboutActivityTest.kt
@@ -14,7 +14,7 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.rule.ActivityTestRule
 import androidx.test.runner.AndroidJUnit4
-import fr.free.nrw.commons.utils.ConfigUtils
+import fr.free.nrw.commons.utils.ConfigUtils.getVersionNameWithSha
 import org.hamcrest.CoreMatchers
 import org.junit.Before
 import org.junit.Rule
@@ -36,7 +36,9 @@ class AboutActivityTest {
     @Test
     fun testBuildNumber() {
         Espresso.onView(ViewMatchers.withId(R.id.about_version))
-                .check(ViewAssertions.matches(withText(ConfigUtils.getVersionNameWithSha(getApplicationContext()))))
+                .check(ViewAssertions.matches(
+                    withText(getApplicationContext<CommonsApplication>().getVersionNameWithSha())
+                ))
     }
 
     @Test

--- a/app/src/androidTest/java/fr/free/nrw/commons/UploadTest.kt
+++ b/app/src/androidTest/java/fr/free/nrw/commons/UploadTest.kt
@@ -26,7 +26,7 @@ import androidx.test.rule.ActivityTestRule
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.runner.AndroidJUnit4
 import fr.free.nrw.commons.auth.LoginActivity
-import fr.free.nrw.commons.upload.DescriptionsAdapter
+import fr.free.nrw.commons.upload.UploadMediaDetailAdapter
 import fr.free.nrw.commons.util.MyViewAction
 import fr.free.nrw.commons.utils.ConfigUtils
 import org.hamcrest.core.AllOf.allOf
@@ -78,7 +78,7 @@ class UploadTest {
 
     @Test
     fun testUploadWithDescription() {
-        if (!ConfigUtils.isBetaFlavour()) {
+        if (!ConfigUtils.isBetaFlavour) {
             throw Error("This test should only be run in Beta!")
         }
 
@@ -96,7 +96,7 @@ class UploadTest {
         // Try to dismiss the error, if there is one (probably about duplicate files on Commons)
         dismissWarning("Yes")
 
-        onView(allOf<View>(isDisplayed(), withId(R.id.et_title)))
+        onView(allOf<View>(isDisplayed(), withId(R.id.tv_title)))
                 .perform(replaceText(commonsFileName))
 
         onView(allOf<View>(isDisplayed(), withId(R.id.description_item_edit_text)))
@@ -150,7 +150,7 @@ class UploadTest {
 
     @Test
     fun testUploadWithoutDescription() {
-        if (!ConfigUtils.isBetaFlavour()) {
+        if (!ConfigUtils.isBetaFlavour) {
             throw Error("This test should only be run in Beta!")
         }
 
@@ -168,7 +168,7 @@ class UploadTest {
         // Try to dismiss the error, if there is one (probably about duplicate files on Commons)
         dismissWarning("Yes")
 
-        onView(allOf<View>(isDisplayed(), withId(R.id.et_title)))
+        onView(allOf<View>(isDisplayed(), withId(R.id.tv_title)))
                 .perform(replaceText(commonsFileName))
 
         onView(allOf(isDisplayed(), withId(R.id.btn_next)))
@@ -209,7 +209,7 @@ class UploadTest {
 
     @Test
     fun testUploadWithMultilingualDescription() {
-        if (!ConfigUtils.isBetaFlavour()) {
+        if (!ConfigUtils.isBetaFlavour) {
             throw Error("This test should only be run in Beta!")
         }
 
@@ -227,12 +227,12 @@ class UploadTest {
         // Try to dismiss the error, if there is one (probably about duplicate files on Commons)
         dismissWarningDialog()
 
-        onView(allOf<View>(isDisplayed(), withId(R.id.et_title)))
+        onView(allOf<View>(isDisplayed(), withId(R.id.tv_title)))
                 .perform(replaceText(commonsFileName))
 
         onView(withId(R.id.rv_descriptions)).perform(
                 RecyclerViewActions
-                        .actionOnItemAtPosition<DescriptionsAdapter.ViewHolder>(0,
+                        .actionOnItemAtPosition<UploadMediaDetailAdapter.ViewHolder>(0,
                                 MyViewAction.typeTextInChildViewWithId(R.id.description_item_edit_text, "Test description")))
 
         onView(withId(R.id.btn_add_description))
@@ -240,12 +240,12 @@ class UploadTest {
 
         onView(withId(R.id.rv_descriptions)).perform(
                 RecyclerViewActions
-                        .actionOnItemAtPosition<DescriptionsAdapter.ViewHolder>(1,
+                        .actionOnItemAtPosition<UploadMediaDetailAdapter.ViewHolder>(1,
                                 MyViewAction.selectSpinnerItemInChildViewWithId(R.id.spinner_description_languages, 2)))
 
         onView(withId(R.id.rv_descriptions)).perform(
                 RecyclerViewActions
-                        .actionOnItemAtPosition<DescriptionsAdapter.ViewHolder>(1,
+                        .actionOnItemAtPosition<UploadMediaDetailAdapter.ViewHolder>(1,
                                 MyViewAction.typeTextInChildViewWithId(R.id.description_item_edit_text, "Description")))
 
         onView(allOf(isDisplayed(), withId(R.id.btn_next)))

--- a/app/src/androidTest/java/fr/free/nrw/commons/WelcomeActivityTest.kt
+++ b/app/src/androidTest/java/fr/free/nrw/commons/WelcomeActivityTest.kt
@@ -23,7 +23,7 @@ class WelcomeActivityTest {
 
     @Test
     fun ifBetaShowsSkipButton() {
-        if (ConfigUtils.isBetaFlavour()) {
+        if (ConfigUtils.isBetaFlavour) {
             onView(withId(R.id.finishTutorialButton))
                     .check(matches(isDisplayed()))
         }
@@ -31,7 +31,7 @@ class WelcomeActivityTest {
 
     @Test
     fun ifProdHidesSkipButton() {
-        if (!ConfigUtils.isBetaFlavour()) {
+        if (!ConfigUtils.isBetaFlavour) {
             onView(withId(R.id.finishTutorialButton))
                     .check(matches(not(isDisplayed())))
         }
@@ -39,7 +39,7 @@ class WelcomeActivityTest {
 
     @Test
     fun testBetaSkipButton() {
-        if (ConfigUtils.isBetaFlavour()) {
+        if (ConfigUtils.isBetaFlavour) {
             onView(withId(R.id.finishTutorialButton))
                     .perform(ViewActions.click())
             assert(activityRule.activity.isDestroyed)


### PR DESCRIPTION
**Description (required)**

Fixes Instrumentation Tests unable to run on device/emulator because the project fails to compile. Some classes changed names without updating the tests. Additionally there were some compat issues when calling Kotlin code from Java.

Some instrumentation tests are not passing. They need to be fixed but that is out of scope of what this PR is trying to fix.

**Tests performed (required)**

Tested _betaDebug_ on _Samsung S9_ with _API level 29_.
