### PR TITLE
READ_EXTERNAL_STORAGE permission is not necessary while picking file from gallery

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
@@ -55,20 +55,16 @@ public class ContributionController {
     }
 
     /**
-     * Check for permissions and initiate gallery picker
+     * Initiate gallery picker
      */
-    public void initiateGalleryPick(Activity activity, boolean allowMultipleUploads) {
-        PermissionUtils.checkPermissionsAndPerformAction(activity,
-                Manifest.permission.READ_EXTERNAL_STORAGE,
-                () -> initiateGalleryUpload(activity, allowMultipleUploads),
-                R.string.storage_permission_title,
-                R.string.read_storage_permission_rationale);
+    public void initiateGalleryPick(final Activity activity, final boolean allowMultipleUploads) {
+        initiateGalleryUpload(activity, allowMultipleUploads);
     }
 
     /**
      * Open chooser for gallery uploads
      */
-    private void initiateGalleryUpload(Activity activity, boolean allowMultipleUploads) {
+    private void initiateGalleryUpload(final Activity activity, final boolean allowMultipleUploads) {
         setPickerConfiguration(activity, allowMultipleUploads);
         FilePicker.openGallery(activity, 0);
     }


### PR DESCRIPTION
**Description**

Fixes #3744 

**What changes did you make and why?**
As READ_EXTERNAL_STORAGE permission isn't required for picking an image from the gallery. So if storage permission is turned off app should not show a dialog to turn on the permission for READ_EXTERNAL_STORAGE.

**Tests performed**

Tested 3.0.0-debug-master on Pixel 4 with API level 27 and OPPO A57 with API level 23

**Screenshots (for UI changes only)**

**Permission is turned off.**

https://user-images.githubusercontent.com/71203077/114605749-08c55e00-9cb8-11eb-803b-486cd6441564.mp4

