### PR TITLE
Fixes #4129 Resolved App crash on logging out from Contributors Tab

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionBoundaryCallback.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionBoundaryCallback.kt
@@ -27,8 +27,7 @@ class ContributionBoundaryCallback @Inject constructor(
      * network
      */
     override fun onZeroItemsLoaded() {
-        if (sessionManager.userName != null)
-            fetchContributions()
+        fetchContributions()
     }
 
     /**
@@ -51,21 +50,23 @@ class ContributionBoundaryCallback @Inject constructor(
      * Fetches contributions using the MediaWiki API
      */
     fun fetchContributions() {
-        compositeDisposable.add(
-            mediaClient.getMediaListForUser(sessionManager.userName!!)
-                .map { mediaList ->
-                    mediaList.map {
-                        Contribution(media = it, state = Contribution.STATE_COMPLETED)
+        if (sessionManager.userName != null) {
+            compositeDisposable.add(
+                mediaClient.getMediaListForUser(sessionManager.userName!!)
+                    .map { mediaList ->
+                        mediaList.map {
+                            Contribution(media = it, state = Contribution.STATE_COMPLETED)
+                        }
                     }
-                }
-                .subscribeOn(ioThreadScheduler)
-                .subscribe(::saveContributionsToDB) { error: Throwable ->
-                    Timber.e(
-                        "Failed to fetch contributions: %s",
-                        error.message
-                    )
-                }
-        )
+                    .subscribeOn(ioThreadScheduler)
+                    .subscribe(::saveContributionsToDB) { error: Throwable ->
+                        Timber.e(
+                            "Failed to fetch contributions: %s",
+                            error.message
+                        )
+                    }
+            )
+        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionBoundaryCallback.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionBoundaryCallback.kt
@@ -27,7 +27,8 @@ class ContributionBoundaryCallback @Inject constructor(
      * network
      */
     override fun onZeroItemsLoaded() {
-        fetchContributions()
+        if (sessionManager.userName != null)
+            fetchContributions()
     }
 
     /**
@@ -54,7 +55,7 @@ class ContributionBoundaryCallback @Inject constructor(
             mediaClient.getMediaListForUser(sessionManager.userName!!)
                 .map { mediaList ->
                     mediaList.map {
-                        Contribution(media=it, state=Contribution.STATE_COMPLETED)
+                        Contribution(media = it, state = Contribution.STATE_COMPLETED)
                     }
                 }
                 .subscribeOn(ioThreadScheduler)


### PR DESCRIPTION
**Description (required)**

Fixes #4129 

What changes did you make and why?
After logging out `fetchContributions` is called once but username is null at that time. So added a **if** condition checking whether username is null or not and reformatted a line of code.

**Tests performed (required)**
Tested {build variant-betaDebug} on {Redmi Note 7S} with API level {API 29}.