### PR TITLE
Added title name and a tooltip for all the media upload steps

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.java
@@ -4,7 +4,9 @@ import android.os.Bundle;
 import android.text.Editable;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
@@ -42,6 +44,8 @@ public class UploadCategoriesFragment extends UploadBaseFragment implements Cate
     ProgressBar pbCategories;
     @BindView(R.id.rv_categories)
     RecyclerView rvCategories;
+    @BindView(R.id.tooltip)
+    ImageView tooltip;
 
     @Inject
     CategoriesContract.UserActionListener presenter;
@@ -64,7 +68,13 @@ public class UploadCategoriesFragment extends UploadBaseFragment implements Cate
 
     private void init() {
         tvTitle.setText(getString(R.string.step_count, callback.getIndexInViewFlipper(this) + 1,
-                callback.getTotalNumberOfSteps()));
+                callback.getTotalNumberOfSteps(), getString(R.string.categories_activity_title)));
+        tooltip.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                DialogUtil.showAlertDialog(getActivity(), getString(R.string.categories_activity_title), getString(R.string.categories_tooltip), getString(android.R.string.ok), null, true);
+            }
+        });
         presenter.onAttachView(this);
         initRecyclerView();
         addTextChangeListenerToEtSearch();

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
@@ -3,7 +3,9 @@ package fr.free.nrw.commons.upload.depicts;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
@@ -45,6 +47,8 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
     ProgressBar depictsSearchInProgress;
     @BindView(R.id.depicts_recycler_view)
     RecyclerView depictsRecyclerView;
+    @BindView(R.id.tooltip)
+    ImageView tooltip;
 
     @Inject
     DepictsContract.UserActionListener presenter;
@@ -71,7 +75,13 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
      */
     private void init() {
         depictsTitle.setText(getString(R.string.step_count, callback.getIndexInViewFlipper(this) + 1,
-                callback.getTotalNumberOfSteps()));
+                callback.getTotalNumberOfSteps(), getString(R.string.depicts_step_title)));
+        tooltip.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                DialogUtil.showAlertDialog(getActivity(), getString(R.string.depicts_step_title), getString(R.string.depicts_tooltip), getString(android.R.string.ok), null, true);
+            }
+        });
         presenter.onAttachView(this);
         initRecyclerView();
         addTextChangeListenerToSearchBox();

--- a/app/src/main/java/fr/free/nrw/commons/upload/license/MediaLicenseFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/license/MediaLicenseFragment.java
@@ -9,14 +9,21 @@ import android.text.style.ClickableSpan;
 import android.text.style.URLSpan;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
+import android.widget.ImageView;
 import android.widget.Spinner;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import fr.free.nrw.commons.utils.DialogUtil;
+import java.util.List;
+
+import javax.inject.Inject;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
@@ -35,6 +42,8 @@ public class MediaLicenseFragment extends UploadBaseFragment implements MediaLic
     Spinner spinnerLicenseList;
     @BindView(R.id.tv_share_license_summary)
     TextView tvShareLicenseSummary;
+    @BindView(R.id.tooltip)
+    ImageView tooltip;
 
     @Inject
     MediaLicenseContract.UserActionListener presenter;
@@ -63,7 +72,13 @@ public class MediaLicenseFragment extends UploadBaseFragment implements MediaLic
 
     private void init() {
         tvTitle.setText(getString(R.string.step_count, callback.getIndexInViewFlipper(this) + 1,
-                callback.getTotalNumberOfSteps()));
+                callback.getTotalNumberOfSteps(), getString(R.string.license_step_title)));
+        tooltip.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                DialogUtil.showAlertDialog(getActivity(), getString(R.string.license_step_title), getString(R.string.license_tooltip), getString(android.R.string.ok), null, true);
+            }
+        });
         initPresenter();
         initLicenseSpinner();
         presenter.getLicenses();

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -6,7 +6,9 @@ import android.annotation.SuppressLint;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
@@ -63,6 +65,8 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
     AppCompatButton btnNext;
     @BindView(R.id.btn_previous)
     AppCompatButton btnPrevious;
+    @BindView(R.id.tooltip)
+    ImageView tooltip;
     private UploadMediaDetailAdapter uploadMediaDetailAdapter;
     @BindView(R.id.btn_copy_prev_title_desc)
     AppCompatButton btnCopyPreviousTitleDesc;
@@ -111,7 +115,13 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
 
     private void init() {
         tvTitle.setText(getString(R.string.step_count, callback.getIndexInViewFlipper(this) + 1,
-            callback.getTotalNumberOfSteps()));
+            callback.getTotalNumberOfSteps(), getString(R.string.media_detail_step_title)));
+        tooltip.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showInfoAlert(R.string.media_detail_step_title, R.string.media_details_tooltip);
+            }
+        });
         initRecyclerView();
         initPresenter();
         presenter.receiveImage(uploadableFile, place);

--- a/app/src/main/res/layout/fragment_media_license.xml
+++ b/app/src/main/res/layout/fragment_media_license.xml
@@ -12,16 +12,28 @@
     android:layout_above="@+id/ll_container_license_desc"
     android:orientation="vertical">
 
