### PR TITLE
Fixed #4232 App crashes on trying to upload a media from gallery.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
@@ -124,10 +124,10 @@ public class UploadableFile implements Parcelable {
     private DateTimeWithSource getDateTimeFromExif() {
         try {
             ExifInterface exif = new ExifInterface(file.getAbsolutePath());
-                @SuppressLint("RestrictedApi") Long dateTime = exif.getDateTime();
-                if(dateTime != null){
-                    Date date = new Date(dateTime);
-                    return new DateTimeWithSource(date, DateTimeWithSource.EXIF_SOURCE);
+            @SuppressLint("RestrictedApi") Long dateTime = exif.getDateTime();
+            if(dateTime != null){
+                Date date = new Date(dateTime);
+                return new DateTimeWithSource(date, DateTimeWithSource.EXIF_SOURCE);
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
@@ -80,11 +80,11 @@ public class UploadableFile implements Parcelable {
      */
     @Nullable
     public DateTimeWithSource getFileCreatedDate(Context context) {
-        DateTimeWithSource dateTime = getDateTime();
-        if (dateTime == null) {
+        DateTimeWithSource dateTimeFromExif = getDateTimeFromExif();
+        if (dateTimeFromExif == null) {
             return getFileCreatedDateFromCP(context);
         } else {
-            return dateTime;
+            return dateTimeFromExif;
         }
     }
 
@@ -117,11 +117,11 @@ public class UploadableFile implements Parcelable {
     }
 
     /**
-     * Get filePath creation date from uri
+     * Get filePath creation date from uri from EXIF
      *
      * @return
      */
-    private DateTimeWithSource getDateTime() {
+    private DateTimeWithSource getDateTimeFromExif() {
         try {
             ExifInterface exif = new ExifInterface(file.getAbsolutePath());
                 @SuppressLint("RestrictedApi") Long dateTime = exif.getDateTime();

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
@@ -4,20 +4,14 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
-import android.os.Build.VERSION_CODES;
 import android.os.Parcel;
 import android.os.Parcelable;
 
 import androidx.annotation.Nullable;
-
+import androidx.exifinterface.media.ExifInterface;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileTime;
 import java.util.Date;
 
 import fr.free.nrw.commons.upload.FileUtils;
@@ -129,27 +123,12 @@ public class UploadableFile implements Parcelable {
      */
     private DateTimeWithSource getDateTime() {
         try {
-            /**
-             * fetch the last modified date of the selected file.
-             */
-                Date lastModDate= new Date(file.lastModified());
-            /**
-             * if android version is greater than 8.0 then
-             * we can get the creation Time of the file.
-             */
-                if(android.os.Build.VERSION.SDK_INT >= VERSION_CODES.O){
-                    Path path= Paths.get(file.getAbsolutePath());
-                    BasicFileAttributes attr= Files.readAttributes(path,BasicFileAttributes.class);
-                    FileTime last=attr.creationTime();
-                    if(last!=null) {
-                        return new DateTimeWithSource(last.toMillis(),
-                            DateTimeWithSource.EXIF_SOURCE);
-                    }
-                }
-                if(lastModDate!=null){
-                        return new DateTimeWithSource(lastModDate.getTime(),
-                            DateTimeWithSource.EXIF_SOURCE);
-                }
+            ExifInterface exif = new ExifInterface(file.getAbsolutePath());
+                @SuppressLint("RestrictedApi") Long dateTime = exif.getDateTime();
+                if(dateTime != null){
+                    Date date = new Date(dateTime);
+                    return new DateTimeWithSource(date, DateTimeWithSource.EXIF_SOURCE);
+            }
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
**Description (required)**

Fixes #4232 

What changes did you make and why?

~As @nicolas-raoul said https://github.com/commons-app/apps-android-commons/issues/4232#issuecomment-779903798 this was due to image with no EXIF.
Fixed by removing Exif and using file functions to get last modified and created time.~

Exif interface now returns null and not -1 so changed the check conditions.


**Tests performed (required)**

3.0.0-debug-master~2695bbaf4 on Nokia 6.1 stock android version 10. 