### PR TITLE
Whole label is clickable

### DIFF
--- a/app/src/main/res/layout/fragment_achievements.xml
+++ b/app/src/main/res/layout/fragment_achievements.xml
@@ -87,29 +87,40 @@
             android:layout_marginRight="@dimen/activity_margin_horizontal"
             android:layout_marginStart="@dimen/activity_margin_horizontal">
 
-            <TextView
-              style="?android:textAppearanceMedium"
+
+            <LinearLayout
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
-              android:layout_marginLeft="@dimen/activity_margin_horizontal"
-              android:layout_marginStart="@dimen/activity_margin_horizontal"
-              android:id="@+id/images_upload_text_param"
-              android:layout_marginTop="@dimen/achievements_activity_margin_vertical"
-              android:text="@string/images_uploaded" />
-
-            <ImageView
-              android:layout_width="@dimen/quarter_standard_height"
-              android:layout_height="@dimen/quarter_standard_height"
               android:id="@+id/images_upload_info"
-              android:layout_marginTop="@dimen/activity_margin_horizontal"
-              android:layout_marginRight="@dimen/activity_margin_horizontal"
-              android:layout_marginEnd="@dimen/activity_margin_horizontal"
-              android:layout_toRightOf="@+id/images_upload_text_param"
-              android:layout_toEndOf="@+id/images_upload_text_param"
-              app:srcCompat="@drawable/ic_info_outline_24dp"
-              android:tint="@color/primaryDarkColor"
-              android:layout_marginLeft="@dimen/activity_margin_horizontal"
-              android:layout_marginStart="@dimen/activity_margin_horizontal"/>
+              android:orientation="horizontal"
+              >
+
+              <TextView
+                style="?android:textAppearanceMedium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_margin_horizontal"
+                android:layout_marginStart="@dimen/activity_margin_horizontal"
+                android:id="@+id/images_upload_text_param"
+                android:layout_marginTop="@dimen/achievements_activity_margin_vertical"
+                android:text="@string/images_uploaded" />
+
+              <ImageView
+                android:layout_width="@dimen/quarter_standard_height"
+                android:layout_height="@dimen/quarter_standard_height"
+                android:layout_marginTop="@dimen/activity_margin_horizontal"
+                android:layout_marginRight="@dimen/activity_margin_horizontal"
+                android:layout_marginEnd="@dimen/activity_margin_horizontal"
+                android:layout_toRightOf="@+id/images_upload_text_param"
+                android:layout_toEndOf="@+id/images_upload_text_param"
+                app:srcCompat="@drawable/ic_info_outline_24dp"
+                android:tint="@color/primaryDarkColor"
+                android:layout_marginLeft="@dimen/activity_margin_horizontal"
+                android:layout_marginStart="@dimen/activity_margin_horizontal"/>
+
+            </LinearLayout>
+
+
 
             <com.dinuscxj.progressbar.CircleProgressBar
               android:layout_width="@dimen/dimen_40"
@@ -141,28 +152,38 @@
             android:layout_marginRight="@dimen/activity_margin_horizontal"
             android:layout_marginStart="@dimen/activity_margin_horizontal">
 
-            <TextView
-              style="?android:textAppearanceMedium"
+            <LinearLayout
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
-              android:layout_marginLeft="@dimen/activity_margin_horizontal"
-              android:id="@+id/images_reverted_text"
-              android:layout_marginStart="@dimen/activity_margin_horizontal"
-              android:text="@string/image_reverts" />
-
-            <ImageView
-              android:layout_width="@dimen/medium_width"
-              android:layout_height="@dimen/medium_height"
-              android:layout_marginTop="@dimen/activity_margin_horizontal"
-              android:layout_marginRight="@dimen/activity_margin_horizontal"
-              android:layout_marginEnd="@dimen/activity_margin_horizontal"
               android:id="@+id/images_reverted_info"