-    <TextView
-      android:id="@+id/tv_title"
-      android:textStyle="bold"
+    <LinearLayout
       android:layout_width="wrap_content"
       android:layout_height="@dimen/half_standard_height"
       android:layout_marginEnd="@dimen/standard_gap"
       android:layout_marginRight="@dimen/standard_gap"
-      android:gravity="center_vertical"
-      android:textSize="@dimen/normal_text"
-      tools:text="Step 1 of 15"/>
+      android:orientation="horizontal">
+      <TextView
+        android:id="@+id/tv_title"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/half_standard_height"
+        android:layout_marginEnd="@dimen/standard_gap"
+        android:layout_marginRight="@dimen/standard_gap"
+        android:gravity="center_vertical"
+        android:textSize="@dimen/normal_text"
+        android:textStyle="bold"
+        tools:text="Step 1 of 15" />
+      <ImageView
+        android:id="@+id/tooltip"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:src="@drawable/mapbox_info_icon_default"/>
+    </LinearLayout>
 
     <TextView
       android:id="@+id/tv_subtitle"

--- a/app/src/main/res/layout/fragment_upload_media_detail_fragment.xml
+++ b/app/src/main/res/layout/fragment_upload_media_detail_fragment.xml
@@ -30,16 +30,28 @@
               android:layout_width="match_parent"
               android:layout_height="wrap_content">
 
-                <TextView
-                  android:id="@+id/tv_title"
+                <LinearLayout
                   android:layout_width="wrap_content"
                   android:layout_height="@dimen/half_standard_height"
                   android:layout_marginEnd="@dimen/standard_gap"
                   android:layout_marginRight="@dimen/standard_gap"
-                  android:gravity="center_vertical"
-                  android:textSize="@dimen/normal_text"
-                  android:textStyle="bold"
-                  tools:text="Step 1 of 15" />
+                  android:orientation="horizontal">
+                    <TextView
+                      android:id="@+id/tv_title"
+                      android:layout_width="wrap_content"
+                      android:layout_height="@dimen/half_standard_height"
+                      android:layout_marginEnd="@dimen/standard_gap"
+                      android:layout_marginRight="@dimen/standard_gap"
+                      android:gravity="center_vertical"
+                      android:textSize="@dimen/normal_text"
+                      android:textStyle="bold"
+                      tools:text="Step 1 of 15" />
+                    <ImageView
+                      android:id="@+id/tooltip"
+                      android:layout_width="wrap_content"
+                      android:layout_height="match_parent"
+                      android:src="@drawable/mapbox_info_icon_default"/>
+                </LinearLayout>
 
                 <androidx.appcompat.widget.AppCompatImageButton
                   android:id="@+id/ib_map"

--- a/app/src/main/res/layout/upload_categories_fragment.xml
+++ b/app/src/main/res/layout/upload_categories_fragment.xml
@@ -11,16 +11,28 @@
     android:layout_height="match_parent"
     android:layout_above="@+id/button_divider"
     android:orientation="vertical">
-    <TextView
-      android:id="@+id/tv_title"
-      android:textStyle="bold"
+    <LinearLayout
       android:layout_width="wrap_content"
       android:layout_height="@dimen/half_standard_height"
       android:layout_marginEnd="@dimen/standard_gap"
       android:layout_marginRight="@dimen/standard_gap"
-      android:gravity="center_vertical"
-      android:textSize="@dimen/normal_text"
-      tools:text="Step 1 of 15"/>
+      android:orientation="horizontal">
+      <TextView
+        android:id="@+id/tv_title"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/half_standard_height"
+        android:layout_marginEnd="@dimen/standard_gap"
+        android:layout_marginRight="@dimen/standard_gap"
+        android:gravity="center_vertical"
+        android:textSize="@dimen/normal_text"
+        android:textStyle="bold"
+        tools:text="Step 1 of 15" />
+      <ImageView
+        android:id="@+id/tooltip"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:src="@drawable/mapbox_info_icon_default"/>
+    </LinearLayout>
 
     <TextView
       android:id="@+id/tv_subtitle"

--- a/app/src/main/res/layout/upload_depicts_fragment.xml
+++ b/app/src/main/res/layout/upload_depicts_fragment.xml
@@ -12,22 +12,34 @@
         android:layout_above="@+id/button_divider"
         android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/depicts_title"
