### PR TITLE
fixes-Failed to send thanks" notification, but thank actually sent successfully

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/actions/ThanksClient.kt
+++ b/app/src/main/java/fr/free/nrw/commons/actions/ThanksClient.kt
@@ -27,7 +27,7 @@ class ThanksClient @Inject constructor(
     fun thank(revisionId: Long): Observable<Boolean> {
         return try {
             service.thank(revisionId.toString(), null, csrfTokenClient.tokenBlocking, CommonsApplication.getInstance().userAgent)
-                .map { mwQueryResponse -> mwQueryResponse.successVal == 1 }
+                .map { mwThankPostResponse -> mwThankPostResponse.result.success== 1 }
         } catch (throwable: Throwable) {
             Observable.just(false)
         }

--- a/data-client/src/main/java/org/wikipedia/dataclient/Service.java
+++ b/data-client/src/main/java/org/wikipedia/dataclient/Service.java
@@ -11,6 +11,7 @@ import org.wikipedia.dataclient.mwapi.SiteMatrix;
 import org.wikipedia.dataclient.mwapi.page.MwMobileViewPageLead;
 import org.wikipedia.dataclient.mwapi.page.MwMobileViewPageRemaining;
 import org.wikipedia.dataclient.mwapi.page.MwQueryPageSummary;
+import org.wikipedia.dataclient.mwapi.page.MwThankPostResponse;
 import org.wikipedia.edit.Edit;
 import org.wikipedia.edit.preview.EditPreview;
 import org.wikipedia.login.LoginClient;
@@ -192,7 +193,7 @@ public interface Service {
 
     @FormUrlEncoded
     @POST(MW_API_PREFIX + "action=thank")
-    @NonNull Observable<MwPostResponse> thank(@Nullable @Field("rev") String rev,
+    @NonNull Observable<MwThankPostResponse> thank(@Nullable @Field("rev") String rev,
                                               @Nullable @Field("log") String log,
                                               @NonNull @Field("token") String token,
                                               @Nullable @Field("source") String source);

--- a/data-client/src/main/java/org/wikipedia/dataclient/mwapi/page/MwThankPostResponse.java
+++ b/data-client/src/main/java/org/wikipedia/dataclient/mwapi/page/MwThankPostResponse.java
@@ -1,0 +1,38 @@
+package org.wikipedia.dataclient.mwapi.page;
+
+
+import org.wikipedia.dataclient.mwapi.MwResponse;
+
+public class MwThankPostResponse extends MwResponse {
+  private Result result;
+
+  public Result getResult() {
+    return result;
+  }
+
+  public void setResult(Result result) {
+    this.result = result;
+  }
+
+  public class Result {
+    private Integer success;
+    private String recipient;
+
+    public Integer getSuccess() {
+      return success;
+    }
+
+    public void setSuccess(Integer success) {
+      this.success = success;
+    }
+
+    public String getRecipient() {
+      return recipient;
+    }
+
+    public void setRecipient(String recipient) {
+      this.recipient = recipient;
+    }
+
+  }
+}


### PR DESCRIPTION
**Description (required)**

Fixes #3559 

What changes did you make and why?
**Cause of Bug**

Model class -**MwPostResponse.java** is not appropriate class to store result of Post request   **POST(MW_API_PREFIX+"action=thank")** 

Result of Post Request  -**POST(MW_API_PREFIX+"action=thank")**  in json check out in link-**https://commons.wikimedia.org/wiki/Special:ApiSandbox#action=thank&format=json&rev=456&token=4491d3fdef1a8e0603e23765f7ae5cf2600c5019%2B%5C&source=diff**

Show that  i create another Model Class->"MwThankPostResponse.java" to store the Result of Post Request  **POST(MW_API_PREFIX+"action=thank")**  


**Tests performed (required)**
Tested {build variant-ProdDebug} on {Redmi y4 Device } with API level {26}.

