### PR TITLE
fix bug #4101  In MediaDetailfragment Editext Dailog is Blank in Dark mode

### DIFF
--- a/app/src/main/res/layout/layout_edit_categories.xml
+++ b/app/src/main/res/layout/layout_edit_categories.xml
@@ -5,7 +5,7 @@ xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width=
   android:layout_height="wrap_content"
   android:layout_margin="15dp"
   android:orientation="vertical"
-  android:background="@color/white"
+  android:background="?attr/mainBackground"
   android:elevation="30dp">
 
   <TextView
@@ -82,7 +82,7 @@ xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width=
       android:layout_width="match_parent"
       android:layout_height="0dp"
       android:layout_weight="4"
-      android:background="@color/white"/>
+      android:background="?attr/mainBackground"/>
 
     <LinearLayout
       android:layout_width="match_parent"


### PR DESCRIPTION
**Description (required)**

Fixes #4101

What changes did you make and why?
Remove the attribute **android:background="@color/white"** becouse it color is white in light and Dark mode
Add the attribute **android:background="?att/mainBackground**" becouse it color is white in light mode and Black in 
dark mode
Android Device:Redmi y3
API:29
**Tests performed (required)**
Android Device:Redmi y3;
API:29

**Screenshots (for UI changes only)**
![Screenshot_2020-12-13-09-44-15-182_fr free nrw commons beta](https://user-images.githubusercontent.com/65972015/102037203-9f593f80-3dea-11eb-8de3-6cbd81d226d4.jpg)
