### PR TITLE
Fixes #2252 "Tapping on map doesn't close tab in 'nearby'".

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -10,6 +10,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Animation;
@@ -24,6 +25,7 @@ import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver;
 import androidx.recyclerview.widget.RecyclerView.ItemAnimator;
+import androidx.recyclerview.widget.RecyclerView.OnItemTouchListener;
 import androidx.recyclerview.widget.SimpleItemAnimator;
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -154,6 +156,29 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment impl
             rvContributionsList.scrollToPosition(0);//Newly upload items are always added to the top
           }
         }
+      }
+    });
+
+    //Fab close on touch outside (Scrolling or taping on item triggers this action).
+    rvContributionsList.addOnItemTouchListener(new OnItemTouchListener() {
+      @Override
+      public boolean onInterceptTouchEvent(@NonNull RecyclerView rv, @NonNull MotionEvent e) {
+        if (e.getAction() == MotionEvent.ACTION_DOWN) {
+          if (isFabOpen) {
+            animateFAB(isFabOpen);
+          }
+        }
+        return false;
+      }
+
+      @Override
+      public void onTouchEvent(@NonNull RecyclerView rv, @NonNull MotionEvent e) {
+
+      }
+
+      @Override
+      public void onRequestDisallowInterceptTouchEvent(boolean disallowIntercept) {
+
       }
     });
   }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -171,15 +171,30 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment impl
         return false;
       }
 
+      /**
+       * Process a touch event as part of a gesture that was claimed by returning true
+       * from a previous call to {@link #onInterceptTouchEvent}.
+       *
+       * @param rv
+       * @param e  MotionEvent describing the touch event. All coordinates are in
+       */
       @Override
       public void onTouchEvent(@NonNull RecyclerView rv, @NonNull MotionEvent e) {
-
+        //required abstract method DO NOT DELETE
       }
 
+      /**
+       * Called when a child of RecyclerView does not want RecyclerView and its ancestors
+       * to intercept touch events with {@link ViewGroup#onInterceptTouchEvent(MotionEvent)}.
+       *
+       * @param disallowIntercept True if the child does not want the parent to intercept
+       *                          touch events.
+       */
       @Override
       public void onRequestDisallowInterceptTouchEvent(boolean disallowIntercept) {
-
+        //required abstract method DO NOT DELETE
       }
+
     });
   }
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -181,7 +181,8 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment impl
        * from a previous call to {@link #onInterceptTouchEvent}.
        *
        * @param rv
-       * @param e  MotionEvent describing the touch event. All coordinates are in
+       * @param e  MotionEvent describing the touch event. All coordinates are in the
+       *           RecyclerView's coordinate system.
        */
       @Override
       public void onTouchEvent(@NonNull RecyclerView rv, @NonNull MotionEvent e) {

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -161,6 +161,11 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment impl
 
     //Fab close on touch outside (Scrolling or taping on item triggers this action).
     rvContributionsList.addOnItemTouchListener(new OnItemTouchListener() {
+
+      /**
+       * Silently observe and/or take over touch events sent to the RecyclerView before
+       * they are handled by either the RecyclerView itself or its child views.
+       */
       @Override
       public boolean onInterceptTouchEvent(@NonNull RecyclerView rv, @NonNull MotionEvent e) {
         if (e.getAction() == MotionEvent.ACTION_DOWN) {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -450,9 +450,9 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
      * a) Creates bottom sheet behaviours from bottom sheets, sets initial states and visibility
      * b) Gets the touch event on the map to perform following actions:
      *      collapse fab if fab is open.
-     *      collapse bottom sheet if bottom sheet details are expanded.
-     *      hide the bottom sheet details if bottom sheet details are collapsed.
-     *      hide the list bottom sheet if listBottomSheet is open.
+     *      if bottom sheet details are expanded .
+     *      if bottom sheet details are collapsed then hide the bottom sheet details.
+     *      if listBottomSheet is open then hide the list bottom sheet.
      */
     @SuppressLint("ClickableViewAccessibility")
     private void initBottomSheets() {
@@ -470,21 +470,14 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             if(event.getAction() == MotionEvent.ACTION_DOWN) {
                 if (isFABsExpanded) {
                     collapseFABs(true);
-                    return true;
-                }
-                if (bottomSheetDetailsBehavior.getState()
+                }else if (bottomSheetDetailsBehavior.getState()
                     == BottomSheetBehavior.STATE_EXPANDED) {
                     bottomSheetDetailsBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
-                    return true;
-                }
-                if (bottomSheetDetailsBehavior.getState()
+                }else if (bottomSheetDetailsBehavior.getState()
                     == BottomSheetBehavior.STATE_COLLAPSED) {
                     bottomSheetDetailsBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
-                    return true;
-                }
-                if (isListBottomSheetExpanded()) {
+                }else if (isListBottomSheetExpanded()) {
                     bottomSheetListBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
-                    return true;
                 }
             }
             return false;

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -449,8 +449,8 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     /**
      * a) Creates bottom sheet behaviours from bottom sheets, sets initial states and visibility
      * b) Gets the touch event on the map to perform following actions:
-     *      collapse fab if fab is open.
-     *      if bottom sheet details are expanded .
+     *      if fab is open then close fab.
+     *      if bottom sheet details are expanded then collapse bottom sheet details.
      *      if bottom sheet details are collapsed then hide the bottom sheet details.
      *      if listBottomSheet is open then hide the list bottom sheet.
      */
@@ -470,13 +470,13 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             if(event.getAction() == MotionEvent.ACTION_DOWN) {
                 if (isFABsExpanded) {
                     collapseFABs(true);
-                }else if (bottomSheetDetailsBehavior.getState()
+                } else if (bottomSheetDetailsBehavior.getState()
                     == BottomSheetBehavior.STATE_EXPANDED) {
                     bottomSheetDetailsBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
-                }else if (bottomSheetDetailsBehavior.getState()
+                } else if (bottomSheetDetailsBehavior.getState()
                     == BottomSheetBehavior.STATE_COLLAPSED) {
                     bottomSheetDetailsBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
-                }else if (isListBottomSheetExpanded()) {
+                } else if (isListBottomSheetExpanded()) {
                     bottomSheetListBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
                 }
             }


### PR DESCRIPTION
**Description (required)**

Fixes #2252 

What changes did you make and why?
Handled the touch events on map to close the list.
Handled the touch events on recycler view to close fab in contributions.

**Tests performed (required)**

BetaDebug on Nokia 6.1+ android 10 stock