### PR TITLE
Fixes #4211 "Location not available" while fetching location updates.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
@@ -1,11 +1,16 @@
 package fr.free.nrw.commons.location;
 
+import static com.mapbox.mapboxsdk.Mapbox.getApplicationContext;
+import android.Manifest.permission;
 import android.app.Activity;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 import android.os.Bundle;
+import android.util.Log;
+import androidx.core.app.ActivityCompat;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -37,9 +42,40 @@ public class LocationServiceManager implements LocationListener {
 
     public LatLng getLastLocation() {
         if (lastLocation == null) {
-            return null;
+                lastLocation = getLastKnownLocation();
+                if(lastLocation != null) {
+                    return LatLng.from(lastLocation);
+                }
+                else {
+                    return null;
+                }
         }
         return LatLng.from(lastLocation);
+    }
+
+    private Location getLastKnownLocation() {
+        List<String> providers = locationManager.getProviders(true);
+        Location bestLocation = null;
+        for (String provider : providers) {
+            Location l=null;
+            if (ActivityCompat.checkSelfPermission(getApplicationContext(), permission.ACCESS_FINE_LOCATION)
+                != PackageManager.PERMISSION_GRANTED
+                && ActivityCompat.checkSelfPermission(getApplicationContext(), permission.ACCESS_COARSE_LOCATION)
+                != PackageManager.PERMISSION_GRANTED) {
+                l = locationManager.getLastKnownLocation(provider);
+            }
+            if (l == null) {
+                continue;
+            }
+            if (bestLocation == null
+                || l.getAccuracy() < bestLocation.getAccuracy()) {
+                bestLocation = l;
+            }
+        }
+        if (bestLocation == null) {
+            return null;
+        }
+        return bestLocation;
     }
 
     /**
@@ -58,11 +94,10 @@ public class LocationServiceManager implements LocationListener {
      * @param locationProvider the location provider
      * @return true if successful
      */
-    private boolean requestLocationUpdatesFromProvider(String locationProvider) {
+    public boolean requestLocationUpdatesFromProvider(String locationProvider) {
         try {
             // If both providers are not available
-            if (locationManager == null || !(locationManager.getAllProviders().contains(LocationManager.NETWORK_PROVIDER))
-                || !(locationManager.getAllProviders().contains(LocationManager.GPS_PROVIDER))) {
+            if (locationManager == null || !(locationManager.getAllProviders().contains(locationProvider))) {
                 return false;
             }
             locationManager.requestLocationUpdates(locationProvider,

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -16,6 +16,7 @@ import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.drawable.VectorDrawable;
+import android.location.LocationManager;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.text.Html;
@@ -351,7 +352,13 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
                             .zoom(ZOOM_LEVEL) // Same zoom level
                             .build();
                     mapBox.moveCamera(CameraUpdateFactory.newCameraPosition(position));
-                } else {
+                }
+                else if(locationManager.isGPSProviderEnabled()||locationManager.isNetworkProviderEnabled()){
+                    locationManager.requestLocationUpdatesFromProvider(LocationManager.NETWORK_PROVIDER);
+                    locationManager.requestLocationUpdatesFromProvider(LocationManager.GPS_PROVIDER);
+                    setProgressBarVisibility(true);
+                }
+                else {
                     Toast.makeText(getContext(), getString(R.string.nearby_location_not_available), Toast.LENGTH_LONG).show();
                 }
                 presenter.onMapReady();


### PR DESCRIPTION
**Description (required)**

Fixes #4211

What changes did you make and why?
I send a location update request when the providers are enabled.
Set the visibility of the progress bar to show the location is being fetched.
If the providers are not enabled the default message of "location not available" is shown.
To improve fetching the last known location I've created a function that gets the best last known location from all the providers.

**Tests performed (required)**

Tested betaDebug on Nokia 6.1+ with API level 29.