### PR TITLE
Fixes #4244 - App crash in WikidataItemDetailsActivity resolved

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -100,7 +100,10 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
         pager.addOnPageChangeListener(this);
 
         adapter = new MediaDetailAdapter(getChildFragmentManager());
-        ((BaseActivity)getActivity()).getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+        if (((BaseActivity) getActivity()).getSupportActionBar() != null) {
+            ((BaseActivity) getActivity()).getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
 
         if (savedInstanceState != null) {
             final int pageNumber = savedInstanceState.getInt("current-page");


### PR DESCRIPTION
**Description (required)**

Fixes #4244 

What changes did you make and why?
Added an **if** condition for checking that `getSupportActionBar()` is not null.

**Tests performed (required)**
Tested {build variant-betaDebug} on {Redmi Note 7S} with API level {API 29}.