### PR TITLE
Fixes #4329 "Back button in edit categories triggers back of media details."

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkFragment.java
@@ -95,8 +95,11 @@ public class BookmarkFragment extends CommonsDaggerSupportFragment {
 
 
   public void onBackPressed() {
-    ((BookmarkListRootFragment) (adapter.getItem(tabLayout.getSelectedTabPosition())))
-        .backPressed();
+    if(((BookmarkListRootFragment)(adapter.getItem(tabLayout.getSelectedTabPosition()))).backPressed()) {
+      // The event is handled internally by the adapter , no further action required.
+      return;
+    }
+    // Event is not handled by the adapter ( performed back action ) change action bar.
     ((BaseActivity)getActivity()).getSupportActionBar().setDisplayHomeAsUpEnabled(false);
   }
 }

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
@@ -180,10 +180,14 @@ public class BookmarkListRootFragment extends CommonsDaggerSupportFragment imple
     }
   }
 
-  public void backPressed() {
+  public boolean backPressed() {
     //check mediaDetailPage fragment is not null then we check mediaDetail.is Visible or not to avoid NullPointerException
     if(mediaDetails!=null) {
       if (mediaDetails.isVisible()) {
+        if(mediaDetails.backButtonClicked()) {
+          // mediaDetails handled the back clicked , no further action required.
+          return true;
+        }
         // todo add get list fragment
         ((BookmarkFragment) getParentFragment()).setupTabLayout();
         ArrayList<Integer> removed=mediaDetails.getRemovedItems();
@@ -206,6 +210,8 @@ public class BookmarkListRootFragment extends CommonsDaggerSupportFragment imple
     } else {
       moveToContributionsFragment();
     }
+    // notify mediaDetails did not handled the backPressed further actions required.
+    return false;
   }
 
   void moveToContributionsFragment(){

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -203,7 +203,12 @@ public class CategoryDetailsActivity extends BaseActivity
     @Override
     public void onBackPressed() {
         if (supportFragmentManager.getBackStackEntryCount() == 1){
-            // back to search so show search toolbar and hide navigation toolbar
+
+            // the back press is handled by the mediaDetails , no further action required.
+            if(mediaDetails.backButtonClicked()){
+                return;
+            }
+
             tabLayout.setVisibility(View.VISIBLE);
             viewPager.setVisibility(View.VISIBLE);
             mediaContainer.setVisibility(View.GONE);

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -658,6 +658,10 @@ public class ContributionsFragment
 
     public void backButtonClicked() {
         if (mediaDetailPagerFragment.isVisible()) {
+            if(mediaDetailPagerFragment.backButtonClicked()) {
+                // MediaDetailed handled the backPressed no further action required.
+                return;
+            }
             if (store.getBoolean("displayNearbyCardView", true)) {
                 if (nearbyNotificationCardView.cardViewVisibilityState == NearbyNotificationCardView.CardViewVisibilityState.READY) {
                     nearbyNotificationCardView.setVisibility(View.VISIBLE);

--- a/app/src/main/java/fr/free/nrw/commons/explore/ExploreFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/ExploreFragment.java
@@ -93,10 +93,17 @@ public class ExploreFragment extends CommonsDaggerSupportFragment {
 
     public void onBackPressed() {
         if (tabLayout.getSelectedTabPosition() == 0) {
-            featuredRootFragment.backPressed();
+            if(featuredRootFragment.backPressed()){
+                // Event is handled by the Fragment we need not do anything.
+                return;
+            }
         } else {
-            mobileRootFragment.backPressed();
+            if(mobileRootFragment.backPressed()){
+                // Event is handled by the Fragment we need not do anything.
+                return;
+            }
         }
+        // Event is not handled by the fragment ( i.e performed back action ) therefore change action bar.
         ((BaseActivity)getActivity()).getSupportActionBar().setDisplayHomeAsUpEnabled(false);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
@@ -164,9 +164,18 @@ public class ExploreListRootFragment extends CommonsDaggerSupportFragment implem
     }
   }
 
-  public void backPressed() {
+  /**
+   * Performs back pressed action on the fragment.
+   * Return true if the event was handled by the mediaDetails otherwise returns false.
+   * @return
+   */
+  public boolean backPressed() {
     if (null!=mediaDetails && mediaDetails.isVisible()) {
       // todo add get list fragment
+      if(mediaDetails.backButtonClicked()) {
+        // MediaDetails handled the event no further action required.
+        return true;
+      }
       ((ExploreFragment)getParentFragment()).tabLayout.setVisibility(View.VISIBLE);
       removeFragment(mediaDetails);
       ((ExploreFragment) getParentFragment()).setScroll(true);
@@ -175,5 +184,6 @@ public class ExploreListRootFragment extends CommonsDaggerSupportFragment implem
       ((MainActivity) getActivity()).setSelectedItemId(NavTab.CONTRIBUTIONS.code());
     }
     ((MainActivity)getActivity()).showTabs();
+    return false;
   }
 }

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -245,6 +245,12 @@ public class SearchActivity extends BaseActivity
     @Override
     public void onBackPressed() {
         if (getSupportFragmentManager().getBackStackEntryCount() == 1){
+
+            // the back press is handled by the mediaDetails , no further action required.
+            if(mediaDetails.backButtonClicked()){
+                return;
+            }
+
             // back to search so show search toolbar and hide navigation toolbar
             searchView.setVisibility(View.VISIBLE);//set the searchview
             tabLayout.setVisibility(View.VISIBLE);

--- a/app/src/main/java/fr/free/nrw/commons/explore/depictions/WikidataItemDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/depictions/WikidataItemDetailsActivity.java
@@ -163,7 +163,12 @@ public class WikidataItemDetailsActivity extends BaseActivity implements MediaDe
     @Override
     public void onBackPressed() {
         if (supportFragmentManager.getBackStackEntryCount() == 1){
-            // back to search so show search toolbar and hide navigation toolbar
+
+            // back pressed is handled by the mediaDetails , no further action required.
+            if(mediaDetailPagerFragment.backButtonClicked()){
+                return;
+            }
+
             tabLayout.setVisibility(View.VISIBLE);
             viewPager.setVisibility(View.VISIBLE);
             mediaContainer.setVisibility(View.GONE);

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -16,8 +16,10 @@ import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.View.OnKeyListener;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
@@ -298,6 +300,34 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
                 updateAspectRatio(scrollView.getWidth());
             }
         });
+
+        /**
+         * Key listener on the fragment.
+         * We request focus, to track the key events in fragment.
+         */
+        view.setFocusableInTouchMode(true);
+        view.requestFocus();
+        view.setOnKeyListener( new OnKeyListener()
+        {
+            /**
+             * onKey is triggered on a key event in fragment.
+             */
+            @Override
+            public boolean onKey( View v, int keyCode, KeyEvent event )
+            {
+                // Back pressed
+                if(keyCode == KeyEvent.KEYCODE_BACK)
+                {
+                    // If category edit container is visible we remove it.
+                    if (dummyCategoryEditContainer.getVisibility() == VISIBLE) {
+                        dummyCategoryEditContainer.setVisibility(GONE);
+                        return true;
+                    }
+                }
+                return false;
+            }
+        } );
+
         return view;
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -16,6 +16,7 @@ import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -300,33 +301,6 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
                 updateAspectRatio(scrollView.getWidth());
             }
         });
-
-        /**
-         * Key listener on the fragment.
-         * We request focus, to track the key events in fragment.
-         */
-        view.setFocusableInTouchMode(true);
-        view.requestFocus();
-        view.setOnKeyListener( new OnKeyListener()
-        {
-            /**
-             * onKey is triggered on a key event in fragment.
-             */
-            @Override
-            public boolean onKey( View v, int keyCode, KeyEvent event )
-            {
-                // Back pressed
-                if(keyCode == KeyEvent.KEYCODE_BACK)
-                {
-                    // If category edit container is visible we remove it.
-                    if (dummyCategoryEditContainer.getVisibility() == VISIBLE) {
-                        dummyCategoryEditContainer.setVisibility(GONE);
-                        return true;
-                    }
-                }
-                return false;
-            }
-        } );
 
         return view;
     }
@@ -730,6 +704,22 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
     @OnClick(R.id.categoryEditButton)
     public void onCategoryEditButtonClicked(){
         displayHideCategorySearch();
+    }
+
+    /**
+     * Hides the categoryEditContainer.
+     * returns true after closing the categoryEditContainer if open, implying that event was handled.
+     * else returns false
+     * @return
+     */
+    public boolean hideCategoryEditContainerIfOpen(){
+        if (dummyCategoryEditContainer.getVisibility() == VISIBLE) {
+            // editCategory is open, close it and return true as the event was handled.
+            dummyCategoryEditContainer.setVisibility(GONE);
+            return true;
+        }
+        // Event was not handled.
+        return false;
     }
 
     public void displayHideCategorySearch() {

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -375,6 +375,12 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
         }
     }
 
+    /**
+     * backButtonClicked is called on a back event in the media details pager.
+     * returns true after closing the categoryEditContainer if open, implying that event was handled.
+     * else returns false
+     * @return
+     */
     public boolean backButtonClicked(){
         return ((MediaDetailFragment)(adapter.getCurrentFragment())).hideCategoryEditContainerIfOpen();
     }
@@ -392,7 +398,9 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
     //FragmentStatePagerAdapter allows user to swipe across collection of images (no. of images undetermined)
     private class MediaDetailAdapter extends FragmentStatePagerAdapter {
 
-        // Keeps track of the current displayed fragment.
+        /**
+         * Keeps track of the current displayed fragment.
+         */
         private Fragment mCurrentFragment;
 
         public MediaDetailAdapter(FragmentManager fm) {
@@ -426,7 +434,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
         }
 
         /**
-         * getter for mCurrentFragment
+         * Get the currently displayed fragment.
          * @return
          */
         public Fragment getCurrentFragment() {

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -385,8 +385,6 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
         return ((MediaDetailFragment)(adapter.getCurrentFragment())).hideCategoryEditContainerIfOpen();
     }
 
-
-
     public interface MediaDetailProvider {
         Media getMediaAtPosition(int i);
 

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -13,6 +13,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentStatePagerAdapter;
@@ -374,6 +375,12 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
         }
     }
 
+    public boolean backButtonClicked(){
+        return ((MediaDetailFragment)(adapter.getCurrentFragment())).hideCategoryEditContainerIfOpen();
+    }
+
+
+
     public interface MediaDetailProvider {
         Media getMediaAtPosition(int i);
 
@@ -384,6 +391,9 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
 
     //FragmentStatePagerAdapter allows user to swipe across collection of images (no. of images undetermined)
     private class MediaDetailAdapter extends FragmentStatePagerAdapter {
+
+        // Keeps track of the current displayed fragment.
+        private Fragment mCurrentFragment;
 
         public MediaDetailAdapter(FragmentManager fm) {
             super(fm);
@@ -413,6 +423,31 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                 return 0;
             }
             return provider.getTotalMediaCount();
+        }
+
+        /**
+         * getter for mCurrentFragment
+         * @return
+         */
+        public Fragment getCurrentFragment() {
+            return mCurrentFragment;
+        }
+
+        /**
+         * Called to inform the adapter of which item is currently considered to be the "primary",
+         * that is the one show to the user as the current page.
+         * @param container
+         * @param position
+         * @param object
+         */
+        @Override
+        public void setPrimaryItem(@NonNull final ViewGroup container, final int position,
+            @NonNull final Object object) {
+            // Update the current fragment if changed
+            if(getCurrentFragment() != object) {
+                mCurrentFragment = ((Fragment)object);
+            }
+            super.setPrimaryItem(container, position, object);
         }
     }
 }


### PR DESCRIPTION
**Description (required)**

Fixes #4329

What changes did you make and why?

Added onKey listener to the fragment view.

**Tests performed (required)**

Tested BetaDebug on Nokia 6.1+ with API level 29.
