### PR TITLE
Clarify that the caption would also be used as the image title

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -263,7 +263,7 @@
   <string name="error_while_cache">Error while caching pictures</string>
   <string name="title_info">A unique descriptive title for the file, which will serve as a filename. You may use plain language with spaces. Do not include the file extension</string>
   <string name="description_info">Please describe the media as much as possible: Where was it taken? What does it show? What is the context? Please describe the objects or persons. Reveal information that can not be easily guessed, for instance the time of day if it is a landscape. If the media shows something unusual, please explain what makes it unusual.</string>
-  <string name="caption_info">Please write a brief description of the image. (Limit to 255 characters)</string>
+  <string name="caption_info">Please write a brief description of the image. The first caption would be used as the Title for the image.</string>
 
   <string name="upload_image_too_dark">This picture is too dark, are you sure you want to upload it? Wikimedia Commons is only for pictures with encyclopedic value.</string>
   <string name="upload_image_blurry">This picture is blurry, are you sure you want to upload it? Wikimedia Commons is only for pictures with encyclopedic value.</string>


### PR DESCRIPTION
**Description (required)**
The app uses the fist caption as the file title. This should also
be communicated to the user via the info box as they would not be
aware of it otherwise.

Related issue: #3713 

**Tests performed (required)**
Tested prodDebug on Samsung SM-J111F with API level 22.

**Screenshots**
![Screenshot_2020-07-19-23-12-18](https://user-images.githubusercontent.com/12448084/87881293-fadaf900-ca15-11ea-9da3-54e28e00874d.png)
