### PR TITLE
UploadMediaDetail: replace discreet error toast with more-noticeable dialog

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -365,6 +365,14 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
         //If the error message is null, we will probably not show anything
     }
 
+    @Override
+    public void showConnectionErrorPopup() {
+        DialogUtil.showAlertDialog(getActivity(),
+            getString(R.string.upload_connection_error_alert_title),
+            getString(R.string.upload_connection_error_alert_detail), getString(R.string.ok),
+            () -> {}, true);
+    }
+
     @Override public void showMapWithImageCoordinates(boolean shouldShow) {
         ibMap.setVisibility(shouldShow ? View.VISIBLE : View.GONE);
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailsContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailsContract.java
@@ -32,6 +32,8 @@ public interface UploadMediaDetailsContract {
 
         void showBadImagePopup(Integer errorCode, UploadItem uploadItem);
 
+        void showConnectionErrorPopup();
+
         void showMapWithImageCoordinates(boolean shouldShow);
 
         void showExternalMap(UploadItem uploadItem);

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -23,6 +23,7 @@ import io.reactivex.Scheduler;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 import java.lang.reflect.Proxy;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
@@ -138,8 +139,12 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
                         },
                         throwable -> {
                             view.showProgress(false);
-                            view.showMessage("" + throwable.getLocalizedMessage(),
-                                    R.color.color_error);
+                            if (throwable instanceof UnknownHostException) {
+                              view.showConnectionErrorPopup();
+                            } else {
+                              view.showMessage("" + throwable.getLocalizedMessage(),
+                                  R.color.color_error);
+                            }
                             Timber.e(throwable, "Error occurred while handling image");
                         })
         );

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -227,6 +227,9 @@
   <string name="upload_problem_fbmd">Please only upload pictures that you have taken by yourself. Don\'t upload pictures that you have found on other people\'s Facebook accounts.</string>
   <string name="upload_problem_do_you_continue">Do you still want to upload this picture?</string>
 
+  <string name="upload_connection_error_alert_title">Connection Error</string>
+  <string name="upload_connection_error_alert_detail">The upload process requires active internet
+    access. Please check your network connection.</string>
 
   <string name="upload_problem_image">Problems found in image</string>
   <string name="internet_downloaded">Please only upload pictures that you have taken by yourself. Don\'t upload pictures that you have downloaded from the Internet.</string>


### PR DESCRIPTION
**Description (required)**

Fixes #4358

- Add new string resources for connection error dialog title and description
- Add new `showConnectionErrorPopup()` method to `UploadMediaDetailContract`
- Implement `showConnectionErrorPopup()` in `UploadMediaDetailFragment` to launch an alert dialog
- Call `showConnectionErrorPopup()` from `UploadMediaPresenter` when image quality verification fails with an `UnknownHostException`

**Tests performed (required)**

Tested betaDebug on Pixel 4 XL with API level 30.

**Screenshots (for UI changes only)**

![Screenshot_1622495244](https://user-images.githubusercontent.com/6891883/120242476-f0db7680-c232-11eb-8ba6-04e5eed7bb85.png)
