### PR TITLE
fix:In setting Default description language option is needed to get disable when user is not login

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -90,6 +90,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             findPreference("useExternalStorage").setEnabled(false);
             findPreference("useAuthorName").setEnabled(false);
             findPreference("displayNearbyCardView").setEnabled(false);
+            findPreference("descriptionDefaultLanguagePref").setEnabled(false);
             findPreference("displayLocationPermissionForCardView").setEnabled(false);
             findPreference("displayCampaignsCardView").setEnabled(false);
         }


### PR DESCRIPTION

**Description (required)**

Fixes #4330

What changes did you make and why?
 findPreference("descriptionDefaultLanguagePref").setEnabled(false) in setting fragment

**Tests performed (required)**
Android Device :Redmi y3
API Level :29
