### PR TITLE
Fixes #4159 - Issue with options on the toolbar in media detail view.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
@@ -116,7 +116,8 @@ public class ExploreListRootFragment extends CommonsDaggerSupportFragment implem
     Log.d("deneme8","on media clicked");
     container.setVisibility(View.VISIBLE);
     ((ExploreFragment)getParentFragment()).tabLayout.setVisibility(View.GONE);
-    mediaDetails = new MediaDetailPagerFragment(false, true, position);
+    mediaDetails = new MediaDetailPagerFragment(false, true);
+    mediaDetails.showImage(position);
     setFragment(mediaDetails, listFragment);
   }
 


### PR DESCRIPTION
**Description (required)**

Fixes #4159 

What changes did you make and why?

The issue is because of current item position is not set, So instead of passing position as a parameter to MediaDetailPagerFragment constructor, I have passed it to showImage method in MediaDetailPagerFragment that will set the current item position in viewpager.


**Tests performed (required)**

Tested betaDebug on Pixel 3 with API level 29.