### PR TITLE
Fixed state restoration issues in several app components

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
@@ -10,20 +10,16 @@ import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentActivity;
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import com.google.android.material.tabs.TabLayout;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.category.CategoryImagesCallback;
-import fr.free.nrw.commons.contributions.ContributionsListFragment;
 import fr.free.nrw.commons.contributions.MainActivity;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.explore.categories.media.CategoriesMediaFragment;
 import fr.free.nrw.commons.media.MediaDetailPagerFragment;
 import fr.free.nrw.commons.navtab.NavTab;
-import fr.free.nrw.commons.settings.SettingsFragment;
 
 public class ExploreListRootFragment extends CommonsDaggerSupportFragment implements
     MediaDetailPagerFragment.MediaDetailProvider, CategoryImagesCallback {
@@ -33,18 +29,6 @@ public class ExploreListRootFragment extends CommonsDaggerSupportFragment implem
 
   @BindView(R.id.explore_container)
   FrameLayout container;
-
-  public ExploreListRootFragment(){
-    //empty constructor necessary otherwise crashes on recreate
-  }
-
-  public ExploreListRootFragment(Bundle bundle) {
-    String title = bundle.getString("categoryName");
-    listFragment = new CategoriesMediaFragment();
-    Bundle featuredArguments = new Bundle();
-    featuredArguments.putString("categoryName", title);
-    listFragment.setArguments(featuredArguments);
-  }
 
   @Nullable
   @Override
@@ -59,8 +43,28 @@ public class ExploreListRootFragment extends CommonsDaggerSupportFragment implem
   @Override
   public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
-    if(savedInstanceState == null) {
-      setFragment(listFragment, mediaDetails);
+    if (savedInstanceState == null) {
+      final Bundle bundle = getArguments();
+      if (bundle != null) {
+        final String title = bundle.getString("categoryName");
+        listFragment = new CategoriesMediaFragment();
+        final Bundle featuredArguments = new Bundle();
+        featuredArguments.putString("categoryName", title);
+        listFragment.setArguments(featuredArguments);
+        setFragment(listFragment, mediaDetails);
+      }
+    } else {
+      listFragment = (CategoriesMediaFragment) getChildFragmentManager().getFragment(savedInstanceState, "listFragment");
+      mediaDetails = (MediaDetailPagerFragment) getChildFragmentManager().getFragment(savedInstanceState, "mediaDetails");
+    }
+  }
+
+  @Override
+  public void onSaveInstanceState(@NonNull final Bundle outState) {
+    super.onSaveInstanceState(outState);
+    getChildFragmentManager().putFragment(outState, "listFragment", listFragment);
+    if (mediaDetails != null && mediaDetails.isAdded()) {
+      getChildFragmentManager().putFragment(outState, "mediaDetails", mediaDetails);
     }
   }
 

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -222,6 +222,10 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
 
         getScrollPosition();
         outState.putInt("listTop", initialListTop);
+
+        if (media != null) {
+            outState.putParcelable("current-media", media);
+        }
     }
 
     private void getScrollPosition() {
@@ -241,12 +245,14 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             isWikipediaButtonDisplayed = savedInstanceState.getBoolean("isWikipediaButtonDisplayed");
             index = savedInstanceState.getInt("index");
             initialListTop = savedInstanceState.getInt("listTop");
+            media = savedInstanceState.getParcelable("current-media");
         } else {
             editable = getArguments().getBoolean("editable");
             isCategoryImage = getArguments().getBoolean("isCategoryImage");
             isWikipediaButtonDisplayed = getArguments().getBoolean("isWikipediaButtonDisplayed");
             index = getArguments().getInt("index");
             initialListTop = 0;
+            media = detailProvider.getMediaAtPosition(index);
         }
 
         reasonList = new ArrayList<>();
@@ -306,7 +312,6 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         categoryRecyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
         categoryRecyclerView.setAdapter(categoryEditSearchRecyclerViewAdapter);
 
-        media = detailProvider.getMediaAtPosition(index);
         scrollView.getViewTreeObserver().addOnGlobalLayoutListener(
             new OnGlobalLayoutListener() {
                 @Override

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -120,7 +120,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
 
                 getActivity().supportInvalidateOptionsMenu();
                 adapter.notifyDataSetChanged();
-            }, 100);
+            }, 1000);
         } else {
             pager.setAdapter(adapter);
         }


### PR DESCRIPTION
**Description (required)**

Fixes #3906 

Fixed the state restoration issues in MainActivity, ExploreFragment, ExploreListRootFragment, MediaDetailPagerFragment and MediaDetailFragment that where causing the crash.

Restored the state of several variables that were not being restored when the app was returning from it's process being destroyed by the system (due to a permission change or out of memory).

Also had to fix some issues related with fragment creation, ex.: in ExploreFragment's onCreateView(), a new view pager adapter was being created with new ExploreListRootFragments even when ExploreFragment was being restored. This is not a good pattern (https://blog.propaneapps.com/android/fragment-in-viewpager/) because it will cause fragment duplication.

So the use of ViewPagerAdapter needed to be dropped and a new FragmentPagerAdapter implementation was needed. This can probably be generalized as ViewPagerAdapter was to be used everywhere FragmentPagerAdapter is being used but I considered it to be out of the scope of this issue.

**Tests performed (required)**

Tested {build variant, ProdDebug} on {Samsung Galaxy S8} with API level {29}.

