### PR TITLE
Fixes #4254 Fixed crashing on setting avatar when not logged in

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -305,6 +305,11 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                     menu.findItem(R.id.menu_set_as_wallpaper).setEnabled(false)
                             .setVisible(false);
                 }
+
+                if (!sessionManager.isUserLoggedIn()) {
+                    menu.findItem(R.id.menu_set_as_avatar).setVisible(false);
+                }
+
             }
         }
     }


### PR DESCRIPTION
**Description (required)**

Fixes #4254 

What changes did you make and why?
If user is not logged in, the option for setting as avatar in menu will not be visible. For this, added an if condition to check whether user is logged in or not. 

**Tests performed (required)**
Tested {build variant-betaDebug} on {Redmi Note 7S} with API level {API 29}.