### PR TITLE
Fixes #4364 Removed dependency to fix build for Instrumentation Tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,12 +97,6 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.3.1"
     testImplementation 'com.facebook.soloader:soloader:0.9.0'
 
-    // Mockito and PowerMock
-    androidTestCompile ('org.powermock:powermock-mockito-release-full:1.6.0') {
-        exclude module: 'hamcrest-core'
-        exclude module: 'objenesis'
-    }
-
     // Android testing
     androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'


### PR DESCRIPTION
**Description**
Removed `powermock-mockito-release-full` dependency from `androidTestImplementation` to fix build for Instrumentation Tests

Fixes #4364

**Tests performed**
Tested ProdDebug on Google Pixel 2 with API level 29