### PR TITLE
Fixed issue 3681  List of languages for captions does not seem to match 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/SpinnerLanguagesAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/SpinnerLanguagesAdapter.kt
@@ -12,6 +12,7 @@ import fr.free.nrw.commons.utils.LangCodeUtils
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.row_item_languages_spinner.*
 import org.apache.commons.lang3.StringUtils
+import org.wikipedia.language.AppLanguageLookUpTable
 import java.util.*
 
 /**
@@ -28,13 +29,10 @@ class SpinnerLanguagesAdapter constructor(
 
     private val languageNamesList: List<String>
     private val languageCodesList: List<String>
-
+    var language: AppLanguageLookUpTable = AppLanguageLookUpTable(context)
     init {
-        val sortedLanguages = Locale.getAvailableLocales()
-            .map(::Language)
-            .sortedBy { it.locale.displayName }
-        languageNamesList = sortedLanguages.map { it.locale.displayName }
-        languageCodesList = sortedLanguages.map { it.locale.language }
+        languageNamesList = language.localizedNames;
+        languageCodesList = language.codes;
     }
 
     var selectedLangCode = ""


### PR DESCRIPTION
**Description (required)**

Fixes #3681 

What changes did you make and why?

Displaying less languages by retrieving the language values from language_list.xml instead of Locale.getAvailableLocale().
No redundancy of language remains.
Easy to find the language and select the required on.
Languages  are sorted as per popularity.
**Tests performed (required)**

Tested {build variant, e.g. ProdDebug} on {Realme 3 pro} with API level {29}.

**Screenshots (for UI changes only)**
![WhatsApp Image 2020-12-15 at 8 47 38 PM](https://user-images.githubusercontent.com/54104573/102234745-9b770b80-3f17-11eb-8286-c7a335c5305f.jpeg)


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
