### PR TITLE
Fixes #4203 - Blank Screen Appears on clicking any media after a theme change

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -235,6 +235,26 @@ public class MainActivity  extends BaseActivity
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putInt("viewPagerCurrentItem", viewPager.getCurrentItem());
+        outState.putString("activeFragment", activeFragment.name());
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+        String currentFragmentName = savedInstanceState.getString("activeFragment");
+        if(currentFragmentName == ActiveFragment.CONTRIBUTIONS.name()) {
+            setTitle(getString(R.string.contributions_fragment));
+            loadFragment(ContributionsFragment.newInstance(),false);
+        }else if(currentFragmentName == ActiveFragment.NEARBY.name()) {
+            setTitle(getString(R.string.nearby_fragment));
+            loadFragment(NearbyParentFragment.newInstance(),false);
+        }else if(currentFragmentName == ActiveFragment.EXPLORE.name()) {
+            setTitle(getString(R.string.navigation_item_explore));
+            loadFragment(ExploreFragment.newInstance(),false);
+        }else if(currentFragmentName == ActiveFragment.BOOKMARK.name()) {
+            setTitle(getString(R.string.favorites));
+            loadFragment(BookmarkFragment.newInstance(),false);
+        }
     }
 
     private void initMain() {


### PR DESCRIPTION
**Description (required)**

Fixes #4203 & #3531 

What changes did you make and why?
The issue was because the active fragment returns null on returning back to MainActivity after a theme change.
I have added an onRestoreInstanceState method that will load the previous fragment as the active fragment. It also solves the crash mentioned in #3531  Since the cause is almost similar.

**Tests performed (required)**
Tested betaDebug on Pixel 3 with API level 29