### PR TITLE
Fixes #4293 - Leaderboard rank text fixed to show rank in one line only

### DIFF
--- a/app/src/main/res/layout/leaderboard_list_element.xml
+++ b/app/src/main/res/layout/leaderboard_list_element.xml
@@ -16,7 +16,10 @@
       android:gravity="center_vertical|center_horizontal"
       android:layout_width="0dp"
       android:layout_weight="0.1"
-      android:layout_height="match_parent"/>
+      android:layout_height="match_parent"
+      android:maxLines="1"
+      android:inputType="text"
+      />
 
     <com.facebook.drawee.view.SimpleDraweeView
       android:id="@+id/user_avatar"


### PR DESCRIPTION
**This commit fixes UI issue with rank number containing 3 or more digits to fit in one line.**

Fixes #4293

**Changes made:**

In the TextView added maxLines attribute and inputType attribute that makes text to fit in single line only.

**Tests performed**

Tested prodRelease on Android Emulator with API level 29.

**Screenshots**
![SharedScreenshot](https://user-images.githubusercontent.com/49794220/111065001-5e51f380-84dd-11eb-9bc5-46e776eb4dfd.jpg)
