### PR TITLE
Added bookmark section in not-logged-in version

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkFragment.java
@@ -14,6 +14,7 @@ import com.google.android.material.tabs.TabLayout;
 
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.explore.ParentViewPager;
+import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.theme.BaseActivity;
 import javax.inject.Inject;
 
@@ -21,6 +22,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.contributions.ContributionController;
+import javax.inject.Named;
 
 public class BookmarkFragment extends CommonsDaggerSupportFragment {
 
@@ -35,6 +37,10 @@ public class BookmarkFragment extends CommonsDaggerSupportFragment {
 
   @Inject
   ContributionController controller;
+  @Inject
+  @Named("default_preferences")
+  public
+  JsonKvStore applicationKvStore;
 
   @NonNull
   public static BookmarkFragment newInstance() {
@@ -65,11 +71,25 @@ public class BookmarkFragment extends CommonsDaggerSupportFragment {
     // reference to the Fragment from FragmentManager, using findFragmentById()
     supportFragmentManager = getChildFragmentManager();
 
-    adapter = new BookmarksPagerAdapter(supportFragmentManager, getContext());
+    adapter = new BookmarksPagerAdapter(supportFragmentManager, getContext(),
+                                        applicationKvStore.getBoolean("login_skipped"));
     viewPager.setAdapter(adapter);
     tabLayout.setupWithViewPager(viewPager);
+    setupTabLayout();
     return view;
   }
+
+  /**
+   * This method sets up the tab layout.
+   * If the adapter has only one element it sets the visibility of tabLayout to gone.
+   */
+  public void setupTabLayout(){
+    tabLayout.setVisibility(View.VISIBLE);
+    if(adapter.getCount()==1){
+      tabLayout.setVisibility(View.GONE);
+    }
+  }
+
 
   public void onBackPressed() {
     ((BookmarkListRootFragment) (adapter.getItem(tabLayout.getSelectedTabPosition())))

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkFragment.java
@@ -88,7 +88,7 @@ public class BookmarkFragment extends CommonsDaggerSupportFragment {
    */
   public void setupTabLayout(){
     tabLayout.setVisibility(View.VISIBLE);
-    if(adapter.getCount()==1){
+    if (adapter.getCount() == 1) {
       tabLayout.setVisibility(View.GONE);
     }
   }

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkFragment.java
@@ -37,6 +37,9 @@ public class BookmarkFragment extends CommonsDaggerSupportFragment {
 
   @Inject
   ContributionController controller;
+  /**
+   * To check if the user is loggedIn or not.
+   */
   @Inject
   @Named("default_preferences")
   public

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
@@ -185,7 +185,7 @@ public class BookmarkListRootFragment extends CommonsDaggerSupportFragment imple
     if(mediaDetails!=null) {
       if (mediaDetails.isVisible()) {
         // todo add get list fragment
-        ((BookmarkFragment) getParentFragment()).tabLayout.setVisibility(View.VISIBLE);
+        ((BookmarkFragment) getParentFragment()).setupTabLayout();
         ArrayList<Integer> removed=mediaDetails.getRemovedItems();
         removeFragment(mediaDetails);
         ((BookmarkFragment) getParentFragment()).setScroll(true);

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarksPagerAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarksPagerAdapter.java
@@ -19,6 +19,13 @@ public class BookmarksPagerAdapter extends FragmentPagerAdapter {
 
     private ArrayList<BookmarkPages> pages;
 
+    /**
+     * Default Constructor
+     * @param fm
+     * @param context
+     * @param onlyPictures is true if the fragment requires only BookmarkPictureFragment
+     *                     (i.e. when no user is logged in).
+     */
     BookmarksPagerAdapter(FragmentManager fm, Context context,boolean onlyPictures) {
         super(fm);
         pages = new ArrayList<>();
@@ -29,6 +36,7 @@ public class BookmarksPagerAdapter extends FragmentPagerAdapter {
                 new BookmarkListRootFragment(picturesBundle, this),
                 context.getString(R.string.title_page_bookmarks_pictures)));
         if (!onlyPictures) {
+            // if onlyPictures is false we also add the location fragment.
             Bundle locationBundle = new Bundle();
             locationBundle.putString("categoryName",
                 context.getString(R.string.title_page_bookmarks_locations));

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarksPagerAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarksPagerAdapter.java
@@ -19,7 +19,7 @@ public class BookmarksPagerAdapter extends FragmentPagerAdapter {
 
     private ArrayList<BookmarkPages> pages;
 
-    BookmarksPagerAdapter(FragmentManager fm, Context context) {
+    BookmarksPagerAdapter(FragmentManager fm, Context context,boolean onlyPictures) {
         super(fm);
         pages = new ArrayList<>();
         Bundle picturesBundle = new Bundle();
@@ -28,13 +28,15 @@ public class BookmarksPagerAdapter extends FragmentPagerAdapter {
         pages.add(new BookmarkPages(
                 new BookmarkListRootFragment(picturesBundle, this),
                 context.getString(R.string.title_page_bookmarks_pictures)));
-
-        Bundle locationBundle = new Bundle();
-        locationBundle.putString("categoryName", context.getString(R.string.title_page_bookmarks_locations));
-        locationBundle.putInt("order", 1);
-        pages.add(new BookmarkPages(
-            new BookmarkListRootFragment(locationBundle, this),
-            context.getString(R.string.title_page_bookmarks_locations)));
+        if (!onlyPictures) {
+            Bundle locationBundle = new Bundle();
+            locationBundle.putString("categoryName",
+                context.getString(R.string.title_page_bookmarks_locations));
+            locationBundle.putInt("order", 1);
+            pages.add(new BookmarkPages(
+                new BookmarkListRootFragment(locationBundle, this),
+                context.getString(R.string.title_page_bookmarks_locations)));
+        }
         notifyDataSetChanged();
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -113,7 +113,7 @@ public class MainActivity  extends BaseActivity
             onSupportNavigateUp();
         });
         if (applicationKvStore.getBoolean("login_skipped") == true) {
-            setTitle(getString(R.string.explore_tab_title_mobile));
+            setTitle(getString(R.string.navigation_item_explore));
             setUpLoggedOutPager();
         } else {
             if(savedInstanceState == null){

--- a/app/src/main/java/fr/free/nrw/commons/navtab/NavTabLoggedOut.java
+++ b/app/src/main/java/fr/free/nrw/commons/navtab/NavTabLoggedOut.java
@@ -5,6 +5,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.fragment.app.Fragment;
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.bookmarks.BookmarkFragment;
 import fr.free.nrw.commons.explore.ExploreFragment;
 import org.wikipedia.model.EnumCode;
 import org.wikipedia.model.EnumCodeMap;
@@ -17,6 +18,13 @@ public enum NavTabLoggedOut implements EnumCode {
     @Override
     public Fragment newInstance() {
       return ExploreFragment.newInstance();
+    }
+  },
+  FAVORITES(R.string.favorites, R.drawable.ic_round_star_border_24px) {
+    @NonNull
+    @Override
+    public Fragment newInstance() {
+      return BookmarkFragment.newInstance();
     }
   },
   MORE(R.string.more, R.drawable.ic_menu_black_24dp) {

--- a/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/BookmarksPagerAdapterTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/BookmarksPagerAdapterTests.kt
@@ -21,7 +21,7 @@ class BookmarksPagerAdapterTests {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        bookmarksPagerAdapter = BookmarksPagerAdapter(fragmentManager, context)
+        bookmarksPagerAdapter = BookmarksPagerAdapter(fragmentManager, context, false)
     }
 
     @Test

--- a/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/LoggedOutBookmarksPagerAdapterTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/LoggedOutBookmarksPagerAdapterTests.kt
@@ -1,0 +1,66 @@
+package fr.free.nrw.commons.bookmarks
+
+import android.content.Context
+import androidx.fragment.app.FragmentManager
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+
+/**
+ * BookmarksPagerAdapter when user is not loggedIn.
+ */
+class LoggedOutBookmarksPagerAdapterTests {
+    @Mock
+    private lateinit var bookmarksPagerAdapter: BookmarksPagerAdapter
+
+    @Mock
+    private lateinit var fragmentManager: FragmentManager
+
+    @Mock
+    private lateinit var context: Context
+
+    /**
+     * Setup the adapter
+     */
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+        bookmarksPagerAdapter = BookmarksPagerAdapter(fragmentManager, context, true)
+    }
+
+    /**
+     * checkNotNull
+     */
+    @Test
+    fun checkNotNull() {
+        Assert.assertNotNull(bookmarksPagerAdapter)
+    }
+
+    /**
+     * getItems
+     * Logged out bookmark adapter has just one item.
+     */
+    @Test
+    fun testGetItem() {
+        bookmarksPagerAdapter.getItem(0)
+    }
+
+    /**
+     * itemCount
+     * Logged out bookmark adapter has just one item.
+     */
+    @Test
+    fun testGetCount() {
+        Assert.assertEquals(bookmarksPagerAdapter.count, 1)
+    }
+
+    /**
+     * getTitle.
+     */
+    @Test
+    fun testGetPageTitle() {
+        bookmarksPagerAdapter.getPageTitle(0)
+    }
+}


### PR DESCRIPTION
**Description (required)**

Fixes #4250 

What changes did you make and why?

BookmarkPagerFragment 
* Added a constructor parameter which tells Adapter if onlyPicture fragment of bookmark is to initialized (i.e. when user not logged in).
* If onlyPicture is true we do not add location bookmark fragment in the pages.


BookmarkFragment
* Used preferences to check if the user is logged in.
* Added a method to set up the Tab Layout that considers the case when the adapter has only one element.

NavTabLoggedOut
* Added 'favorites' navTabElement.

BookmarksPagerAdaterTests.kt
* Updated the function according to the new constructor.

MainActivity
* Minor inhancement as it showed uploaded from mobile instead of explore.
 


**Tests performed (required)**

Tested betaDebug on Nokia 6.1+ with API level 29.