### PR TITLE
Fixes Empty Space on Settings Preference 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -6,11 +6,16 @@ import android.os.Bundle;
 import android.text.InputFilter;
 import android.text.InputType;
 import androidx.preference.EditTextPreference;
+import android.view.View;
 import androidx.preference.ListPreference;
 import androidx.preference.MultiSelectListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 import com.google.android.material.snackbar.Snackbar;
+import androidx.preference.PreferenceGroupAdapter;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.PreferenceViewHolder;
+import androidx.recyclerview.widget.RecyclerView.Adapter;
 import com.karumi.dexter.Dexter;
 import com.karumi.dexter.listener.PermissionGrantedResponse;
 import com.karumi.dexter.listener.single.BasePermissionListener;
@@ -85,6 +90,21 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             findPreference("displayLocationPermissionForCardView").setEnabled(false);
             findPreference("displayCampaignsCardView").setEnabled(false);
         }
+    }
+
+    @Override
+    protected Adapter onCreateAdapter(PreferenceScreen preferenceScreen) {
+        return new PreferenceGroupAdapter(preferenceScreen) {
+            @Override
+            public void onBindViewHolder(PreferenceViewHolder holder, int position) {
+                super.onBindViewHolder(holder, position);
+                Preference preference = getItem(position);
+                View iconFrame = holder.itemView.findViewById(R.id.icon_frame);
+                if (iconFrame != null) {
+                    iconFrame.setVisibility(View.GONE);
+                }
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
**Description (required)**

Fixes #3573 

What changes did you make and why?
I set the visibility of `iconFrame` to `View.GONE` for all preferences. 

**Tests performed (required)**
I tested it on my device Vivo V11 Pro, Android 9.

**Screenshots (for UI changes only)**
![WhatsApp Image 2020-07-02 at 15 18 06](https://user-images.githubusercontent.com/35730054/86344197-99760480-bc77-11ea-9dbc-fdff3cb61f27.jpeg)

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
