### PR TITLE
Fixed app crash in bookmark fragment backpress

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
@@ -172,16 +172,15 @@ public class BookmarkListRootFragment extends CommonsDaggerSupportFragment imple
   }
 
   public void backPressed() {
-    if (mediaDetails.isVisible()) {
+    if (mediaDetails != null && mediaDetails.isVisible()) {
       // todo add get list fragment
-      ((BookmarkFragment)getParentFragment()).tabLayout.setVisibility(View.VISIBLE);
+      ((BookmarkFragment) getParentFragment()).tabLayout.setVisibility(View.VISIBLE);
       removeFragment(mediaDetails);
       setFragment(listFragment, mediaDetails);
-      ((MainActivity)getActivity()).showTabs();
     } else {
       ((MainActivity) getActivity()).setSelectedItemId(NavTab.CONTRIBUTIONS.code());
-      ((MainActivity)getActivity()).showTabs();
     }
+    ((MainActivity) getActivity()).showTabs();
   }
 
   @Override


### PR DESCRIPTION
**Description (required)**

Fixes #4226 

What changes did you make and why?

Added a check in **if** condition that the `mediaDetails != null`. Also removed the redundant code from **if** condition.

Tested {build variant, betaDebug} on {Redmi Note 7S} with API level {29}.
