### PR TITLE
view in browser changes to view file page

### DIFF
--- a/app/src/main/res/menu/fragment_category_detail.xml
+++ b/app/src/main/res/menu/fragment_category_detail.xml
@@ -4,6 +4,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/menu_browser_current_category"
-        android:title="@string/menu_open_in_browser"
+        android:title="@string/menu_view_file_page"
         app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/menu/fragment_image_detail.xml
+++ b/app/src/main/res/menu/fragment_image_detail.xml
@@ -19,7 +19,7 @@
         app:showAsAction="always" />
     <item
         android:id="@+id/menu_browser_current_image"
-        android:title="@string/menu_open_in_browser"
+        android:title="@string/menu_view_file_page"
         app:showAsAction="never" />
     <item
         android:id="@+id/menu_set_as_wallpaper"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,7 +73,7 @@
   <string name="menu_nearby">Nearby</string>
   <string name="provider_contributions">My uploads</string>
   <string name="menu_share">Share</string>
-  <string name="menu_view_file_page">View File Page</string>
+  <string name="menu_view_file_page">View file page</string>
   <string name="share_title_hint">Caption (Required)</string>
   <string name="add_caption_toast">Please provide a caption for this file</string>
   <string name="share_description_hint">Description</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,7 +73,7 @@
   <string name="menu_nearby">Nearby</string>
   <string name="provider_contributions">My uploads</string>
   <string name="menu_share">Share</string>
-  <string name="menu_open_in_browser">View in Browser</string>
+  <string name="menu_view_file_page">View File Page</string>
   <string name="share_title_hint">Caption (Required)</string>
   <string name="add_caption_toast">Please provide a caption for this file</string>
   <string name="share_description_hint">Description</string>


### PR DESCRIPTION
**Description (required)**

Fixes #4201 

What changes did you make and why?

**Changed the text "view in broswer" to "view file page" because clicking didn't actually opened in any browser and so the later text makes more sense as discussed in issue #4201**

Tested {BetaDebug} on {Motorola One Action} with API level {29}.

**Screenshots (for UI changes only)**
![WhatsApp Image 2021-02-06 at 2 23 37 PM](https://user-images.githubusercontent.com/58428413/107113808-4f957280-6887-11eb-8b1f-0e5e3185d257.jpeg)

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
