### PR TITLE
Fix #4147  Pre-fill desc in Nearby uploads with Wikidata item's label + description

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
@@ -60,10 +60,20 @@ public class Place implements Parcelable {
         if(!StringUtils.isBlank(itemClass)) {
             classEntityId = itemClass.replace("http://www.wikidata.org/entity/", "");
         }
+        // Capitalize first letter of description when not null and not empty
         String description = (item.getDescription().getValue() != null && !item.getDescription().getValue().isEmpty())
             ? StringUtils.capitalize(item.getDescription().getValue()) : "";
+        // When description is "?" but we have a valid label, just use the label. So replace "?" by "" in description
+        description = (description.equals("?")
+            && (item.getLabel().getValue() != null
+            && !item.getLabel().getValue().isEmpty()) ? "" : description);
+        /** If we have a valid label
+         *     - If have a valid description add the label at the end of the string with parenthesis
+         *     - If we don't have a valid description, string will include only the label. So add it without paranthesis
+         */
         description += ((item.getLabel().getValue() != null && !item.getLabel().getValue().isEmpty())
-            ? ", (" + item.getLabel().getValue() + ")" : "");
+            ? ((description != null && !description.isEmpty())
+                ? ", (" + item.getLabel().getValue() + ")" : item.getLabel().getValue()) : "");
         return new Place(
                 item.getLabel().getValue(),
                 Label.fromText(classEntityId), // list

--- a/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
@@ -60,10 +60,14 @@ public class Place implements Parcelable {
         if(!StringUtils.isBlank(itemClass)) {
             classEntityId = itemClass.replace("http://www.wikidata.org/entity/", "");
         }
+        String description = (item.getDescription().getValue() != null && !item.getDescription().getValue().isEmpty())
+            ? StringUtils.capitalize(item.getDescription().getValue()) : "";
+        description += ((item.getLabel().getValue() != null && !item.getLabel().getValue().isEmpty())
+            ? ", (" + item.getLabel().getValue() + ")" : "");
         return new Place(
                 item.getLabel().getValue(),
                 Label.fromText(classEntityId), // list
-                item.getClassLabel().getValue(), // details
+                description, // description and label of Wikidata item
                 PlaceUtils.latLngFromPointString(item.getLocation().getValue()),
                 item.getCommonsCategory().getValue(),
                 new Sitelinks.Builder()

--- a/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
@@ -60,20 +60,21 @@ public class Place implements Parcelable {
         if(!StringUtils.isBlank(itemClass)) {
             classEntityId = itemClass.replace("http://www.wikidata.org/entity/", "");
         }
-        // Capitalize first letter of description when not null and not empty
-        String description = (item.getDescription().getValue() != null && !item.getDescription().getValue().isEmpty())
-            ? StringUtils.capitalize(item.getDescription().getValue()) : "";
+        // Set description when not null and not empty
+        String description = (item.getDescription().getValue() != null && !item.getDescription().getValue().isEmpty()) ? item.getDescription().getValue() : "";
         // When description is "?" but we have a valid label, just use the label. So replace "?" by "" in description
         description = (description.equals("?")
             && (item.getLabel().getValue() != null
             && !item.getLabel().getValue().isEmpty()) ? "" : description);
         /** If we have a valid label
-         *     - If have a valid description add the label at the end of the string with parenthesis
-         *     - If we don't have a valid description, string will include only the label. So add it without paranthesis
+         *     - If have a valid label add the description at the end of the string with parenthesis
+         *     - If we don't have a valid label, string will include only the description. So add it without paranthesis
          */
-        description += ((item.getLabel().getValue() != null && !item.getLabel().getValue().isEmpty())
-            ? ((description != null && !description.isEmpty())
-                ? ", (" + item.getLabel().getValue() + ")" : item.getLabel().getValue()) : "");
+        description = ((item.getLabel().getValue() != null && !item.getLabel().getValue().isEmpty())
+            ? item.getLabel().getValue()
+                + ((description != null && !description.isEmpty())
+                ? " (" + item.getLabel().getValue() + ")" : "")
+            : "" + description);
         return new Place(
                 item.getLabel().getValue(),
                 Label.fromText(classEntityId), // list

--- a/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
@@ -66,7 +66,8 @@ public class Place implements Parcelable {
         description = (description.equals("?")
             && (item.getLabel().getValue() != null
             && !item.getLabel().getValue().isEmpty()) ? "" : description);
-        /** If we have a valid label
+        /*
+         * If we have a valid label
          *     - If have a valid label add the description at the end of the string with parenthesis
          *     - If we don't have a valid label, string will include only the description. So add it without paranthesis
          */

--- a/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
@@ -73,8 +73,8 @@ public class Place implements Parcelable {
         description = ((item.getLabel().getValue() != null && !item.getLabel().getValue().isEmpty())
             ? item.getLabel().getValue()
                 + ((description != null && !description.isEmpty())
-                ? " (" + item.getLabel().getValue() + ")" : "")
-            : "" + description);
+                ? " (" + description + ")" : "")
+            : description);
         return new Place(
                 item.getLabel().getValue(),
                 Label.fromText(classEntityId), // list

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceAdapterDelegate.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceAdapterDelegate.kt
@@ -51,7 +51,7 @@ fun placeAdapterDelegate(
                 tvDesc.setText(R.string.no_description_found)
                 tvDesc.visibility = INVISIBLE
             } else {
-                tvDesc.text = descriptionText
+                tvDesc.text = descriptionText.replace("\\(.*?\\)","");
             }
             distance.text = item.distance
             icon.setImageResource(item.label.icon)

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceAdapterDelegate.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceAdapterDelegate.kt
@@ -51,8 +51,8 @@ fun placeAdapterDelegate(
                 tvDesc.setText(R.string.no_description_found)
                 tvDesc.visibility = INVISIBLE
             } else {
-                // Remove the last texts inside pharentheses since too long
-                tvDesc.text = descriptionText.replace("\\(.*?\\)$".toRegex(),"");
+                // Remove the label and display only texts inside pharentheses (description) since too long
+                tvDesc.text = descriptionText.substringAfter(tvName.text.toString()+" (").substringBeforeLast(")");
             }
             distance.text = item.distance
             icon.setImageResource(item.label.icon)

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceAdapterDelegate.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceAdapterDelegate.kt
@@ -51,7 +51,8 @@ fun placeAdapterDelegate(
                 tvDesc.setText(R.string.no_description_found)
                 tvDesc.visibility = INVISIBLE
             } else {
-                tvDesc.text = descriptionText.replace("\\(.*?\\)","");
+                // Remove the last texts inside pharentheses since too long
+                tvDesc.text = descriptionText.replace("\\(.*?\\)$".toRegex(),"");
             }
             distance.text = item.distance
             icon.setImageResource(item.label.icon)

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceAdapterDelegate.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceAdapterDelegate.kt
@@ -52,7 +52,7 @@ fun placeAdapterDelegate(
                 tvDesc.visibility = INVISIBLE
             } else {
                 // Remove the label and display only texts inside pharentheses (description) since too long
-                tvDesc.text = descriptionText.substringAfter(tvName.text.toString()+" (").substringBeforeLast(")");
+                tvDesc.text = descriptionText.substringAfter(tvName.text.toString() + " (").substringBeforeLast(")");
             }
             distance.text = item.distance
             icon.setImageResource(item.label.icon)

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1435,7 +1435,12 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
         title.setText(selectedPlace.name);
         distance.setText(selectedPlace.distance);
-        description.setText(selectedPlace.getLongDescription());
+        // Remove label since it is double information
+        String descriptionText = selectedPlace.getLongDescription()
+            .replace(selectedPlace.getName() + " (","");
+        descriptionText = (descriptionText.equals(selectedPlace.getLongDescription()) ? descriptionText : descriptionText.replaceFirst(".$",""));
+        // Set the short description after we remove place name from long description
+        description.setText(descriptionText);
 
         fabCamera.setOnClickListener(view -> {
             if (fabCamera.isShown()) {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/model/NearbyResultItem.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/model/NearbyResultItem.kt
@@ -11,7 +11,8 @@ class NearbyResultItem(private val item: ResultTuple?,
                        @field:SerializedName("classLabel") private val classLabel: ResultTuple?,
                        @field:SerializedName("commonsCategory") private val commonsCategory: ResultTuple?,
                        @field:SerializedName("pic") private val pic: ResultTuple?,
-                       @field:SerializedName("destroyed") private val destroyed: ResultTuple?) {
+                       @field:SerializedName("destroyed") private val destroyed: ResultTuple?,
+                       @field:SerializedName("description") private val description: ResultTuple?) {
 
     fun getItem(): ResultTuple {
         return item ?: ResultTuple()
@@ -55,6 +56,10 @@ class NearbyResultItem(private val item: ResultTuple?,
 
     fun getDestroyed(): ResultTuple {
         return destroyed ?: ResultTuple()
+    }
+
+    fun getDescription(): ResultTuple {
+        return description ?: ResultTuple()
     }
 
 }

--- a/app/src/main/resources/queries/nearby_query.rq
+++ b/app/src/main/resources/queries/nearby_query.rq
@@ -2,6 +2,7 @@ SELECT
      (SAMPLE(?location) as ?location)
      ?item
      (SAMPLE(COALESCE(?itemLabelPreferredLanguage, ?itemLabelAnyLanguage)) as ?label)
+     (SAMPLE(COALESCE(?itemDescriptionPreferredLanguage, ?itemDescriptionAnyLanguage, "?")) as ?description)
      (SAMPLE(?classId) as ?class)
      (SAMPLE(COALESCE(?classLabelPreferredLanguage, ?classLabelAnyLanguage, "?")) as ?classLabel)
      (SAMPLE(COALESCE(?icon0, ?icon1)) as ?icon)
@@ -21,6 +22,10 @@ SELECT
      # Get the label in the preferred language of the user, or any other language if no label is available in that language.
      OPTIONAL {?item rdfs:label ?itemLabelPreferredLanguage. FILTER (lang(?itemLabelPreferredLanguage) = "${LANG}")}
      OPTIONAL {?item rdfs:label ?itemLabelAnyLanguage}
+
+     # Get the description in the preferred language of the user, or any other language if no description is available in that language.
+     OPTIONAL {?item schema:description ?itemDescriptionPreferredLanguage. FILTER (lang(?itemDescriptionPreferredLanguage) = "${LANG}")}
+     OPTIONAL {?item schema:description ?itemDescriptionAnyLanguage }
 
      # Get Commons category (P373)
      OPTIONAL { ?item wdt:P373 ?commonsCategory. }


### PR DESCRIPTION
**Description (required)**

Fixes #4147 

Previously we were using label of class do fill description of nearby item. This was semantically wrong so with these changes we uses description of the Wikidata item itself and label of the item if exists. First I had to edit nearby query to fetch description (if possible in users language, if not in any languages it is found) and then used it instead of longDescription which refers to the description of the label from previous implementation. 

- If a description and no label exists -> shows only description
- If a description and a label exists -> shows description and label in parenthesis
- If no description and a label exists -> shows label without parenthesis

**Tests performed (required)**

Tested betaDebug on Samsung Galaxy A50 with Android 10.

