### PR TITLE
Fixes #4300 Limited connection mode banner occupies too much space

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -621,11 +621,19 @@ public class ContributionsFragment
         return mediaDetailPagerFragment;
     }
 
-    // click listener to toggle description
-    private OnClickListener toggleDescriptionListener = view -> {
-      if(view.getVisibility() == View.GONE) {
-        view.setVisibility(View.VISIBLE);
-      } else {view.setVisibility(View.GONE); }
-    };
+  // click listener to toggle description
+  private View.OnClickListener toggleDescriptionListener = new View.OnClickListener() {
+
+      @Override
+      public void onClick(View view) {
+          View view2 = limitedConnectionDescriptionTv;
+          if (view2.getVisibility() == View.GONE) {
+              view2.setVisibility(View.VISIBLE);
+          } else {
+              view2.setVisibility(View.GONE);
+          }
+      }
+  };
+
 }
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -14,7 +14,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.MenuItem.OnMenuItemClickListener;
 import android.view.View;
-import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.LinearLayout;
@@ -90,7 +89,7 @@ public class ContributionsFragment
     @BindView(R.id.card_view_nearby) public NearbyNotificationCardView nearbyNotificationCardView;
     @BindView(R.id.campaigns_view) CampaignView campaignView;
     @BindView(R.id.limited_connection_enabled_layout) LinearLayout limitedConnectionEnabledLayout;
-    @BindView(R.id.limited_connection_description_tv) TextView limitedConnectionDescriptionTv;
+    @BindView(R.id.limited_connection_description_text_view) TextView limitedConnectionDescriptionTextView;
 
     @Inject ContributionsPresenter contributionsPresenter;
 
@@ -621,12 +620,13 @@ public class ContributionsFragment
         return mediaDetailPagerFragment;
     }
 
-  // click listener to toggle description
+  // click listener to toggle description that means uses can press the limited connection
+  // banner and description will hide. Tap again to show description.
   private View.OnClickListener toggleDescriptionListener = new View.OnClickListener() {
 
       @Override
       public void onClick(View view) {
-          View view2 = limitedConnectionDescriptionTv;
+          View view2 = limitedConnectionDescriptionTextView;
           if (view2.getVisibility() == View.GONE) {
               view2.setVisibility(View.VISIBLE);
           } else {

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -14,6 +14,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.MenuItem.OnMenuItemClickListener;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.LinearLayout;
@@ -89,6 +90,7 @@ public class ContributionsFragment
     @BindView(R.id.card_view_nearby) public NearbyNotificationCardView nearbyNotificationCardView;
     @BindView(R.id.campaigns_view) CampaignView campaignView;
     @BindView(R.id.limited_connection_enabled_layout) LinearLayout limitedConnectionEnabledLayout;
+    @BindView(R.id.limited_connection_description_tv) TextView limitedConnectionDescriptionTv;
 
     @Inject ContributionsPresenter contributionsPresenter;
 
@@ -158,6 +160,7 @@ public class ContributionsFragment
             && sessionManager.getCurrentAccount() != null) {
             setUploadCount();
         }
+        limitedConnectionEnabledLayout.setOnClickListener(toggleDescriptionListener);
         setHasOptionsMenu(true);
         return view;
     }
@@ -617,5 +620,12 @@ public class ContributionsFragment
     public MediaDetailPagerFragment getMediaDetailPagerFragment() {
         return mediaDetailPagerFragment;
     }
+
+    // click listener to toggle description
+    private OnClickListener toggleDescriptionListener = view -> {
+      if(view.getVisibility() == View.GONE) {
+        view.setVisibility(View.VISIBLE);
+      } else {view.setVisibility(View.GONE); }
+    };
 }
 

--- a/app/src/main/res/layout/fragment_contributions.xml
+++ b/app/src/main/res/layout/fragment_contributions.xml
@@ -20,25 +20,27 @@
 
   <LinearLayout
     android:id="@+id/limited_connection_enabled_layout"
+    android:animateLayoutChanges="true"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="@dimen/miniscule_margin"
     android:padding="@dimen/standard_gap"
     android:orientation="vertical"
+    android:clickable="true"
+    android:focusable="true"
     android:background="@color/wikimedia_green">
-    <ImageView
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="@dimen/small_gap"
-      app:srcCompat="@drawable/ic_baseline_cloud_off_72"/>
     <TextView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:drawablePadding="5dp"
       android:textColor="@android:color/white"
       android:layout_marginBottom="@dimen/tiny_gap"
       android:textSize="@dimen/subheading_text_size"
-      android:text="@string/limited_connection_is_on"/>
+      android:text="@string/limited_connection_is_on"
+      app:drawableTint="@color/white"
+      app:drawableStartCompat="@drawable/ic_baseline_cloud_off_24"/>
     <TextView
+      android:id="@+id/limited_connection_description_tv"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:textColor="@android:color/white"

--- a/app/src/main/res/layout/fragment_contributions.xml
+++ b/app/src/main/res/layout/fragment_contributions.xml
@@ -40,7 +40,7 @@
       app:drawableTint="@color/white"
       app:drawableStartCompat="@drawable/ic_baseline_cloud_off_24"/>
     <TextView
-      android:id="@+id/limited_connection_description_tv"
+      android:id="@+id/limited_connection_description_text_view"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:textColor="@android:color/white"


### PR DESCRIPTION
**Description (required)**
clicking on banned hides the detail text but the banner is still visible.

Fixes #4300 

What changes did you make and why?
I added a click listener to toggle the detail text

**Screenshots (for UI changes only)**
before:
https://user-images.githubusercontent.com/12448084/111917062-f9ca0200-8aa3-11eb-83a4-2d66f5e8cddf.png
After:
https://user-images.githubusercontent.com/56196007/115973663-65f0c780-a574-11eb-82dc-72bc1d1981ba.mp4