### PR TITLE
fixes #4266 'Image Dimensions should be reduced if too large"

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -288,7 +288,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             delete.setVisibility(GONE);
         }
         /**
-         * gets the height of the frame layout as soon as the view is ready and updates aspect ratio
+         * Gets the height of the frame layout as soon as the view is ready and updates aspect ratio
          * of the picture.
          */
         view.post(new Runnable() {
@@ -353,7 +353,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
                 @Override
                 public void onGlobalLayout() {
                     /**
-                     * we update the height of the frame layout as the configuration changes.
+                     * We update the height of the frame layout as the configuration changes.
                      */
                     frameLayout.post(new Runnable() {
                         @Override
@@ -372,7 +372,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
                 }
             }
         );
-        // ensuring correct aspect ratio for landscape mode
+        // Ensuring correct aspect ratio for landscape mode
         if (heightVerifyingBoolean) {
             updateAspectRatio(newWidthOfImageView);
             heightVerifyingBoolean = false;
@@ -454,7 +454,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             params.width = scrollWidth;
             if(finalHeight > frameLayoutHeight - minimumHeightOfMetadata) {
 
-                // adjust the height and width of image.
+                // Adjust the height and width of image.
                 int temp = frameLayoutHeight - minimumHeightOfMetadata;
                 params.width = (scrollWidth*temp) / finalHeight;
                 finalHeight = temp;

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -216,13 +216,16 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
     private ArrayList<String> reasonList;
 
     /**
-     * Height stores the height of the frame layout as soon as its intialised and updates itself on
-     * configuration change.
+     * Height stores the height of the frame layout as soon as it is initialised and updates itself on
+     * configuration changes.
      * Used to adjust aspect ratio of image when length of the image is too large.
      */
-    private int heightFrameLayuot;
+    private int frameLayoutHeight;
 
-    private int minimumHeightOfMetadata=200;
+    /**
+     * minimumHeightOfMetadataLayout in pixels.
+     */
+    private int minimumHeightOfMetadata = 200;
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
@@ -293,7 +296,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         view.post(new Runnable() {
             @Override
             public void run() {
-                heightFrameLayuot = frameLayout.getMeasuredHeight();
+                frameLayoutHeight = frameLayout.getMeasuredHeight();
                 updateAspectRatio(scrollView.getWidth());
             }
         });
@@ -356,7 +359,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         frameLayout.post(new Runnable() {
             @Override
             public void run() {
-                heightFrameLayuot = frameLayout.getMeasuredHeight();
+                frameLayoutHeight = frameLayout.getMeasuredHeight();
                 updateAspectRatio(scrollView.getWidth());
             }
         });
@@ -461,13 +464,15 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             int finalHeight = (scrollWidth*imageInfoCache.getHeight()) / imageInfoCache.getWidth();
             ViewGroup.LayoutParams params = image.getLayoutParams();
             ViewGroup.LayoutParams spacerParams = imageSpacer.getLayoutParams();
-            params.width=scrollWidth;
-                if(finalHeight>heightFrameLayuot-minimumHeightOfMetadata)
-                {
-                    int temp=heightFrameLayuot-minimumHeightOfMetadata;
-                    params.width=scrollWidth*temp/finalHeight;
-                    finalHeight=temp;
-                }
+            params.width  = scrollWidth;
+            if(finalHeight > frameLayoutHeight - minimumHeightOfMetadata) {
+
+                // adjust the height and width of image.
+                int temp = frameLayoutHeight - minimumHeightOfMetadata;
+                params.width = (scrollWidth*temp) / finalHeight;
+                finalHeight = temp;
+
+            }
             params.height = finalHeight;
             spacerParams.height = finalHeight;
             image.setLayoutParams(params);

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -60,13 +60,6 @@
               android:layout_width="match_parent"
               android:layout_height="wrap_content" >
 
-                <com.facebook.drawee.view.SimpleDraweeView
-                  android:id="@+id/mediaDetailImageViewLandscape"
-                  android:layout_width="match_parent"
-                  android:layout_height="@dimen/dimen_250"
-                  app:actualImageScaleType="none"
-                  android:visibility="gone" />
-
                 <LinearLayout
                   android:layout_width="match_parent"
                   android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -6,6 +6,7 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:background="?attr/mainBackground"
+  android:id="@+id/mediaDetailFrameLayout"
   >
 
     <LinearLayout
@@ -34,8 +35,9 @@
 
     <com.facebook.drawee.view.SimpleDraweeView
       android:id="@+id/mediaDetailImageView"
-      android:layout_width="match_parent"
+      android:layout_width="wrap_content"
       android:layout_height="@dimen/dimen_250"
+      android:layout_gravity="center_horizontal"
       app:actualImageScaleType="none" />
 
     <ScrollView


### PR DESCRIPTION
**Description (required)**

Fixes #4266 

What changes did you make and why?
Fixed dimension when the image is larger than a bound set by minimumHeightOfMetadata.
Minor bug on scrolling the image on orientation change fixed.

**Tests performed (required)**
3.0.0 betadebug api 29

**Screenshots (for UI changes only)**

