### PR TITLE
Fixes #4111 Search icon is hard to see

### DIFF
--- a/app/src/main/res/drawable/ic_search_blue_24dp.xml
+++ b/app/src/main/res/drawable/ic_search_blue_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#0C609C"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+</vector>

--- a/app/src/main/res/menu/menu_search.xml
+++ b/app/src/main/res/menu/menu_search.xml
@@ -5,7 +5,7 @@
     <item
         android:id="@+id/action_search"
         android:title="@string/menu_search_button"
-        android:icon="@drawable/ic_search_white_24dp"
+        android:icon="?attr/search_icon"
         android:orderInCategory="1"
         app:showAsAction="ifRoom"
         />

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -47,6 +47,7 @@
     <attr name="contributionsListTextSecondary" format="reference"/>
     <attr name="contributionsListTextPrimary" format="reference"/>
     <attr name="menu_item_tint" format="reference"/>
+    <attr name="search_icon" format="reference"/>
 
     <declare-styleable name="Badge">
         <attr name="boundary" format="color"/>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -53,6 +53,7 @@
         <item name="contributionsListTextPrimary">@color/white</item>
         <item name="contributionsListTextSecondary">@color/white</item>
         <item name="menu_item_tint">@color/white</item>
+        <item name="search_icon">@drawable/ic_search_white_24dp</item>
     </style>
 
     <style name="LightAppTheme" parent="Theme.AppCompat.Light.NoActionBar">
@@ -107,6 +108,7 @@
         <item name="contributionsListTextPrimary">@color/black</item>
         <item name="contributionsListTextSecondary">@color/disabled_button_text_color_dark</item>
         <item name="menu_item_tint">@color/primaryDarkColor</item>
+        <item name="search_icon">@drawable/ic_search_blue_24dp</item>
     </style>
 
     <style name="LightMoreBottomSheetStyle" parent="LightAppTheme">


### PR DESCRIPTION
**Description (required)**

Fixes #4111 , uses blue search icon for light theme and white icon for dark theme.

What changes did you make and why?

**Tests performed (required)**

Tested ProdDebug on Android 9

**Screenshots (for UI changes only)**
![resim](https://user-images.githubusercontent.com/3127881/103443310-f4aca200-4c6e-11eb-8a52-479da426069d.png)

![resim](https://user-images.githubusercontent.com/3127881/103443319-1c9c0580-4c6f-11eb-8939-a1e29c83ee4e.png)


