### PR TITLE
Added Help link in Alert Dialogue

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -5,6 +5,7 @@ import android.app.AlertDialog;
 import android.app.AlertDialog.Builder;
 import android.content.Intent;
 import android.graphics.Bitmap;
+import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
@@ -21,11 +22,14 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 
 import com.dinuscxj.progressbar.CircleProgressBar;
+import fr.free.nrw.commons.BuildConfig;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
@@ -56,7 +60,15 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
 
     private static final double BADGE_IMAGE_WIDTH_RATIO = 0.4;
     private static final double BADGE_IMAGE_HEIGHT_RATIO = 0.3;
+
+    // Help link URLs
     private static final String IMAGES_UPLOADED_URL = "https://commons.wikimedia.org/wiki/Commons:Project_scope";
+    private static final String IMAGES_REVERT_URL = "https://commons.wikimedia.org/wiki/Commons:Deletion_policy#Reasons_for_deletion";
+    private static final String IMAGES_USED_URL = "https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Images";
+    private static final String IMAGES_NEARBY_PLACES_URL = "https://www.wikidata.org/wiki/Property:P18";
+    private static final String IMAGES_FEATURED_URL = "https://commons.wikimedia.org/wiki/Commons:Featured_pictures";
+    private static final String QUALITY_IMAGE_URL = "https://commons.wikimedia.org/wiki/Commons:Quality_images";
+    private static final String THANKS_URL = "https://www.mediawiki.org/wiki/Extension:Thanks";
 
 
     private LevelController.LevelInfo levelInfo;
@@ -454,43 +466,50 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
     @OnClick(R.id.images_upload_info)
     public void showUploadInfo(){
         launchAlertWithHelpLink(getResources().getString(R.string.images_uploaded)
-                ,getResources().getString(R.string.images_uploaded_explanation));
+                ,getResources().getString(R.string.images_uploaded_explanation)
+            ,IMAGES_UPLOADED_URL);
     }
 
     @OnClick(R.id.images_reverted_info)
     public void showRevertedInfo(){
         launchAlertWithHelpLink(getResources().getString(R.string.image_reverts)
-                ,getResources().getString(R.string.images_reverted_explanation));
+                ,getResources().getString(R.string.images_reverted_explanation)
+            ,IMAGES_REVERT_URL);
     }
 
     @OnClick(R.id.images_used_by_wiki_info)
     public void showUsedByWikiInfo(){
         launchAlertWithHelpLink(getResources().getString(R.string.images_used_by_wiki)
-                ,getResources().getString(R.string.images_used_explanation));
+                ,getResources().getString(R.string.images_used_explanation)
+            ,IMAGES_USED_URL);
     }
 
     @OnClick(R.id.images_nearby_info)
     public void showImagesViaNearbyInfo(){
         launchAlertWithHelpLink(getResources().getString(R.string.statistics_wikidata_edits)
-                ,getResources().getString(R.string.images_via_nearby_explanation));
+                ,getResources().getString(R.string.images_via_nearby_explanation)
+            ,IMAGES_NEARBY_PLACES_URL);
     }
 
     @OnClick(R.id.images_featured_info)
     public void showFeaturedImagesInfo(){
         launchAlertWithHelpLink(getResources().getString(R.string.statistics_featured)
-                ,getResources().getString(R.string.images_featured_explanation));
+                ,getResources().getString(R.string.images_featured_explanation)
+            , IMAGES_FEATURED_URL);
     }
 
     @OnClick(R.id.thanks_received_info)
     public void showThanksReceivedInfo(){
         launchAlertWithHelpLink(getResources().getString(R.string.statistics_thanks)
-                ,getResources().getString(R.string.thanks_received_explanation));
+                ,getResources().getString(R.string.thanks_received_explanation)
+            ,THANKS_URL);
     }
 
     @OnClick(R.id.quality_images_info)
     public void showQualityImagesInfo() {
         launchAlertWithHelpLink(getResources().getString(R.string.statistics_quality)
-            , getResources().getString(R.string.quality_images_info));
+            , getResources().getString(R.string.quality_images_info)
+            ,QUALITY_IMAGE_URL);
     }
 
     /**
@@ -507,14 +526,15 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
                 .create()
                 .show();
     }
-    private void launchAlertWithHelpLink(String title, String message){
+    // Launch Alert with a READ MORE button and clicking it open a custom webpage
+    private void launchAlertWithHelpLink(String title, String message, String helpLinkUrl){
         new Builder(getActivity())
             .setTitle(title)
             .setMessage(message)
             .setCancelable(true)
             .setPositiveButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
             .setNegativeButton(R.string.Help_Link_Read, (dialog ,id) ->{
-                Toast.makeText(requireActivity(),"Replace this with a link",Toast.LENGTH_LONG).show();
+                Utils.handleWebUrl(requireContext(), Uri.parse(helpLinkUrl));;
             })
             .create()
             .show();

--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -5,7 +5,6 @@ import android.app.AlertDialog;
 import android.app.AlertDialog.Builder;
 import android.content.Intent;
 import android.graphics.Bitmap;
-import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
@@ -20,16 +19,12 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 import androidx.appcompat.view.ContextThemeWrapper;
-import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 
 import com.dinuscxj.progressbar.CircleProgressBar;
-import fr.free.nrw.commons.BuildConfig;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
@@ -61,7 +56,9 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
     private static final double BADGE_IMAGE_WIDTH_RATIO = 0.4;
     private static final double BADGE_IMAGE_HEIGHT_RATIO = 0.3;
 
-    // Help link URLs
+    /**
+     * Help link URLs
+     */
     private static final String IMAGES_UPLOADED_URL = "https://commons.wikimedia.org/wiki/Commons:Project_scope";
     private static final String IMAGES_REVERT_URL = "https://commons.wikimedia.org/wiki/Commons:Deletion_policy#Reasons_for_deletion";
     private static final String IMAGES_USED_URL = "https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Images";
