### PR TITLE
fixes click on the nearbyNotification app crash(#4086)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
+import android.os.Handler;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -293,7 +294,15 @@ public class MainActivity  extends BaseActivity
 
     public void centerMapToPlace(Place place) {
         setSelectedItemId(NavTab.NEARBY.code());
-        nearbyParentFragment.centerMapToPlace(place);
+//        addd the postDelayed function so that before call the nearbyParentFragment.centerMapToplace(). nearbyParentFragment
+//      initialise complete so that it so that it dooes give any Nullpointer exception when we nearbyParentFragment.centerMapToplace() is called
+      Handler handler=new Handler();
+      handler.postDelayed(new Runnable() {
+        @Override
+        public void run() {
+          nearbyParentFragment.centerMapToPlace(place);
+        }
+      },1000);
     }
 
     @Override


### PR DESCRIPTION
**Description (required)**

Fixes #4086 

What changes did you make and why?
 addd the postDelayed function so that before call the nearbyParentFragment.centerMapToplace(). nearbyParentFragment
initialise complete so that it so that it dooes give any Nullpointer exception when we nearbyParentFragment.centerMapToplace() is called

**Tests performed (required)**
Android Device:Redmi  y3
API:29
ScreenShots
![20201211_092422](https://user-images.githubusercontent.com/65972015/101861289-af2c1600-3b95-11eb-9ff0-d1efaa12a3a0.gif)