-        android:layout_width="wrap_content"
-        android:layout_height="24dp"
-        android:layout_marginStart="@dimen/standard_gap"
-        android:layout_marginLeft="@dimen/standard_gap"
-        android:layout_marginTop="@dimen/standard_gap"
-        android:layout_marginEnd="@dimen/standard_gap"
-        android:layout_marginRight="@dimen/standard_gap"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentTop="true"
-        android:gravity="center_vertical"
-        android:textSize="@dimen/normal_text"
-        android:textStyle="bold"
-        tools:text="Step 1 of 15" />
+        <LinearLayout
+          android:layout_width="wrap_content"
+          android:layout_height="@dimen/half_standard_height"
+          android:layout_marginStart="@dimen/standard_gap"
+          android:layout_marginLeft="@dimen/standard_gap"
+          android:layout_marginTop="@dimen/standard_gap"
+          android:layout_marginEnd="@dimen/standard_gap"
+          android:layout_marginRight="@dimen/standard_gap"
+          android:layout_alignParentStart="true"
+          android:layout_alignParentLeft="true"
+          android:layout_alignParentTop="true"
+          android:orientation="horizontal">
+            <TextView
+              android:id="@+id/depicts_title"
+              android:layout_width="wrap_content"
+              android:layout_height="@dimen/half_standard_height"
+              android:layout_marginEnd="@dimen/standard_gap"
+              android:layout_marginRight="@dimen/standard_gap"
+              android:gravity="center_vertical"
+              android:textSize="@dimen/normal_text"
+              android:textStyle="bold"
+              tools:text="Step 1 of 15" />
+            <ImageView
+              android:id="@+id/tooltip"
+              android:layout_width="wrap_content"
+              android:layout_height="match_parent"
+              android:src="@drawable/mapbox_info_icon_default"/>
+        </LinearLayout>
 
     <TextView
         android:id="@+id/depicts_subtitle"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -436,7 +436,7 @@
 
   <string name="write_storage_permission_rationale_for_image_share">We need your permission to access the external storage of your device in order to upload images.</string>
   <string name="nearby_notification_dismiss_message">You won\'t see the nearest place that needs pictures anymore. However, you can re-enable this notification in Settings if you wish.</string>
-  <string name="step_count">Step %1$d of %2$d</string>
+  <string name="step_count">Step %1$d of %2$d: %3$s</string>
   <string name="image_in_set_label">Image %1$d in set</string>
   <string name="next">Next</string>
   <string name="previous">Previous</string>
@@ -703,4 +703,13 @@ Upload your first media by tapping on the add button.</string>
   <string name="quality_images_info">Quality images are diagrams or photographs that meet certain quality standards (which are mostly technical in nature) and are valuable for Wikimedia projects</string>
   <string name="resuming_upload">Resuming upload…</string>
   <string name="pausing_upload">Pausing upload…</string>
+
+  <string name="media_details_tooltip">Please write a short caption that says what your picture shows. In the description, say what makes the picture interesting or typical or rare, and explain the context, visible or not. Use exact terminology as much as you can.</string>
+  <string name="depicts_tooltip">Please find and select all concepts that this image portrays. Be as specific as you can. If the image portrays multiple items, choose them all within reason. Do not choose generic tags if more specific tags are available.</string>
+  <string name="categories_tooltip">Please select the appropriate categories. Unlike depictions, categories are only in English.</string>
+  <string name="license_tooltip">Commons makes your pictures reusable and adapted by everyone. Do you want to waive all rights? Do you want to be attributed? Do you want adaptations to use the same license?</string>
+  <string name="depicts_step_title">Depicts</string>
+  <string name="license_step_title">Media License</string>
+  <string name="media_detail_step_title">Media Details</string>
+
 </resources>


### PR DESCRIPTION
**Description (required)**
> @PaulinaQuintero We want the name of the step and then a tooltip. So for instance in your screenshot, the title would have "Step 3 of 4: Categories ["i"]".
https://github.com/commons-app/apps-android-commons/issues/3757#issuecomment-647343028

This PR tries to accomplish as stated above.

Fixes #3757 

What changes did you make and why?

- Changed step_count inside strings.xml to include ": [Step title here]"
- Added necessary strings inside strings.xml
- Added an ImageView next to the titleTV TextView for all the steps of media upload by putting them inside a horizontal LinearLayout

**Tests performed (required)**

Tested ProdDebug(and BetaDebug) on Realme 6 with API level 29.

**Screenshots (for UI changes only)**
[Step 1 ](https://drive.google.com/file/d/1ZUfKBd8GsV6TSMhUgr7olmLduSReEjHe/view?usp=sharing)
[Step 1 tooltip](https://drive.google.com/file/d/1ZSNz3C280Jx90JV1K-EcFW9A_A_FeFkj/view?usp=sharing)
[Step 2 ](https://drive.google.com/file/d/1ZNU26gD4mT07am9ZswJGXenZRVsnOkUm/view?usp=sharing)
[Step 2 tooltip](https://drive.google.com/file/d/1ZDoUY-_07O4Ak3_9RF1fMhcO-qGdQZuU/view?usp=sharing)
[Step 3 ](https://drive.google.com/file/d/1ZAcQsu73mc6FIjeu32oyIcPA5um5k2uL/view?usp=sharing)
[Step 3 tooltip](https://drive.google.com/file/d/1Z4V0S_yRCXfPU0Cd1HaTnwe4dJ-QxB63/view?usp=sharing)
[Step 4 ](https://drive.google.com/file/d/1Z3u95pzEn82tJCBVpfNWrGGsWkhw8WYs/view?usp=sharing)
[Step 4 tooltip](https://drive.google.com/file/d/1YqH9pfHlKoe21k7T6iOdtGC-VTBL6DNb/view?usp=sharing)