### PR TITLE
Fixed crashing in ExploreListRootFragment

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
@@ -130,7 +130,7 @@ public class ExploreListRootFragment extends CommonsDaggerSupportFragment implem
    */
   @Override
   public Media getMediaAtPosition(int i) {
-    if (listFragment != null) {
+    if (listFragment != null && i < listFragment.getTotalMediaCount()) {
       return listFragment.getMediaAtPosition(i);
     } else {
       return null;

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -302,7 +302,11 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
                         imageLandscape.setVisibility(VISIBLE);
                     }
                     oldWidthOfImageView = scrollView.getWidth();
+
+                    // If this is not checked app will crash with IndexOutOfBoundsException
+                    if (index < detailProvider.getTotalMediaCount()) {
                     displayMediaDetails();
+                    }
                 }
             }
         );


### PR DESCRIPTION
**Description (required)**

Fixes #4224 

What changes did you make and why?
I changed the **if** condition and added a check that whether the index passing to list is valid or not (i.e. index is less than the size of list). Also, if the index is invalid then prevented displaying the media details. 

**Tests performed (required)**
Tested {betaDebug} on {Redmi Note 7S} with API level {29}.