### PR TITLE
Fixes #3389 [User Profiles] - Show user's profile when his name is clicked

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionBoundaryCallback.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionBoundaryCallback.kt
@@ -16,11 +16,11 @@ import javax.inject.Named
  */
 class ContributionBoundaryCallback @Inject constructor(
     private val repository: ContributionsRepository,
-    private val sessionManager: SessionManager,
     private val mediaClient: MediaClient,
     @param:Named(CommonsApplicationModule.IO_THREAD) private val ioThreadScheduler: Scheduler
 ) : BoundaryCallback<Contribution>() {
     private val compositeDisposable: CompositeDisposable = CompositeDisposable()
+    var userName: String?=null
 
     /**
      * It is triggered when the list has no items User's Contributions are then fetched from the
@@ -50,9 +50,8 @@ class ContributionBoundaryCallback @Inject constructor(
      * Fetches contributions using the MediaWiki API
      */
     fun fetchContributions() {
-        if (sessionManager.userName != null) {
             compositeDisposable.add(
-                mediaClient.getMediaListForUser(sessionManager.userName!!)
+                mediaClient.getMediaListForUser(userName!!)
                     .map { mediaList ->
                         mediaList.map {
                             Contribution(media = it, state = Contribution.STATE_COMPLETED)
@@ -66,7 +65,6 @@ class ContributionBoundaryCallback @Inject constructor(
                         )
                     }
             )
-        }
     }
 
     /**
@@ -80,5 +78,12 @@ class ContributionBoundaryCallback @Inject constructor(
                     repository["last_fetch_timestamp"] = System.currentTimeMillis()
                 }
         )
+    }
+
+    /**
+     * Clean up
+     */
+    fun dispose() {
+        compositeDisposable.dispose()
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionViewHolder.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionViewHolder.java
@@ -18,6 +18,7 @@ import com.facebook.imagepipeline.request.ImageRequestBuilder;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.contributions.ContributionsListAdapter.Callback;
 import fr.free.nrw.commons.media.MediaClient;
+import fr.free.nrw.commons.ui.widget.HtmlTextView;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
@@ -30,7 +31,7 @@ public class ContributionViewHolder extends RecyclerView.ViewHolder {
   @BindView(R.id.contributionTitle)
   TextView titleView;
   @BindView(R.id.authorView)
-  TextView authorView;
+  HtmlTextView authorView;
   @BindView(R.id.contributionState)
   TextView stateView;
   @BindView(R.id.contributionSequenceNumber)

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -33,15 +33,17 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
+import fr.free.nrw.commons.auth.SessionManager;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
+import fr.free.nrw.commons.profile.ProfileActivity;
 import fr.free.nrw.commons.utils.DialogUtil;
 import fr.free.nrw.commons.media.MediaClient;
 import fr.free.nrw.commons.utils.ViewUtil;
 import java.util.Locale;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.dataclient.WikiSite;
-import timber.log.Timber;
 
 /**
  * Created by root on 01.06.2018.
@@ -80,6 +82,9 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment impl
   @Inject
   ContributionsListPresenter contributionsListPresenter;
 
+  @Inject
+  SessionManager sessionManager;
+
   private Animation fab_close;
   private Animation fab_open;
   private Animation rotate_forward;
@@ -95,6 +100,21 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment impl
   private final int SPAN_COUNT_LANDSCAPE = 3;
   private final int SPAN_COUNT_PORTRAIT = 1;
 
+  String userName;
+
+  @Override
+  public void onCreate(@Nullable final Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    //Now that we are allowing this fragment to be started for
+    // any userName- we expect it to be passed as an argument
+    if (getArguments() != null) {
+      userName = getArguments().getString(ProfileActivity.KEY_USERNAME);
+    }
+
+    if (StringUtils.isEmpty(userName)) {
+      userName = sessionManager.getUserName();
+    }
+  }
 
   @Override
   public View onCreateView(
@@ -144,8 +164,8 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment impl
       ((SimpleItemAnimator) animator).setSupportsChangeAnimations(false);
     }
 
-    contributionsListPresenter.setup();
-    contributionsListPresenter.contributionList.observe(this.getViewLifecycleOwner(), adapter::submitList);
+    contributionsListPresenter.setup(userName, sessionManager.getUserName().equals(userName));
+    contributionsListPresenter.contributionList.observe(getViewLifecycleOwner(), adapter::submitList);
     rvContributionsList.setAdapter(adapter);
     adapter.registerAdapterDataObserver(new AdapterDataObserver() {
       @Override

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsRemoteDataSource.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsRemoteDataSource.kt
@@ -1,0 +1,73 @@
+package fr.free.nrw.commons.contributions
+
+import androidx.paging.ItemKeyedDataSource
+import fr.free.nrw.commons.di.CommonsApplicationModule
+import fr.free.nrw.commons.media.MediaClient
+import io.reactivex.Scheduler
+import io.reactivex.disposables.CompositeDisposable
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Named
+
+/**
+ * Data-Source which acts as mediator for contributions-data from the API
+ */
+class ContributionsRemoteDataSource @Inject constructor(
+    private val mediaClient: MediaClient,
+    @param:Named(CommonsApplicationModule.IO_THREAD) private val ioThreadScheduler: Scheduler
+) : ItemKeyedDataSource<Int, Contribution>() {
+    private val compositeDisposable: CompositeDisposable = CompositeDisposable()
+    var userName: String? = null
+
+    override fun loadInitial(
+        params: LoadInitialParams<Int>,
+        callback: LoadInitialCallback<Contribution>
+    ) {
+        fetchContributions(callback)
+    }
+
+    override fun loadAfter(
+        params: LoadParams<Int>,
+        callback: LoadCallback<Contribution>
+    ) {
+        fetchContributions(callback)
+    }
+
+    override fun loadBefore(
+        params: LoadParams<Int>,
+        callback: LoadCallback<Contribution>
+    ) {
+    }
+
+    override fun getKey(item: Contribution): Int {
+        return item.pageId.hashCode()
+    }
+
+
+    /**
+     * Fetches contributions using the MediaWiki API
+     */
+    private fun fetchContributions(callback: LoadCallback<Contribution>) {
+        compositeDisposable.add(
+            mediaClient.getMediaListForUser(userName!!)
+                .map { mediaList ->
+                    mediaList.map {
+                        Contribution(media = it, state = Contribution.STATE_COMPLETED)
+                    }
+                }
+                .subscribeOn(ioThreadScheduler)
+                .subscribe({
+                    callback.onResult(it)
+                }) { error: Throwable ->
+                    Timber.e(
+                        "Failed to fetch contributions: %s",
+                        error.message
+                    )
+                }
+        )
+    }
+
+    fun dispose() {
+        compositeDisposable.dispose()
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/explore/media/PageableMediaFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/media/PageableMediaFragment.kt
@@ -8,13 +8,14 @@ import fr.free.nrw.commons.R
 import fr.free.nrw.commons.category.CategoryImagesCallback
 import fr.free.nrw.commons.explore.paging.BasePagingFragment
 import fr.free.nrw.commons.media.MediaDetailPagerFragment.MediaDetailProvider
+import fr.free.nrw.commons.profile.ProfileActivity
 import kotlinx.android.synthetic.main.fragment_search_paginated.*
 
 
 abstract class PageableMediaFragment : BasePagingFragment<Media>(), MediaDetailProvider {
 
     override val pagedListAdapter by lazy {
-        PagedMediaAdapter(categoryImagesCallback::onMediaClicked)
+        PagedMediaAdapter({ categoryImagesCallback.onMediaClicked(it) })
     }
 
     override val errorTextId: Int = R.string.error_loading_images

--- a/app/src/main/java/fr/free/nrw/commons/explore/media/PagedMediaAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/media/PagedMediaAdapter.kt
@@ -8,9 +8,11 @@ import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.explore.paging.BaseViewHolder
 import fr.free.nrw.commons.explore.paging.inflate
+import fr.free.nrw.commons.profile.ProfileActivity
 import kotlinx.android.synthetic.main.layout_category_images.*
 
-class PagedMediaAdapter(private val onImageClicked: (Int) -> Unit) :
+class PagedMediaAdapter(
+    private val onImageClicked: (Int) -> Unit) :
     PagedListAdapter<Media, SearchImagesViewHolder>(object : DiffUtil.ItemCallback<Media>() {
         override fun areItemsTheSame(oldItem: Media, newItem: Media) =
             oldItem.pageId == newItem.pageId

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -16,11 +16,8 @@ import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
-import android.util.Log;
-import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.view.View.OnKeyListener;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
@@ -64,10 +61,11 @@ import fr.free.nrw.commons.category.CategoryEditSearchRecyclerViewAdapter.Callba
 import fr.free.nrw.commons.contributions.ContributionsFragment;
 import fr.free.nrw.commons.delete.DeleteHelper;
 import fr.free.nrw.commons.delete.ReasonBuilder;
-import fr.free.nrw.commons.explore.depictions.WikidataItemDetailsActivity;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
+import fr.free.nrw.commons.explore.depictions.WikidataItemDetailsActivity;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.nearby.Label;
+import fr.free.nrw.commons.profile.ProfileActivity;
 import fr.free.nrw.commons.ui.widget.HtmlTextView;
 import fr.free.nrw.commons.utils.ViewUtilWrapper;
 import io.reactivex.Single;
@@ -77,8 +75,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.TimeUnit;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.commons.lang3.StringUtils;
@@ -999,5 +997,15 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             rebuildCatList(categories);
             return true;
         }
+    }
+
+
+    @OnClick(R.id.mediaDetailAuthor)
+    public void onAuthorViewClicked(){
+        if(media==null || media.getUser()==null){
+            return;
+        }
+
+        ProfileActivity.startYourself(getActivity(), media.getUser(), true);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -31,6 +31,7 @@ import fr.free.nrw.commons.contributions.Contribution;
 import fr.free.nrw.commons.contributions.MainActivity;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient;
+import fr.free.nrw.commons.profile.ProfileActivity;
 import fr.free.nrw.commons.theme.BaseActivity;
 import fr.free.nrw.commons.utils.DownloadUtils;
 import fr.free.nrw.commons.utils.ImageUtils;
@@ -196,6 +197,11 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                 // Set avatar
                 setAvatar(m);
                 return true;
+            case R.id.menu_view_user_page:
+                if (m != null && m.getUser() != null) {
+                    ProfileActivity.startYourself(getActivity(), m.getUser(),
+                        !sessionManager.getUserName().equals(m.getUser()));
+                }
             default:
                 return super.onOptionsItemSelected(item);
         }
@@ -253,6 +259,9 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                     menu.findItem(R.id.menu_download_current_image).setEnabled(true).setVisible(true);
                     menu.findItem(R.id.menu_bookmark_current_image).setEnabled(true).setVisible(true);
                     menu.findItem(R.id.menu_set_as_wallpaper).setEnabled(true).setVisible(true);
+                    if (m.getUser() != null) {
+                        menu.findItem(R.id.menu_view_user_page).setEnabled(true).setVisible(true);
+                    }
 
                     // Initialize bookmark object
                     bookmark = new Bookmark(

--- a/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetFragment.java
@@ -74,11 +74,16 @@ public class MoreBottomSheetFragment extends BottomSheetDialogFragment {
      * Set the username in navigationHeader.
      */
     private void setUserName() {
+        moreProfile.setText(getUserName());
+    }
+
+    private String getUserName(){
         AccountManager accountManager = AccountManager.get(getActivity());
         Account[] allAccounts = accountManager.getAccountsByType(BuildConfig.ACCOUNT_TYPE);
         if (allAccounts.length != 0) {
-            moreProfile.setText(allAccounts[0].name);
+            return allAccounts[0].name;
         }
+        return "";
     }
 
     @OnClick(R.id.more_logout)
@@ -136,9 +141,7 @@ public class MoreBottomSheetFragment extends BottomSheetDialogFragment {
 
     @OnClick(R.id.more_profile)
     public void onProfileClicked() {
-        final Intent intent = new Intent(getActivity(), ProfileActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        getActivity().startActivity(intent);
+        ProfileActivity.startYourself(getActivity(), getUserName(), false);
     }
 
     @OnClick(R.id.more_peer_review)

--- a/app/src/main/java/fr/free/nrw/commons/profile/ProfileActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/ProfileActivity.java
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.profile;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.viewpager.widget.ViewPager;
@@ -11,6 +12,7 @@ import butterknife.ButterKnife;
 import com.google.android.material.tabs.TabLayout;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.ViewPagerAdapter;
+import fr.free.nrw.commons.contributions.ContributionsListFragment;
 import fr.free.nrw.commons.profile.achievements.AchievementsFragment;
 import fr.free.nrw.commons.profile.leaderboard.LeaderboardFragment;
 import fr.free.nrw.commons.theme.BaseActivity;
@@ -35,12 +37,30 @@ public class ProfileActivity extends BaseActivity {
     private AchievementsFragment achievementsFragment;
     private LeaderboardFragment leaderboardFragment;
 
+    public static final String KEY_USERNAME ="username";
+    public static final String KEY_SHOULD_SHOW_CONTRIBUTIONS ="shouldShowContributions";
+
+    String userName;
+    private boolean  shouldShowContributions;
+
+    @Override
+    protected void onRestoreInstanceState(final Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+        if(savedInstanceState!=null){
+            userName = savedInstanceState.getString(KEY_USERNAME);
+            shouldShowContributions = savedInstanceState.getBoolean(KEY_SHOULD_SHOW_CONTRIBUTIONS);
+        }
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_profile);
         ButterKnife.bind(this);
         setTitle(R.string.Profile);
+
+        userName = getIntent().getStringExtra(KEY_USERNAME);
+        shouldShowContributions = getIntent().getBooleanExtra(KEY_SHOULD_SHOW_CONTRIBUTIONS, false);
 
         supportFragmentManager = getSupportFragmentManager();
         viewPagerAdapter = new ViewPagerAdapter(getSupportFragmentManager());
@@ -53,9 +73,11 @@ public class ProfileActivity extends BaseActivity {
      * Creates a way to change current activity to AchievementActivity
      * @param context
      */
-    public static void startYourself(Context context) {
+    public static void startYourself(Context context, String userName, boolean shouldShowContributions) {
         Intent intent = new Intent(context, ProfileActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        intent.putExtra(KEY_USERNAME, userName);
+        intent.putExtra(KEY_SHOULD_SHOW_CONTRIBUTIONS, shouldShowContributions);
         context.startActivity(intent);
     }
 
@@ -65,12 +87,31 @@ public class ProfileActivity extends BaseActivity {
     private void setTabs() {
         List<Fragment> fragmentList = new ArrayList<>();
         List<String> titleList = new ArrayList<>();
+
         achievementsFragment = new AchievementsFragment();
+        Bundle achievementsBundle=new Bundle();
+        achievementsBundle.putString(KEY_USERNAME, userName);
+        achievementsFragment.setArguments(achievementsBundle);
         fragmentList.add(achievementsFragment);
+
         titleList.add(getResources().getString(R.string.achievements_tab_title).toUpperCase());
         leaderboardFragment = new LeaderboardFragment();
+        Bundle leaderBoardBundle = new Bundle();
+        leaderBoardBundle.putString(KEY_USERNAME, userName);
+        leaderboardFragment.setArguments(leaderBoardBundle);
+
         fragmentList.add(leaderboardFragment);
         titleList.add(getResources().getString(R.string.leaderboard_tab_title).toUpperCase());
+
+        if (shouldShowContributions) {
+            ContributionsListFragment contributionsListFragment = new ContributionsListFragment();
+            Bundle contributionsListBundle = new Bundle();
+            contributionsListBundle.putString(KEY_USERNAME, userName);
+            contributionsListFragment.setArguments(contributionsListBundle);
+            fragmentList.add(contributionsListFragment);
+            titleList.add(getString(R.string.contributions_fragment).toUpperCase());
+        }
+
         viewPagerAdapter.setTabData(fragmentList, titleList);
         viewPagerAdapter.notifyDataSetChanged();
 
@@ -81,4 +122,9 @@ public class ProfileActivity extends BaseActivity {
         compositeDisposable.clear();
     }
 
+    @Override
+    protected void onSaveInstanceState(@NonNull final Bundle outState) {
+        outState.putString(KEY_USERNAME, userName);
+        super.onSaveInstanceState(outState);
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -19,12 +19,14 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+import androidx.annotation.Nullable;
 import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.core.content.FileProvider;
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 
 import com.dinuscxj.progressbar.CircleProgressBar;
+import fr.free.nrw.commons.profile.ProfileActivity;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
@@ -139,6 +141,16 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
 
     // menu item for action bar
     private MenuItem item;
+
+    private String userName;
+
+    @Override
+    public void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            userName = getArguments().getString(ProfileActivity.KEY_USERNAME);
+        }
+    }
 
     /**
      * This method helps in the creation Achievement screen and
@@ -262,7 +274,7 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
             try{
 
                 compositeDisposable.add(okHttpJsonApiClient
-                        .getAchievements(Objects.requireNonNull(sessionManager.getCurrentAccount()).name)
+                        .getAchievements(Objects.requireNonNull(userName))
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(
@@ -305,7 +317,6 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
      *  in the form of JavaRx Single object<JSONobject>
      */
     private void setWikidataEditCount() {
-        String userName = sessionManager.getUserName();
         if (StringUtils.isBlank(userName)) {
             return;
         }
@@ -354,7 +365,7 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
     private void setUploadCount(Achievements achievements) {
         if (checkAccount()) {
             compositeDisposable.add(okHttpJsonApiClient
-                    .getUploadCount(Objects.requireNonNull(sessionManager.getCurrentAccount()).name)
+                    .getUploadCount(Objects.requireNonNull(userName))
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(
@@ -394,10 +405,14 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
     }
 
     private void setZeroAchievements() {
-        AlertDialog.Builder builder=new AlertDialog.Builder(getActivity())
-                .setMessage(getString(R.string.no_achievements_yet))
-                .setPositiveButton(getString(R.string.ok), (dialog, which) -> {
-                });
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
+            .setMessage(
+                !userName.equals(sessionManager.getUserName()) ?
+                    getString(R.string.no_achievements_yet, userName) :
+                    getString(R.string.you_have_no_achievements_yet)
+            )
+            .setPositiveButton(getString(R.string.ok), (dialog, which) -> {
+            });
         AlertDialog dialog = builder.create();
         dialog.show();
         imagesUploadedProgressbar.setVisibility(View.INVISIBLE);

--- a/app/src/main/java/fr/free/nrw/commons/profile/leaderboard/LeaderboardFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/leaderboard/LeaderboardFragment.java
@@ -17,6 +17,7 @@ import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.Spinner;
 import android.widget.Toast;
+import androidx.annotation.Nullable;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.MergeAdapter;
@@ -27,6 +28,7 @@ import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.auth.SessionManager;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient;
+import fr.free.nrw.commons.profile.ProfileActivity;
 import fr.free.nrw.commons.utils.ViewUtil;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
@@ -103,6 +105,16 @@ public class LeaderboardFragment extends CommonsDaggerSupportFragment {
      * This variable represents if user wants to scroll to his rank or not
      */
     private boolean scrollToRank;
+
+    private String userName;
+
+    @Override
+    public void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            userName = getArguments().getString(ProfileActivity.KEY_USERNAME);
+        }
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -220,7 +232,7 @@ public class LeaderboardFragment extends CommonsDaggerSupportFragment {
         if (checkAccount()) {
             try {
                 compositeDisposable.add(okHttpJsonApiClient
-                    .getLeaderboard(Objects.requireNonNull(sessionManager.getCurrentAccount()).name,
+                    .getLeaderboard(Objects.requireNonNull(userName),
                         duration, category, null, null)
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/fr/free/nrw/commons/profile/leaderboard/LeaderboardListAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/leaderboard/LeaderboardListAdapter.java
@@ -1,7 +1,6 @@
 package fr.free.nrw.commons.profile.leaderboard;
 
-import static fr.free.nrw.commons.profile.leaderboard.LeaderboardConstants.USER_LINK_PREFIX;
-
+import android.app.Activity;
 import android.content.Context;
 import android.net.Uri;
 import android.view.LayoutInflater;
@@ -13,7 +12,7 @@ import androidx.paging.PagedListAdapter;
 import androidx.recyclerview.widget.RecyclerView;
 import com.facebook.drawee.view.SimpleDraweeView;
 import fr.free.nrw.commons.R;
-import fr.free.nrw.commons.Utils;
+import fr.free.nrw.commons.profile.ProfileActivity;
 
 /**
  * This class extends RecyclerView.Adapter and creates the List section of the leaderboard
@@ -74,16 +73,22 @@ public class LeaderboardListAdapter extends PagedListAdapter<LeaderboardList, Le
         TextView username = holder.username;
         TextView count = holder.count;
 
-        rank.setText(getItem(position).getRank().toString());
+        LeaderboardList leaderboardList = getItem(position);
 
-        avatar.setImageURI(Uri.parse(getItem(position).getAvatar()));
-        username.setText(getItem(position).getUsername());
-        count.setText(getItem(position).getCategoryCount().toString());
+        rank.setText(leaderboardList.getRank().toString());
+
+        avatar.setImageURI(Uri.parse(leaderboardList.getAvatar()));
+        username.setText(leaderboardList.getUsername());
+        count.setText(leaderboardList.getCategoryCount().toString());
 
         /*
-          Open the user profile in a webview when a username is clicked on leaderboard
+          Now that we have our in app profile-section, lets take the user there
          */
-        holder.itemView.setOnClickListener(view -> Utils.handleWebUrl(holder.getContext(), Uri.parse(
-            String.format("%s%s", USER_LINK_PREFIX, getItem(position).getUsername()))));
+        holder.itemView.setOnClickListener(view -> {
+            if (view.getContext() instanceof ProfileActivity) {
+                ((Activity) (view.getContext())).finish();
+            }
+            ProfileActivity.startYourself(view.getContext(), leaderboardList.getUsername(), true);
+        });
     }
 }

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -15,8 +15,6 @@
           android:layout_height="wrap_content"
           android:background="?attr/mainBackground">
 
-            <include layout="@layout/toolbar"/>
-
             <com.google.android.material.tabs.TabLayout
               android:id="@+id/tab_layout"
               android:layout_width="match_parent"

--- a/app/src/main/res/layout/layout_contribution.xml
+++ b/app/src/main/res/layout/layout_contribution.xml
@@ -80,7 +80,7 @@
           android:scaleType="centerInside"
           app:srcCompat="@drawable/ic_baseline_person_14"/>
 
-        <TextView
+        <fr.free.nrw.commons.ui.widget.HtmlTextView
           android:id="@+id/authorView"
           android:textStyle="normal"
           android:textSize="14sp"

--- a/app/src/main/res/menu/fragment_image_detail.xml
+++ b/app/src/main/res/menu/fragment_image_detail.xml
@@ -29,5 +29,9 @@
       android:id="@+id/menu_set_as_avatar"
       android:title="@string/menu_set_avatar"
       app:showAsAction="never" />
+    <item
+      android:id="@+id/menu_view_user_page"
+      android:title="@string/view_user_page"
+      app:showAsAction="never" />
 
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -512,7 +512,8 @@ Upload your first media by tapping on the add button.</string>
   <string name="category_edit_button_text">Update categories</string>
 
   <string name="share_image_via">Share image via</string>
-  <string name="no_achievements_yet">You haven\'t made any contributions yet</string>
+  <string name="you_have_no_achievements_yet">You haven\'t made any contributions yet</string>
+  <string name="no_achievements_yet">%s has not made any contributions yet</string>
   <string name="account_created">Account created!</string>
   <string name="text_copy">Text copied to clipboard</string>
   <string name="notification_mark_read">Notification marked as read</string>
@@ -611,5 +612,6 @@ Upload your first media by tapping on the add button.</string>
   <string name="menu_view_category_page">View category page</string>
   <string name="menu_view_item_page">View item page</string>
   <string name="read_help_link">Read more</string>
+  <string name="view_user_page">View user page</string>
 
 </resources>


### PR DESCRIPTION
**Description (required)**![image](https://user-images.githubusercontent.com/17375274/116788539-c7aab780-aac7-11eb-8f85-fe4d9d24483b.png)![image](https://user-images.githubusercontent.com/17375274/116788553-e1e49580-aac7-11eb-8005-dc618772e7a9.png)Fixes #3389 ![image](https://user-images.githubusercontent.com/17375274/116788557-ea3cd080-aac7-11eb-9511-0163942c5dac.png)![image](https://user-images.githubusercontent.com/17375274/116788563-f45ecf00-aac7-11eb-8422-44245735bce5.png)What changes did you make and why?![image](https://user-images.githubusercontent.com/17375274/116788573-03458180-aac8-11eb-9eac-254934a5ce15.png)- Profile Activity, AchievementsFragment, ContributionsFragment & LeaderboardFragment  accept username instead of using the default account![image](https://user-images.githubusercontent.com/17375274/116788585-15272480-aac8-11eb-9b37-27c911602cab.png)- Added RemoteDataSource for contributions that do not persist contributions![image](https://user-images.githubusercontent.com/17375274/116788594-21ab7d00-aac8-11eb-95fc-e580e0cad67f.png)- On Clicks on AuthorNames in 1. MediaDetails, Menu-Options in MediaDetails & Leaderboard list takes to the profile of that user with the corresponding Achievements, Leaderboard and ContributionsList

**Tests performed (required)**

Tested betaDebug/prodDebug on API 29

**Screenshots (for UI changes only)**


---![image](https://user-images.githubusercontent.com/17375274/116788539-c7aab780-aac7-11eb-8f85-fe4d9d24483b.png)

![image](https://user-images.githubusercontent.com/17375274/116788585-15272480-aac8-11eb-9b37-27c911602cab.png)


