### PR TITLE
fix-Incomplete Nearby List shown in Landscape mode (#2770)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1547,7 +1547,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     @Override
     public void onConfigurationChanged(@NonNull final Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-        ViewGroup.LayoutParams rlBottomSheetLayoutParams=rlBottomSheet.getLayoutParams();
+        ViewGroup.LayoutParams rlBottomSheetLayoutParams = rlBottomSheet.getLayoutParams();
         rlBottomSheetLayoutParams.height = getActivity().getWindowManager().getDefaultDisplay().getHeight() / 16 * 9;
         rlBottomSheet.setLayoutParams(rlBottomSheetLayoutParams);
         }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1543,4 +1543,11 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     public void setNearbyParentFragmentInstanceReadyCallback(NearbyParentFragmentInstanceReadyCallback nearbyParentFragmentInstanceReadyCallback) {
         this.nearbyParentFragmentInstanceReadyCallback = nearbyParentFragmentInstanceReadyCallback;
     }
+
+    @Override
+    public void onConfigurationChanged(@NonNull final Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+            rlBottomSheet.getLayoutParams().height = getActivity().getWindowManager()
+                .getDefaultDisplay().getHeight() / 16 * 9;
+        }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1547,7 +1547,8 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     @Override
     public void onConfigurationChanged(@NonNull final Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-            rlBottomSheet.getLayoutParams().height = getActivity().getWindowManager()
-                .getDefaultDisplay().getHeight() / 16 * 9;
+        ViewGroup.LayoutParams rlBottomSheetLayoutParams=rlBottomSheet.getLayoutParams();
+        rlBottomSheetLayoutParams.height = getActivity().getWindowManager().getDefaultDisplay().getHeight() / 16 * 9;
+        rlBottomSheet.setLayoutParams(rlBottomSheetLayoutParams);
         }
 }


### PR DESCRIPTION
**Description (required)**

Fixes #2770

What changes did you make and why?
Cause of Bug
 when the view is generated in portrait  mode  the height was set according to the portrait mode, when we rotate screen to Landscope mode   the height of the container remained same as of portrait, due to which we were not able to see the rest of the list which was already generated but was hidden 

To solve this issue there need to update the height of  **rlBottomSheet.getLayoutParams().height** on configuration or orientation change of device screen 

**Tests performed (required)**
Android Device:Redmi y3 

**Screenshots (for UI changes only)**

![WhatsApp Image 2021-01-18 at 11 38 27 AM](https://user-images.githubusercontent.com/65972015/104878508-18b3f700-5982-11eb-84c8-dd3a1b89f1e4.jpeg)


![WhatsApp Image 2021-01-18 at 11 38 28 AM](https://user-images.githubusercontent.com/65972015/104878610-49942c00-5982-11eb-9721-b4d1fc27edac.jpeg)

