### PR TITLE
fix-Upload count does not get updated right away post successful upload

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -38,6 +38,7 @@ import fr.free.nrw.commons.auth.SessionManager;
 import fr.free.nrw.commons.notification.Notification;
 import fr.free.nrw.commons.notification.NotificationController;
 import fr.free.nrw.commons.theme.BaseActivity;
+import fr.free.nrw.commons.upload.UploadService.ServiceCallback;
 import io.reactivex.disposables.Disposable;
 import java.util.List;
 
@@ -84,7 +85,7 @@ public class ContributionsFragment
         OnBackStackChangedListener,
         LocationUpdateListener,
     MediaDetailProvider,
-    ICampaignsView, ContributionsContract.View, Callback {
+    ICampaignsView, ContributionsContract.View, Callback , ServiceCallback {
     @Inject @Named("default_preferences") JsonKvStore store;
     @Inject NearbyController nearbyController;
     @Inject OkHttpJsonApiClient okHttpJsonApiClient;
@@ -135,6 +136,7 @@ public class ContributionsFragment
         public void onServiceConnected(ComponentName componentName, IBinder binder) {
             uploadService = (UploadService) ((UploadService.UploadServiceLocalBinder) binder)
                     .getService();
+            uploadService.setServiceCallback(ContributionsFragment.this);
             isUploadServiceConnected = true;
         }
 
@@ -520,6 +522,7 @@ public class ContributionsFragment
 
             if (isUploadServiceConnected) {
                 if (getActivity() != null) {
+                    uploadService.setServiceCallback(null);
                     getActivity().unbindService(uploadServiceConnection);
                     isUploadServiceConnected = false;
                 }
@@ -665,6 +668,11 @@ public class ContributionsFragment
     // Getter for mediaDetailPagerFragment
     public MediaDetailPagerFragment getMediaDetailPagerFragment() {
         return mediaDetailPagerFragment;
+    }
+
+    @Override
+    public void updateUploadCount() {
+        setUploadCount();
     }
 }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadService.java
@@ -80,6 +80,7 @@ public class UploadService extends CommonsDaggerService {
   private NotificationCompat.Builder curNotification;
   private int toUpload;
   private CompositeDisposable compositeDisposable;
+  private ServiceCallback serviceCallback;
 
   /**
    * The filePath names of unfinished uploads, used to prevent overwriting
@@ -395,6 +396,10 @@ public class UploadService extends CommonsDaggerService {
       }
     }
     saveCompletedContribution(contribution, uploadResult);
+    if(serviceCallback!=null) {
+      //this function update the tatol number media Uploaded  or contributions
+      serviceCallback.updateUploadCount();
+    }
   }
 
   private void saveCompletedContribution(Contribution contribution, UploadResult uploadResult) {
@@ -471,4 +476,13 @@ public class UploadService extends CommonsDaggerService {
     }
     return sequenceFileName;
   }
+
+  public interface  ServiceCallback{
+    void updateUploadCount() ;
+  }
+
+  public void setServiceCallback(ServiceCallback serviceCallback) {
+    this.serviceCallback = serviceCallback;
+  }
+
 }


### PR DESCRIPTION
**Description (required)**

Fixes #1984 

What changes did you make and why?

**Cause of Bug**
when the any medai (image,video) is uploaded then number of Upload count not update
**Solution**
To solve this issue i implement ServiceCallback in ContriutionsFragment to update Upload count

->when an (image ,video) is uploaded then onSuccessfulUpload() function called in UploadService 
then we call the ServiceCallback method updateUploadCount() function to update the total number of 
contribution

**Tests performed (required)**

Tested {build variant, e.g. ProdDebug,betaDebug} with API level {25,29}.
