### PR TITLE
Fixes #4385 - App crash On categoryDetail activity when click on image after orientation change

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -111,11 +111,13 @@
         <activity
             android:name=".category.CategoryDetailsActivity"
             android:label="@string/title_activity_featured_images"
+            android:configChanges="screenSize|keyboard|orientation"
             android:parentActivityName=".contributions.MainActivity" />
 
         <activity
             android:name=".explore.depictions.WikidataItemDetailsActivity"
             android:label="@string/title_activity_featured_images"
+            android:configChanges="screenSize|keyboard|orientation"
             android:parentActivityName=".contributions.MainActivity" />
 
         <activity

--- a/app/src/main/java/fr/free/nrw/commons/explore/paging/BasePagingFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/paging/BasePagingFragment.kt
@@ -48,6 +48,9 @@ abstract class BasePagingFragment<T> : CommonsDaggerSupportFragment(),
         )
     }
 
+    /**
+     * Called on configuration change, update the spanCount according to the orientation state.
+     */
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         paginatedSearchResultsList.apply {

--- a/app/src/main/java/fr/free/nrw/commons/explore/paging/BasePagingFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/paging/BasePagingFragment.kt
@@ -48,6 +48,13 @@ abstract class BasePagingFragment<T> : CommonsDaggerSupportFragment(),
         )
     }
 
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        paginatedSearchResultsList.apply {
+            layoutManager = GridLayoutManager(context, if (isPortrait) 1 else 2)
+        }
+    }
+
     override fun observePagingResults(searchResults: LiveData<PagedList<T>>) {
         this.searchResults?.removeObservers(viewLifecycleOwner)
         this.searchResults = searchResults


### PR DESCRIPTION
**Description (required)**

Fixes #4385 

What changes did you make and why?

Added `android:configChanges="screenSize|keyboard|orientation"` attribute in AndroidManifest.xml to avoid restarting on configuration change.

**Tests performed (required)**

Tested prodDebug on Pixel 3 with API level 29.