### PR TITLE
Fixed help icon invisible issue.

### DIFF
--- a/app/src/main/res/layout/fragment_achievements.xml
+++ b/app/src/main/res/layout/fragment_achievements.xml
@@ -281,7 +281,7 @@
             android:layout_marginStart="@dimen/activity_margin_horizontal"
             android:layout_marginTop="@dimen/activity_margin_horizontal">
 
-            <LinearLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:layout_centerVertical="true"
@@ -293,19 +293,26 @@
               android:gravity="center_vertical">
 
               <ImageView
+                android:id="@+id/wikidata_edits_icon"
                 android:layout_width="@dimen/overflow_icon_dimen"
                 android:layout_height="@dimen/overflow_icon_dimen"
-                android:id="@+id/wikidata_edits_icon"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_custom_map_marker" />
 
               <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:id="@+id/images_nearby_data"
                 style="?android:textAppearanceMedium"
                 android:layout_marginStart="@dimen/activity_margin_horizontal"
                 android:layout_marginLeft="@dimen/activity_margin_horizontal"
                 android:layout_marginEnd="@dimen/activity_margin_horizontal"
                 android:layout_marginRight="@dimen/activity_margin_horizontal"
+                app:layout_constraintLeft_toRightOf="@id/wikidata_edits_icon"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintRight_toLeftOf="@id/images_nearby_info"
                 android:text="@string/statistics_wikidata_edits"  />
 
               <ImageView
@@ -316,10 +323,13 @@
                 android:layout_marginRight="@dimen/activity_margin_horizontal"
                 android:layout_marginEnd="@dimen/activity_margin_horizontal"
                 android:layout_gravity="top"
+                app:layout_constraintLeft_toRightOf="@id/images_nearby_data"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
                 app:srcCompat="@drawable/ic_info_outline_24dp"
                 android:tint="@color/primaryDarkColor" />
 
-            </LinearLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
 
             <TextView
@@ -348,7 +358,7 @@
             android:layout_marginStart="@dimen/activity_margin_horizontal"
             android:layout_marginTop="@dimen/activity_margin_horizontal">
 
-            <LinearLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:layout_centerVertical="true"
@@ -363,17 +373,24 @@
                 android:layout_width="@dimen/overflow_icon_dimen"
                 android:layout_height="@dimen/overflow_icon_dimen"
                 android:id="@+id/featured_image_icon"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/featured"
                 android:scaleType="centerCrop" />
 
               <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
                 style="?android:textAppearanceMedium"
+                android:id="@+id/images_featured_data"
                 android:layout_marginStart="@dimen/activity_margin_horizontal"
                 android:layout_marginLeft="@dimen/activity_margin_horizontal"
                 android:layout_marginEnd="@dimen/activity_margin_horizontal"
                 android:layout_marginRight="@dimen/activity_margin_horizontal"
+                app:layout_constraintLeft_toRightOf="@id/featured_image_icon"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintRight_toLeftOf="@id/images_featured_info"
                 android:text="@string/statistics_featured"  />
 
               <ImageView
@@ -383,11 +400,14 @@
                 android:layout_marginTop="@dimen/activity_margin_horizontal"
                 android:layout_marginRight="@dimen/activity_margin_horizontal"
                 android:layout_marginEnd="@dimen/activity_margin_horizontal"
+                app:layout_constraintLeft_toRightOf="@id/images_featured_data"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
                 android:layout_gravity="top"
                 app:srcCompat="@drawable/ic_info_outline_24dp"
                 android:tint="@color/primaryDarkColor" />
 
-            </LinearLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <TextView
               android:layout_width="wrap_content"
@@ -415,7 +435,7 @@
             android:layout_marginStart="@dimen/activity_margin_horizontal"
             android:layout_marginTop="@dimen/activity_margin_horizontal">
 
-            <LinearLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:layout_centerVertical="true"
@@ -430,17 +450,24 @@
                 android:layout_width="@dimen/overflow_icon_dimen"
                 android:layout_height="@dimen/overflow_icon_dimen"
                 android:id="@+id/quality_image_icon"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_quality_images_logo"
                 android:scaleType="centerInside" />
 
               <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
                 style="?android:textAppearanceMedium"
