### PR TITLE
Fixes #4245 Removed category editing accessibility when user not logged in

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -51,6 +51,7 @@ import fr.free.nrw.commons.MediaDataExtractor;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.auth.AccountUtil;
+import fr.free.nrw.commons.auth.SessionManager;
 import fr.free.nrw.commons.category.CategoryClient;
 import fr.free.nrw.commons.category.CategoryDetailsActivity;
 import fr.free.nrw.commons.category.CategoryEditHelper;
@@ -104,6 +105,9 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
 
         return mf;
     }
+
+    @Inject
+    SessionManager sessionManager;
 
     @Inject
     MediaDataExtractor mediaDataExtractor;
@@ -256,6 +260,10 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             authorLayout.setVisibility(VISIBLE);
         } else {
             authorLayout.setVisibility(GONE);
+        }
+
+        if (!sessionManager.isUserLoggedIn()) {
+            categoryEditButton.setVisibility(GONE);
         }
 
         return view;


### PR DESCRIPTION
**Description (required)**

Fixes #4245 

What changes did you make and why?
Removed the pencil icon when user is not logged in, so that they cannot edit details.

**Tests performed (required)**
Tested {build variant-betaDebug} on {Redmi Note 7S} with API level {API 29}.
