### PR TITLE
Revert build changes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.triplet.play' version '2.8.1' apply false
+    id 'com.github.triplet.play' version '2.7.2' apply false
 }
 apply from: '../gitutils.gradle'
 apply plugin: 'com.android.application'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "com.hiya:jacoco-android:0.2"
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Dec 06 19:30:44 GMT 2020
+#Thu Dec 26 14:27:31 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip


### PR DESCRIPTION
**Description (required)**

Ah I was so hopeful for #4076 and #4083, however unfortunately they are failing the build.

This is because to support the Android Gradle build tools 4.1 we need the triplet play plugin version 3 (see https://github.com/Triple-T/gradle-play-publisher/issues/790). This requires migrating to JSON service account credentials from GCP (should be just a matter of finding the service account and generating JSON credentials, then encrypting it as we did before for the .p12 key).

This undoes the changes temporarily until we can migrate to using JSON service account credentials.