### PR TITLE
Fixes #4218 - In-App notifications appear on media detail fragment

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -431,6 +431,7 @@ public class ContributionsFragment
             showNearbyCardPermissionRationale();
         });
 
+        //notification cards should only be seen on contributions list, not in media details
         if(mediaDetailPagerFragment == null){
             if (store.getBoolean("displayNearbyCardView", true)) {
                 checkPermissionsAndShowNearbyCardView();

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -431,8 +431,8 @@ public class ContributionsFragment
             showNearbyCardPermissionRationale();
         });
 
-        //notification cards should only be seen on contributions list, not in media details
-        if(mediaDetailPagerFragment == null){
+        // Notification cards should only be seen on contributions list, not in media details
+        if (mediaDetailPagerFragment == null) {
             if (store.getBoolean("displayNearbyCardView", true)) {
                 checkPermissionsAndShowNearbyCardView();
                 if (nearbyNotificationCardView.cardViewVisibilityState == NearbyNotificationCardView.CardViewVisibilityState.READY) {

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -431,19 +431,21 @@ public class ContributionsFragment
             showNearbyCardPermissionRationale();
         });
 
-        if (store.getBoolean("displayNearbyCardView", true)) {
-            checkPermissionsAndShowNearbyCardView();
-            if (nearbyNotificationCardView.cardViewVisibilityState == NearbyNotificationCardView.CardViewVisibilityState.READY) {
-                nearbyNotificationCardView.setVisibility(View.VISIBLE);
+        if(mediaDetailPagerFragment == null){
+            if (store.getBoolean("displayNearbyCardView", true)) {
+                checkPermissionsAndShowNearbyCardView();
+                if (nearbyNotificationCardView.cardViewVisibilityState == NearbyNotificationCardView.CardViewVisibilityState.READY) {
+                    nearbyNotificationCardView.setVisibility(View.VISIBLE);
+                }
+
+            } else {
+                // Hide nearby notification card view if related shared preferences is false
+                nearbyNotificationCardView.setVisibility(View.GONE);
             }
 
-        } else {
-            // Hide nearby notification card view if related shared preferences is false
-            nearbyNotificationCardView.setVisibility(View.GONE);
+            setNotificationCount();
+            fetchCampaigns();
         }
-
-        setNotificationCount();
-        fetchCampaigns();
     }
 
     private void checkPermissionsAndShowNearbyCardView() {


### PR DESCRIPTION
**Description (required)**

Fixes #4218 

What changes did you make and why?
Added a condition to fetch and show in-app notifications only when the list fragment is visible i.e, media detail fragment should be null.

**Tests performed (required)**
Tested betaDebug on Pixel 3 with API level 29.