### PR TITLE
#4047: Field tip truncated on small screen / big font

### DIFF
--- a/app/src/main/res/layout/row_item_description.xml
+++ b/app/src/main/res/layout/row_item_description.xml
@@ -30,7 +30,8 @@
             android:layout_height="wrap_content"
             android:hint="@string/share_caption_hint"
             android:imeOptions="actionNext|flagNoExtractUi"
-            android:inputType="textMultiLine" />
+            android:inputType="textMultiLine"
+            android:maxLength="255" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,7 +77,7 @@
   <string name="share_title_hint">Caption (Required)</string>
   <string name="add_caption_toast">Please provide a caption for this file</string>
   <string name="share_description_hint">Description</string>
-  <string name="share_caption_hint">Caption (limit 255 characters)</string>
+  <string name="share_caption_hint">Caption</string>
   <string name="login_failed_network">Unable to login - network failure</string>
   <string name="login_failed_wrong_credentials">Unable to login - please check your username and password</string>
   <string name="login_failed_throttled">Too many unsuccessful attempts. Please try again in a few minutes.</string>
@@ -263,7 +263,7 @@
   <string name="error_while_cache">Error while caching pictures</string>
   <string name="title_info">A unique descriptive title for the file, which will serve as a filename. You may use plain language with spaces. Do not include the file extension</string>
   <string name="description_info">Please describe the media as much as possible: Where was it taken? What does it show? What is the context? Please describe the objects or persons. Reveal information that can not be easily guessed, for instance the time of day if it is a landscape. If the media shows something unusual, please explain what makes it unusual.</string>
-  <string name="caption_info">Please write a brief description of the image. The first caption would be used as the Title for the image.</string>
+  <string name="caption_info">Please write a brief description of the image. The first caption would be used as the Title for the image. Limit 255 characters.</string>
 
   <string name="upload_image_too_dark">This picture is too dark, are you sure you want to upload it? Wikimedia Commons is only for pictures with encyclopedic value.</string>
   <string name="upload_image_blurry">This picture is blurry, are you sure you want to upload it? Wikimedia Commons is only for pictures with encyclopedic value.</string>


### PR DESCRIPTION
**Description (required)**

Fixes #4047

Removed the "(limit 255 characters)" text from the caption hint string and added it to the info tool tip to the right of the EditText. Added `android:maxLength="255"` to the EditText to enforce the character limit.

**Tests performed (required)**

Tested on Pixel 3 with API level 28.

**Screenshots (for UI changes only)**
![screenshot1](https://user-images.githubusercontent.com/26350151/102872232-cd8ded80-4482-11eb-8d9d-de3aa3859988.png)![screenshot1x](https://user-images.githubusercontent.com/26350151/102872241-cf57b100-4482-11eb-97aa-7cae7576e0e0.png)
![screenshot3](https://user-images.githubusercontent.com/26350151/102872286-da124600-4482-11eb-9d93-e55056aaa6b1.png)![screenshot3x](https://user-images.githubusercontent.com/26350151/102872292-dbdc0980-4482-11eb-9567-ac88dac975af.png)
![screenshot2](https://user-images.githubusercontent.com/26350151/102872259-d41c6500-4482-11eb-900a-36948e03efd1.png)![screenshot2x](https://user-images.githubusercontent.com/26350151/102872268-d5e62880-4482-11eb-90f0-7187123cd33e.png)

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
