### PR TITLE
Telemetry Opt Out: add word "DON'T"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -692,7 +692,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="leaderboard_used">Used</string>
   <string name="leaderboard_my_rank_button_text">My Rank</string>
   <string name="mapbox_telemetry">Telemetry Opt Out</string>
-  <string name="telemetry_opt_out_summary">Send anonymized location and usage data to Mapbox when using Nearby feature</string>
+  <string name="telemetry_opt_out_summary">Don't send anonymized location and usage data to Mapbox when using Nearby feature</string>
   <string name="map_attribution" translatable="false"><![CDATA[&#169; <a href="https://www.mapbox.com/about/maps/">Mapbox</a> &#169; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> <a href="https://www.mapbox.com/map-feedback/">Improve this map</a>]]></string>
   <string name="limited_connection_enabled">Limited connection mode enabled!</string>
   <string name="limited_connection_disabled">Limited connection mode disabled. Pending uploads will resume now.</string>


### PR DESCRIPTION
Here I am guessing the word "Don't" was forgotten.
Else why would it be called an 'Opt-out'?
Of course this is just a guess. I did not test what the program actually does.