### PR TITLE
Fixes #4311 "First item in location bookmarks in expanded state"

### DIFF
--- a/app/src/main/res/layout/fragment_bookmarks_pictures.xml
+++ b/app/src/main/res/layout/fragment_bookmarks_pictures.xml
@@ -3,7 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/parentLayout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:descendantFocusability="blocksDescendants">
 
     <TextView
         android:id="@+id/statusMessage"


### PR DESCRIPTION
**Description (required)**

Fixes #4311

What changes did you make and why?

On investigation, I found out that we have used on focus changed listeners to expand and collapse location bookmarks, but as we switch the fragment to bookmarkPicturesFragment the focus is lost and all the items of location fragment are unfocused, collapsing them.

As soon as the fragment is switched the first item in the container gains focus thus expanding the first locationBookmark item.

To fix the bug I removed the focus on pictures fragment that way the locations fragment won't lose focus and maintain the expanded state of its children.

**Tests performed (required)**

Tested betaDebug on Nokia 6.1+ android 10 stock.

