### PR TITLE
Removed NestedScrollView in Upload Media Fragment to avoid lag when adding multiple caption+description pair

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -188,6 +188,7 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
         UploadMediaDetail uploadMediaDetail = new UploadMediaDetail();
         uploadMediaDetail.setManuallyAdded(true);//This was manually added by the user
         uploadMediaDetailAdapter.addDescription(uploadMediaDetail);
+        rvDescriptions.scrollToPosition(uploadMediaDetailAdapter.getItemCount()-1);
     }
 
     @Override

--- a/app/src/main/res/layout/fragment_upload_media_detail_fragment.xml
+++ b/app/src/main/res/layout/fragment_upload_media_detail_fragment.xml
@@ -19,11 +19,6 @@
         android:layout_margin="@dimen/dimen_10"
         android:elevation="@dimen/cardview_default_elevation">
 
-        <androidx.core.widget.NestedScrollView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fillViewport="true">
-
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -139,8 +134,6 @@
 
                 </LinearLayout>
             </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
-
 
     </androidx.cardview.widget.CardView>
 </RelativeLayout>


### PR DESCRIPTION
**Description (required)**

Fixes #3561 

What changes did you make and why?
I removed the `NestedScrollView` over the `RecyclerView`and called `recyclerView.scrollToPosition()` on adding a new item to the `RecyclerView`.

**Tests performed (required)**
I tested it on my device Vivo V11 Pro, Android 9.

**Screenshots (for UI changes only)**
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/35730054/86235165-a2060680-bbb5-11ea-94ac-81dbd657272c.gif)

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
