### PR TITLE
fix: app crash in CategoryDetailsActivity when click on any media (image or video)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -11,6 +11,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.FrameLayout;
+import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.viewpager.widget.ViewPager;
@@ -47,7 +48,7 @@ public class CategoryDetailsActivity extends BaseActivity
     @BindView(R.id.mediaContainer) FrameLayout mediaContainer;
     @BindView(R.id.tab_layout) TabLayout tabLayout;
     @BindView(R.id.viewPager) ViewPager viewPager;
-
+    @BindView(R.id.toolbar) Toolbar toolbar;
     ViewPagerAdapter viewPagerAdapter;
 
     @Override
@@ -60,6 +61,7 @@ public class CategoryDetailsActivity extends BaseActivity
         viewPager.setAdapter(viewPagerAdapter);
         viewPager.setOffscreenPageLimit(2);
         tabLayout.setupWithViewPager(viewPager);
+        setSupportActionBar(toolbar);
         setTabs();
         setPageTitle();
     }


### PR DESCRIPTION
**Description (required)**

Fixes #4196 

What changes did you make and why?
**Cause of issue
**java.lang.NullPointerException: Attempt to invoke virtual method 'void androidx.appcompat.app.ActionBar.setDisplayHomeAsUpEnabled(boolean)' on a null object reference In MediaDetailsFragment****
So that i add toolbar in CategoryDetailsActivity 

**Tests performed (required)**

Tested {ProBeta,ProdDebug} on Redmi y3 with API level {API level}.

