### PR TITLE
Modified warning about existing picture name and added never see again checkbox

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -8,6 +8,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
+import android.widget.CheckBox;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -272,19 +273,33 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
 
     @Override
     public void showDuplicatePicturePopup(UploadItem uploadItem) {
-        String uploadTitleFormat = getString(R.string.upload_title_duplicate);
-        DialogUtil.showAlertDialog(getActivity(),
-            getString(R.string.duplicate_image_found),
-            String.format(Locale.getDefault(),
-                uploadTitleFormat,
-                uploadItem.getFileName()),
-            getString(R.string.upload),
-            getString(R.string.cancel),
-            () -> {
-                uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
-                onNextButtonClicked();
-            }, null);
-
+        if (defaultKvStore.getBoolean("showDuplicatePicturePopup", true)) {
+            String uploadTitleFormat = getString(R.string.upload_title_duplicate);
+            View checkBoxView = View
+                .inflate(getActivity(), R.layout.nearby_permission_dialog, null);
+            CheckBox checkBox = (CheckBox) checkBoxView.findViewById(R.id.never_ask_again);
+            checkBox.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                if (isChecked) {
+                    defaultKvStore.putBoolean("showDuplicatePicturePopup", false);
+                }
+            });
+            DialogUtil.showAlertDialog(getActivity(),
+                getString(R.string.duplicate_image_found),
+                String.format(Locale.getDefault(),
+                    uploadTitleFormat,
+                    uploadItem.getFileName()),
+                getString(R.string.upload),
+                getString(R.string.cancel),
+                () -> {
+                    uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
+                    onNextButtonClicked();
+                }, null,
+                checkBoxView,
+                false);
+        } else {
+            uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
+            onNextButtonClicked();
+        }
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/utils/DialogUtil.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/DialogUtil.kt
@@ -100,6 +100,31 @@ object DialogUtil {
         title: String,
         message: String,
         positiveButtonText: String?,
+        negativeButtonText: String?,
+        onPositiveBtnClick: Runnable?,
+        onNegativeBtnClick: Runnable?,
+        customView: View?,
+        cancelable: Boolean
+    ) {
+        createAndShowDialogSafely(
+            activity = activity,
+            title = title,
+            message = message,
+            positiveButtonText = positiveButtonText,
+            negativeButtonText = negativeButtonText,
+            onPositiveBtnClick = onPositiveBtnClick,
+            onNegativeBtnClick = onNegativeBtnClick,
+            customView = customView,
+            cancelable = cancelable
+        )
+    }
+
+    @JvmStatic
+    fun showAlertDialog(
+        activity: Activity,
+        title: String,
+        message: String,
+        positiveButtonText: String?,
         onPositiveBtnClick: Runnable?,
         cancelable: Boolean
     ) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -441,7 +441,7 @@
   <string name="next">Next</string>
   <string name="previous">Previous</string>
   <string name="submit">Submit</string>
-  <string formatted="true" name="upload_title_duplicate">A file with the file name %1$s exists. Are you sure you want to proceed?</string>
+  <string formatted="true" name="upload_title_duplicate">A file with the file name %1$s exists. Are you sure you want to proceed?\n\nNote: A suitable suffix will be added to the file name automatically.</string>
   <string name="map_application_missing">No compatible map application could be found on your device. Please install a map application to use this feature.</string>
   <string name="navigation_item_bookmarks">Bookmarks</string>
   <string name="title_activity_bookmarks">Bookmarks</string>


### PR DESCRIPTION


**Description (required)**

Fixes #2818

What changes did you make and why?
- Added a "Note: ..." at the end of `strings/upload_title_duplicate)`
- Overloaded `DialogUtil.kt/showAlertDialog` to take positive/negative texts, callbacks and a custom view as earlier we had to choose either a detailed positive/negative text and leave out the custom view or the other way round.
- Reused `R.layout.nearby_permission_dialog` that was used in ContributionsFragment to provide a checkbox and followed similar process as there to store boolean "showDuplicatePicturePopup" in shared preferences. These changes were inside `UploadMediaDetailFragment.java`.

**Tests performed (required)**
Tested betaDebug with and without the changes the following on a Realme 6 running on API level 29: 
- Tried to upload an image with title "a" and got the output as in the screenshot below.
- Tried to do the same after checking the checkbox in the previous upload and this time there was no interruption.

**Screenshots (for UI changes only)**
[Dialog](https://drive.google.com/file/d/1bv2CNJNpuAtKPmUqZ91pzH-zy-KOyDyI/view?usp=sharing)

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
