### PR TITLE
Fixes #2803 - Cancel nearby upload -> Next upload gets the same title/description

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
@@ -89,6 +89,7 @@ public interface NearbyParentFragmentContract {
         void detachView();
 
         void setActionListeners(JsonKvStore applicationKvStore);
+        void removeNearbyPreferences(JsonKvStore applicationKvStore);
         boolean backButtonClicked();
         void onCameraMove(com.mapbox.mapboxsdk.geometry.LatLng latLng);
         void filterByMarkerType(List<Label> selectedLabels, int state, boolean filterForPlaceState, boolean filterForAllNoneType);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -426,6 +426,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     public void onDestroyView() {
         super.onDestroyView();
         mapView.onDestroy();
+        presenter.removeNearbyPreferences(applicationKvStore);
     }
 
     private void initViews() {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.java
@@ -33,6 +33,7 @@ import static fr.free.nrw.commons.location.LocationServiceManager.LocationChange
 import static fr.free.nrw.commons.nearby.CheckBoxTriStates.CHECKED;
 import static fr.free.nrw.commons.nearby.CheckBoxTriStates.UNCHECKED;
 import static fr.free.nrw.commons.nearby.CheckBoxTriStates.UNKNOWN;
+import static fr.free.nrw.commons.wikidata.WikidataConstants.PLACE_OBJECT;
 
 public class NearbyParentFragmentPresenter
         implements NearbyParentFragmentContract.UserActions,
@@ -81,6 +82,12 @@ public class NearbyParentFragmentPresenter
     @Override
     public void detachView(){
         this.nearbyParentFragmentView=DUMMY;
+    }
+
+    @Override
+    public void removeNearbyPreferences(JsonKvStore applicationKvStore) {
+        Timber.d("Remove place objects");
+        applicationKvStore.remove(PLACE_OBJECT);
     }
 
     public void initializeMapOperations() {


### PR DESCRIPTION
**Description (required)**

Fixes #2803 

What changes did you make and why?

I have added a removeNearbyPreferences function to remove the stored place object, and This function will be called from the onDestroyView method in NearbyParentFragment.

**Tests performed (required)**

Tested betaDebug on Pixel 3 with API level 29