### PR TITLE
Fix category links in media detail

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -1,5 +1,7 @@
 package fr.free.nrw.commons.category;
 
+import static fr.free.nrw.commons.category.CategoryClientKt.CATEGORY_PREFIX;
+
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -26,6 +28,7 @@ import fr.free.nrw.commons.media.MediaDetailPagerFragment;
 import fr.free.nrw.commons.theme.NavigationBaseActivity;
 import java.util.ArrayList;
 import java.util.List;
+import org.wikipedia.page.PageTitle;
 
 /**
  * This activity displays details of a particular category
@@ -181,7 +184,8 @@ public class CategoryDetailsActivity extends NavigationBaseActivity
         // Handle item selection
         switch (item.getItemId()) {
             case R.id.menu_browser_current_category:
-                Utils.handleWebUrl(this, Uri.parse(Utils.getPageTitle(categoryName).getCanonicalUri()));
+                PageTitle title = Utils.getPageTitle(CATEGORY_PREFIX + categoryName);
+                Utils.handleWebUrl(this, Uri.parse(title.getCanonicalUri()));
                 return true;
             default:
                 return super.onOptionsItemSelected(item);

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -3,7 +3,6 @@ package fr.free.nrw.commons.media;
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 import static fr.free.nrw.commons.category.CategoryClientKt.CATEGORY_NEEDING_CATEGORIES;
-import static fr.free.nrw.commons.category.CategoryClientKt.CATEGORY_PREFIX;
 import static fr.free.nrw.commons.category.CategoryClientKt.CATEGORY_UNCATEGORISED;
 
 import android.annotation.SuppressLint;
@@ -295,6 +294,9 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             new OnGlobalLayoutListener() {
                 @Override
                 public void onGlobalLayout() {
+                    if (getContext() == null) {
+                        return;
+                    }
                     scrollView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
                     if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
                         imageLandscape.setVisibility(VISIBLE);
@@ -837,9 +839,8 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         if(!getString(R.string.detail_panel_cats_none).equals(catName)) {
             textView.setOnClickListener(view -> {
                 // Open Category Details page
-                String selectedCategoryTitle = CATEGORY_PREFIX + catName;
                 Intent intent = new Intent(getContext(), CategoryDetailsActivity.class);
-                intent.putExtra("categoryName", selectedCategoryTitle);
+                intent.putExtra("categoryName", catName);
                 getContext().startActivity(intent);
             });
         }


### PR DESCRIPTION
**Description**

The prefix "Category:" is not expected by the category activity. I changed the category links in the media detail view to no longer add that prefix.  
Additionally, I added a workaround for a crash where the media detail fragment somehow lost it's context.

**Tests performed**

Tested prodDebug on Huawei P8 Lite with API level 23.

**Screenshots (for UI changes only)**

Category browser now no longer sometimes displays "Category:" in the title bar.