### PR TITLE
Fixes #4184 - Incomplete bottom sheet appears in landscape mode 

### DIFF
--- a/app/src/main/res/layout/fragment_more_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_more_bottom_sheet.xml
@@ -5,80 +5,95 @@
     android:theme="?attr/more_bottom_sheet_style"
     android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/more_profile"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="12dp"
-        android:drawableStart="@drawable/ic_person_black_24dp"
-        android:drawablePadding="12dp"
-        android:padding="8dp"
-        android:text="@string/Profile"
-        android:textSize="18sp" />
+    <ScrollView
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:nestedScrollingEnabled="true">
 
-    <TextView
-        android:id="@+id/more_peer_review"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="12dp"
-        android:drawableStart="@drawable/ic_check_black_24dp"
-        android:drawablePadding="12dp"
-        android:padding="8dp"
-        android:text="@string/navigation_item_review"
-        android:textSize="18sp" />
+        <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/more_settings"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="12dp"
-        android:drawableStart="@drawable/ic_settings_black_24dp"
-        android:drawablePadding="12dp"
-        android:padding="8dp"
-        android:text="@string/menu_settings"
-        android:textSize="18sp" />
+            <TextView
+              android:id="@+id/more_profile"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_margin="12dp"
+              android:drawableStart="@drawable/ic_person_black_24dp"
+              android:drawablePadding="12dp"
+              android:padding="8dp"
+              android:text="@string/Profile"
+              android:textSize="18sp" />
 
-    <TextView
-        android:id="@+id/more_tutorial"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="12dp"
-        android:drawableStart="@drawable/ic_help_black_24dp"
-        android:drawablePadding="12dp"
-        android:padding="8dp"
-        android:text="@string/navigation_item_info"
-        android:textSize="18sp" />
+            <TextView
+              android:id="@+id/more_peer_review"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_margin="12dp"
+              android:drawableStart="@drawable/ic_check_black_24dp"
+              android:drawablePadding="12dp"
+              android:padding="8dp"
+              android:text="@string/navigation_item_review"
+              android:textSize="18sp" />
 
-    <TextView
-        android:id="@+id/more_feedback"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="12dp"
-        android:drawableLeft="@drawable/ic_feedback_black_24dp"
-        android:drawablePadding="12dp"
-        android:padding="8dp"
-        android:text="@string/navigation_item_feedback"
-        android:textSize="18sp" />
+            <TextView
+              android:id="@+id/more_settings"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_margin="12dp"
+              android:drawableStart="@drawable/ic_settings_black_24dp"
+              android:drawablePadding="12dp"
+              android:padding="8dp"
+              android:text="@string/menu_settings"
+              android:textSize="18sp" />
 
-    <TextView
-        android:id="@+id/more_about"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="12dp"
-        android:drawableStart="@drawable/ic_info_outline_24dp"
-        android:drawablePadding="12dp"
-        android:padding="8dp"
-        android:text="@string/navigation_item_about"
-        android:textSize="18sp" />
+            <TextView
+              android:id="@+id/more_tutorial"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_margin="12dp"
+              android:drawableStart="@drawable/ic_help_black_24dp"
+              android:drawablePadding="12dp"
+              android:padding="8dp"
+              android:text="@string/navigation_item_info"
+              android:textSize="18sp" />
 
-    <TextView
-        android:id="@+id/more_logout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="12dp"
-        android:drawableStart="@drawable/ic_exit_to_app_black_24dp"
-        android:drawablePadding="12dp"
-        android:padding="8dp"
-        android:text="@string/navigation_item_logout"
-        android:textSize="18sp" />
+            <TextView
+              android:id="@+id/more_feedback"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_margin="12dp"
+              android:drawableLeft="@drawable/ic_feedback_black_24dp"
+              android:drawablePadding="12dp"
+              android:padding="8dp"
+              android:text="@string/navigation_item_feedback"
+              android:textSize="18sp" />
+
+            <TextView
+              android:id="@+id/more_about"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_margin="12dp"
+              android:drawableStart="@drawable/ic_info_outline_24dp"
+              android:drawablePadding="12dp"
+              android:padding="8dp"
+              android:text="@string/navigation_item_about"
+              android:textSize="18sp" />
+
+            <TextView
+              android:id="@+id/more_logout"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_margin="12dp"
+              android:drawableStart="@drawable/ic_exit_to_app_black_24dp"
+              android:drawablePadding="12dp"
+              android:padding="8dp"
+              android:text="@string/navigation_item_logout"
+              android:textSize="18sp" />
+
+        </LinearLayout>
+
+    </ScrollView>
+
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_more_bottom_sheet_logged_out.xml
+++ b/app/src/main/res/layout/fragment_more_bottom_sheet_logged_out.xml
@@ -5,58 +5,73 @@
     android:theme="?attr/more_bottom_sheet_style"
     android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/more_settings"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="12dp"
