### PR TITLE
Rename Mapbox telemetry setting

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -691,7 +691,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="leaderboard_nearby">Nearby</string>
   <string name="leaderboard_used">Used</string>
   <string name="leaderboard_my_rank_button_text">My Rank</string>
-  <string name="mapbox_telemetry">Telemetry Opt Out</string>
+  <string name="mapbox_telemetry">Mapbox Telemetry</string>
   <string name="telemetry_opt_out_summary">Send anonymized location and usage data to Mapbox when using Nearby feature</string>
   <string name="map_attribution" translatable="false"><![CDATA[&#169; <a href="https://www.mapbox.com/about/maps/">Mapbox</a> &#169; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> <a href="https://www.mapbox.com/map-feedback/">Improve this map</a>]]></string>
   <string name="limited_connection_enabled">Limited connection mode enabled!</string>


### PR DESCRIPTION
**Description (required)**
Fixes #3946

"Telemetry Opt Out" is a contradictory name for the telemetry setting
as it contradicts the option description by conveying that enabling
the setting means the user has opted out of telemetry while that is
not the case. Enabling the setting means telemetry would be sent
to Mapbox.

So, use a better name that conveys the meaning in a better way without
any contradiction.

**Tests performed (required)**
Tested prodDebug on Samsung SM-J111F with API level 22.

**Screenshots (for UI changes only)**
![Screenshot_2020-10-28-00-44-03](https://user-images.githubusercontent.com/12448084/97350708-c26d7580-18b6-11eb-8d22-49c4d87688de.png)
