### PR TITLE
Fixes #4255 - Media details activity shows depictions in random languages, rather than in the user's locale

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -616,7 +616,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
      */
     private void buildDepictionList(List<IdAndCaptions> idAndCaptions) {
         depictionContainer.removeAllViews();
-        String locale = applicationKvStore.getString(Prefs.KEY_LANGUAGE_VALUE, "");
+        String locale = Locale.getDefault().getLanguage();
         for (IdAndCaptions idAndCaption : idAndCaptions) {
                 depictionContainer.addView(buildDepictLabel(
                     //Check if the Depiction Caption is available in user's locale if not then check for english, else show any available.

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -64,7 +64,6 @@ import fr.free.nrw.commons.explore.depictions.WikidataItemDetailsActivity;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.nearby.Label;
-import fr.free.nrw.commons.settings.Prefs;
 import fr.free.nrw.commons.ui.widget.HtmlTextView;
 import fr.free.nrw.commons.utils.ViewUtilWrapper;
 import io.reactivex.Single;
@@ -619,15 +618,22 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         String locale = Locale.getDefault().getLanguage();
         for (IdAndCaptions idAndCaption : idAndCaptions) {
                 depictionContainer.addView(buildDepictLabel(
-                    //Check if the Depiction Caption is available in user's locale if not then check for english, else show any available.
-                    idAndCaption.getCaptions().get(locale) != null
-                        ? idAndCaption.getCaptions().get(locale)
-                        : ((idAndCaption.getCaptions().get("en") != null) ? idAndCaption.getCaptions().get("en")
-                            : idAndCaption.getCaptions().values().iterator().next()),
+                    getDepictionCaption(idAndCaption, locale),
                     idAndCaption.getId(),
                     depictionContainer
                 ));
         }
+    }
+
+    private String getDepictionCaption(IdAndCaptions idAndCaption, String locale) {
+        //Check if the Depiction Caption is available in user's locale if not then check for english, else show any available.
+        if(idAndCaption.getCaptions().get(locale) != null) {
+            return idAndCaption.getCaptions().get(locale);
+        }
+        if(idAndCaption.getCaptions().get("en") != null) {
+            return idAndCaption.getCaptions().get("en");
+        }
+        return idAndCaption.getCaptions().values().iterator().next();
     }
 
     @OnClick(R.id.mediaDetailLicense)

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -64,6 +64,7 @@ import fr.free.nrw.commons.explore.depictions.WikidataItemDetailsActivity;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.nearby.Label;
+import fr.free.nrw.commons.settings.Prefs;
 import fr.free.nrw.commons.ui.widget.HtmlTextView;
 import fr.free.nrw.commons.utils.ViewUtilWrapper;
 import io.reactivex.Single;
@@ -615,9 +616,14 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
      */
     private void buildDepictionList(List<IdAndCaptions> idAndCaptions) {
         depictionContainer.removeAllViews();
+        String locale = applicationKvStore.getString(Prefs.KEY_LANGUAGE_VALUE, "");
         for (IdAndCaptions idAndCaption : idAndCaptions) {
                 depictionContainer.addView(buildDepictLabel(
-                    idAndCaption.getCaptions().values().iterator().next(),
+                    //Check if the Depiction Caption is available in user's locale if not then check for english, else show any available.
+                    idAndCaption.getCaptions().get(locale) != null
+                        ? idAndCaption.getCaptions().get(locale)
+                        : ((idAndCaption.getCaptions().get("en") != null) ? idAndCaption.getCaptions().get("en")
+                            : idAndCaption.getCaptions().values().iterator().next()),
                     idAndCaption.getId(),
                     depictionContainer
                 ));


### PR DESCRIPTION
**Description (required)**

Fixes #4255 

What changes did you make and why?

Since App fetches a list of a depiction in different languages but I have noticed that depiction is only shown in the first language given in list, which is causing this issue. I have added the conditions Now it will first check if the depiction caption is available in the user's locale and if not then it will also check for English as it is the default language, else show in any available language.

**Tests performed (required)**
Tested prodDebug on Pixel 3 with API level 29.

(image selected from the feature tab with depictions)
https://commons.m.wikimedia.org/wiki/File%3AD%C3%BClmen%2C_Merfeld%2C_Feldweg_am_M%C3%BChlenbach_--_2021_--_4278-80.jpg

default language: English

Latest Master 3.0.0-debug
>![Screenshot_1614252218](https://user-images.githubusercontent.com/54663429/109146794-46af0700-778a-11eb-85fd-60c02167e312.png)

Updated
> ![Screenshot_1614251879](https://user-images.githubusercontent.com/54663429/109146730-31d27380-778a-11eb-8d45-3bb946063db1.png)
