### PR TITLE
Losing filled data when screen rotate (#3973)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -94,7 +94,7 @@
 
         <activity
             android:name=".auth.SignupActivity"
-          android:configChanges="orientation|screenLayout|screenSize"
+            android:configChanges="orientation|screenLayout|screenSize"
             android:label="@string/title_activity_signup" />
 
         <activity
@@ -183,7 +183,7 @@
             android:authorities="${applicationId}.categories.contentprovider"
             android:exported="false"
             android:label="@string/provider_categories"
-          android:syncable="false" />
+            android:syncable="false" />
 
         <provider
             android:name=".explore.recentsearches.RecentSearchesContentProvider"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -94,6 +94,7 @@
 
         <activity
             android:name=".auth.SignupActivity"
+          android:configChanges="orientation|screenLayout|screenSize"
             android:label="@string/title_activity_signup" />
 
         <activity


### PR DESCRIPTION
**Description (required)**

Fixes #3973 
What changes did you make and why?

**_Bug_** is due to the restart of SignupActivity  on the configuration change 
So  ****Add an attribute android:configChanges="screenSize|orientation|screenLayout" in   Manifes.xml** of auth.SignupActivity** so that SignupActivity does not restart on configuration change.


**Tests performed (required)**
Tested prodDebug on samsung m11 API level 29

Screenshots (for UI changes only)
Not losing filled data when screen rotate

![20201025_191542](https://user-images.githubusercontent.com/65972015/97109025-06b21780-16f7-11eb-93b8-cd460fb1229a.gif)
