### PR TITLE
Update comments in ThanksClient.java

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/actions/ThanksClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/actions/ThanksClient.java
@@ -11,7 +11,7 @@ import fr.free.nrw.commons.CommonsApplication;
 import io.reactivex.Observable;
 
 /**
- * Facilitates the Wkikimedia Thanks api extention, as described in the 
+ * Facilitates the Wkikimedia Thanks api extension, as described in the 
  * api documentation: "The Thanks extension includes an API for sending thanks"
  * 
  * In simple terms this class is used by a user to thank someone for adding 
@@ -32,8 +32,8 @@ public class ThanksClient {
 
     /**
      * Handles the Thanking logic
-     * @param revesionID The revision ID you would like to thank someone for
-     * @return if thanks was successfully sent to intended recepient, returned as a boolean observable
+     * @param revisionID The revision ID you would like to thank someone for
+     * @return if thanks was successfully sent to intended recipient, returned as a boolean observable
      */
     public Observable<Boolean> thank(long revisionId) {
         try {


### PR DESCRIPTION
**Description (required)**
The spelling of extension is written incorrectly in the first line. It is written as "extention".
Later in the thanking logic, it is written "@param revesionID" which should be "@param revisionID".
The Spelling of recipient is also mentioned incorrectly. It is written as "recepient".

Fixes #4182 

Extention changes to extension.
@param revesionID changed to @param revisionID.
recepient changed to recipient.

