### PR TITLE
#3732 - Nearby Tab Accessible Without Location Permission

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -451,6 +451,7 @@ public class ContributionsFragment
             onLocationPermissionGranted();
         } else if (shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)
                 && store.getBoolean("displayLocationPermissionForCardView", true)
+                && !store.getBoolean("DoNotAskForLocationPermission", false)
                 && (((MainActivity) getActivity()).activeFragment == ActiveFragment.CONTRIBUTIONS)) {
             nearbyNotificationCardView.permissionType = NearbyNotificationCardView.PermissionType.ENABLE_LOCATION_PERMISSION;
             showNearbyCardPermissionRationale();
@@ -483,6 +484,7 @@ public class ContributionsFragment
 
     private void displayYouWontSeeNearbyMessage() {
         ViewUtil.showLongToast(getActivity(), getResources().getString(R.string.unable_to_display_nearest_place));
+        store.putBoolean("DoNotAskForLocationPermission", true);
     }
 
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -451,7 +451,7 @@ public class ContributionsFragment
             onLocationPermissionGranted();
         } else if (shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)
                 && store.getBoolean("displayLocationPermissionForCardView", true)
-                && !store.getBoolean("DoNotAskForLocationPermission", false)
+                && !store.getBoolean("doNotAskForLocationPermission", false)
                 && (((MainActivity) getActivity()).activeFragment == ActiveFragment.CONTRIBUTIONS)) {
             nearbyNotificationCardView.permissionType = NearbyNotificationCardView.PermissionType.ENABLE_LOCATION_PERMISSION;
             showNearbyCardPermissionRationale();
@@ -484,7 +484,7 @@ public class ContributionsFragment
 
     private void displayYouWontSeeNearbyMessage() {
         ViewUtil.showLongToast(getActivity(), getResources().getString(R.string.unable_to_display_nearest_place));
-        store.putBoolean("DoNotAskForLocationPermission", true);
+        store.putBoolean("doNotAskForLocationPermission", true);
     }
 
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
@@ -22,7 +22,7 @@ public interface NearbyParentFragmentContract {
         void listOptionMenuItemClicked();
         void populatePlaces(LatLng curlatLng);
         boolean isListBottomSheetExpanded();
-        void checkPermissionsAndPerformAction(Runnable runnable);
+        void checkPermissionsAndPerformAction();
         void displayLoginSkippedWarning();
         void setFABPlusAction(android.view.View.OnClickListener onClickListener);
         void setFABRecenterAction(android.view.View.OnClickListener onClickListener);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -345,7 +345,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     private void performMapReadyActions() {
         if (((MainActivity)getActivity()).activeFragment == ActiveFragment.NEARBY && isMapBoxReady) {
-            if(!applicationKvStore.getBoolean("NotDisplayLocationPermissionAlertBox", false) ||
+            if(!applicationKvStore.getBoolean("DoNotAskForLocationPermission", false) ||
                 PermissionUtils.hasPermission(getActivity(), Manifest.permission.ACCESS_FINE_LOCATION)){
                 checkPermissionsAndPerformAction();
             }else{
@@ -358,7 +358,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private void locationPermissionGranted() {
         isPermissionDenied = false;
 
-        applicationKvStore.putBoolean("NotDisplayLocationPermissionAlertBox", false);
+        applicationKvStore.putBoolean("DoNotAskForLocationPermission", false);
         lastKnownLocation = locationManager.getLastLocation();
         fr.free.nrw.commons.location.LatLng target=lastFocusLocation;
         if(null==lastFocusLocation){
@@ -391,7 +391,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         presenter.attachView(this);
         registerNetworkReceiver();
         if (isResumed() && ((MainActivity)getActivity()).activeFragment == ActiveFragment.NEARBY) {
-            if(!isPermissionDenied && !applicationKvStore.getBoolean("NotDisplayLocationPermissionAlertBox", false)){
+            if(!isPermissionDenied && !applicationKvStore.getBoolean("DoNotAskForLocationPermission", false)){
                 startTheMap();
             }else{
                 startMapWithoutPermission();
@@ -402,7 +402,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private void startMapWithoutPermission() {
         mapView.onStart();
 
-        applicationKvStore.putBoolean("NotDisplayLocationPermissionAlertBox", true);
+        applicationKvStore.putBoolean("DoNotAskForLocationPermission", true);
         lastKnownLocation = new fr.free.nrw.commons.location.LatLng(51.50550,-0.07520,1f);
         final CameraPosition position = new CameraPosition.Builder()
             .target(LocationUtils.commonsLatLngToMapBoxLatLng(lastKnownLocation))

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -345,7 +345,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     private void performMapReadyActions() {
         if (((MainActivity)getActivity()).activeFragment == ActiveFragment.NEARBY && isMapBoxReady) {
-            if(!applicationKvStore.getBoolean("DoNotAskForLocationPermission", false) ||
+            if(!applicationKvStore.getBoolean("doNotAskForLocationPermission", false) ||
                 PermissionUtils.hasPermission(getActivity(), Manifest.permission.ACCESS_FINE_LOCATION)){
                 checkPermissionsAndPerformAction();
             }else{
@@ -358,7 +358,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private void locationPermissionGranted() {
         isPermissionDenied = false;
 
-        applicationKvStore.putBoolean("DoNotAskForLocationPermission", false);
+        applicationKvStore.putBoolean("doNotAskForLocationPermission", false);
         lastKnownLocation = locationManager.getLastLocation();
         fr.free.nrw.commons.location.LatLng target=lastFocusLocation;
         if(null==lastFocusLocation){
@@ -391,7 +391,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         presenter.attachView(this);
         registerNetworkReceiver();
         if (isResumed() && ((MainActivity)getActivity()).activeFragment == ActiveFragment.NEARBY) {
-            if(!isPermissionDenied && !applicationKvStore.getBoolean("DoNotAskForLocationPermission", false)){
+            if(!isPermissionDenied && !applicationKvStore.getBoolean("doNotAskForLocationPermission", false)){
                 startTheMap();
             }else{
                 startMapWithoutPermission();
@@ -402,7 +402,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private void startMapWithoutPermission() {
         mapView.onStart();
 
-        applicationKvStore.putBoolean("DoNotAskForLocationPermission", true);
+        applicationKvStore.putBoolean("doNotAskForLocationPermission", true);
         lastKnownLocation = new fr.free.nrw.commons.location.LatLng(51.50550,-0.07520,1f);
         final CameraPosition position = new CameraPosition.Builder()
             .target(LocationUtils.commonsLatLngToMapBoxLatLng(lastKnownLocation))

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -189,6 +189,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private Animation rotate_forward;
 
     private static final float ZOOM_LEVEL = 14f;
+    private static final float ZOOM_OUT = 0f;
     private final String NETWORK_INTENT_ACTION = "android.net.conn.CONNECTIVITY_CHANGE";
     private BroadcastReceiver broadcastReceiver;
     private boolean isNetworkErrorOccurred;
@@ -204,6 +205,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private final double CAMERA_TARGET_SHIFT_FACTOR_LANDSCAPE = 0.004;
 
     private boolean isMapBoxReady;
+    private boolean isPermissionDenied;
     private MapboxMap mapBox;
     IntentFilter intentFilter = new IntentFilter(NETWORK_INTENT_ACTION);
     private Marker currentLocationMarker;
@@ -257,6 +259,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         cameraMoveListener= () -> presenter.onCameraMove(mapBox.getCameraPosition().target);
         addCheckBoxCallback();
         presenter.attachView(this);
+        isPermissionDenied = false;
         initRvNearbyList();
         initThemePreferences();
         mapView.onCreate(savedInstanceState);
@@ -279,7 +282,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
                 performMapReadyActions();
                 final CameraPosition cameraPosition = new CameraPosition.Builder()
                         .target(new LatLng(51.50550, -0.07520))
-                        .zoom(ZOOM_LEVEL)
+                        .zoom(ZOOM_OUT)
                         .build();
                 mapBoxMap.setCameraPosition(cameraPosition);
 
@@ -340,32 +343,35 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     private void performMapReadyActions() {
         if (((MainActivity)getActivity()).activeFragment == ActiveFragment.NEARBY && isMapBoxReady) {
-            checkPermissionsAndPerformAction(() -> {
-                lastKnownLocation = locationManager.getLastLocation();
-                fr.free.nrw.commons.location.LatLng target=lastFocusLocation;
-                if(null==lastFocusLocation){
-                    target=lastKnownLocation;
-                }
-                if (lastKnownLocation != null) {
-                    final CameraPosition position = new CameraPosition.Builder()
-                            .target(LocationUtils.commonsLatLngToMapBoxLatLng(target)) // Sets the new camera position
-                            .zoom(ZOOM_LEVEL) // Same zoom level
-                            .build();
-                    mapBox.moveCamera(CameraUpdateFactory.newCameraPosition(position));
-                }
-                else if(locationManager.isGPSProviderEnabled()||locationManager.isNetworkProviderEnabled()){
-                    locationManager.requestLocationUpdatesFromProvider(LocationManager.NETWORK_PROVIDER);
-                    locationManager.requestLocationUpdatesFromProvider(LocationManager.GPS_PROVIDER);
-                    setProgressBarVisibility(true);
-                }
-                else {
-                    Toast.makeText(getContext(), getString(R.string.nearby_location_not_available), Toast.LENGTH_LONG).show();
-                }
-                presenter.onMapReady();
-                registerUnregisterLocationListener(false);
-                addOnCameraMoveListener();
-            });
+            checkPermissionsAndPerformAction();
         }
+    }
+
+    private void locationPermissionGranted() {
+        isPermissionDenied = false;
+        lastKnownLocation = locationManager.getLastLocation();
+        fr.free.nrw.commons.location.LatLng target=lastFocusLocation;
+        if(null==lastFocusLocation){
+            target=lastKnownLocation;
+        }
+        if (lastKnownLocation != null) {
+            final CameraPosition position = new CameraPosition.Builder()
+                .target(LocationUtils.commonsLatLngToMapBoxLatLng(target)) // Sets the new camera position
+                .zoom(ZOOM_LEVEL) // Same zoom level
+                .build();
+            mapBox.moveCamera(CameraUpdateFactory.newCameraPosition(position));
+        }
+        else if(locationManager.isGPSProviderEnabled()||locationManager.isNetworkProviderEnabled()){
+            locationManager.requestLocationUpdatesFromProvider(LocationManager.NETWORK_PROVIDER);
+            locationManager.requestLocationUpdatesFromProvider(LocationManager.GPS_PROVIDER);
+            setProgressBarVisibility(true);
+        }
+        else {
+            Toast.makeText(getContext(), getString(R.string.nearby_location_not_available), Toast.LENGTH_LONG).show();
+        }
+        presenter.onMapReady();
+        registerUnregisterLocationListener(false);
+        addOnCameraMoveListener();
     }
 
     @Override
@@ -375,8 +381,27 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         presenter.attachView(this);
         registerNetworkReceiver();
         if (isResumed() && ((MainActivity)getActivity()).activeFragment == ActiveFragment.NEARBY) {
-            startTheMap();
+            if(!isPermissionDenied){
+                startTheMap();
+            }else{
+                startMapWithoutPermission();
+            }
         }
+    }
+
+    private void startMapWithoutPermission() {
+        mapView.onStart();
+
+        lastKnownLocation = new fr.free.nrw.commons.location.LatLng(51.50550,-0.07520,1f);
+        final CameraPosition position = new CameraPosition.Builder()
+            .target(LocationUtils.commonsLatLngToMapBoxLatLng(lastKnownLocation))
+            .zoom(ZOOM_OUT)
+            .build();
+        mapBox.moveCamera(CameraUpdateFactory.newCameraPosition(position));
+
+        presenter.onMapReady();
+        addOnCameraMoveListener();
+        removeCurrentLocationMarker();
     }
 
     private void registerNetworkReceiver() {
@@ -888,12 +913,12 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     }
 
     @Override
-    public void checkPermissionsAndPerformAction(final Runnable runnable) {
+    public void checkPermissionsAndPerformAction() {
         Timber.d("Checking permission and perfoming action");
         PermissionUtils.checkPermissionsAndPerformAction(getActivity(),
                 Manifest.permission.ACCESS_FINE_LOCATION,
-                runnable,
-                () -> ((MainActivity) getActivity()).setSelectedItemId(NavTab.CONTRIBUTIONS.code()),
+                () -> locationPermissionGranted(),
+                () -> isPermissionDenied = true,
                 R.string.location_permission_title,
                 R.string.location_permission_rationale_nearby);
     }
@@ -1065,7 +1090,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
      */
     @Override
     public void addCurrentLocationMarker(final fr.free.nrw.commons.location.LatLng curLatLng) {
-        if (null != curLatLng) {
+        if (null != curLatLng && !isPermissionDenied) {
             ExecutorUtils.get().submit(() -> {
                 mapView.post(() -> removeCurrentLocationMarker());
                 Timber.d("Adds current location marker");
@@ -1111,8 +1136,15 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     @Override
     public void updateMapToTrackPosition(final fr.free.nrw.commons.location.LatLng curLatLng) {
         Timber.d("Updates map camera to track user position");
-        final CameraPosition cameraPosition = new CameraPosition.Builder().target
+        final CameraPosition cameraPosition;
+        if(isPermissionDenied){
+            cameraPosition = new CameraPosition.Builder().target
                 (LocationUtils.commonsLatLngToMapBoxLatLng(curLatLng)).build();
+        }else{
+            cameraPosition = new CameraPosition.Builder().target
+                (LocationUtils.commonsLatLngToMapBoxLatLng(curLatLng))
+                .zoom(ZOOM_LEVEL).build();
+        }
         if(null!=mapBox) {
             mapBox.setCameraPosition(cameraPosition);
             mapBox.animateCamera(CameraUpdateFactory
@@ -1296,8 +1328,9 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
     @Override
     public void recenterMap(final fr.free.nrw.commons.location.LatLng curLatLng) {
-        if (curLatLng == null) {
-            if (!(locationManager.isNetworkProviderEnabled() || locationManager.isGPSProviderEnabled())) {
+        if (isPermissionDenied || curLatLng == null) {
+            checkPermissionsAndPerformAction();
+            if (!isPermissionDenied && !(locationManager.isNetworkProviderEnabled() || locationManager.isGPSProviderEnabled())) {
                 showLocationOffDialog();
             }
             return;

--- a/app/src/main/java/fr/free/nrw/commons/utils/PermissionUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/PermissionUtils.java
@@ -138,7 +138,8 @@ public class PermissionUtils {
                         activity.getString(rationaleMessage),
                         activity.getString(android.R.string.ok),
                         activity.getString(android.R.string.cancel),
-                        token::continuePermissionRequest, token::cancelPermissionRequest);
+                        token::continuePermissionRequest, token::cancelPermissionRequest,
+                        null,false);
                 }
             })
             .check();

--- a/app/src/main/java/fr/free/nrw/commons/utils/PermissionUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/PermissionUtils.java
@@ -138,8 +138,10 @@ public class PermissionUtils {
                         activity.getString(rationaleMessage),
                         activity.getString(android.R.string.ok),
                         activity.getString(android.R.string.cancel),
-                        token::continuePermissionRequest, token::cancelPermissionRequest,
-                        null,false);
+                        token::continuePermissionRequest,
+                        token::cancelPermissionRequest,
+                        null,
+                        false);
                 }
             })
             .check();


### PR DESCRIPTION
**Description (required)**

Fixes #3732 

What changes did you make and why?

Summary : 

Nearby tab initially show a zoom-out map, which will be zoomed to the user's location if permission granted, and if not then still a zoom-out map will be shown with "Search this Area" enabled.

Major Changes:

Added a function that will set the Tower of London as the camera position on completely zoomed-out map, instead of going back to the contribution tab, if the user denies the location permission and also enabled the "Search this Area" button.

Changed the functionality of recenter button when permission is denied, as it is of no use if the user's location is unknown. and also disable the disappearing of the permission alertbox by clicking outside the box which is causing the empty map problem.

**Tests performed (required)**
Tested betaDebug on Pixel 3 with API level 29.