### PR TITLE
Fixes 4344 - Duplicate Uploads

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -322,7 +322,7 @@ public class MainActivity  extends BaseActivity
         } else {
             WorkManager.getInstance(getApplicationContext()).enqueueUniqueWork(
                 UploadWorker.class.getSimpleName(),
-                ExistingWorkPolicy.KEEP, OneTimeWorkRequest.from(UploadWorker.class));
+                ExistingWorkPolicy.APPEND_OR_REPLACE, OneTimeWorkRequest.from(UploadWorker.class));
 
             viewUtilWrapper
                 .showShortToast(getBaseContext(), getString(R.string.limited_connection_disabled));

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -289,7 +289,7 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
     public void makeUploadRequest() {
         WorkManager.getInstance(getApplicationContext()).enqueueUniqueWork(
             UploadWorker.class.getSimpleName(),
-            ExistingWorkPolicy.KEEP, OneTimeWorkRequest.from(UploadWorker.class));
+            ExistingWorkPolicy.APPEND_OR_REPLACE, OneTimeWorkRequest.from(UploadWorker.class));
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
@@ -7,6 +7,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.google.gson.Gson
 import com.mapbox.mapboxsdk.plugins.localization.BuildConfig
 import dagger.android.ContributesAndroidInjector
 import fr.free.nrw.commons.CommonsApplication
@@ -146,61 +147,51 @@ class UploadWorker(var appContext: Context, workerParams: WorkerParameters) :
             CommonsApplication.NOTIFICATION_CHANNEL_ID_ALL
         )!!
         withContext(Dispatchers.IO) {
-            //Doing this so that retry requests do not create new work requests and while a work is
-            // already running, all the requests should go through this, so kind of a queue
-            while (contributionDao.getContribution(statesToProcess)
-                    .blockingGet().isNotEmpty()
-            ) {
-                val queuedContributions = contributionDao.getContribution(statesToProcess)
-                    .blockingGet()
-                //Showing initial notification for the number of uploads being processed
+            val queuedContributions = contributionDao.getContribution(statesToProcess)
+                .blockingGet()
+            //Showing initial notification for the number of uploads being processed
 
-                processingUploads.setContentTitle(appContext.getString(R.string.starting_uploads))
-                processingUploads.setContentText(
-                    appContext.resources.getQuantityString(
-                        R.plurals.starting_multiple_uploads,
-                        queuedContributions.size,
-                        queuedContributions.size
-                    )
-                )
-                notificationManager?.notify(
-                    PROCESSING_UPLOADS_NOTIFICATION_TAG,
-                    PROCESSING_UPLOADS_NOTIFICATION_ID,
-                    processingUploads.build()
-                )
+            Timber.e("Queued Contributions: "+ queuedContributions.size)
 
-                queuedContributions.asFlow().map { contribution ->
-                    /**
-                     * If the limited connection mode is on, lets iterate through the queued
-                     * contributions
-                     * and set the state as STATE_QUEUED_LIMITED_CONNECTION_MODE ,
-                     * otherwise proceed with the upload
-                     */
-                    if(isLimitedConnectionModeEnabled()){
-                        if (contribution.state == Contribution.STATE_QUEUED) {
-                            contribution.state = Contribution.STATE_QUEUED_LIMITED_CONNECTION_MODE
-                            contributionDao.save(contribution)
-                        }
-                    } else {
-                        contribution.transferred = 0
-                        contribution.state = Contribution.STATE_IN_PROGRESS
+            processingUploads.setContentTitle(appContext.getString(R.string.starting_uploads))
+            processingUploads.setContentText(
+                appContext.resources.getQuantityString(
+                    R.plurals.starting_multiple_uploads,
+                    queuedContributions.size,
+                    queuedContributions.size
+                )
+            )
+            notificationManager?.notify(
+                PROCESSING_UPLOADS_NOTIFICATION_TAG,
+                PROCESSING_UPLOADS_NOTIFICATION_ID,
+                processingUploads.build()
+            )
+
+            queuedContributions.asFlow().map { contribution ->
+                /**
+                 * If the limited connection mode is on, lets iterate through the queued
+                 * contributions
+                 * and set the state as STATE_QUEUED_LIMITED_CONNECTION_MODE ,
+                 * otherwise proceed with the upload
+                 */
+                if (isLimitedConnectionModeEnabled()) {
+                    if (contribution.state == Contribution.STATE_QUEUED) {
+                        contribution.state = Contribution.STATE_QUEUED_LIMITED_CONNECTION_MODE
                         contributionDao.save(contribution)
-                        uploadContribution(contribution = contribution)
                     }
-                }.collect()
-
-                //Dismiss the global notification
-                notificationManager?.cancel(
-                    PROCESSING_UPLOADS_NOTIFICATION_TAG,
-                    PROCESSING_UPLOADS_NOTIFICATION_ID
-                )
-
-                //No need to keep looking if the limited connection mode is on,
-                //If the user toggles it, the work manager will be started again
-                if(isLimitedConnectionModeEnabled()){
-                    break;
+                } else {
+                    contribution.transferred = 0
+                    contribution.state = Contribution.STATE_IN_PROGRESS
+                    contributionDao.save(contribution)
+                    uploadContribution(contribution = contribution)
                 }
-            }
+            }.collect()
+
+            //Dismiss the global notification
+            notificationManager?.cancel(
+                PROCESSING_UPLOADS_NOTIFICATION_TAG,
+                PROCESSING_UPLOADS_NOTIFICATION_ID
+            )
         }
         //TODO make this smart, think of handling retries in the future
         return Result.success()


### PR DESCRIPTION
**Description (required)**
The app uploads multiple copies of the same image.
Fixes #4344 

What changes did you make and why?
Update the retention policy of the Work Manager to ExistingWorkPolicy.APPEND_OR_REPLACE- which would append the new work to the end of an existing one. This helps remove the while loop in UploadWorker which was meant to handle the cases where a new worker would be created for retries. The while loop seemed to have race conditions uploading duplicate entries.


**Tests performed (required)**

Tested betaDebug on API 27
