### PR TITLE
Spell error in crash message removed.

### DIFF
--- a/app/src/main/res/values-en-rGB/error.xml
+++ b/app/src/main/res/values-en-rGB/error.xml
@@ -6,6 +6,6 @@
 <resources>
   <string name="crash_dialog_title">Commons has crashed! 🙁</string>
   <string name="crash_dialog_text">Oops. Something went wrong! 😐</string>
-  <string name="crash_dialog_comment_prompt">Tell us what you were doing, then share it via email to us. wE Will help us fix it!</string>
-  <string name="crash_dialog_ok_toast">ThankS!</string>
+  <string name="crash_dialog_comment_prompt">Tell us what you were doing, then share it via email to us.Will help us fix it!</string>
+  <string name="crash_dialog_ok_toast">Thanks!</string>
 </resources>


### PR DESCRIPTION
**Description (required)**

Fixes #4241

What changes did you make and why?
Spell and grammar errors in the crash message. For better User Experience.
**Tests performed (required)**

Tested {build variant, e.g. ProdDebug} on {Redmi Note 5} with API level {Android 4.0 IceCream Sandwich}.
