### PR TITLE
fix:App should respect device font-size

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
@@ -28,9 +28,11 @@ public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
         super.onCreate(savedInstanceState);
         wasPreviouslyDarkTheme = systemThemeUtils.isDeviceInNightMode();
         setTheme(wasPreviouslyDarkTheme ? R.style.DarkAppTheme : R.style.LightAppTheme);
-        float fontScale = android.provider.Settings.System.getFloat(getBaseContext().getContentResolver()
-                , android.provider.Settings.System.FONT_SCALE, 1f);
-        adjustFontScale(getResources().getConfiguration(),fontScale);
+        float fontScale = android.provider.Settings.System.getFloat(
+            getBaseContext().getContentResolver(),
+            android.provider.Settings.System.FONT_SCALE,
+            1f);
+        adjustFontScale(getResources().getConfiguration(), fontScale);
     }
 
     @Override
@@ -50,9 +52,9 @@ public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
     }
 
     /**
-     * its function is apply fontScale on device
+     * Apply fontScale on device
      */
-    public  void adjustFontScale( Configuration configuration,float scale) {
+    public void adjustFontScale(Configuration configuration, float scale) {
         configuration.fontScale = scale;
         DisplayMetrics metrics = getResources().getDisplayMetrics();
         WindowManager wm = (WindowManager) getSystemService(WINDOW_SERVICE);

--- a/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
@@ -28,7 +28,8 @@ public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
         super.onCreate(savedInstanceState);
         wasPreviouslyDarkTheme = systemThemeUtils.isDeviceInNightMode();
         setTheme(wasPreviouslyDarkTheme ? R.style.DarkAppTheme : R.style.LightAppTheme);
-        float fontScale = android.provider.Settings.System.getFloat(getBaseContext().getContentResolver(),android.provider.Settings.System.FONT_SCALE, 1f);
+        float fontScale = android.provider.Settings.System.getFloat(getBaseContext().getContentResolver()
+                , android.provider.Settings.System.FONT_SCALE, 1f);
         adjustFontScale(getResources().getConfiguration(),fontScale);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
@@ -1,10 +1,11 @@
 package fr.free.nrw.commons.theme;
 
+import android.content.res.Configuration;
 import android.os.Bundle;
-
+import android.util.DisplayMetrics;
+import android.view.WindowManager;
 import javax.inject.Inject;
 import javax.inject.Named;
-
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.di.CommonsDaggerAppCompatActivity;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
@@ -27,6 +28,8 @@ public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
         super.onCreate(savedInstanceState);
         wasPreviouslyDarkTheme = systemThemeUtils.isDeviceInNightMode();
         setTheme(wasPreviouslyDarkTheme ? R.style.DarkAppTheme : R.style.LightAppTheme);
+        float fontScale = android.provider.Settings.System.getFloat(getBaseContext().getContentResolver(),android.provider.Settings.System.FONT_SCALE, 1f);
+        adjustFontScale(getResources().getConfiguration(),fontScale);
     }
 
     @Override
@@ -44,4 +47,17 @@ public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
         super.onDestroy();
         compositeDisposable.clear();
     }
+
+    /**
+     * its function is apply fontScale on device
+     */
+    public  void adjustFontScale( Configuration configuration,float scale) {
+        configuration.fontScale = scale;
+        DisplayMetrics metrics = getResources().getDisplayMetrics();
+        WindowManager wm = (WindowManager) getSystemService(WINDOW_SERVICE);
+        wm.getDefaultDisplay().getMetrics(metrics);
+        metrics.scaledDensity = configuration.fontScale * metrics.density;
+        getBaseContext().getResources().updateConfiguration(configuration, metrics);
+    }
+
 }

--- a/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/theme/BaseActivity.java
@@ -56,8 +56,8 @@ public abstract class BaseActivity extends CommonsDaggerAppCompatActivity {
      */
     public void adjustFontScale(Configuration configuration, float scale) {
         configuration.fontScale = scale;
-        DisplayMetrics metrics = getResources().getDisplayMetrics();
-        WindowManager wm = (WindowManager) getSystemService(WINDOW_SERVICE);
+        final DisplayMetrics metrics = getResources().getDisplayMetrics();
+        final WindowManager wm = (WindowManager) getSystemService(WINDOW_SERVICE);
         wm.getDefaultDisplay().getMetrics(metrics);
         metrics.scaledDensity = configuration.fontScale * metrics.density;
         getBaseContext().getResources().updateConfiguration(configuration, metrics);


### PR DESCRIPTION

**Description (required)**

Fixes #4299 

What changes did you make and why?
Add the function adjustFontScale in Base Activity get the fontScale from device and apply fontScale to the app using adjectFontScale function
 

**Tests performed (required)**

Tested {build variant: ProdDebug} with API level {25,29}.

**Screenshots (for UI changes only)**

**Screenshot when Device font size(Extra small)**

![Screenshot_2021-03-28-18-59-26-242_fr free nrw commons](https://user-images.githubusercontent.com/65972015/112754306-1c56a080-8ff9-11eb-9d39-ebda9bb561a4.jpg)

**Screenshot when Device font size(small)**

![Screenshot_2021-03-28-18-59-38-940_fr free nrw commons](https://user-images.githubusercontent.com/65972015/112754311-1f519100-8ff9-11eb-915d-ee2f72d20f82.jpg)

**Screenshot when Device font size(Medium)**

![Screenshot_2021-03-28-18-59-50-994_fr free nrw commons](https://user-images.githubusercontent.com/65972015/112754315-211b5480-8ff9-11eb-820b-13d62a192179.jpg)
**Screenshot when Device font size(Large)**

![Screenshot_2021-03-28-19-00-03-585_fr free nrw commons](https://user-images.githubusercontent.com/65972015/112754317-224c8180-8ff9-11eb-9ebc-fc59059e845c.jpg)
**Screenshot when Device font size(ExtraLarge)**

![Screenshot_2021-03-28-19-00-16-251_fr free nrw commons](https://user-images.githubusercontent.com/65972015/112754318-24164500-8ff9-11eb-963d-f426e314a6bb.jpg)
