### PR TITLE
solved issue 4043 : overlapping

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -9,6 +9,7 @@ import android.annotation.SuppressLint;
 import android.app.ProgressDialog;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.DisplayMetrics;
 import android.view.View;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
@@ -119,6 +120,13 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
                 this::receiveSharedItems,
                 R.string.storage_permission_title,
                 R.string.write_storage_permission_rationale_for_image_share);
+        //getting the current dpi of the device and if it is less than 320dp i.e. overlapping
+        //threshold, thumbnails automatically minimizes
+        DisplayMetrics metrics = getResources().getDisplayMetrics();
+        float dpi = (metrics.widthPixels)/(metrics.density);
+        if (dpi<=321) {
+            onRlContainerTitleClicked();
+        }
     }
 
     private void init() {


### PR DESCRIPTION
**Description (required)**

Fixes #4043 

What changes did you make and why?
1. Imported new library android.util.DisplayMetrics;
2. Now the thumbnail view automatically hides if the dpi is smaller that 320.(overlapping was occurring below 320 dpi)
3. I simply called the function `onRlContainerTitleClicked();` at the creation of uploadactivity.java
4. User still has the option for maximizing it by toggle switch.

**Tests performed (required)**
Tried for  dpis : 180,240,360,480 - its working properly.
Tested {build variant, e.g. ProdDebug} on {Realme 3 pro} with API level {29}.

@misaochan  Please review this and tell if any further improvements are needed.
