### PR TITLE
Fixes #4229 - App Crashes while trying to nominate an item for deletion, When User is not logged in

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -263,7 +263,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             authorLayout.setVisibility(GONE);
         }
 
-        if(applicationKvStore.getBoolean("login_skipped") == true){
+        if(applicationKvStore.getBoolean("login_skipped")){
             delete.setVisibility(GONE);
         }
 

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -61,6 +61,7 @@ import fr.free.nrw.commons.delete.DeleteHelper;
 import fr.free.nrw.commons.delete.ReasonBuilder;
 import fr.free.nrw.commons.explore.depictions.WikidataItemDetailsActivity;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
+import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.nearby.Label;
 import fr.free.nrw.commons.ui.widget.HtmlTextView;
 import fr.free.nrw.commons.utils.ViewUtilWrapper;
@@ -74,6 +75,7 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.Map;
 import javax.inject.Inject;
+import javax.inject.Named;
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.util.DateUtil;
 import timber.log.Timber;
@@ -117,6 +119,9 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
     ViewUtilWrapper viewUtil;
     @Inject
     CategoryClient categoryClient;
+    @Inject
+    @Named("default_preferences")
+    JsonKvStore applicationKvStore;
 
     private int initialListTop = 0;
 
@@ -256,6 +261,10 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             authorLayout.setVisibility(VISIBLE);
         } else {
             authorLayout.setVisibility(GONE);
+        }
+
+        if(applicationKvStore.getBoolean("login_skipped") == true){
+            delete.setVisibility(GONE);
         }
 
         return view;


### PR DESCRIPTION
**Description (required)**

Fixes #4229 

What changes did you make and why?
Added a condition to check the user is logged in or not, if not logged in then simply hide the delete button. As the feature is of no use for the non-logged-in users.

**Tests performed (required)**
Tested betaDebug on Pixel 3 with API level 29.