### PR TITLE
Fixed issue "Hard to see the search icon in explore tab" issue number…

### DIFF
--- a/app/src/main/res/drawable/ic_search_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_search_black_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+</vector>

--- a/app/src/main/res/layout/filter_chip_view.xml
+++ b/app/src/main/res/layout/filter_chip_view.xml
@@ -11,7 +11,8 @@
         android:layout_gravity="center_vertical"
         android:paddingStart="@dimen/filter_padding"
         android:text="@string/place_state"
-        android:textColor="@color/white"/>
+        android:textColor="@color/white"
+        android:textSize="@dimen/subheading_text_size"/>
 
     <com.google.android.material.chip.ChipGroup
         android:id="@+id/choice_chip_group"

--- a/app/src/main/res/layout/filter_search_view_layout.xml
+++ b/app/src/main/res/layout/filter_search_view_layout.xml
@@ -6,12 +6,13 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:paddingStart="@dimen/filter_padding"
-        android:text="@string/place_type"
-        android:textColor="@color/white"/>
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_vertical"
+      android:paddingStart="@dimen/filter_padding"
+      android:text="@string/place_type"
+      android:textColor="@color/white"
+      android:textSize="@dimen/subheading_text_size" />
 
     <SearchView
         android:id="@+id/search_view"

--- a/app/src/main/res/menu/menu_search.xml
+++ b/app/src/main/res/menu/menu_search.xml
@@ -5,7 +5,7 @@
     <item
         android:id="@+id/action_search"
         android:title="@string/menu_search_button"
-        android:icon="@drawable/ic_search_white_24dp"
+        android:icon="@drawable/ic_search_black_24dp"
         android:orderInCategory="1"
         app:showAsAction="ifRoom"
         />


### PR DESCRIPTION
… : 4111.

I have added a new vector asset in drawable folder named "ic_search_black_24dp.xml"



Fixes #4111 

What changes did you make and why?

I have added a new vector asset in drawable folder named "ic_search_black_24dp.xml"

**Tests performed (required)**
Realme 5 pro.



**Screenshots (for UI changes only)**

![WhatsApp Image 2020-12-24 at 11 33 22](https://user-images.githubusercontent.com/57288532/103065278-36d54400-45dc-11eb-84d1-c127fd2eae77.jpeg)


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
