### PR TITLE
For #3997 - Add new FOREGROUND_SERVICE permission for AndroidP+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
     <uses-permission android:name="com.google.android.apps.photos.permission.GOOGLE_PHOTOS" />
     <uses-permission android:name="android.permission.SET_WALLPAPER"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
 
     <!-- Needed only if your app targets Android 5.0 (API level 21) or higher. -->


### PR DESCRIPTION
**Description (required)**

Fixes #3997 
On Android 28+ the FOREGROUND_SERVICE permission is required for starting foreground services.
It is a normal permission, automatically granted by Android.

**Tests performed (required)**
Tested {BetaDebug} - camera upload on {Pixel 3} with API level {30}.

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