+                android:id="@+id/quality_images_data"
                 android:layout_marginStart="@dimen/activity_margin_horizontal"
                 android:layout_marginLeft="@dimen/activity_margin_horizontal"
                 android:layout_marginEnd="@dimen/activity_margin_horizontal"
                 android:layout_marginRight="@dimen/activity_margin_horizontal"
+                app:layout_constraintLeft_toRightOf="@id/quality_image_icon"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintRight_toLeftOf="@id/quality_images_info"
                 android:text="@string/statistics_quality"  />
 
               <ImageView
@@ -450,11 +477,14 @@
                 android:layout_marginTop="@dimen/activity_margin_horizontal"
                 android:layout_marginRight="@dimen/activity_margin_horizontal"
                 android:layout_marginEnd="@dimen/activity_margin_horizontal"
+                app:layout_constraintLeft_toRightOf="@id/quality_images_data"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
                 android:layout_gravity="top"
                 app:srcCompat="@drawable/ic_info_outline_24dp"
                 android:tint="@color/primaryDarkColor" />
 
-            </LinearLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <TextView
               android:layout_width="wrap_content"
@@ -483,7 +513,7 @@
             android:layout_marginTop="@dimen/activity_margin_horizontal"
             android:layout_marginEnd="@dimen/activity_margin_horizontal">
 
-            <LinearLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:layout_centerVertical="true"
@@ -498,17 +528,24 @@
                 android:layout_width="@dimen/overflow_icon_dimen"
                 android:layout_height="@dimen/overflow_icon_dimen"
                 android:id="@+id/thanks_image_icon"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_thanks"
                 android:scaleType="centerCrop" />
 
               <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
                 style="?android:textAppearanceMedium"
+                android:id="@+id/thanks_received_data"
                 android:layout_marginStart="@dimen/activity_margin_horizontal"
                 android:layout_marginLeft="@dimen/activity_margin_horizontal"
                 android:layout_marginEnd="@dimen/activity_margin_horizontal"
                 android:layout_marginRight="@dimen/activity_margin_horizontal"
+                app:layout_constraintLeft_toRightOf="@id/thanks_image_icon"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintRight_toLeftOf="@id/thanks_received_info"
                 android:text="@string/statistics_thanks"  />
 
               <ImageView
@@ -518,11 +555,14 @@
                 android:layout_marginTop="@dimen/activity_margin_horizontal"
                 android:layout_marginRight="@dimen/activity_margin_horizontal"
                 android:layout_marginEnd="@dimen/activity_margin_horizontal"
+                app:layout_constraintLeft_toRightOf="@id/thanks_received_data"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
                 android:layout_gravity="top"
                 app:srcCompat="@drawable/ic_info_outline_24dp"
                 android:tint="@color/primaryDarkColor" />
 
-            </LinearLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <TextView
               android:layout_width="wrap_content"


### PR DESCRIPTION
**Description**
The help icon is getting invisible for small screen devices.

Fixes #3434 

What changes did you make and why?
The help icon is getting invisible for small screen devices. So I changed the Linerlayout with ConstraintLayout and make height and weight 0dp. Now the icon is visible for every device cause it's adjusting its lines instead of overlapping.

**Tests performed (required)**

Tested 3.0.0-debug-helpLink~afd977c on Pixel 3a with API level 27 ( Normal ) and Nexus One with API level 26.

**Screenshots (for UI changes only)**

<table>
<tr>
<td> Device Size = Normal || Device = Pixel 3a</td>
<td> Device Size = Small || Device = Nexus One</td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/71203077/113508828-dad17280-956f-11eb-9b57-4e36bdc69ef2.png"width="300"></td>
<td><img src="https://user-images.githubusercontent.com/71203077/113508809-bf666780-956f-11eb-8e27-991f270fb252.png"width="300"></td>
</tr>
</table>