### PR TITLE
Fixes #3879 #4283 Other pictures flickers when a media is selected from contributions list

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
@@ -112,9 +112,9 @@ public class ExploreListRootFragment extends CommonsDaggerSupportFragment implem
     container.setVisibility(View.VISIBLE);
     ((ExploreFragment) getParentFragment()).tabLayout.setVisibility(View.GONE);
     mediaDetails = new MediaDetailPagerFragment(false, true);
-    mediaDetails.showImage(position);
     ((ExploreFragment) getParentFragment()).setScroll(false);
     setFragment(mediaDetails, listFragment);
+    mediaDetails.showImage(position);
   }
 
   /**

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -105,24 +105,13 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
             ((BaseActivity) getActivity()).getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
 
+        pager.setAdapter(adapter);
         if (savedInstanceState != null) {
             final int pageNumber = savedInstanceState.getInt("current-page");
-            // Adapter doesn't seem to be loading immediately.
-            // Dear God, please forgive us for our sins
-            view.postDelayed(() -> {
-                pager.setAdapter(adapter);
-                pager.setCurrentItem(pageNumber, false);
+            pager.setCurrentItem(pageNumber, false);
+            getActivity().invalidateOptionsMenu();
+            adapter.notifyDataSetChanged();
 
-                if (getActivity() == null) {
-                    Timber.d("Returning as activity is destroyed!");
-                    return;
-                }
-
-                getActivity().supportInvalidateOptionsMenu();
-                adapter.notifyDataSetChanged();
-            }, 100);
-        } else {
-            pager.setAdapter(adapter);
         }
         if (getActivity() instanceof MainActivity) {
             ((MainActivity)getActivity()).hideTabs();
@@ -332,13 +321,31 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
 
     public void showImage(int i, boolean isWikipediaButtonDisplayed) {
         this.isWikipediaButtonDisplayed = isWikipediaButtonDisplayed;
-        Handler handler =  new Handler();
-        handler.postDelayed(() -> pager.setCurrentItem(i), 5);
+        setViewPagerCurrentItem(i);
     }
 
     public void showImage(int i) {
-        Handler handler =  new Handler();
-        handler.postDelayed(() -> pager.setCurrentItem(i), 5);
+        setViewPagerCurrentItem(i);
+    }
+
+    /**
+     * This function waits for the item to load then sets the item to current item
+     * @param position current item that to be shown
+     */
+    private void setViewPagerCurrentItem(int position) {
+        final Boolean[] currentItemNotShown = {true};
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                while(currentItemNotShown[0]){
+                    if(adapter.getCount() > position){
+                        pager.setCurrentItem(position, false);
+                        currentItemNotShown[0] = false;
+                    }
+                }
+            }
+        };
+        new Thread(runnable).start();
     }
 
     /**


### PR DESCRIPTION
Description (required)
Fixes #3879 #4283

What changes did you make and why?
I just added a feature to check it the clicked item is loaded before setting that item, which will remove image flicker as program will not wait for 5 milliseconds and random crashes

Tests performed (required)
manual testing

please check this pull request @neslihanturan