### PR TITLE
fixed #4230 'Opening notifications in "Read" section still marks them read and removes them from the list'.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -70,7 +70,7 @@ public class NotificationActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        isRead=getIntent().getStringExtra("title").equals("read");
+        isRead = getIntent().getStringExtra("title").equals("read");
         setContentView(R.layout.activity_notification);
         ButterKnife.bind(this);
         mNotificationWorkerFragment = (NotificationWorkerFragment) getFragmentManager()
@@ -89,7 +89,7 @@ public class NotificationActivity extends BaseActivity {
 
     @SuppressLint("CheckResult")
     public void removeNotification(Notification notification) {
-        if(isRead) {
+        if (isRead) {
             return;
         }
         Disposable disposable = Observable.defer((Callable<ObservableSource<Boolean>>)

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -64,11 +64,13 @@ public class NotificationActivity extends BaseActivity {
     private NotificationWorkerFragment mNotificationWorkerFragment;
     private NotificatinAdapter adapter;
     private List<Notification> notificationList;
+    private boolean isRead;
     MenuItem notificationMenuItem;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        isRead=getIntent().getStringExtra("title").equals("read");
         setContentView(R.layout.activity_notification);
         ButterKnife.bind(this);
         mNotificationWorkerFragment = (NotificationWorkerFragment) getFragmentManager()
@@ -87,6 +89,9 @@ public class NotificationActivity extends BaseActivity {
 
     @SuppressLint("CheckResult")
     public void removeNotification(Notification notification) {
+        if(isRead) {
+            return;
+        }
         Disposable disposable = Observable.defer((Callable<ObservableSource<Boolean>>)
                 () -> controller.markAsRead(notification))
                 .subscribeOn(Schedulers.io())
@@ -126,7 +131,7 @@ public class NotificationActivity extends BaseActivity {
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         DividerItemDecoration itemDecor = new DividerItemDecoration(recyclerView.getContext(), DividerItemDecoration.VERTICAL);
         recyclerView.addItemDecoration(itemDecor);
-        if (getIntent().getStringExtra("title").equals("read")) {
+        if (isRead) {
             refresh(true);
         } else {
             refresh(false);
@@ -240,7 +245,7 @@ public class NotificationActivity extends BaseActivity {
 
     private void setPageTitle() {
         if (getSupportActionBar() != null) {
-            if (getIntent().getStringExtra("title").equals("read")) {
+            if (isRead) {
                 getSupportActionBar().setTitle(R.string.read_notifications);
             } else {
                 getSupportActionBar().setTitle(R.string.notifications);
@@ -249,7 +254,7 @@ public class NotificationActivity extends BaseActivity {
     }
 
     private void setEmptyView() {
-        if (getIntent().getStringExtra("title").equals("read")) {
+        if (isRead) {
             noNotificationText.setText(R.string.no_read_notification);
         }else {
             noNotificationText.setText(R.string.no_notification);
@@ -257,7 +262,7 @@ public class NotificationActivity extends BaseActivity {
     }
 
     private void setMenuItemTitle() {
-        if (getIntent().getStringExtra("title").equals("read")) {
+        if (isRead) {
             notificationMenuItem.setTitle(R.string.menu_option_unread);
 
         }else {

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -64,8 +64,11 @@ public class NotificationActivity extends BaseActivity {
     private NotificationWorkerFragment mNotificationWorkerFragment;
     private NotificatinAdapter adapter;
     private List<Notification> notificationList;
-    private boolean isRead;
     MenuItem notificationMenuItem;
+    /**
+     * Boolean isRead is true if this notification activity is for read section of notification.
+     */
+    private boolean isRead;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -87,6 +90,16 @@ public class NotificationActivity extends BaseActivity {
         return true;
     }
 
+    /**
+     * If this is unread section of the notifications, removeNotification method
+     *  Marks the notification as read,
+     *  Removes the notification from unread,
+     *  Displays the Snackbar.
+     *
+     * Otherwise returns (read section).
+     *
+     * @param notification
+     */
     @SuppressLint("CheckResult")
     public void removeNotification(Notification notification) {
         if (isRead) {


### PR DESCRIPTION
**Description (required)**

Fixes #4230

What changes did you make and why?

Added a private variable which is true when in read section of the notifications.
Used it whenever required.

**Tests performed (required)**

Tested 3.0.0-notification on Nokia 6.1+ android 10.
