### PR TITLE
Fixes #4286 - Contributions didn't appear after logging in again

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/ContinuationClient.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/ContinuationClient.kt
@@ -38,4 +38,15 @@ abstract class ContinuationClient<Network, Domain> {
         continuationStore.remove("$prefix$category")
     }
 
+    /**
+     * Remove the existing the key from continuationExists and continuationStore
+     *
+     * @param prefix
+     * @param userName the username
+     */
+    protected fun resetUserContinuation(prefix: String, userName: String) {
+        continuationExists.remove("$prefix$userName")
+        continuationStore.remove("$prefix$userName")
+    }
+
 }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionBoundaryCallback.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionBoundaryCallback.kt
@@ -27,6 +27,9 @@ class ContributionBoundaryCallback @Inject constructor(
      * network
      */
     override fun onZeroItemsLoaded() {
+        if (sessionManager.userName != null) {
+            mediaClient.resetUserNameContinuation(sessionManager.userName!!)
+        }
         fetchContributions()
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionBoundaryCallback.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionBoundaryCallback.kt
@@ -69,6 +69,8 @@ class ContributionBoundaryCallback @Inject constructor(
                         )
                     }
             )
+        }else {
+            compositeDisposable.clear()
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/data/DBOpenHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/data/DBOpenHelper.java
@@ -50,6 +50,7 @@ public class DBOpenHelper  extends SQLiteOpenHelper {
     public void deleteTable(SQLiteDatabase db, String tableName) {
         try {
             db.execSQL(String.format(DROP_TABLE_STATEMENT, tableName));
+            onCreate(db);
         } catch (SQLiteException e) {
             e.printStackTrace();
         }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaClient.kt
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaClient.kt
@@ -149,6 +149,14 @@ class MediaClient @Inject constructor(
         resetContinuation(CATEGORY_CONTINUATION_PREFIX, category)
     }
 
+    /**
+     * Call the resetUserContinuation method
+     *
+     * @param userName the username
+     */
+    fun resetUserNameContinuation(userName: String) =
+        resetUserContinuation("user_", userName)
+
     override fun responseMapper(
         networkResult: Single<MwQueryResponse>,
         key: String?


### PR DESCRIPTION
**Description (required)**

Fixes #4286 

What changes did you make and why?

The issue was because after logging in again, the previous username key with boolean false is not removed from the continuationStore map, that is why it is returning the empty list. Now I have added a method that will remove and reset the existing key, and it will be called when the list has no items in the User's Contribution.

**Tests performed (required)**

Tested betaDebug on Pixel 3 with API level 29.