### PR TITLE
Fixed 4115 achievement issue

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -164,7 +164,6 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
 
         // Set the initial value of WikiData edits to 0
         wikidataEditsText.setText("0");
-        hideLayouts();
         setWikidataEditCount();
         setAchievements();
         return rootView;
@@ -451,26 +450,9 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
             setImageRevertPercentage(achievements.getNotRevertPercentage());
             progressBar.setVisibility(View.GONE);
             item.setVisible(true);
-            layoutImageReverts.setVisibility(View.VISIBLE);
-            layoutImageUploaded.setVisibility(View.VISIBLE);
-            layoutImageUsedByWiki.setVisibility(View.VISIBLE);
-            layoutStatistics.setVisibility(View.VISIBLE);
-            imageView.setVisibility(View.VISIBLE);
-            levelNumber.setVisibility(View.VISIBLE);
         }
     }
 
-    /**
-     * used to hide the layouts while fetching results from api
-     */
-    private void hideLayouts(){
-        layoutImageUsedByWiki.setVisibility(View.INVISIBLE);
-        layoutImageUploaded.setVisibility(View.INVISIBLE);
-        layoutImageReverts.setVisibility(View.INVISIBLE);
-        layoutStatistics.setVisibility(View.INVISIBLE);
-        imageView.setVisibility(View.INVISIBLE);
-        levelNumber.setVisibility(View.INVISIBLE);
-    }
 
     @OnClick(R.id.images_upload_info)
     public void showUploadInfo(){


### PR DESCRIPTION
**Description (required)**

Fixes #4115 

What changes did you make and why?

1. Achievement fragment now looks like the screenshot attached below.
2. There was a function HideLayouts() which was hiding all the layouts till the fetching of all data is complete.
3. when their visibility was again set to VISIBLE it was not working properly because, in HideLayouts() we were hiding complete relative layouts and according to android documentation hiding complete layouts cannot be undo after loading activity(or after execution of onCreate function, hideLayout() was called inside onCreate and commands for showing layout were called outside onCreate thats why this problem was occuring).
4. as they all are linked using bindview like "RelativeLayout layoutImageUploaded;" , using layoutImageUploaded.setVisibility(View.INVISIBLE); makes them invisible but when we try to use visible it doesn't work.
5. I have currently deleted the HideLayouts() funtion and removed it from places it was called.
6. It is now working all fine according to me.
6. If you want me to keep it like it was earlier and find a way to display layout after fetching results I could try that : )

**Tests performed (required)**

Tested {build variant, e.g. ProdDebug} on {Realme 3 pro} with API level {29}.

**Screenshots (for UI changes only)**
![WhatsApp Image 2020-12-28 at 1 24 47 AM](https://user-images.githubusercontent.com/54104573/103178832-910c2880-48ac-11eb-8a9a-269ca8350d68.jpeg)

@misaochan @sivaraam Please review this
Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
