### PR TITLE
Login error message is displayed in native phone locale language and not in just English. Fixes #4290

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -30,6 +30,7 @@ import androidx.core.content.ContextCompat;
 import com.google.android.material.textfield.TextInputLayout;
 
 import fr.free.nrw.commons.utils.ActivityUtils;
+import java.util.Locale;
 import org.wikipedia.AppAdapter;
 import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.dataclient.WikiSite;
@@ -265,7 +266,7 @@ public class LoginActivity extends AccountAuthenticatorActivity {
                     public void onResponse(Call<MwQueryResponse> call,
                                            Response<MwQueryResponse> response) {
                         loginClient.login(commonsWikiSite, username, password, null, twoFactorCode,
-                                response.body().query().loginToken(), new LoginCallback() {
+                                response.body().query().loginToken(), Locale.getDefault().getLanguage(), new LoginCallback() {
                                     @Override
                                     public void success(@NonNull LoginResult result) {
                                         Timber.d("Login Success");

--- a/data-client/src/main/java/org/wikipedia/dataclient/Service.java
+++ b/data-client/src/main/java/org/wikipedia/dataclient/Service.java
@@ -229,14 +229,14 @@ public interface Service {
     @FormUrlEncoded
     @POST(MW_API_PREFIX + "action=clientlogin&rememberMe=")
     @NonNull Call<LoginClient.LoginResponse> postLogIn(@Field("username") String user, @Field("password") String pass,
-                                                       @Field("logintoken") String token, @Field("loginreturnurl") String url);
+                                                       @Field("logintoken") String token, @Field("uselang") String userLang, @Field("loginreturnurl") String url);
 
     @Headers("Cache-Control: no-cache")
     @FormUrlEncoded
     @POST(MW_API_PREFIX + "action=clientlogin&rememberMe=")
     @NonNull Call<LoginClient.LoginResponse> postLogIn(@Field("username") String user, @Field("password") String pass,
                                                        @Field("retype") String retypedPass, @Field("OATHToken") String twoFactorCode,
-                                                       @Field("logintoken") String token,
+                                                       @Field("logintoken") String token, @Field("uselang") String userLang,
                                                        @Field("logincontinue") boolean loginContinue);
 
     @Headers("Cache-Control: no-cache")

--- a/data-client/src/main/java/org/wikipedia/dataclient/Service.java
+++ b/data-client/src/main/java/org/wikipedia/dataclient/Service.java
@@ -229,14 +229,14 @@ public interface Service {
     @FormUrlEncoded
     @POST(MW_API_PREFIX + "action=clientlogin&rememberMe=")
     @NonNull Call<LoginClient.LoginResponse> postLogIn(@Field("username") String user, @Field("password") String pass,
-                                                       @Field("logintoken") String token, @Field("uselang") String userLang, @Field("loginreturnurl") String url);
+                                                       @Field("logintoken") String token, @Field("uselang") String userLanguage, @Field("loginreturnurl") String url);
 
     @Headers("Cache-Control: no-cache")
     @FormUrlEncoded
     @POST(MW_API_PREFIX + "action=clientlogin&rememberMe=")
     @NonNull Call<LoginClient.LoginResponse> postLogIn(@Field("username") String user, @Field("password") String pass,
                                                        @Field("retype") String retypedPass, @Field("OATHToken") String twoFactorCode,
-                                                       @Field("logintoken") String token, @Field("uselang") String userLang,
+                                                       @Field("logintoken") String token, @Field("uselang") String userLanguage,
                                                        @Field("logincontinue") boolean loginContinue);
 
     @Headers("Cache-Control: no-cache")

--- a/data-client/src/main/java/org/wikipedia/login/LoginClient.java
+++ b/data-client/src/main/java/org/wikipedia/login/LoginClient.java
@@ -33,7 +33,7 @@ import retrofit2.Response;
 public class LoginClient {
     @Nullable private Call<MwQueryResponse> tokenCall;
     @Nullable private Call<LoginResponse> loginCall;
-
+    @NonNull private String userLang;
     public interface LoginCallback {
         void success(@NonNull LoginResult result);
         void twoFactorPrompt(@NonNull Throwable caught, @Nullable String token);
@@ -49,7 +49,8 @@ public class LoginClient {
         tokenCall.enqueue(new Callback<MwQueryResponse>() {
             @Override public void onResponse(@NonNull Call<MwQueryResponse> call,
                                              @NonNull Response<MwQueryResponse> response) {
-                login(wiki, userName, password, null, null, response.body().query().loginToken(), cb);
+                login(wiki, userName, password, null, null, response.body().query().loginToken(),
+                    userLang , cb);
             }
 
             @Override
@@ -64,10 +65,11 @@ public class LoginClient {
 
     public void login(@NonNull final WikiSite wiki, @NonNull final String userName, @NonNull final String password,
                @Nullable final String retypedPassword, @Nullable final String twoFactorCode,
-               @Nullable final String loginToken, @NonNull final LoginCallback cb) {
+               @Nullable final String loginToken, @NonNull final String userLang, @NonNull final LoginCallback cb) {
+        this.userLang=userLang;
         loginCall = TextUtils.isEmpty(twoFactorCode) && TextUtils.isEmpty(retypedPassword)
-                ? ServiceFactory.get(wiki).postLogIn(userName, password, loginToken, Service.WIKIPEDIA_URL)
-                : ServiceFactory.get(wiki).postLogIn(userName, password, retypedPassword, twoFactorCode, loginToken, true);
+                ? ServiceFactory.get(wiki).postLogIn(userName, password, loginToken, userLang, Service.WIKIPEDIA_URL)
+                : ServiceFactory.get(wiki).postLogIn(userName, password, retypedPassword, twoFactorCode, loginToken, userLang, true);
         loginCall.enqueue(new Callback<LoginResponse>() {
             @Override
             public void onResponse(@NonNull Call<LoginResponse> call, @NonNull Response<LoginResponse> response) {
@@ -114,8 +116,8 @@ public class LoginClient {
         String loginToken = tokenResponse.body().query().loginToken();
 
         Call<LoginResponse> tempLoginCall = StringUtils.defaultIfEmpty(twoFactorCode, "").isEmpty()
-                ? ServiceFactory.get(wiki).postLogIn(userName, password, loginToken, Service.WIKIPEDIA_URL)
-                : ServiceFactory.get(wiki).postLogIn(userName, password, null, twoFactorCode, loginToken, true);
+                ? ServiceFactory.get(wiki).postLogIn(userName, password, loginToken, userLang, Service.WIKIPEDIA_URL)
+                : ServiceFactory.get(wiki).postLogIn(userName, password, null, twoFactorCode, loginToken, userLang, true);
         Response<LoginResponse> response = tempLoginCall.execute();
         LoginResponse loginResponse = response.body();
         if (loginResponse == null) {

--- a/data-client/src/main/java/org/wikipedia/login/LoginClient.java
+++ b/data-client/src/main/java/org/wikipedia/login/LoginClient.java
@@ -33,7 +33,14 @@ import retrofit2.Response;
 public class LoginClient {
     @Nullable private Call<MwQueryResponse> tokenCall;
     @Nullable private Call<LoginResponse> loginCall;
-    @NonNull private String userLang;
+    /**
+     * userLanguage
+     * It holds the value of the user's device language code.
+     * For example, if user's device language is English it will hold En
+     * The value will be fetched when the user clicks Login Button in the LoginActivity
+     */
+    @NonNull private String userLanguage;
+    
     public interface LoginCallback {
         void success(@NonNull LoginResult result);
         void twoFactorPrompt(@NonNull Throwable caught, @Nullable String token);
@@ -50,7 +57,7 @@ public class LoginClient {
             @Override public void onResponse(@NonNull Call<MwQueryResponse> call,
                                              @NonNull Response<MwQueryResponse> response) {
                 login(wiki, userName, password, null, null, response.body().query().loginToken(),
-                    userLang , cb);
+                    userLanguage, cb);
             }
 
             @Override
@@ -65,11 +72,12 @@ public class LoginClient {
 
     public void login(@NonNull final WikiSite wiki, @NonNull final String userName, @NonNull final String password,
                @Nullable final String retypedPassword, @Nullable final String twoFactorCode,
-               @Nullable final String loginToken, @NonNull final String userLang, @NonNull final LoginCallback cb) {
-        this.userLang=userLang;
+               @Nullable final String loginToken, @NonNull final String userLanguage, @NonNull final LoginCallback cb) {
+        this.userLanguage = userLanguage;
         loginCall = TextUtils.isEmpty(twoFactorCode) && TextUtils.isEmpty(retypedPassword)
-                ? ServiceFactory.get(wiki).postLogIn(userName, password, loginToken, userLang, Service.WIKIPEDIA_URL)
-                : ServiceFactory.get(wiki).postLogIn(userName, password, retypedPassword, twoFactorCode, loginToken, userLang, true);
+                ? ServiceFactory.get(wiki).postLogIn(userName, password, loginToken, userLanguage, Service.WIKIPEDIA_URL)
+                : ServiceFactory.get(wiki).postLogIn(userName, password, retypedPassword, twoFactorCode, loginToken,
+                    userLanguage, true);
         loginCall.enqueue(new Callback<LoginResponse>() {
             @Override
             public void onResponse(@NonNull Call<LoginResponse> call, @NonNull Response<LoginResponse> response) {
@@ -116,8 +124,9 @@ public class LoginClient {
         String loginToken = tokenResponse.body().query().loginToken();
 
         Call<LoginResponse> tempLoginCall = StringUtils.defaultIfEmpty(twoFactorCode, "").isEmpty()
-                ? ServiceFactory.get(wiki).postLogIn(userName, password, loginToken, userLang, Service.WIKIPEDIA_URL)
-                : ServiceFactory.get(wiki).postLogIn(userName, password, null, twoFactorCode, loginToken, userLang, true);
+                ? ServiceFactory.get(wiki).postLogIn(userName, password, loginToken, userLanguage, Service.WIKIPEDIA_URL)
+                : ServiceFactory.get(wiki).postLogIn(userName, password, null, twoFactorCode, loginToken,
+                    userLanguage, true);
         Response<LoginResponse> response = tempLoginCall.execute();
         LoginResponse loginResponse = response.body();
         if (loginResponse == null) {


### PR DESCRIPTION
**Description (required)**

Before this when a user attempted to log in and entered the wrong login info he got an error message in English no matter whats the language selected, now he will receive it in the language of the locale phone.
Fixes #4290 

What changes did you make and why?
Added an uselang parameter in the API call

**Tests performed (required)**
Android Device (Android 9)

**Screenshots (for UI changes only)**
![image](https://user-images.githubusercontent.com/46752548/116677189-8a5e0100-a9c5-11eb-801f-75e7bb207ecc.png)
For English

![image](https://user-images.githubusercontent.com/46752548/116677222-9649c300-a9c5-11eb-9c48-683d802d0398.png)
For Detusch

![image](https://user-images.githubusercontent.com/46752548/116677259-a366b200-a9c5-11eb-8201-2361d19c657a.png)
For Espanol


_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
