### PR TITLE
Create a Custom Decoder for Fresco Library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -114,6 +114,9 @@ dependencies {
     //swipe_layout
     implementation 'com.daimajia.swipelayout:library:1.2.0@aar'
 
+    // SVG rendering library
+    implementation 'com.caverock:androidsvg-aar:1.4'
+
     //Room
     implementation "androidx.room:room-runtime:$ROOM_VERSION"
     implementation "androidx.room:room-ktx:$ROOM_VERSION"

--- a/app/src/main/java/fr/free/nrw/commons/media/CustomImageDecoder.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/CustomImageDecoder.java
@@ -69,9 +69,6 @@ public class CustomImageDecoder implements ImageDecoder {
   /** SVG drawable factory that creates {@link PictureDrawable}s for SVG images. */
   public static class SvgDrawableFactory implements DrawableFactory {
 
-    static int width;
-    static int height;
-
     @Override
     public boolean supportsImageType(CloseableImage image) {
       return image instanceof CloseableSvgImage;
@@ -87,8 +84,8 @@ public class CustomImageDecoder implements ImageDecoder {
   public static class SvgPictureDrawable extends PictureDrawable {
 
     private final SVG mSvg;
-    public static int imagewidth;
-    public static int imageheight;
+    public static int width;
+    public static int height;
 
     public SvgPictureDrawable(SVG svg) {
       super(null);
@@ -98,8 +95,8 @@ public class CustomImageDecoder implements ImageDecoder {
     @Override
     protected void onBoundsChange(Rect bounds) {
       super.onBoundsChange(bounds);
-      imageheight = bounds.height();
-      imagewidth = bounds.width();
+      height = bounds.height();
+      width = bounds.width();
       setPicture(mSvg.renderToPicture(bounds.width(), bounds.height()));
     }
   }
@@ -135,12 +132,12 @@ public class CustomImageDecoder implements ImageDecoder {
 
     @Override
     public int getWidth() {
-      return SvgPictureDrawable.imagewidth;
+      return SvgPictureDrawable.width;
     }
 
     @Override
     public int getHeight() {
-      return SvgPictureDrawable.imageheight;
+      return SvgPictureDrawable.height;
     }
   }
 }

--- a/app/src/main/java/fr/free/nrw/commons/media/CustomImageDecoder.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/CustomImageDecoder.java
@@ -1,0 +1,146 @@
+package fr.free.nrw.commons.media;
+
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.PictureDrawable;
+import androidx.annotation.Nullable;
+import com.caverock.androidsvg.SVG;
+import com.caverock.androidsvg.SVGParseException;
+import com.facebook.imageformat.ImageFormat;
+import com.facebook.imageformat.ImageFormatCheckerUtils;
+import com.facebook.imagepipeline.common.ImageDecodeOptions;
+import com.facebook.imagepipeline.decoder.ImageDecoder;
+import com.facebook.imagepipeline.drawable.DrawableFactory;
+import com.facebook.imagepipeline.image.CloseableImage;
+import com.facebook.imagepipeline.image.EncodedImage;
+import com.facebook.imagepipeline.image.QualityInfo;
+
+public class CustomImageDecoder implements ImageDecoder {
+
+  public static final ImageFormat SVG_FORMAT = new ImageFormat("SVG_FORMAT", "svg");
+  private static final String HEADER_TAG = "<svg";
+
+  private static final byte[][] POSSIBLE_HEADER_TAGS = {
+      ImageFormatCheckerUtils.asciiBytes("<?xml")
+  };
+
+  @Override
+  public CloseableImage decode(EncodedImage encodedImage, int length, QualityInfo qualityInfo,
+      ImageDecodeOptions options) {
+      try {
+        SVG svg = SVG.getFromInputStream(encodedImage.getInputStream());
+        return new CloseableSvgImage(svg);
+      } catch (SVGParseException e) {
+        e.printStackTrace();
+      }
+      return null;
+  }
+
+  public static class SvgFormatChecker implements ImageFormat.FormatChecker {
+
+    public static final byte[] HEADER = ImageFormatCheckerUtils.asciiBytes(HEADER_TAG);
+
+    @Override
+    public int getHeaderSize() {
+      return HEADER.length;
+    }
+
+    @Nullable
+    @Override
+    public ImageFormat determineFormat(byte[] headerBytes, int headerSize) {
+      if (headerSize < getHeaderSize()) {
+        return null;
+      }
+      if (ImageFormatCheckerUtils.startsWithPattern(headerBytes, HEADER)) {
+        return SVG_FORMAT;
+      }
+      for (byte[] possibleHeaderTag : POSSIBLE_HEADER_TAGS) {
+        if (ImageFormatCheckerUtils.startsWithPattern(headerBytes, possibleHeaderTag)
+            && ImageFormatCheckerUtils.indexOfPattern(
+            headerBytes, headerBytes.length, HEADER, HEADER.length)
+            > -1) {
+          return SVG_FORMAT;
+        }
+      }
+      return null;
+    }
+  }
+
+  /** SVG drawable factory that creates {@link PictureDrawable}s for SVG images. */
+  public static class SvgDrawableFactory implements DrawableFactory {
+
+    static int width;
+    static int height;
+
+    @Override
+    public boolean supportsImageType(CloseableImage image) {
+      return image instanceof CloseableSvgImage;
+    }
+
+    @Nullable
+    @Override
+    public Drawable createDrawable(CloseableImage image) {
+      return new SvgPictureDrawable(((CloseableSvgImage) image).getSvg());
+    }
+  }
+
+  public static class SvgPictureDrawable extends PictureDrawable {
+
+    private final SVG mSvg;
+    public static int imagewidth;
+    public static int imageheight;
+
+    public SvgPictureDrawable(SVG svg) {
+      super(null);
+      mSvg = svg;
+    }
+
+    @Override
+    protected void onBoundsChange(Rect bounds) {
+      super.onBoundsChange(bounds);
+      imageheight = bounds.height();
+      imagewidth = bounds.width();
+      setPicture(mSvg.renderToPicture(bounds.width(), bounds.height()));
+    }
+  }
+
+  public static class CloseableSvgImage extends CloseableImage {
+
+    private final SVG mSvg;
+
+    private boolean mClosed = false;
+
+    public CloseableSvgImage(SVG svg) {
+      mSvg = svg;
+    }
+
+    public SVG getSvg() {
+      return mSvg;
+    }
+
+    @Override
+    public int getSizeInBytes() {
+      return 0;
+    }
+
+    @Override
+    public void close() {
+      mClosed = true;
+    }
+
+    @Override
+    public boolean isClosed() {
+      return mClosed;
+    }
+
+    @Override
+    public int getWidth() {
+      return SvgPictureDrawable.imagewidth;
+    }
+
+    @Override
+    public int getHeight() {
+      return SvgPictureDrawable.imageheight;
+    }
+  }
+}

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -36,8 +36,10 @@ import com.facebook.drawee.controller.BaseControllerListener;
 import com.facebook.drawee.controller.ControllerListener;
 import com.facebook.drawee.interfaces.DraweeController;
 import com.facebook.drawee.view.SimpleDraweeView;
+import com.facebook.imagepipeline.common.ImageDecodeOptions;
 import com.facebook.imagepipeline.image.ImageInfo;
 import com.facebook.imagepipeline.request.ImageRequest;
+import com.facebook.imagepipeline.request.ImageRequestBuilder;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.MediaDataExtractor;
 import fr.free.nrw.commons.R;
@@ -371,13 +373,27 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
     private void setupImageView() {
         DraweeController controller = Fresco.newDraweeControllerBuilder()
                 .setLowResImageRequest(ImageRequest.fromUri(media.getThumbUrl()))
-                .setImageRequest(ImageRequest.fromUri(media.getImageUrl()))
+                .setImageRequest(ImageRequestBuilder.newBuilderWithSource(
+                    Uri.parse(media.getImageUrl()))
+                    .setImageDecodeOptions(
+                        ImageDecodeOptions.newBuilder()
+                        .setCustomImageDecoder(new CustomImageDecoder())
+                        .build())
+                    .build()
+                )
                 .setControllerListener(aspectRatioListener)
                 .setOldController(image.getController())
                 .build();
         DraweeController controllerLandscape = Fresco.newDraweeControllerBuilder()
             .setLowResImageRequest(ImageRequest.fromUri(media.getThumbUrl()))
-            .setImageRequest(ImageRequest.fromUri(media.getImageUrl()))
+            .setImageRequest(ImageRequestBuilder.newBuilderWithSource(
+                Uri.parse(media.getImageUrl()))
+                .setImageDecodeOptions(
+                    ImageDecodeOptions.newBuilder()
+                        .setCustomImageDecoder(new CustomImageDecoder())
+                        .build())
+                .build()
+            )
             .setControllerListener(aspectRatioListener)
             .setOldController(imageLandscape.getController())
             .build();

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -45,13 +45,13 @@ import fr.free.nrw.commons.MediaDataExtractor;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.auth.AccountUtil;
-import fr.free.nrw.commons.category.CategoryClient;
 import fr.free.nrw.commons.category.CategoryDetailsActivity;
 import fr.free.nrw.commons.contributions.ContributionsFragment;
 import fr.free.nrw.commons.delete.DeleteHelper;
 import fr.free.nrw.commons.delete.ReasonBuilder;
 import fr.free.nrw.commons.explore.depictions.WikidataItemDetailsActivity;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
+import fr.free.nrw.commons.media.CustomImageDecoder.SvgDrawableFactory;
 import fr.free.nrw.commons.ui.widget.HtmlTextView;
 import fr.free.nrw.commons.utils.ViewUtilWrapper;
 import io.reactivex.Single;
@@ -381,6 +381,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
                         .build())
                     .build()
                 )
+                .setCustomDrawableFactory(new SvgDrawableFactory())
                 .setControllerListener(aspectRatioListener)
                 .setOldController(image.getController())
                 .build();
@@ -394,6 +395,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment {
                         .build())
                 .build()
             )
+            .setCustomDrawableFactory(new SvgDrawableFactory())
             .setControllerListener(aspectRatioListener)
             .setOldController(imageLandscape.getController())
             .build();


### PR DESCRIPTION
**Description (required)**

Fixes #3678 

What changes did you make and why?
I created a custom Decoder that extends `ImageDecoder` class, it checks for SVG formats and converts them to Closeable image. 

**Tests performed (required)**
I tested it on Android 9 on Vivo V11

**Screenshots (for UI changes only)**
The only problem I'm facing is I cannot find a way to resize the image according to the `scrollView` dimensions.

| Thumbnail Image  | Final Image |
| ------------- | ------------- |
| ![WhatsApp Image 2020-07-04 at 10 32 43](https://user-images.githubusercontent.com/35730054/86505429-03aab880-bde2-11ea-8223-71caaf1022ee.jpeg)  | ![WhatsApp Image 2020-07-04 at 10 32 43 (3)](https://user-images.githubusercontent.com/35730054/86505425-fc83aa80-bde1-11ea-8f04-4a9cc72dc83f.jpeg)  |
| ![WhatsApp Image 2020-07-04 at 10 32 43 (1)](https://user-images.githubusercontent.com/35730054/86505427-00173180-bde2-11ea-9fb6-18bffbd10312.jpeg)  | ![WhatsApp Image 2020-07-04 at 10 32 43 (2)](https://user-images.githubusercontent.com/35730054/86505426-fee60480-bde1-11ea-9fa8-9ca7f3a7b29c.jpeg)  |

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
