### PR TITLE
Fixed issue with "Copy previous captions & descriptions".

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
@@ -179,9 +179,12 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
                     // If user has chosen a default language from settings activity savedLanguageValue is not null
                     spinnerDescriptionLanguages.setSelection(languagesAdapter.getIndexOfLanguageCode(savedLanguageValue));
                 } else {
+                    //Checking whether Language Code attribute is null or not.
                     if(uploadMediaDetails.get(position).getLanguageCode() != null){
+                        //If it is not null that means it is fetching details from the previous upload (i.e. when user has pressed copy previous caption & description)
+                        //hence providing same language code for the current upload.
                         spinnerDescriptionLanguages.setSelection(languagesAdapter
-                            .getIndexOfLanguageCode(uploadMediaDetails.get(position).getLanguageCode()),true);
+                            .getIndexOfLanguageCode(uploadMediaDetails.get(position).getLanguageCode()), true);
                     } else {
                         if (position == 0) {
                             int defaultLocaleIndex = languagesAdapter

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
@@ -179,12 +179,17 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
                     // If user has chosen a default language from settings activity savedLanguageValue is not null
                     spinnerDescriptionLanguages.setSelection(languagesAdapter.getIndexOfLanguageCode(savedLanguageValue));
                 } else {
-                    if (position == 0) {
-                        int defaultLocaleIndex = languagesAdapter
-                                .getIndexOfUserDefaultLocale(spinnerDescriptionLanguages.getContext());
-                        spinnerDescriptionLanguages.setSelection(defaultLocaleIndex, true);
+                    if(uploadMediaDetails.get(position).getLanguageCode() != null){
+                        spinnerDescriptionLanguages.setSelection(languagesAdapter
+                            .getIndexOfLanguageCode(uploadMediaDetails.get(position).getLanguageCode()),true);
                     } else {
-                        spinnerDescriptionLanguages.setSelection(0,true);
+                        if (position == 0) {
+                            int defaultLocaleIndex = languagesAdapter
+                                .getIndexOfUserDefaultLocale(spinnerDescriptionLanguages.getContext());
+                            spinnerDescriptionLanguages.setSelection(defaultLocaleIndex, true);
+                        } else {
+                            spinnerDescriptionLanguages.setSelection(0,true);
+                        }
                     }
                 }
 


### PR DESCRIPTION
**Description (required)**

Fixes #4037

What changes did you make and why?

Added a condition, after clicking "copy previous captions & description", to check whether the language code from the previous upload is null or not, and if it is not null then simply provided the same language code for the current upload.


**Tests performed (required)**
Tested on Pixel 2 with API level 29
