### PR TITLE
#4048 - "copy to subsequent media" button

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
+++ b/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
@@ -205,16 +205,16 @@ public class UploadRepository {
     }
 
     /**
-     * fetches and returns the previous upload item
+     * fetches and returns the upload item
      *
      * @param index
      * @return
      */
-    public UploadItem getPreviousUploadItem(int index) {
-        if (index - 1 >= 0) {
-            return uploadModel.getItems().get(index - 1);
+    public UploadItem getUploadItem(int index) {
+        if (index >= 0) {
+            return uploadModel.getItems().get(index);
         }
-        return null; //There is no previous item to copy details
+        return null; //There is no item to copy details
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -12,6 +12,7 @@ import android.widget.CheckBox;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatButton;
@@ -69,8 +70,8 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
     @BindView(R.id.tooltip)
     ImageView tooltip;
     private UploadMediaDetailAdapter uploadMediaDetailAdapter;
-    @BindView(R.id.btn_copy_prev_title_desc)
-    AppCompatButton btnCopyPreviousTitleDesc;
+    @BindView(R.id.btn_copy_subsequent_media)
+    AppCompatButton btnCopyToSubsequentMedia;
 
     @Inject
     UploadMediaDetailsContract.UserActionListener presenter;
@@ -123,9 +124,9 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
                 showInfoAlert(R.string.media_detail_step_title, R.string.media_details_tooltip);
             }
         });
-        initRecyclerView();
         initPresenter();
         presenter.receiveImage(uploadableFile, place);
+        initRecyclerView();
 
         if (callback.getIndexInViewFlipper(this) == 0) {
             btnPrevious.setEnabled(false);
@@ -135,11 +136,11 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
             btnPrevious.setAlpha(1.0f);
         }
 
-        //If this is the first media, we have nothing to copy, lets not show the button
-        if (callback.getIndexInViewFlipper(this) == 0) {
-            btnCopyPreviousTitleDesc.setVisibility(View.GONE);
+        //If this is the last media, we have nothing to copy, lets not show the button
+        if (callback.getIndexInViewFlipper(this) == callback.getTotalNumberOfSteps()-4) {
+            btnCopyToSubsequentMedia.setVisibility(View.GONE);
         } else {
-            btnCopyPreviousTitleDesc.setVisibility(View.VISIBLE);
+            btnCopyToSubsequentMedia.setVisibility(View.VISIBLE);
         }
 
         attachImageViewScaleChangeListener();
@@ -262,6 +263,12 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
     }
 
     @Override
+    protected void onBecameVisible() {
+        super.onBecameVisible();
+        presenter.fetchTitleAndDescription(callback.getIndexInViewFlipper(this));
+    }
+
+    @Override
     public void showMessage(int stringResourceId, int colorResourceId) {
         ViewUtil.showLongToast(getContext(), stringResourceId);
     }
@@ -369,6 +376,9 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
 
     @Override
     public void onPrimaryCaptionTextChange(boolean isNotEmpty) {
+        btnCopyToSubsequentMedia.setEnabled(isNotEmpty);
+        btnCopyToSubsequentMedia.setClickable(isNotEmpty);
+        btnCopyToSubsequentMedia.setAlpha(isNotEmpty ? 1.0f: 0.5f);
         btnNext.setEnabled(isNotEmpty);
         btnNext.setClickable(isNotEmpty);
         btnNext.setAlpha(isNotEmpty ? 1.0f: 0.5f);
@@ -380,9 +390,10 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
     }
 
 
