### PR TITLE
Updated dependencies and Gradle Plugin to latest versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,26 +20,28 @@ dependencies {
     implementation project(':wikimedia-data-client')
     // Utils
     implementation 'in.yuvi:http.fluent:1.3'
-    implementation 'com.google.code.gson:gson:2.8.5'
-    implementation ("com.squareup.okhttp3:okhttp:$OKHTTP_VERSION"){
-        force = true //API 19 support
+    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation ('com.squareup.okhttp3:okhttp'){
+    version {
+        strictly '4.9.0'
+        }
     }
-    implementation 'com.squareup.okio:okio:2.2.2'
+    implementation 'com.squareup.okio:okio:2.9.0'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.3'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.9'
     implementation 'com.jakewharton.rxbinding2:rxbinding:2.1.1'
     implementation 'com.jakewharton.rxbinding2:rxbinding-support-v4:2.1.1'
     implementation 'com.jakewharton.rxbinding2:rxbinding-appcompat-v7:2.1.1'
     implementation 'com.jakewharton.rxbinding2:rxbinding-design:2.1.1'
-    implementation 'com.facebook.fresco:fresco:1.13.0'
-    implementation 'org.apache.commons:commons-lang3:3.8.1'
+    implementation 'com.facebook.fresco:fresco:2.3.0'
+    implementation 'org.apache.commons:commons-lang3:3.11'
 
     // UI
     implementation 'fr.avianey.com.viewpagerindicator:library:2.4.1.1@aar'
     implementation 'com.github.chrisbanes:PhotoView:2.0.0'
-    implementation 'com.github.pedrovgs:renderers:3.3.3'
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:8.6.2'
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v8:0.11.0'
+    implementation 'com.github.pedrovgs:renderers:4.0.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.0.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v9:0.12.0'
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-scalebar-v9:0.4.0'
     implementation 'com.github.deano2390:MaterialShowcaseView:1.2.0'
     implementation 'com.dinuscxj:circleprogressbar:1.1.1'
@@ -53,7 +55,7 @@ dependencies {
     implementation "androidx.paging:paging-runtime-ktx:$PAGING_VERSION"
     testImplementation "androidx.paging:paging-common-ktx:$PAGING_VERSION"
     implementation "androidx.paging:paging-rxjava2-ktx:$PAGING_VERSION"
-    implementation "androidx.recyclerview:recyclerview:1.2.0-alpha02"
+    implementation "androidx.recyclerview:recyclerview:1.2.0-beta01"
     implementation "com.squareup.okhttp3:okhttp-ws:$OKHTTP_VERSION"
 
     // Logging
@@ -76,39 +78,39 @@ dependencies {
     //Mocking
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     testImplementation 'org.mockito:mockito-inline:2.13.0'
-    testImplementation 'org.mockito:mockito-core:2.23.0'
+    testImplementation 'org.mockito:mockito-core:2.23.4'
     testImplementation "org.powermock:powermock-module-junit4:2.0.0-beta.5"
     testImplementation "org.powermock:powermock-api-mockito2:2.0.0-beta.5"
 
     // Unit testing
     testImplementation 'junit:junit:4.13.1'
-    testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation "com.squareup.okhttp3:mockwebserver:$OKHTTP_VERSION"
     testImplementation "org.powermock:powermock-module-junit4:2.0.0-beta.5"
     testImplementation "org.powermock:powermock-api-mockito2:2.0.0-beta.5"
-    testImplementation 'org.mockito:mockito-core:2.23.0'
+    testImplementation 'org.mockito:mockito-core:2.23.4'
     testImplementation "com.jraska.livedata:testing-ktx:1.1.2"
     testImplementation "androidx.arch.core:core-testing:2.1.0"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.3.1"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.3.1"
 
     // Mockito and PowerMock
-    androidTestCompile ('org.powermock:powermock-mockito-release-full:1.6.0') {
+    androidTestImplementation ('org.powermock:powermock-mockito-release-full:1.6.0') {
         exclude module: 'hamcrest-core'
         exclude module: 'objenesis'
     }
 
     // Android testing
     androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.2.0'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.3.0'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation 'androidx.annotation:annotation:1.1.0'
-    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:4.8.0'
-    androidTestUtil 'androidx.test:orchestrator:1.2.0'
+    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
+    androidTestUtil 'androidx.test:orchestrator:1.3.0'
 
     // Debugging
     debugImplementation "com.squareup.leakcanary:leakcanary-android:$LEAK_CANARY_VERSION"
@@ -116,11 +118,11 @@ dependencies {
     testImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$LEAK_CANARY_VERSION"
 
     // Support libraries
-    implementation "com.google.android.material:material:1.1.0-alpha04"
-    implementation "androidx.browser:browser:1.0.0"
+    implementation "com.google.android.material:material:1.3.0-alpha04"
+    implementation "androidx.browser:browser:1.3.0"
     implementation "androidx.cardview:cardview:1.0.0"
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation "androidx.exifinterface:exifinterface:1.0.0"
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation "androidx.exifinterface:exifinterface:1.3.2"
     implementation "androidx.core:core-ktx:$CORE_KTX_VERSION"
     implementation "androidx.multidex:multidex:2.0.1"
 
@@ -146,7 +148,7 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         //applicationId 'fr.free.nrw.commons'

--- a/data-client/build.gradle
+++ b/data-client/build.gradle
@@ -1,13 +1,13 @@
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.kotlin_version = '1.4.21'
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
     }
 }
 
@@ -59,25 +59,25 @@ android {
 
 dependencies {
 
-    String retrofitVersion = '2.4.0'
+    String retrofitVersion = '2.8.1'
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation "androidx.core:core:1.0.2"
+    implementation "androidx.core:core:1.3.2"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofitVersion"
-    implementation "io.reactivex.rxjava2:rxjava:2.2.3"
+    implementation "io.reactivex.rxjava2:rxjava:2.2.9"
     implementation "io.reactivex.rxjava2:rxandroid:2.1.0"
-    implementation 'org.apache.commons:commons-lang3:3.8.1'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'org.apache.commons:commons-lang3:3.11'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
 
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.8.9'
-    testImplementation 'org.robolectric:robolectric:3.8'
-    testImplementation "com.squareup.okhttp3:mockwebserver:3.12.1"
+    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'org.mockito:mockito-core:2.23.4'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.9.0"
     testImplementation "commons-io:commons-io:2.6"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,20 +16,20 @@
 org.gradle.jvmargs=-Xmx1536M
 android.enableBuildCache=true
 
-KOTLIN_VERSION=1.3.72
+KOTLIN_VERSION=1.4.21
 BUTTERKNIFE_VERSION=10.1.0
 LEAK_CANARY_VERSION=1.6.2
 DAGGER_VERSION=2.21
-ROOM_VERSION=2.2.3
-PREFERENCE_VERSION=1.1.0
-CORE_KTX_VERSION=1.2.0
+ROOM_VERSION=2.2.5
+PREFERENCE_VERSION=1.1.1
+CORE_KTX_VERSION=1.3.2
 ADAPTER_DELEGATES_VERSION=4.3.0
 PAGING_VERSION=2.1.2
 MULTIDEX_VERSION=2.0.1
-OKHTTP_VERSION=3.12.1
+OKHTTP_VERSION=4.9.0
 
 systemProp.http.proxyPort=0
 systemProp.http.proxyHost=
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=false
+#android.enableR8=false


### PR DESCRIPTION
Updated the Gradle dependencies and Android Gradle Build Tools

Fixes #4088

I made these changes to eliminate the build warnings and also replaced the deprecated  code in gradle with the correct one.
Tested on API Level 27 (real device).

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