@@ -69,7 +66,6 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
     private static final String IMAGES_FEATURED_URL = "https://commons.wikimedia.org/wiki/Commons:Featured_pictures";
     private static final String QUALITY_IMAGE_URL = "https://commons.wikimedia.org/wiki/Commons:Quality_images";
     private static final String THANKS_URL = "https://www.mediawiki.org/wiki/Extension:Thanks";
-
 
     private LevelController.LevelInfo levelInfo;
 
@@ -251,8 +247,9 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
      */
     @OnClick(R.id.achievement_info)
     public void showInfoDialog(){
-        launchAlert(getResources().getString(R.string.Achievements)
-                ,getResources().getString(R.string.achievements_info_message));
+        launchAlert(
+            getResources().getString(R.string.Achievements),
+            getResources().getString(R.string.achievements_info_message));
     }
 
     /**
@@ -465,51 +462,58 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
 
     @OnClick(R.id.images_upload_info)
     public void showUploadInfo(){
-        launchAlertWithHelpLink(getResources().getString(R.string.images_uploaded)
-                ,getResources().getString(R.string.images_uploaded_explanation)
-            ,IMAGES_UPLOADED_URL);
+        launchAlertWithHelpLink(
+            getResources().getString(R.string.images_uploaded),
+            getResources().getString(R.string.images_uploaded_explanation),
+            IMAGES_UPLOADED_URL);
     }
 
     @OnClick(R.id.images_reverted_info)
     public void showRevertedInfo(){
-        launchAlertWithHelpLink(getResources().getString(R.string.image_reverts)
-                ,getResources().getString(R.string.images_reverted_explanation)
-            ,IMAGES_REVERT_URL);
+        launchAlertWithHelpLink(
+            getResources().getString(R.string.image_reverts),
+            getResources().getString(R.string.images_reverted_explanation),
+            IMAGES_REVERT_URL);
     }
 
     @OnClick(R.id.images_used_by_wiki_info)
     public void showUsedByWikiInfo(){
-        launchAlertWithHelpLink(getResources().getString(R.string.images_used_by_wiki)
-                ,getResources().getString(R.string.images_used_explanation)
-            ,IMAGES_USED_URL);
+        launchAlertWithHelpLink(
+            getResources().getString(R.string.images_used_by_wiki),
+            getResources().getString(R.string.images_used_explanation),
+            IMAGES_USED_URL);
     }
 
     @OnClick(R.id.images_nearby_info)
     public void showImagesViaNearbyInfo(){
-        launchAlertWithHelpLink(getResources().getString(R.string.statistics_wikidata_edits)
-                ,getResources().getString(R.string.images_via_nearby_explanation)
-            ,IMAGES_NEARBY_PLACES_URL);
+        launchAlertWithHelpLink(
+            getResources().getString(R.string.statistics_wikidata_edits),
+            getResources().getString(R.string.images_via_nearby_explanation),
+            IMAGES_NEARBY_PLACES_URL);
     }
 
     @OnClick(R.id.images_featured_info)
     public void showFeaturedImagesInfo(){
-        launchAlertWithHelpLink(getResources().getString(R.string.statistics_featured)
-                ,getResources().getString(R.string.images_featured_explanation)
-            , IMAGES_FEATURED_URL);
+        launchAlertWithHelpLink(
+            getResources().getString(R.string.statistics_featured),
+            getResources().getString(R.string.images_featured_explanation),
+            IMAGES_FEATURED_URL);
     }
 
     @OnClick(R.id.thanks_received_info)
     public void showThanksReceivedInfo(){
-        launchAlertWithHelpLink(getResources().getString(R.string.statistics_thanks)
-                ,getResources().getString(R.string.thanks_received_explanation)
-            ,THANKS_URL);
+        launchAlertWithHelpLink(
+            getResources().getString(R.string.statistics_thanks),
+            getResources().getString(R.string.thanks_received_explanation),
+            THANKS_URL);
     }
 
     @OnClick(R.id.quality_images_info)
     public void showQualityImagesInfo() {
-        launchAlertWithHelpLink(getResources().getString(R.string.statistics_quality)
-            , getResources().getString(R.string.quality_images_info)
-            ,QUALITY_IMAGE_URL);
+        launchAlertWithHelpLink(
+            getResources().getString(R.string.statistics_quality),
+            getResources().getString(R.string.quality_images_info),
+            QUALITY_IMAGE_URL);
     }
 
     /**
@@ -526,14 +530,17 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
                 .create()
                 .show();
     }
-    // Launch Alert with a READ MORE button and clicking it open a custom webpage
+
+    /**
+     *  Launch Alert with a READ MORE button and clicking it open a custom webpage
+     */
     private void launchAlertWithHelpLink(String title, String message, String helpLinkUrl){
         new Builder(getActivity())
             .setTitle(title)
             .setMessage(message)
             .setCancelable(true)
             .setPositiveButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
-            .setNegativeButton(R.string.Help_Link_Read, (dialog ,id) ->{
+            .setNegativeButton(R.string.read_help_link, (dialog ,id) ->{
                 Utils.handleWebUrl(requireContext(), Uri.parse(helpLinkUrl));;
             })
             .create()

--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -2,6 +2,7 @@ package fr.free.nrw.commons.profile.achievements;
 
 import android.accounts.Account;
 import android.app.AlertDialog;
+import android.app.AlertDialog.Builder;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
@@ -18,6 +19,7 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.core.content.FileProvider;
@@ -36,7 +38,6 @@ import javax.inject.Inject;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
-import com.dinuscxj.progressbar.CircleProgressBar;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.auth.SessionManager;
@@ -46,12 +47,6 @@ import fr.free.nrw.commons.utils.ViewUtil;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.Objects;
-import javax.inject.Inject;
-import org.apache.commons.lang3.StringUtils;
 import timber.log.Timber;
 
 /**
@@ -61,6 +56,8 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
 
     private static final double BADGE_IMAGE_WIDTH_RATIO = 0.4;
     private static final double BADGE_IMAGE_HEIGHT_RATIO = 0.3;
+    private static final String IMAGES_UPLOADED_URL = "https://commons.wikimedia.org/wiki/Commons:Project_scope";
+
 
     private LevelController.LevelInfo levelInfo;
 
@@ -456,43 +453,43 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
 
     @OnClick(R.id.images_upload_info)
     public void showUploadInfo(){
-        launchAlert(getResources().getString(R.string.images_uploaded)
+        launchAlertWithHelpLink(getResources().getString(R.string.images_uploaded)
                 ,getResources().getString(R.string.images_uploaded_explanation));
     }
 
     @OnClick(R.id.images_reverted_info)
     public void showRevertedInfo(){
-        launchAlert(getResources().getString(R.string.image_reverts)
+        launchAlertWithHelpLink(getResources().getString(R.string.image_reverts)
                 ,getResources().getString(R.string.images_reverted_explanation));
     }
 
     @OnClick(R.id.images_used_by_wiki_info)
     public void showUsedByWikiInfo(){
-        launchAlert(getResources().getString(R.string.images_used_by_wiki)
+        launchAlertWithHelpLink(getResources().getString(R.string.images_used_by_wiki)
                 ,getResources().getString(R.string.images_used_explanation));
     }
 
     @OnClick(R.id.images_nearby_info)
     public void showImagesViaNearbyInfo(){
-        launchAlert(getResources().getString(R.string.statistics_wikidata_edits)
+        launchAlertWithHelpLink(getResources().getString(R.string.statistics_wikidata_edits)
                 ,getResources().getString(R.string.images_via_nearby_explanation));
     }
 
     @OnClick(R.id.images_featured_info)
     public void showFeaturedImagesInfo(){
-        launchAlert(getResources().getString(R.string.statistics_featured)
+        launchAlertWithHelpLink(getResources().getString(R.string.statistics_featured)
                 ,getResources().getString(R.string.images_featured_explanation));
     }
 
     @OnClick(R.id.thanks_received_info)
     public void showThanksReceivedInfo(){
-        launchAlert(getResources().getString(R.string.statistics_thanks)
+        launchAlertWithHelpLink(getResources().getString(R.string.statistics_thanks)
                 ,getResources().getString(R.string.thanks_received_explanation));
     }
 
     @OnClick(R.id.quality_images_info)
     public void showQualityImagesInfo() {
-        launchAlert(getResources().getString(R.string.statistics_quality)
+        launchAlertWithHelpLink(getResources().getString(R.string.statistics_quality)
             , getResources().getString(R.string.quality_images_info));
     }
 
@@ -509,6 +506,18 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
                 .setPositiveButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
                 .create()
                 .show();
+    }
+    private void launchAlertWithHelpLink(String title, String message){
+        new Builder(getActivity())
+            .setTitle(title)
+            .setMessage(message)
+            .setCancelable(true)
+            .setPositiveButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
+            .setNegativeButton(R.string.Help_Link_Read, (dialog ,id) ->{
+                Toast.makeText(requireActivity(),"Replace this with a link",Toast.LENGTH_LONG).show();
+            })
+            .create()
+            .show();
     }
 
     /**

--- a/app/src/main/res/layout/fragment_achievements.xml
+++ b/app/src/main/res/layout/fragment_achievements.xml
@@ -112,20 +112,20 @@
               android:layout_marginStart="@dimen/activity_margin_horizontal"/>
 
             <com.dinuscxj.progressbar.CircleProgressBar
+              android:id="@+id/images_uploaded_progressbar"
               android:layout_width="@dimen/dimen_40"
               android:layout_height="@dimen/dimen_40"
-              android:layout_alignParentRight="true"
               android:layout_alignParentEnd="true"
+              android:layout_alignParentRight="true"
               android:layout_marginEnd="@dimen/large_gap"
               android:layout_marginRight="@dimen/large_gap"
-              android:id="@+id/images_uploaded_progressbar"
               android:progress="50"
-              app:progress_text_size="@dimen/progressbar_text"
               app:progress_end_color="#8C8B98"
               app:progress_start_color="#3A3381"
               app:progress_stroke_width="@dimen/progressbar_stroke"
-              app:progress_text_format_pattern="573/110"
               app:progress_text_color="@color/secondaryColor"
+              app:progress_text_format_pattern="573/110"
+              app:progress_text_size="@dimen/progressbar_text"
               app:style="solid_line" />
 
           </RelativeLayout>

--- a/app/src/main/res/layout/fragment_achievements.xml
+++ b/app/src/main/res/layout/fragment_achievements.xml
@@ -112,20 +112,20 @@
               android:layout_marginStart="@dimen/activity_margin_horizontal"/>
 
             <com.dinuscxj.progressbar.CircleProgressBar
-              android:id="@+id/images_uploaded_progressbar"
               android:layout_width="@dimen/dimen_40"
               android:layout_height="@dimen/dimen_40"
-              android:layout_alignParentEnd="true"
               android:layout_alignParentRight="true"
+              android:layout_alignParentEnd="true"
               android:layout_marginEnd="@dimen/large_gap"
               android:layout_marginRight="@dimen/large_gap"
+              android:id="@+id/images_uploaded_progressbar"
               android:progress="50"
+              app:progress_text_size="@dimen/progressbar_text"
               app:progress_end_color="#8C8B98"
               app:progress_start_color="#3A3381"
               app:progress_stroke_width="@dimen/progressbar_stroke"
-              app:progress_text_color="@color/secondaryColor"
               app:progress_text_format_pattern="573/110"
-              app:progress_text_size="@dimen/progressbar_text"
+              app:progress_text_color="@color/secondaryColor"
               app:style="solid_line" />
 
           </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -609,5 +609,6 @@ Upload your first media by tapping on the add button.</string>
   <string name="media_detail_step_title">Media Details</string>
   <string name="menu_view_category_page">View category page</string>
   <string name="menu_view_item_page">View item page</string>
+  <string name="Help_Link_Read">Read More</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -609,6 +609,6 @@ Upload your first media by tapping on the add button.</string>
   <string name="media_detail_step_title">Media Details</string>
   <string name="menu_view_category_page">View category page</string>
   <string name="menu_view_item_page">View item page</string>
-  <string name="Help_Link_Read">Read More</string>
+  <string name="read_help_link">Read more</string>
 
 </resources>


### PR DESCRIPTION
**Description**
Added help link to each alert dialogue with custom tab.

Fixes #3433 

In each of the help popups, it would be great to have a link that a wiki page that explains things much more deeply. So I added a link to each info button that shows an alert dialogue and there I add a READ ME button from where the user can open the following custom webpage.

**Tests performed **

Tested 3.0.0-debug-helpLink~afd977f6c on Pixel 3a with API level 27.

**Screenshots (for UI changes only)**
<img src="https://user-images.githubusercontent.com/71203077/113322437-504fff80-9332-11eb-8128-a0e8612b195f.png" width="250">
<img src="https://user-images.githubusercontent.com/71203077/113414061-b2b00b00-93d9-11eb-8fa9-2799ad8a772c.png" width="250">

Need help? See https://support.google.com/android/answer/9075928

