### PR TITLE
Fixes #4360 - Captions and descriptions not uploaded to commons

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
@@ -280,6 +280,8 @@ class UploadWorker(var appContext: Context, workerParams: WorkerParameters) :
                                 "Stash Upload success..proceeding to make wikidata edit"
                             )
 
+                            wikidataEditService.addDepictionsAndCaptions(uploadResult, contribution)
+                                .blockingSubscribe();
                             if(contribution.wikidataPlace==null){
                                 Timber.d(
                                     "WikiDataEdit not required, upload success"
@@ -339,7 +341,6 @@ class UploadWorker(var appContext: Context, workerParams: WorkerParameters) :
      * Make the WikiData Edit, if applicable
      */
     private suspend fun makeWikiDataEdit(uploadResult: UploadResult, contribution: Contribution) {
-        wikidataEditService.addDepictionsAndCaptions(uploadResult, contribution)
         val wikiDataPlace = contribution.wikidataPlace
         if (wikiDataPlace != null && wikiDataPlace.imageValue == null) {
             if (!contribution.hasInvalidLocation()) {

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
@@ -179,13 +179,12 @@ public class WikidataEditService {
     }
   }
 
-  public Disposable addDepictionsAndCaptions(UploadResult uploadResult, Contribution contribution) {
+  public Observable addDepictionsAndCaptions(final UploadResult uploadResult, final Contribution contribution) {
     return wikiBaseClient.getFileEntityId(uploadResult)
         .doOnError(throwable -> {
           Timber.e(throwable, "Error occurred while getting EntityID to set DEPICTS property");
           ViewUtil.showLongToast(context, context.getString(R.string.wikidata_edit_failure));
         })
-        .subscribeOn(Schedulers.io())
         .switchMap(fileEntityId -> {
               if (fileEntityId != null) {
                 Timber.d("EntityId for image was received successfully: %s", fileEntityId);
@@ -198,9 +197,6 @@ public class WikidataEditService {
                 return Observable.empty();
               }
             }
-        ).subscribe(
-            success -> Timber.d("edit response: %s", success),
-            throwable -> Timber.e(throwable, "posting edits failed")
         );
   }
 


### PR DESCRIPTION
**Description (required)**

Fixes #4360 - The prior commit had missed making API calls to edit depicts and captions on successful upload as a result of which the captions and depicts were not being added.

What changes did you make and why?

On Successful upload from stash make API calls to add captions and depicts
**Tests performed (required)**

Tested betaDebug on API 30 (Test file : https://commons.m.wikimedia.beta.wmflabs.org/wiki/File%3ABean_bag_caption_test.jpg)