### PR TITLE
Fixes 4019- Memory Leak in UploadActvity's SpinnerListAdapter

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/license/MediaLicenseFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/license/MediaLicenseFragment.java
@@ -92,10 +92,10 @@ public class MediaLicenseFragment extends UploadBaseFragment implements MediaLic
      * Initialise the license spinner
      */
     private void initLicenseSpinner() {
-        if (getContext() == null) {
+        if (getActivity() == null) {
             return;
         }
-        adapter = new ArrayAdapter<>(getContext(), android.R.layout.simple_spinner_dropdown_item);
+        adapter = new ArrayAdapter<>(getActivity().getApplicationContext(), android.R.layout.simple_spinner_dropdown_item);
         spinnerLicenseList.setAdapter(adapter);
         spinnerLicenseList.setOnItemSelectedListener(new OnItemSelectedListener() {
             @Override


### PR DESCRIPTION

**Description (required)**
Possible memory leak in MediaLicenseFragment

**Fixes #4019**

What changes did you make and why?
* Passed application context to adapter instead of the activity context

**Tests performed (required)**

* Tested betaDebug Api 27
* Uploaded a picture in the local emulator and verified no leaks in the said flow in the CanaryLeak app
