### PR TITLE
fix app Crash when tapping on the nearbyNotification 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -32,6 +32,7 @@ import fr.free.nrw.commons.navtab.NavTabLoggedOut;
 import fr.free.nrw.commons.nearby.NearbyNotificationCardView;
 import fr.free.nrw.commons.nearby.Place;
 import fr.free.nrw.commons.nearby.fragments.NearbyParentFragment;
+import fr.free.nrw.commons.nearby.fragments.NearbyParentFragment.CallBack;
 import fr.free.nrw.commons.notification.NotificationActivity;
 import fr.free.nrw.commons.notification.NotificationController;
 import fr.free.nrw.commons.quiz.QuizChecker;
@@ -293,7 +294,15 @@ public class MainActivity  extends BaseActivity
 
     public void centerMapToPlace(Place place) {
         setSelectedItemId(NavTab.NEARBY.code());
-        nearbyParentFragment.centerMapToPlace(place);
+        // interface
+        nearbyParentFragment.setCallBack(new CallBack() {
+            // if mapBox initialize in nearbyParentFragment then MapReady() function called
+            // so that nearbyParentFragemt.centerMaptoPlace(place) not throw any null pointer exception
+            @Override
+            public void MapReady() {
+                nearbyParentFragment.centerMapToPlace(place);
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -32,7 +32,7 @@ import fr.free.nrw.commons.navtab.NavTabLoggedOut;
 import fr.free.nrw.commons.nearby.NearbyNotificationCardView;
 import fr.free.nrw.commons.nearby.Place;
 import fr.free.nrw.commons.nearby.fragments.NearbyParentFragment;
-import fr.free.nrw.commons.nearby.fragments.NearbyParentFragment.CallBack;
+import fr.free.nrw.commons.nearby.fragments.NearbyParentFragment.NearbyParentFragmentListener;
 import fr.free.nrw.commons.notification.NotificationActivity;
 import fr.free.nrw.commons.notification.NotificationController;
 import fr.free.nrw.commons.quiz.QuizChecker;
@@ -294,12 +294,11 @@ public class MainActivity  extends BaseActivity
 
     public void centerMapToPlace(Place place) {
         setSelectedItemId(NavTab.NEARBY.code());
-        // interface
-        nearbyParentFragment.setCallBack(new CallBack() {
+        nearbyParentFragment.setNearbyParentFragmentListener(new NearbyParentFragmentListener() {
             // if mapBox initialize in nearbyParentFragment then MapReady() function called
             // so that nearbyParentFragemt.centerMaptoPlace(place) not throw any null pointer exception
             @Override
-            public void MapReady() {
+            public void onMapReady() {
                 nearbyParentFragment.centerMapToPlace(place);
             }
         });

--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -32,7 +32,7 @@ import fr.free.nrw.commons.navtab.NavTabLoggedOut;
 import fr.free.nrw.commons.nearby.NearbyNotificationCardView;
 import fr.free.nrw.commons.nearby.Place;
 import fr.free.nrw.commons.nearby.fragments.NearbyParentFragment;
-import fr.free.nrw.commons.nearby.fragments.NearbyParentFragment.NearbyParentFragmentListener;
+import fr.free.nrw.commons.nearby.fragments.NearbyParentFragment.NearbyParentFragmentInstanceReadyCallback;
 import fr.free.nrw.commons.notification.NotificationActivity;
 import fr.free.nrw.commons.notification.NotificationController;
 import fr.free.nrw.commons.quiz.QuizChecker;
@@ -294,11 +294,11 @@ public class MainActivity  extends BaseActivity
 
     public void centerMapToPlace(Place place) {
         setSelectedItemId(NavTab.NEARBY.code());
-        nearbyParentFragment.setNearbyParentFragmentListener(new NearbyParentFragmentListener() {
+        nearbyParentFragment.setNearbyParentFragmentInstanceReadyCallback(new NearbyParentFragmentInstanceReadyCallback() {
             // if mapBox initialize in nearbyParentFragment then MapReady() function called
             // so that nearbyParentFragemt.centerMaptoPlace(place) not throw any null pointer exception
             @Override
-            public void onMapReady() {
+            public void onReady() {
                 nearbyParentFragment.centerMapToPlace(place);
             }
         });

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -214,6 +214,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private fr.free.nrw.commons.location.LatLng lastFocusLocation;
     private LatLngBounds latLngBounds;
     private PlaceAdapter adapter;
+    private CallBack callBack;
 
     @NonNull
     public static NearbyParentFragment newInstance() {
@@ -271,6 +272,9 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
                 uiSettings.setAttributionEnabled(false);
                 uiSettings.setRotateGesturesEnabled(false);
                 isMapBoxReady =true;
+                if(callBack!=null){
+                    callBack.MapReady();
+                }
                 performMapReadyActions();
                 final CameraPosition cameraPosition = new CameraPosition.Builder()
                         .target(new LatLng(51.50550, -0.07520))
@@ -1530,5 +1534,13 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private void startTheMap() {
         mapView.onStart();
         performMapReadyActions();
+    }
+
+    public interface  CallBack{
+        void MapReady();
+    }
+
+    public void setCallBack(final CallBack callBack) {
+        this.callBack = callBack;
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -214,7 +214,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private fr.free.nrw.commons.location.LatLng lastFocusLocation;
     private LatLngBounds latLngBounds;
     private PlaceAdapter adapter;
-    private NearbyParentFragmentListener nearbyParentFragmentListener;
+    private NearbyParentFragmentInstanceReadyCallback nearbyParentFragmentInstanceReadyCallback;
 
     @NonNull
     public static NearbyParentFragment newInstance() {
@@ -272,8 +272,8 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
                 uiSettings.setAttributionEnabled(false);
                 uiSettings.setRotateGesturesEnabled(false);
                 isMapBoxReady =true;
-                if(nearbyParentFragmentListener!=null){
-                    nearbyParentFragmentListener.onMapReady();
+                if(nearbyParentFragmentInstanceReadyCallback!=null){
+                    nearbyParentFragmentInstanceReadyCallback.onReady();
                 }
                 performMapReadyActions();
                 final CameraPosition cameraPosition = new CameraPosition.Builder()
@@ -1536,11 +1536,11 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         performMapReadyActions();
     }
 
-    public interface  NearbyParentFragmentListener{
-        void onMapReady();
+    public interface  NearbyParentFragmentInstanceReadyCallback{
+        void onReady();
     }
 
-    public void setNearbyParentFragmentListener(final NearbyParentFragmentListener nearbyParentFragmentListener) {
-        this.nearbyParentFragmentListener = nearbyParentFragmentListener;
+    public void setNearbyParentFragmentInstanceReadyCallback(NearbyParentFragmentInstanceReadyCallback nearbyParentFragmentInstanceReadyCallback) {
+        this.nearbyParentFragmentInstanceReadyCallback = nearbyParentFragmentInstanceReadyCallback;
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -214,7 +214,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private fr.free.nrw.commons.location.LatLng lastFocusLocation;
     private LatLngBounds latLngBounds;
     private PlaceAdapter adapter;
-    private CallBack callBack;
+    private NearbyParentFragmentListener nearbyParentFragmentListener;
 
     @NonNull
     public static NearbyParentFragment newInstance() {
@@ -272,8 +272,8 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
                 uiSettings.setAttributionEnabled(false);
                 uiSettings.setRotateGesturesEnabled(false);
                 isMapBoxReady =true;
-                if(callBack!=null){
-                    callBack.MapReady();
+                if(nearbyParentFragmentListener!=null){
+                    nearbyParentFragmentListener.onMapReady();
                 }
                 performMapReadyActions();
                 final CameraPosition cameraPosition = new CameraPosition.Builder()
@@ -1536,11 +1536,11 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         performMapReadyActions();
     }
 
-    public interface  CallBack{
-        void MapReady();
+    public interface  NearbyParentFragmentListener{
+        void onMapReady();
     }
 
-    public void setCallBack(final CallBack callBack) {
-        this.callBack = callBack;
+    public void setNearbyParentFragmentListener(final NearbyParentFragmentListener nearbyParentFragmentListener) {
+        this.nearbyParentFragmentListener = nearbyParentFragmentListener;
     }
 }


### PR DESCRIPTION
**Description (required)**
Fixes #4086 

What changes did you make and why?

 Add the setNearbyParentFragmentListener() in MainActivity of  centerMapToPlace() function
 becouse when mapBox is ready in nearbyParentFragment then  ->onMapReady() function called  
 onMapReady() function calll to   ->nearbyParentFragment.centerMapToPlace(place)  

**Tests performed (required)**
Android Device:Redmi y3;
API :28