### PR TITLE
#171: Bump Triple-T gradle-play-publisher

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.triplet.play' version '2.7.2' apply false
+    id 'com.github.triplet.play' version '2.8.1' apply false
 }
 apply from: '../gitutils.gradle'
 apply plugin: 'com.android.application'


### PR DESCRIPTION
**Description (required)**

For alpha builds we use the gradle-play-publisher to automatically package and publish the app. In older versions there was a compatibility bug with Gradle 6.3 (https://github.com/Triple-T/gradle-play-publisher/issues/797). Using the updated version (2.8.1) should fix the problem.

There is version 3.0.0, however I've stuck to 2.8.1 as the breaking change of 3.0.0 is that it no longer supports PKCS keys (.p12 files) which we use.

Fixes the publishing step of the build, related to #171, #1056, #3469