### PR TITLE
Theme change

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
@@ -39,7 +39,7 @@ public class BookmarkListRootFragment extends CommonsDaggerSupportFragment imple
   FrameLayout container;
 
   public BookmarkListRootFragment(){
-    //empty constructor necessary otherwise crashes or recreate
+    //empty constructor necessary otherwise crashes on recreate
   }
 
   public BookmarkListRootFragment(Bundle bundle, BookmarksPagerAdapter bookmarksPagerAdapter) {

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
@@ -38,6 +38,10 @@ public class BookmarkListRootFragment extends CommonsDaggerSupportFragment imple
   @BindView(R.id.explore_container)
   FrameLayout container;
 
+  public BookmarkListRootFragment(){
+    //empty constructor necessary otherwise crashes or recreate
+  }
+
   public BookmarkListRootFragment(Bundle bundle, BookmarksPagerAdapter bookmarksPagerAdapter) {
     String title = bundle.getString("categoryName");
     int order = bundle.getInt("order");
@@ -65,7 +69,9 @@ public class BookmarkListRootFragment extends CommonsDaggerSupportFragment imple
   @Override
   public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
-    setFragment(listFragment, mediaDetails);
+    if(savedInstanceState==null) {
+      setFragment(listFragment, mediaDetails);
+    }
   }
 
   public void setFragment(Fragment fragment, Fragment otherFragment) {

--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -111,9 +111,9 @@ public class MainActivity  extends BaseActivity
             setTitle(getString(R.string.explore_tab_title_mobile));
             setUpLoggedOutPager();
         } else {
-            setTitle(getString(R.string.contributions_fragment));
             if(savedInstanceState == null){
                 //starting a fresh fragment.
+                setTitle(getString(R.string.contributions_fragment));
                 loadFragment(ContributionsFragment.newInstance(),false);
             }
             setUpPager();

--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -112,6 +112,10 @@ public class MainActivity  extends BaseActivity
             setUpLoggedOutPager();
         } else {
             setTitle(getString(R.string.contributions_fragment));
+            if(savedInstanceState == null){
+                //starting a fresh fragment.
+                loadFragment(ContributionsFragment.newInstance(),false);
+            }
             setUpPager();
             initMain();
         }
@@ -122,30 +126,31 @@ public class MainActivity  extends BaseActivity
     }
 
     private void setUpPager() {
-        loadFragment(ContributionsFragment.newInstance());
         tabLayout.setOnNavigationItemSelectedListener(item -> {
             if (!item.getTitle().equals("More")) {
                 // do not change title for more fragment
                 setTitle(item.getTitle());
             }
             Fragment fragment = NavTab.of(item.getOrder()).newInstance();
-            return loadFragment(fragment);
+            return loadFragment(fragment,true);
         });
     }
 
     private void setUpLoggedOutPager() {
-        loadFragment(ExploreFragment.newInstance());
+        loadFragment(ExploreFragment.newInstance(),false);
         tabLayout.setOnNavigationItemSelectedListener(item -> {
             if (!item.getTitle().equals("More")) {
                 // do not change title for more fragment
                 setTitle(item.getTitle());
             }
             Fragment fragment = NavTabLoggedOut.of(item.getOrder()).newInstance();
-            return loadFragment(fragment);
+            return loadFragment(fragment,true);
         });
     }
 
-    private boolean loadFragment(Fragment fragment) {
+    private boolean loadFragment(Fragment fragment,boolean showBottom ) {
+        //showBottom so that we do not show the bottom tray again when constructing
+        //from the saved instance state.
         if (fragment instanceof ContributionsFragment) {
             if (activeFragment == ActiveFragment.CONTRIBUTIONS) { // Do nothing if same tab
                 return true;
@@ -170,7 +175,7 @@ public class MainActivity  extends BaseActivity
             }
             bookmarkFragment = (BookmarkFragment) fragment;
             activeFragment = ActiveFragment.BOOKMARK;
-        } else if (fragment == null) {
+        } else if (fragment == null && showBottom) {
             if (applicationKvStore.getBoolean("login_skipped") == true) { // If logged out, more sheet is different
                 MoreBottomSheetLoggedOutFragment bottomSheet = new MoreBottomSheetLoggedOutFragment();
                 bottomSheet.show(getSupportFragmentManager(),

--- a/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
@@ -35,7 +35,7 @@ public class ExploreListRootFragment extends CommonsDaggerSupportFragment implem
   FrameLayout container;
 
   public ExploreListRootFragment(){
-    //empty constructor necessary otherwise crashes or recreate
+    //empty constructor necessary otherwise crashes on recreate
   }
 
   public ExploreListRootFragment(Bundle bundle) {

--- a/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
@@ -34,6 +34,10 @@ public class ExploreListRootFragment extends CommonsDaggerSupportFragment implem
   @BindView(R.id.explore_container)
   FrameLayout container;
 
+  public ExploreListRootFragment(){
+    //empty constructor necessary otherwise crashes or recreate
+  }
+
   public ExploreListRootFragment(Bundle bundle) {
     String title = bundle.getString("categoryName");
     listFragment = new CategoriesMediaFragment();
@@ -55,7 +59,9 @@ public class ExploreListRootFragment extends CommonsDaggerSupportFragment implem
   @Override
   public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
-    setFragment(listFragment, mediaDetails);
+    if(savedInstanceState == null) {
+      setFragment(listFragment, mediaDetails);
+    }
   }
 
   public void setFragment(Fragment fragment, Fragment otherFragment) {


### PR DESCRIPTION
**Description (required)**

Fixes #3352, #4123, #4135

What changes did you make and why?

The reason of crashes when changing the theme was primarily the requirement of an empty constructor.
In the case of nearby, the contributions tab was loading instead of nearby that is handled by the savedInstanceState condition.
Proper comments are written wherever required.

Tested betaDebug on Nokia 6.1+ with API level 29.
