### PR TITLE
Fixes #4179 - App crashes on back press while in bookmarks tab

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
@@ -172,16 +172,15 @@ public class BookmarkListRootFragment extends CommonsDaggerSupportFragment imple
   }
 
   public void backPressed() {
-    if (mediaDetails.isVisible()) {
+    if (null != mediaDetails && mediaDetails.isVisible()) {
       // todo add get list fragment
-      ((BookmarkFragment)getParentFragment()).tabLayout.setVisibility(View.VISIBLE);
+      ((BookmarkFragment) getParentFragment()).tabLayout.setVisibility(View.VISIBLE);
       removeFragment(mediaDetails);
       setFragment(listFragment, mediaDetails);
-      ((MainActivity)getActivity()).showTabs();
     } else {
       ((MainActivity) getActivity()).setSelectedItemId(NavTab.CONTRIBUTIONS.code());
-      ((MainActivity)getActivity()).showTabs();
     }
+    ((MainActivity) getActivity()).showTabs();
   }
 
   @Override


### PR DESCRIPTION
**Description (required)**

Fixes #4179

What changes did you make and why?
* Handled possible null check on MediaDetails in BookmarkListRootFragment#backPressed()

**Tests performed (required)**

Tested betaDebug on Android version 10
