### PR TITLE
fixes #3440 "Campaign notification is not removed from Home even when disabling it in the setting"

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/campaigns/CampaignView.java
+++ b/app/src/main/java/fr/free/nrw/commons/campaigns/CampaignView.java
@@ -57,8 +57,8 @@ public class CampaignView extends SwipableCardView {
 
     @Override public boolean onSwipe(View view) {
         view.setVisibility(View.GONE);
-        /*((MainActivity) getContext()).defaultKvStore
-                .putBoolean("displayCampaignsCardView", false);*/
+        ((MainActivity) getContext()).defaultKvStore
+                .putBoolean("displayCampaignsCardView", false);
         ViewUtil.showLongToast(getContext(),
             getResources().getString(R.string.nearby_campaign_dismiss_message));
         return true;

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -582,7 +582,9 @@ public class ContributionsFragment
     }
 
     @Override public void showCampaigns(Campaign campaign) {
+        if ( campaign != null) {
             campaignView.setCampaign(campaign);
+        }
     }
 
     @Override public void onDestroyView() {

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -572,6 +572,9 @@ public class ContributionsFragment
         if (store.getBoolean("displayCampaignsCardView", true)) {
             presenter.getCampaigns();
         }
+        else{
+            campaignView.setVisibility(View.GONE);
+        }
     }
 
     @Override public void showMessage(String message) {
@@ -579,9 +582,7 @@ public class ContributionsFragment
     }
 
     @Override public void showCampaigns(Campaign campaign) {
-        if (campaign != null) {
             campaignView.setCampaign(campaign);
-        }
     }
 
     @Override public void onDestroyView() {

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -582,7 +582,7 @@ public class ContributionsFragment
     }
 
     @Override public void showCampaigns(Campaign campaign) {
-        if ( campaign != null) {
+        if (campaign != null) {
             campaignView.setCampaign(campaign);
         }
     }


### PR DESCRIPTION
**Description (required)**

Fixes #3440

What changes did you make and why?

Added missing else statement while fetching campaign.
Swipe to disable notification enabled.


**Tests performed (required)**

Tested betadebug on Nokia 6.1+ android 10 stock.