### PR TITLE
 Fixes #4178 Bookmarks not Updated in Picture section after remove 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
@@ -19,10 +19,13 @@ import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.bookmarks.locations.BookmarkLocationsFragment;
 import fr.free.nrw.commons.bookmarks.pictures.BookmarkPicturesFragment;
 import fr.free.nrw.commons.category.CategoryImagesCallback;
+import fr.free.nrw.commons.category.GridViewAdapter;
 import fr.free.nrw.commons.contributions.MainActivity;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.media.MediaDetailPagerFragment;
 import fr.free.nrw.commons.navtab.NavTab;
+import java.util.ArrayList;
+import java.util.Iterator;
 
 public class BookmarkListRootFragment extends CommonsDaggerSupportFragment implements
     FragmentManager.OnBackStackChangedListener,
@@ -183,9 +186,19 @@ public class BookmarkListRootFragment extends CommonsDaggerSupportFragment imple
       if (mediaDetails.isVisible()) {
         // todo add get list fragment
         ((BookmarkFragment) getParentFragment()).tabLayout.setVisibility(View.VISIBLE);
+        ArrayList<Integer> removed=mediaDetails.getRemovedItems();
         removeFragment(mediaDetails);
         setFragment(listFragment, mediaDetails);
         ((MainActivity) getActivity()).showTabs();
+        if(listFragment instanceof BookmarkPicturesFragment){
+          GridViewAdapter adapter=((GridViewAdapter)((BookmarkPicturesFragment)listFragment).getAdapter());
+          Iterator i = removed.iterator();
+          while (i.hasNext()) {
+            adapter.remove(adapter.getItem((int)i.next()));
+          }
+          mediaDetails.clearRemoved();
+
+        }
       } else {
         moveToContributionsFragment();
       }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -36,6 +36,7 @@ import fr.free.nrw.commons.utils.ImageUtils;
 import fr.free.nrw.commons.utils.NetworkUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
 import io.reactivex.disposables.CompositeDisposable;
+import java.util.ArrayList;
 import java.util.Objects;
 import javax.inject.Inject;
 import timber.log.Timber;
@@ -61,6 +62,15 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
     private MediaDetailProvider provider;
     private boolean isFromFeaturedRootFragment;
     private int position;
+
+    private ArrayList<Integer> removedItems=new ArrayList<Integer>();
+
+    public void clearRemoved(){
+        removedItems.clear();
+    }
+    public ArrayList<Integer> getRemovedItems() {
+        return removedItems;
+    }
 
     public MediaDetailPagerFragment() {
         this(false, false);
@@ -298,6 +308,16 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
 
     private void updateBookmarkState(MenuItem item) {
         boolean isBookmarked = bookmarkDao.findBookmark(bookmark);
+        if(isBookmarked) {
+            if(removedItems.contains(pager.getCurrentItem())) {
+                removedItems.remove(new Integer(pager.getCurrentItem()));
+            }
+        }
+        else {
+            if(!removedItems.contains(pager.getCurrentItem())) {
+                removedItems.add(pager.getCurrentItem());
+            }
+        }
         int icon = isBookmarked ? R.drawable.menu_ic_round_star_filled_24px : R.drawable.menu_ic_round_star_border_24px;
         item.setIcon(icon);
     }


### PR DESCRIPTION
**Description (required)**

Fixes #4178

What changes did you make and why?
Apparently, the removed bookmarks weren't tracked so I added an `ArrayList<Integer> removedItems`in the view pager to track the removed items from the bookmarks. It is updated as the user clicks on the bookmark option on any of the pages. 

As soon as the user exits the details view Pager, The root fragments `backPressed` function is called and therein I've accessed the removed items and removed them one by one, and clears the list finally.

For access to the removed ArrayList, I've created a getter and also a clear function that clears the list.

**Tests performed (required)**

Tested betaDebug on Nokia 6.1 with API level 29.
