### PR TITLE
fixes Progress Bar Visibility change with Orientation Change and login process terminated (#4001)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -483,7 +483,6 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     @Override
     protected void onRestoreInstanceState(final Bundle savedInstanceState) {
         super.onRestoreInstanceState(savedInstanceState);
-
         usernameEdit.setText(savedInstanceState.getString(saveUsername));
         passwordEdit.setText(savedInstanceState.getString(savePassword));
         if(savedInstanceState.getBoolean(saveProgressDailog)) {
@@ -495,6 +494,5 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         } else {
             showMessage(errorMessage, R.color.secondaryDarkColor);
         }
-
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -116,8 +116,10 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     private LoginTextWatcher textWatcher = new LoginTextWatcher();
     private CompositeDisposable compositeDisposable = new CompositeDisposable();
     private Call<MwQueryResponse> loginToken;
-    final  String progressDailog_key="ProgressDailog_state";
-    final String errorMessage_key ="errorMessage";
+    final  String Save_progressDailog="ProgressDailog_state";
+    final String Save_errorMessage ="errorMessage";
+    final String Save_username="username";
+    final  String Save_password="password";
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -460,24 +462,45 @@ public class LoginActivity extends AccountAuthenticatorActivity {
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {
-
+        // if progressDialog is visible during the configuration change  then store state as  true else false so that
+        // we maintain visiblity of progressDailog after configuration change
         if(progressDialog!=null&&progressDialog.isShowing()){
-            outState.putBoolean(progressDailog_key,true);
+            outState.putBoolean(Save_progressDailog,true);
         }else{
-            outState.putBoolean(progressDailog_key,false);
+            outState.putBoolean(Save_progressDailog,false);
         }
 
-        outState.putString(errorMessage_key,errorMessage.getText().toString());
+        outState.putString(Save_errorMessage,errorMessage.getText().toString()); //Save the errorMessage
+        outState.putString(Save_username,getUsername()); // Save the username
+        outState.putString(Save_password,getPassword()); // Save thte password
     }
 
+    private String getUsername() {
+        return usernameEdit.getText().toString();
+    }
+    private String getPassword(){
+        return  passwordEdit.getText().toString();
+  }
 
     @Override
     protected void onRestoreInstanceState(final Bundle savedInstanceState) {
         super.onRestoreInstanceState(savedInstanceState);
-        if(savedInstanceState.getBoolean(progressDailog_key)){
+
+        usernameEdit.setText(savedInstanceState.getString(Save_username));
+        passwordEdit.setText(savedInstanceState.getString(Save_password));
+
+
+        if(savedInstanceState.getBoolean(Save_progressDailog)){
             performLogin();
         }
-        String error=savedInstanceState.getString(errorMessage_key);
-        showMessage(error,R.color.secondaryDarkColor);
+
+        String errorMessage=savedInstanceState.getString(Save_errorMessage);
+
+        if(sessionManager.isUserLoggedIn()){
+            showMessage(R.string.login_success, R.color.primaryDarkColor);
+        }else{
+            showMessage(errorMessage, R.color.secondaryDarkColor);
+        }
+
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -116,7 +116,8 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     private LoginTextWatcher textWatcher = new LoginTextWatcher();
     private CompositeDisposable compositeDisposable = new CompositeDisposable();
     private Call<MwQueryResponse> loginToken;
-
+    final  String progressDailog_key="ProgressDailog_state";
+    final String errorMessage_key ="errorMessage";
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -455,5 +456,28 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     public static void startYourself(Context context) {
         Intent intent = new Intent(context, LoginActivity.class);
         context.startActivity(intent);
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+
+        if(progressDialog!=null&&progressDialog.isShowing()){
+            outState.putBoolean(progressDailog_key,true);
+        }else{
+            outState.putBoolean(progressDailog_key,false);
+        }
+
+        outState.putString(errorMessage_key,errorMessage.getText().toString());
+    }
+
+
+    @Override
+    protected void onRestoreInstanceState(final Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+        if(savedInstanceState.getBoolean(progressDailog_key)){
+            performLogin();
+        }
+        String error=savedInstanceState.getString(errorMessage_key);
+        showMessage(error,R.color.secondaryDarkColor);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -116,10 +116,10 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     private LoginTextWatcher textWatcher = new LoginTextWatcher();
     private CompositeDisposable compositeDisposable = new CompositeDisposable();
     private Call<MwQueryResponse> loginToken;
-    final  String Save_progressDailog="ProgressDailog_state";
-    final String Save_errorMessage ="errorMessage";
-    final String Save_username="username";
-    final  String Save_password="password";
+    final  String saveProgressDailog="ProgressDailog_state";
+    final String saveErrorMessage ="errorMessage";
+    final String saveUsername="username";
+    final  String savePassword="password";
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -464,17 +464,15 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     protected void onSaveInstanceState(Bundle outState) {
         // if progressDialog is visible during the configuration change  then store state as  true else false so that
         // we maintain visiblity of progressDailog after configuration change
-        if(progressDialog!=null&&progressDialog.isShowing()){
-            outState.putBoolean(Save_progressDailog,true);
-        }else{
-            outState.putBoolean(Save_progressDailog,false);
+        if(progressDialog!=null&&progressDialog.isShowing()) {
+            outState.putBoolean(saveProgressDailog,true);
+        } else {
+            outState.putBoolean(saveProgressDailog,false);
         }
-
-        outState.putString(Save_errorMessage,errorMessage.getText().toString()); //Save the errorMessage
-        outState.putString(Save_username,getUsername()); // Save the username
-        outState.putString(Save_password,getPassword()); // Save thte password
+        outState.putString(saveErrorMessage,errorMessage.getText().toString()); //Save the errorMessage
+        outState.putString(saveUsername,getUsername()); // Save the username
+        outState.putString(savePassword,getPassword()); // Save thte password
     }
-
     private String getUsername() {
         return usernameEdit.getText().toString();
     }
@@ -486,19 +484,15 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     protected void onRestoreInstanceState(final Bundle savedInstanceState) {
         super.onRestoreInstanceState(savedInstanceState);
 
-        usernameEdit.setText(savedInstanceState.getString(Save_username));
-        passwordEdit.setText(savedInstanceState.getString(Save_password));
-
-
-        if(savedInstanceState.getBoolean(Save_progressDailog)){
+        usernameEdit.setText(savedInstanceState.getString(saveUsername));
+        passwordEdit.setText(savedInstanceState.getString(savePassword));
+        if(savedInstanceState.getBoolean(saveProgressDailog)) {
             performLogin();
         }
-
-        String errorMessage=savedInstanceState.getString(Save_errorMessage);
-
-        if(sessionManager.isUserLoggedIn()){
+        String errorMessage=savedInstanceState.getString(saveErrorMessage);
+        if(sessionManager.isUserLoggedIn()) {
             showMessage(R.string.login_success, R.color.primaryDarkColor);
-        }else{
+        } else {
             showMessage(errorMessage, R.color.secondaryDarkColor);
         }
 


### PR DESCRIPTION
**Description (required)**
Fixes #4001 
What changes did you make and why?
**Bug** is due to the restart of LoginActivity on the configuration change 
* Overrides the onSaveInstanceState method and onRestoreInstanceState method in LoginActivity.java
* In onSaveInstanceState save  ProgressDailog state or visiblity and text of TextView(errorMessage)
* In onRestoreInstanceState restore All saved Data

**Tests performed (required)**
Tested prodDebug on Redmi Y3 level 29



**Screenshots (for UI changes only)**

![20201111_145410](https://user-images.githubusercontent.com/65972015/98796606-9531d300-2431-11eb-8a24-bb86c5f274df.gif)