-    @OnClick(R.id.btn_copy_prev_title_desc)
-    public void onButtonCopyPreviousTitleDesc(){
-        presenter.fetchPreviousTitleAndDescription(callback.getIndexInViewFlipper(this));
+    @OnClick(R.id.btn_copy_subsequent_media)
+    public void onButtonCopyTitleDescToSubsequentMedia(){
+        presenter.copyTitleAndDescriptionToSubsequentMedia(callback.getIndexInViewFlipper(this));
+        Toast.makeText(getContext(), getResources().getString(R.string.copied_successfully), Toast.LENGTH_SHORT).show();
     }
 
 }

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailsContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailsContract.java
@@ -45,7 +45,9 @@ public interface UploadMediaDetailsContract {
 
         void verifyImageQuality(int uploadItemIndex);
 
-        void fetchPreviousTitleAndDescription(int indexInViewFlipper);
+        void copyTitleAndDescriptionToSubsequentMedia(int indexInViewFlipper);
+
+        void fetchTitleAndDescription(int indexInViewFlipper);
 
         void useSimilarPictureCoordinates(ImageCoordinates imageCoordinates, int uploadItemIndex);
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -147,21 +147,28 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
 
 
     /**
-     * Fetches and sets the caption and desctiption of the previous item
+     * Copies the caption and description of the current item to the subsequent media
      *
      * @param indexInViewFlipper
      */
     @Override
-    public void fetchPreviousTitleAndDescription(int indexInViewFlipper) {
-        UploadItem previousUploadItem = repository.getPreviousUploadItem(indexInViewFlipper);
-      if (null != previousUploadItem) {
-            final UploadItem currentUploadItem = repository.getUploads().get(indexInViewFlipper);
-            currentUploadItem.setMediaDetails(deepCopy(previousUploadItem.getUploadMediaDetails()));
-            view.updateMediaDetails(currentUploadItem.getUploadMediaDetails());
-        } else {
-            view.showMessage(R.string.previous_image_title_description_not_found, R.color.color_error);
-        }
+    public void copyTitleAndDescriptionToSubsequentMedia(int indexInViewFlipper) {
+      for(int i = indexInViewFlipper+1; i < repository.getCount(); i++){
+        final UploadItem subsequentUploadItem = repository.getUploads().get(i);
+        subsequentUploadItem.setMediaDetails(deepCopy(repository.getUploads().get(indexInViewFlipper).getUploadMediaDetails()));
+      }
     }
+
+  /**
+   * Fetches and set the caption and description of the item, if it is not null that means the user has pressed the copy button
+   *
+   * @param indexInViewFlipper
+   */
+  @Override
+  public void fetchTitleAndDescription(int indexInViewFlipper) {
+    final UploadItem currentUploadItem = repository.getUploads().get(indexInViewFlipper);
+    view.updateMediaDetails(currentUploadItem.getUploadMediaDetails());
+  }
 
   @NotNull
   private List<UploadMediaDetail> deepCopy(List<UploadMediaDetail> uploadMediaDetails) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -160,7 +160,7 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
     }
 
   /**
-   * Fetches and set the caption and description of the item, if it is not null that means the user has pressed the copy button
+   * Fetches and set the caption and description of the item
    *
    * @param indexInViewFlipper
    */

--- a/app/src/main/res/layout/fragment_upload_media_detail_fragment.xml
+++ b/app/src/main/res/layout/fragment_upload_media_detail_fragment.xml
@@ -99,11 +99,11 @@
 
 
                 <androidx.appcompat.widget.AppCompatButton
-                  android:id="@+id/btn_copy_prev_title_desc"
+                  android:id="@+id/btn_copy_subsequent_media"
                   style="@style/Widget.AppCompat.Button.Borderless"
                   android:layout_width="match_parent"
                   android:layout_height="wrap_content"
-                  android:text="@string/previous_image_caption_description"
+                  android:text="@string/copy_image_caption_description"
                   android:padding="@dimen/miniscule_margin"
                   android:textAlignment="textEnd"
                   android:textColor="@color/button_blue"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -460,7 +460,8 @@ Upload your first media by tapping on the add button.</string>
   <string name="images_featured_explanation">Featured pictures are images from highly skilled photographers and illustrators that the Wikimedia Commons community has chosen as some of the highest quality on the site.</string>
   <string name="images_via_nearby_explanation">Images Uploaded via Nearby places are the images which are uploaded by discovering places on the map.</string>
   <string name="thanks_received_explanation">This feature allows editors to send a Thank you notification to users who make useful edits – by using a small thank link on the history page or diff page.</string>
-  <string name="previous_image_caption_description">Copy previous captions &amp; description</string>
+  <string name="copy_image_caption_description">Copy to subsequent Media</string>
+  <string name="copied_successfully">Copied Successfully</string>
   <string name="welcome_do_upload_content_description">Examples of good images to upload to Commons</string>
   <string name="welcome_dont_upload_content_description">Examples of images not to upload</string>
   <string name="skip_image">Skip this image</string>

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaPresenterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaPresenterTest.kt
@@ -164,28 +164,17 @@ class UploadMediaPresenterTest {
     }
 
     /**
-     * Test fetch previous image title when there was one
+     * Test fetch image title when there was one
      */
     @Test
-    fun fetchPreviousImageAndTitleTestPositive() {
+    fun fetchImageAndTitleTest() {
         whenever(repository.uploads).thenReturn(listOf(uploadItem))
-        whenever(repository.getPreviousUploadItem(ArgumentMatchers.anyInt()))
+        whenever(repository.getUploadItem(ArgumentMatchers.anyInt()))
             .thenReturn(uploadItem)
         whenever(uploadItem.uploadMediaDetails).thenReturn(listOf())
 
-        uploadMediaPresenter.fetchPreviousTitleAndDescription(0)
+        uploadMediaPresenter.fetchTitleAndDescription(0)
         verify(view).updateMediaDetails(ArgumentMatchers.any())
-    }
-
-    /**
-     * Test fetch previous image title when there was none
-     */
-    @Test
-    fun fetchPreviousImageAndTitleTestNegative() {
-        whenever(repository.getPreviousUploadItem(ArgumentMatchers.anyInt()))
-            .thenReturn(null)
-        uploadMediaPresenter.fetchPreviousTitleAndDescription(0)
-        verify(view).showMessage(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
     }
 
     /**


### PR DESCRIPTION
**Description (required)**

Fixes #4048

What changes did you make and why?

Replaced the "copy previous captions & description" button, Added methods in UploadMediaPresenter that will copy and fetch the caption & description respectively, and also added a onBecameVisible() method in UploadMediaFragment which will be called after pressing next/previous button, this method will fetch and set the copied media details. And other minor changes in UploadMediaFragment, UploadRepository, and unit tests.

**Tests performed (required)**

Tested betaDebug on Pixel 3 with API level 29.