### PR TITLE
Fixes #3767 : Set a default value for Nearby Edit count in AchievementsFragment

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -149,6 +149,8 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
 
         setHasOptionsMenu(true);
 
+        // Set the initial value of WikiData edits to 0
+        wikidataEditsText.setText("0");
         hideLayouts();
         setWikidataEditCount();
         setAchievements();


### PR DESCRIPTION
**Description (required)**

Fixes #3767 

What changes did you make and why?
Set a default value for Nearby Edit count in AchievementsFragment
Referred #3796 
**Tests performed (required)**

Tested betaDebug Api 27

**Screenshots (for UI changes only)**
![Screenshot_1602930073](https://user-images.githubusercontent.com/17375274/96334751-ab49af00-1090-11eb-9ec3-3e177accb6e1.png)
