### PR TITLE
Bump ABT and Gradle versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "com.hiya:jacoco-android:0.2"
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Dec 26 14:27:31 IST 2019
+#Sun Dec 06 19:30:44 GMT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
**Description (required)**

#171

Bumps Android Build Tools Gralde plugin and Gradle versions to eliminate many build warnings and to get performance improvements. This should also make running tests in CI easier (I'd like to get UI tests working in either Travis or GitHub Actions at some point).

**Tests performed (required)**

Tested BetaDebug on Oneplus 6T with API level 29.