-              android:layout_toRightOf="@+id/images_reverted_text"
-              android:layout_toEndOf="@+id/images_reverted_text"
-              app:srcCompat="@drawable/ic_info_outline_24dp"
-              android:tint="@color/primaryDarkColor"
-              android:layout_marginLeft="@dimen/activity_margin_horizontal"
-              android:layout_marginStart="@dimen/activity_margin_horizontal"/>
+              android:orientation="horizontal"
+              >
+
+              <TextView
+                style="?android:textAppearanceMedium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_margin_horizontal"
+                android:id="@+id/images_reverted_text"
+                android:layout_marginStart="@dimen/activity_margin_horizontal"
+                android:text="@string/image_reverts" />
+
+              <ImageView
+                android:layout_width="@dimen/medium_width"
+                android:layout_height="@dimen/medium_height"
+                android:layout_marginTop="@dimen/activity_margin_horizontal"
+                android:layout_marginRight="@dimen/activity_margin_horizontal"
+                android:layout_marginEnd="@dimen/activity_margin_horizontal"
+                android:layout_toRightOf="@+id/images_reverted_text"
+                android:layout_toEndOf="@+id/images_reverted_text"
+                app:srcCompat="@drawable/ic_info_outline_24dp"
+                android:tint="@color/primaryDarkColor"
+                android:layout_marginLeft="@dimen/activity_margin_horizontal"
+                android:layout_marginStart="@dimen/activity_margin_horizontal"/>
+
+            </LinearLayout>
+
+
 
             <TextView
               android:layout_width="wrap_content"
@@ -172,7 +193,7 @@
               android:id="@+id/images_revert_limit_text"
               android:layout_marginLeft="@dimen/activity_margin_horizontal"
               android:layout_marginStart="@dimen/activity_margin_horizontal"
-              android:layout_below="@+id/images_reverted_text"/>
+              android:layout_below="@id/images_reverted_info"/>
 
             <com.dinuscxj.progressbar.CircleProgressBar
               android:layout_width="@dimen/dimen_40"
@@ -205,29 +226,36 @@
             android:layout_marginRight="@dimen/activity_margin_horizontal"
             android:layout_marginStart="@dimen/activity_margin_horizontal">
 
-            <TextView
-              style="?android:textAppearanceMedium"
+            <LinearLayout
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
-              android:id="@+id/images_used_by_wiki_text"
-              android:layout_marginLeft="@dimen/activity_margin_horizontal"
-              android:layout_marginStart="@dimen/activity_margin_horizontal"
-              android:layout_marginTop="@dimen/achievements_activity_margin_vertical"
-              android:text="@string/images_used_by_wiki" />
-
-            <ImageView
-              android:layout_width="@dimen/medium_width"
-              android:layout_height="@dimen/medium_height"
               android:id="@+id/images_used_by_wiki_info"
-              android:layout_marginTop="@dimen/activity_margin_horizontal"
-              android:layout_marginRight="@dimen/activity_margin_horizontal"
-              android:layout_marginEnd="@dimen/activity_margin_horizontal"
-              android:layout_toRightOf="@+id/images_used_by_wiki_text"
-              android:layout_toEndOf="@+id/images_used_by_wiki_text"
-              app:srcCompat="@drawable/ic_info_outline_24dp"
-              android:tint="@color/primaryDarkColor"
-              android:layout_marginLeft="@dimen/activity_margin_horizontal"
-              android:layout_marginStart="@dimen/activity_margin_horizontal"/>
+              android:orientation="horizontal">
+
+              <TextView
+                style="?android:textAppearanceMedium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/images_used_by_wiki_text"
+                android:layout_marginLeft="@dimen/activity_margin_horizontal"
+                android:layout_marginStart="@dimen/activity_margin_horizontal"
+                android:layout_marginTop="@dimen/achievements_activity_margin_vertical"
+                android:text="@string/images_used_by_wiki" />
+
+              <ImageView
+                android:layout_width="@dimen/medium_width"
+                android:layout_height="@dimen/medium_height"
+                android:layout_marginTop="@dimen/activity_margin_horizontal"
+                android:layout_marginRight="@dimen/activity_margin_horizontal"
+                android:layout_marginEnd="@dimen/activity_margin_horizontal"
+                android:layout_toRightOf="@+id/images_used_by_wiki_text"
+                android:layout_toEndOf="@+id/images_used_by_wiki_text"
+                app:srcCompat="@drawable/ic_info_outline_24dp"
+                android:tint="@color/primaryDarkColor"
+                android:layout_marginLeft="@dimen/activity_margin_horizontal"
+                android:layout_marginStart="@dimen/activity_margin_horizontal"/>
+
+            </LinearLayout>
 
             <com.dinuscxj.progressbar.CircleProgressBar
               android:layout_width="@dimen/dimen_40"