-        android:drawableStart="@drawable/ic_settings_black_24dp"
-        android:drawablePadding="12dp"
-        android:padding="8dp"
-        android:text="@string/menu_settings"
-        android:textSize="18sp" />
+    <ScrollView
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:nestedScrollingEnabled="true">
 
-    <TextView
-        android:id="@+id/more_tutorial"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="12dp"
-        android:drawableStart="@drawable/ic_help_black_24dp"
-        android:drawablePadding="12dp"
-        android:padding="8dp"
-        android:text="@string/navigation_item_info"
-        android:textSize="18sp" />
+        <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="vertical" >
 
-    <TextView
-        android:id="@+id/more_feedback"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="12dp"
-        android:drawableLeft="@drawable/ic_feedback_black_24dp"
-        android:drawablePadding="12dp"
-        android:padding="8dp"
-        android:text="@string/navigation_item_feedback"
-        android:textSize="18sp" />
+            <TextView
+              android:id="@+id/more_settings"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_margin="12dp"
+              android:drawableStart="@drawable/ic_settings_black_24dp"
+              android:drawablePadding="12dp"
+              android:padding="8dp"
+              android:text="@string/menu_settings"
+              android:textSize="18sp" />
 
-    <TextView
-        android:id="@+id/more_about"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="12dp"
-        android:drawableStart="@drawable/ic_info_outline_24dp"
-        android:drawablePadding="12dp"
-        android:padding="8dp"
-        android:text="@string/navigation_item_about"
-        android:textSize="18sp" />
+            <TextView
+              android:id="@+id/more_tutorial"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_margin="12dp"
+              android:drawableStart="@drawable/ic_help_black_24dp"
+              android:drawablePadding="12dp"
+              android:padding="8dp"
+              android:text="@string/navigation_item_info"
+              android:textSize="18sp" />
 
-    <TextView
-        android:id="@+id/more_login"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="12dp"
-        android:drawableStart="@drawable/ic_baseline_person_24"
-        android:drawablePadding="12dp"
-        android:padding="8dp"
-        android:text="@string/navigation_item_login"
-        android:textSize="18sp" />
+            <TextView
+              android:id="@+id/more_feedback"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_margin="12dp"
+              android:drawableLeft="@drawable/ic_feedback_black_24dp"
+              android:drawablePadding="12dp"
+              android:padding="8dp"
+              android:text="@string/navigation_item_feedback"
+              android:textSize="18sp" />
+
+            <TextView
+              android:id="@+id/more_about"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_margin="12dp"
+              android:drawableStart="@drawable/ic_info_outline_24dp"
+              android:drawablePadding="12dp"
+              android:padding="8dp"
+              android:text="@string/navigation_item_about"
+              android:textSize="18sp" />
+
+            <TextView
+              android:id="@+id/more_login"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_margin="12dp"
+              android:drawableStart="@drawable/ic_baseline_person_24"
+              android:drawablePadding="12dp"
+              android:padding="8dp"
+              android:text="@string/navigation_item_login"
+              android:textSize="18sp" />
+
+        </LinearLayout>
+
+    </ScrollView>
+
 </LinearLayout>


### PR DESCRIPTION
**Description (required)**

Fixes #4184 

What changes did you make and why?

Added scroll view in the bottom sheet fragment.

**Tests performed (required)**

Tested betaDebug on Pixel 3 emulator with API level 29.


Bottom sheet is not scrollable, hence bottom two options are not reachable

![Screenshot_1614446727](https://user-images.githubusercontent.com/54663429/109395046-4bbdb300-7950-11eb-906b-c91772d74031.png)

After Changes: (Bottom Sheet is now scrollable)

![Screenshot_1614447137](https://user-images.githubusercontent.com/54663429/109395069-6f80f900-7950-11eb-812c-d28492706c7d.png)

