### PR TITLE
Author name in Dark theme fixed.

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -51,7 +51,7 @@
         <item name="notification_icon_text_color">@color/white</item>
         <item name="toggle_theme">@style/SwitchThemeDark</item>
         <item name="contributionsListTextPrimary">@color/white</item>
-        <item name="contributionsListTextSecondary">@color/browser_actions_divider_color</item>
+        <item name="contributionsListTextSecondary">@color/white</item>
         <item name="menu_item_tint">@color/white</item>
     </style>
 


### PR DESCRIPTION
**Description (required)**

Fixes #4098 

What changes did you make and why?

set contributionsListTextSecondary to white in dark theme.
The author names are now visible in both contributions and Uploaded tab of explore fragment.

**Tests performed (required)**

betaDebug on pixel 2 with API level 29.

**Screenshots (for UI changes only)**

Contributions-

<img src="https://user-images.githubusercontent.com/54016427/102344534-1137b180-3fc2-11eb-8441-63b656e54178.png" height=600>     <img src="https://user-images.githubusercontent.com/54016427/102344535-11d04800-3fc2-11eb-9412-39219104a484.png" height=600>


Uploaded tab of explore fragment-

<img src="https://user-images.githubusercontent.com/54016427/102344568-198fec80-3fc2-11eb-9366-882dcd4d6980.png" height=600>    <img src="https://user-images.githubusercontent.com/54016427/102344567-198fec80-3fc2-11eb-8640-798c161cf44f.png" height=600>

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
