### PR TITLE
Fixes #3380 - "Nearby Place found" despite already Nearby upload

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadItem.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadItem.java
@@ -18,7 +18,7 @@ public class UploadItem {
   private final String mimeType;
   private ImageCoordinates gpsCoords;
   private List<UploadMediaDetail> uploadMediaDetails;
-  private final Place place;
+  private Place place;
   private final long createdTimestamp;
   private final String createdTimestampSource;
   private final BehaviorSubject<Integer> imageQuality;
@@ -68,6 +68,10 @@ public class UploadItem {
 
   public void setImageQuality(final int imageQuality) {
     this.imageQuality.onNext(imageQuality);
+  }
+
+  public void setPlace(Place place) {
+    this.place = place;
   }
 
   public Place getPlace() {

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadItem.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadItem.java
@@ -70,6 +70,10 @@ public class UploadItem {
     this.imageQuality.onNext(imageQuality);
   }
 
+  /**
+   * Sets the corresponding place to the uploadItem
+   * @param place geolocated Wikidata item
+   */
   public void setPlace(Place place) {
     this.place = place;
   }

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -92,7 +92,7 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
                           gpsCoords != null && gpsCoords.getImageCoordsExists();
                         view.showMapWithImageCoordinates(hasImageCoordinates);
                         view.showProgress(false);
-                        if (hasImageCoordinates) {
+                        if (hasImageCoordinates && place == null) {
                             checkNearbyPlaces(uploadItem);
                         }
                     },
@@ -194,6 +194,9 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
     final List<UploadMediaDetail> uploadMediaDetails = repository.getUploads()
         .get(uploadItemPosition)
         .getUploadMediaDetails();
+    UploadItem uploadItem = repository.getUploads()
+        .get(uploadItemPosition);
+    uploadItem.setPlace(place);
     uploadMediaDetails.set(0, new UploadMediaDetail(place));
     view.updateMediaDetails(uploadMediaDetails);
   }


### PR DESCRIPTION
**Description (required)**

Fixes #3380 

What changes did you make and why?

Added a condition -> if the place is not null, then don't search for nearbyPlaces
Also if the user confirms a nearby found place then update the place property in uploadItem.

**Tests performed (required)**

Tested betaDebug on Motorola One Fusion + with API level 29.