### PR TITLE
Fixes #3968 But we may already be a Beta Tester

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,7 +207,7 @@
   <string name="media_detail_license">License</string>
   <string name="media_detail_coordinates">Coordinates</string>
   <string name="media_detail_coordinates_empty">None provided</string>
-  <string name="become_a_tester_title">Become a Beta Tester</string>
+  <string name="become_a_tester_title">Become a Beta Tester (if not one already)</string>
   <string name="become_a_tester_description">Opt-in to our beta channel on Google Play and get early access to new features and bug fixes</string>
   <string name="beta_opt_in_link">https://play.google.com/apps/testing/fr.free.nrw.commons</string>
   <string name="map_theme_light">mapbox://styles/mapbox/traffic-day-v2</string>


### PR DESCRIPTION
Adds a qualifying clause to the "Become a Beta Tester" text in Settings > Feedback page.

Fixes #3968 

Previous text might confuse a user who signed up for the Beta.

Tested BetaDebug and ProdDebug on emulated Pixel 4 XL with API level 30.

Screenshot on ProdDebug:
![image](https://user-images.githubusercontent.com/42556668/97089165-de3cf700-15ea-11eb-96fa-db372485e070.png)