@@ -284,6 +312,7 @@
             <LinearLayout
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
+              android:id="@+id/images_nearby_info"
               android:layout_centerVertical="true"
               android:layout_alignParentStart="true"
               android:layout_alignParentLeft="true"
@@ -311,7 +340,6 @@
               <ImageView
                 android:layout_width="@dimen/medium_width"
                 android:layout_height="@dimen/medium_height"
-                android:id="@+id/images_nearby_info"
                 android:layout_marginTop="@dimen/activity_margin_horizontal"
                 android:layout_marginRight="@dimen/activity_margin_horizontal"
                 android:layout_marginEnd="@dimen/activity_margin_horizontal"
@@ -351,6 +379,7 @@
             <LinearLayout
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
+              android:id="@+id/images_featured_info"
               android:layout_centerVertical="true"
               android:layout_alignParentStart="true"
               android:layout_alignParentLeft="true"
@@ -379,7 +408,6 @@
               <ImageView
                 android:layout_width="@dimen/medium_width"
                 android:layout_height="@dimen/medium_height"
-                android:id="@+id/images_featured_info"
                 android:layout_marginTop="@dimen/activity_margin_horizontal"
                 android:layout_marginRight="@dimen/activity_margin_horizontal"
                 android:layout_marginEnd="@dimen/activity_margin_horizontal"
@@ -418,6 +446,7 @@
             <LinearLayout
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
+              android:id="@+id/quality_images_info"
               android:layout_centerVertical="true"
               android:layout_alignParentStart="true"
               android:layout_alignParentLeft="true"
@@ -446,7 +475,6 @@
               <ImageView
                 android:layout_width="@dimen/medium_width"
                 android:layout_height="@dimen/medium_height"
-                android:id="@+id/quality_images_info"
                 android:layout_marginTop="@dimen/activity_margin_horizontal"
                 android:layout_marginRight="@dimen/activity_margin_horizontal"
                 android:layout_marginEnd="@dimen/activity_margin_horizontal"
@@ -486,6 +514,7 @@
             <LinearLayout
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
+              android:id="@+id/thanks_received_info"
               android:layout_centerVertical="true"
               android:layout_alignParentStart="true"
               android:layout_alignParentLeft="true"
@@ -514,7 +543,6 @@
               <ImageView
                 android:layout_width="@dimen/medium_width"
                 android:layout_height="@dimen/medium_height"
-                android:id="@+id/thanks_received_info"
                 android:layout_marginTop="@dimen/activity_margin_horizontal"
                 android:layout_marginRight="@dimen/activity_margin_horizontal"
                 android:layout_marginEnd="@dimen/activity_margin_horizontal"


### PR DESCRIPTION
**Description (required)**

Fixes #4318 

 Toggling the info on the fields in the achievement tab is difficult because the icons are so small. So I make the whole label clickable. Now users can anywhere in the label to see the dialog. I don't remove the icon because It will help the user to understand that the label is clickable.

**Tests performed (required)**

3.0.0-debug master on Pixel 4 API 27.

**Screenshots (for UI changes only)**

Users can click anywhere on the label to see the help popup. **No need to click on the small icon now it is clickable from everywhere.**

<table>
  <tr>
    <td> The whole label is clickable</td>
     <td> After click</td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/71203077/113563970-34947400-9626-11eb-8efd-7d0a5373ccb6.png"width="300"></td>
    <td><img src="https://user-images.githubusercontent.com/71203077/113563986-39f1be80-9626-11eb-83cf-e98b085d0b92.png"width="300"></td>
  </tr>
 </table>
