### PR TITLE
Fixes #3694 Pre-select places as depictions

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
+++ b/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
@@ -254,6 +254,10 @@ public class UploadRepository {
         return depictModel.searchAllEntities(query);
     }
 
+    public Observable<DepictedItem> getPlaceDepiction(final Place place) {
+        return depictModel.getPlaceDepiction(place);
+    }
+
     /**
      * Returns nearest place matching the passed latitude and longitude
      * @param decLatitude

--- a/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
+++ b/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
@@ -254,7 +254,11 @@ public class UploadRepository {
         return depictModel.searchAllEntities(query);
     }
 
-    public Observable<DepictedItem> getPlaceDepiction(final Place place) {
+    public Observable<DepictedItem> getPlaceDepiction() {
+        Place place = null;
+        if (getUploads().size() == 1) {
+            place = getUploadItem(0).getPlace();
+        }
         return depictModel.getPlaceDepiction(place);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
+++ b/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
@@ -19,8 +19,11 @@ import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -254,12 +257,21 @@ public class UploadRepository {
         return depictModel.searchAllEntities(query);
     }
 
-    public Observable<DepictedItem> getPlaceDepiction() {
-        Place place = null;
-        if (getUploads().size() == 1) {
-            place = getUploadItem(0).getPlace();
+    /**
+     * Gets the depiction for each unique {@link Place} associated with an {@link UploadItem}
+     * from {@link #getUploads()}
+     *
+     * @return a single that provides the depictions
+     */
+    public Single<List<DepictedItem>> getPlaceDepictions() {
+        final Set<Place> places = new HashSet<>();
+        for (final UploadItem item : getUploads()) {
+            final Place place = item.getPlace();
+            if (place != null) {
+                places.add(place);
+            }
         }
-        return depictModel.getPlaceDepiction(place);
+        return depictModel.getPlaceDepictions(new ArrayList<>(places));
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -376,6 +376,7 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
 
             depictsFragment = new DepictsFragment();
             depictsFragment.setCallback(this);
+            depictsFragment.setPlace(place);
 
             mediaLicenseFragment = new MediaLicenseFragment();
             mediaLicenseFragment.setCallback(this);

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -376,7 +376,6 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
 
             depictsFragment = new DepictsFragment();
             depictsFragment.setCallback(this);
-            depictsFragment.setPlace(place);
 
             mediaLicenseFragment = new MediaLicenseFragment();
             mediaLicenseFragment.setCallback(this);

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsContract.java
@@ -2,6 +2,7 @@ package fr.free.nrw.commons.upload.depicts;
 
 import androidx.lifecycle.LiveData;
 import fr.free.nrw.commons.BasePresenter;
+import fr.free.nrw.commons.nearby.Place;
 import fr.free.nrw.commons.upload.structure.depictions.DepictedItem;
 import java.util.List;
 
@@ -65,6 +66,15 @@ public interface DepictsContract {
          * from the depiction list
          */
         void verifyDepictions();
+
+        /**
+         * Listener for {@link Place} attachment, which may be called:
+         * 1) on Fragment attach, if the upload process is initiated from the Nearby map, or
+         * 2) upon confirmation of a Nearby place dialog
+         *
+         * @param place the place to be attached
+         */
+        void onNewPlace(Place place);
 
         LiveData<List<DepictedItem>> getDepictedItems();
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsContract.java
@@ -61,6 +61,11 @@ public interface DepictsContract {
         void searchForDepictions(String query);
 
         /**
+         * Selects an associated place (if any) as a depiction
+         */
+        void selectPlaceDepiction();
+
+        /**
          * Check if depictions were selected
          * from the depiction list
          */

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsContract.java
@@ -61,9 +61,9 @@ public interface DepictsContract {
         void searchForDepictions(String query);
 
         /**
-         * Selects an associated place (if any) as a depiction
+         * Selects all associated places (if any) as depictions
          */
-        void selectPlaceDepiction();
+        void selectPlaceDepictions();
 
         /**
          * Check if depictions were selected

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsContract.java
@@ -2,7 +2,6 @@ package fr.free.nrw.commons.upload.depicts;
 
 import androidx.lifecycle.LiveData;
 import fr.free.nrw.commons.BasePresenter;
-import fr.free.nrw.commons.nearby.Place;
 import fr.free.nrw.commons.upload.structure.depictions.DepictedItem;
 import java.util.List;
 
@@ -66,15 +65,6 @@ public interface DepictsContract {
          * from the depiction list
          */
         void verifyDepictions();
-
-        /**
-         * Listener for {@link Place} attachment, which may be called:
-         * 1) on Fragment attach, if the upload process is initiated from the Nearby map, or
-         * 2) upon confirmation of a Nearby place dialog
-         *
-         * @param place the place to be attached
-         */
-        void onNewPlace(Place place);
 
         LiveData<List<DepictedItem>> getDepictedItems();
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
@@ -105,7 +105,7 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
         super.onBecameVisible();
         // Select Place depiction as the fragment becomes visible to ensure that the most up to date
         // Place is used (i.e. if the user accepts a nearby place dialog)
-        presenter.selectPlaceDepiction();
+        presenter.selectPlaceDepictions();
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
@@ -10,6 +10,7 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.lifecycle.MutableLiveData;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
@@ -20,6 +21,7 @@ import com.google.android.material.textfield.TextInputLayout;
 import com.jakewharton.rxbinding2.view.RxView;
 import com.jakewharton.rxbinding2.widget.RxTextView;
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.nearby.Place;
 import fr.free.nrw.commons.upload.UploadBaseFragment;
 import fr.free.nrw.commons.upload.UploadModel;
 import fr.free.nrw.commons.upload.structure.depictions.DepictedItem;
@@ -56,6 +58,9 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
     DepictsContract.UserActionListener presenter;
     private UploadDepictsAdapter adapter;
     private Disposable subscribe;
+
+    private final MutableLiveData<Place> place = new MutableLiveData<>();
+
     @Nullable
     @Override
     public android.view.View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
@@ -84,6 +89,7 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
             }
         });
         presenter.onAttachView(this);
+        place.observe(getViewLifecycleOwner(), presenter::onNewPlace);
         initRecyclerView();
         addTextChangeListenerToSearchBox();
     }
@@ -156,6 +162,14 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
     @OnClick(R.id.depicts_previous)
     public void onPreviousButtonClicked() {
         callback.onPreviousButtonClicked(callback.getIndexInViewFlipper(this));
+    }
+
+    /**
+     * Sets the {@link Place} whose corresponding depiction will be pre-selected
+     * @param place
+     */
+    public void setPlace(final Place place) {
+        this.place.setValue(place);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
@@ -101,6 +101,14 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
     }
 
     @Override
+    protected void onBecameVisible() {
+        super.onBecameVisible();
+        // Select Place depiction as the fragment becomes visible to ensure that the most up to date
+        // Place is used (i.e. if the user accepts a nearby place dialog)
+        presenter.selectPlaceDepiction();
+    }
+
+    @Override
     public void goToNextScreen() {
         callback.onNextButtonClicked(callback.getIndexInViewFlipper(this));
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
@@ -154,6 +154,7 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
     @Override
     public void setDepictsList(List<DepictedItem> depictedItemList) {
         adapter.setItems(depictedItemList);
+        depictsRecyclerView.smoothScrollToPosition(0);
     }
 
     @OnClick(R.id.depicts_next)

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
@@ -10,7 +10,6 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.lifecycle.MutableLiveData;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
@@ -21,7 +20,6 @@ import com.google.android.material.textfield.TextInputLayout;
 import com.jakewharton.rxbinding2.view.RxView;
 import com.jakewharton.rxbinding2.widget.RxTextView;
 import fr.free.nrw.commons.R;
-import fr.free.nrw.commons.nearby.Place;
 import fr.free.nrw.commons.upload.UploadBaseFragment;
 import fr.free.nrw.commons.upload.UploadModel;
 import fr.free.nrw.commons.upload.structure.depictions.DepictedItem;
@@ -58,9 +56,6 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
     DepictsContract.UserActionListener presenter;
     private UploadDepictsAdapter adapter;
     private Disposable subscribe;
-
-    private final MutableLiveData<Place> place = new MutableLiveData<>();
-
     @Nullable
     @Override
     public android.view.View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
@@ -89,7 +84,6 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
             }
         });
         presenter.onAttachView(this);
-        place.observe(getViewLifecycleOwner(), presenter::onNewPlace);
         initRecyclerView();
         addTextChangeListenerToSearchBox();
     }
@@ -162,14 +156,6 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
     @OnClick(R.id.depicts_previous)
     public void onPreviousButtonClicked() {
         callback.onPreviousButtonClicked(callback.getIndexInViewFlipper(this));
-    }
-
-    /**
-     * Sets the {@link Place} whose corresponding depiction will be pre-selected
-     * @param place
-     */
-    public void setPlace(final Place place) {
-        this.place.setValue(place);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
@@ -85,29 +85,30 @@ class DepictsPresenter @Inject constructor(
     }
 
     /**
-     * Selects the depiction retrieved by the repository for an associated place as if it were
-     * clicked by the user
-     *
-     * Retrieves the [DepictedItem] from the repository and calls [onDepictItemClicked]
+     * Selects the place depictions retrieved by the repository
      */
-    override fun selectPlaceDepiction() {
-        compositeDisposable.add(repository.placeDepiction
+    override fun selectPlaceDepictions() {
+        compositeDisposable.add(repository.placeDepictions
             .subscribeOn(ioScheduler)
             .observeOn(mainThreadScheduler)
-            .subscribe { depictedItem ->
-                depictedItem.isSelected = true
-                selectNewDepiction(depictedItem)
-            }
+            .subscribe(::selectNewDepictions)
         )
     }
 
-    private fun selectNewDepiction(depictedItem: DepictedItem) {
-        repository.onDepictItemClicked(depictedItem)
+    /**
+     * Selects each [DepictedItem] in a given list as if they were clicked by the user by calling
+     * [onDepictItemClicked] for each depiction and adding the depictions to [depictedItems]
+     */
+    private fun selectNewDepictions(toSelect: List<DepictedItem>) {
+        toSelect.forEach {
+            it.isSelected = true
+            repository.onDepictItemClicked(it)
+        }
 
-        // Add the new selection to the list of depicted items so that the selection appears
+        // Add the new selections to the list of depicted items so that the selections appear
         // immediately (i.e. without any search term queries)
         depictedItems.value?.toMutableList()
-            ?.let { listOf(depictedItem) + it }
+            ?.let { toSelect + it }
             ?.distinctBy(DepictedItem::id)
             ?.let { depictedItems.value = it }
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
@@ -3,7 +3,6 @@ package fr.free.nrw.commons.upload.depicts
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import fr.free.nrw.commons.di.CommonsApplicationModule
-import fr.free.nrw.commons.nearby.Place
 import fr.free.nrw.commons.repository.UploadRepository
 import fr.free.nrw.commons.upload.structure.depictions.DepictedItem
 import fr.free.nrw.commons.wikidata.WikidataDisambiguationItems
@@ -60,6 +59,7 @@ class DepictsPresenter @Inject constructor(
                     }
                 )
         )
+        selectPlaceDepiction()
     }
 
     private fun searchResultsWithTerm(term: String): Flowable<Pair<List<DepictedItem>, String>> {
@@ -86,23 +86,20 @@ class DepictsPresenter @Inject constructor(
     }
 
     /**
-     * Auto-selects the depiction for a place as if it were clicked by the user when the fragment is
-     * made aware of an associated place
+     * Auto-selects the depiction retrieved by the repository for an associated place as if it were
+     * clicked by the user
      *
-     * Given a [Place], retrieves the corresponding [DepictedItem] from the repository and calls
-     * [onDepictItemClicked]
-     *
-     * @param place the place to be selected
+     * Retrieves the [DepictedItem] from the repository and calls [onDepictItemClicked]
      */
-    override fun onNewPlace(place: Place?) {
-        place?.let { it ->
-            repository.getPlaceDepiction(it)
-                .subscribeOn(ioScheduler)
-                .observeOn(mainThreadScheduler)
-                .subscribe { depictedItem ->
-                    onDepictItemClicked(depictedItem)
-                }
-        }
+    private fun selectPlaceDepiction() {
+        compositeDisposable.add(repository.placeDepiction
+            .subscribeOn(ioScheduler)
+            .observeOn(mainThreadScheduler)
+            .subscribe { depictedItem ->
+                depictedItem.isSelected = true
+                onDepictItemClicked(depictedItem)
+            }
+        )
     }
 
     override fun onPreviousButtonClicked() {

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.upload.depicts
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import fr.free.nrw.commons.di.CommonsApplicationModule
+import fr.free.nrw.commons.nearby.Place
 import fr.free.nrw.commons.repository.UploadRepository
 import fr.free.nrw.commons.upload.structure.depictions.DepictedItem
 import fr.free.nrw.commons.wikidata.WikidataDisambiguationItems
@@ -82,6 +83,26 @@ class DepictsPresenter @Inject constructor(
     override fun onDetachView() {
         view = DUMMY
         compositeDisposable.clear()
+    }
+
+    /**
+     * Auto-selects the depiction for a place as if it were clicked by the user when the fragment is
+     * made aware of an associated place
+     *
+     * Given a [Place], retrieves the corresponding [DepictedItem] from the repository and calls
+     * [onDepictItemClicked]
+     *
+     * @param place the place to be selected
+     */
+    override fun onNewPlace(place: Place?) {
+        place?.let { it ->
+            repository.getPlaceDepiction(it)
+                .subscribeOn(ioScheduler)
+                .observeOn(mainThreadScheduler)
+                .subscribe { depictedItem ->
+                    onDepictItemClicked(depictedItem)
+                }
+        }
     }
 
     override fun onPreviousButtonClicked() {

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/UploadDepictsAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/UploadDepictsAdapter.kt
@@ -6,5 +6,6 @@ import fr.free.nrw.commons.upload.structure.depictions.DepictedItem
 class UploadDepictsAdapter(onDepictsClicked: (DepictedItem) -> Unit) :
     BaseDelegateAdapter<DepictedItem>(
         uploadDepictsDelegate(onDepictsClicked),
-        areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id }
+        areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id },
+        areContentsTheSame = { itemA, itemB -> itemA.isSelected == itemB.isSelected}
     )

--- a/app/src/main/java/fr/free/nrw/commons/upload/structure/depictions/DepictModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/structure/depictions/DepictModel.kt
@@ -42,22 +42,15 @@ class DepictModel @Inject constructor(private val depictsClient: DepictsClient) 
     }
 
     /**
-     * Obtains a [DepictedItem] for a given [Place]
+     * Provides a [DepictedItem] for a given [Place] via an [Observable], returning an empty
+     * observable if the given place is null or has no entity id
      */
-    fun getPlaceDepiction(place: Place): Observable<DepictedItem> {
-        val placeId = place.wikiDataEntityId
-
-        return if (placeId == null) {
-            Observable.empty()
-        } else {
-            depictsClient.getEntities(placeId)
-                .flatMapObservable { Observable.fromIterable(it.entities().values) }
-                .map {
-                    val depictedItem = DepictedItem(it, place)
-                    depictedItem.isSelected = true
-                    depictedItem
-                }
-        }
+    fun getPlaceDepiction(place: Place?): Observable<DepictedItem> {
+        return place?.wikiDataEntityId?.let { id ->
+                depictsClient.getEntities(id)
+                    .flatMapObservable { Observable.fromIterable(it.entities().values) }
+                    .map { DepictedItem(it, place) }
+            } ?: Observable.empty()
     }
 
     private fun networkItems(query: String): Flowable<List<DepictedItem>> {

--- a/app/src/main/java/fr/free/nrw/commons/upload/structure/depictions/DepictModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/structure/depictions/DepictModel.kt
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.upload.structure.depictions
 import fr.free.nrw.commons.explore.depictions.DepictsClient
 import fr.free.nrw.commons.nearby.Place
 import io.reactivex.Flowable
+import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.processors.BehaviorProcessor
 import timber.log.Timber
@@ -38,6 +39,25 @@ class DepictModel @Inject constructor(private val depictsClient: DepictsClient) 
             }
         else
             networkItems(query)
+    }
+
+    /**
+     * Obtains a [DepictedItem] for a given [Place]
+     */
+    fun getPlaceDepiction(place: Place): Observable<DepictedItem> {
+        val placeId = place.wikiDataEntityId
+
+        return if (placeId == null) {
+            Observable.empty()
+        } else {
+            depictsClient.getEntities(placeId)
+                .flatMapObservable { Observable.fromIterable(it.entities().values) }
+                .map {
+                    val depictedItem = DepictedItem(it, place)
+                    depictedItem.isSelected = true
+                    depictedItem
+                }
+        }
     }
 
     private fun networkItems(query: String): Flowable<List<DepictedItem>> {

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
@@ -206,12 +206,7 @@ public class WikidataEditService {
   }
 
   private Observable<Boolean> depictionEdits(Contribution contribution, Long fileEntityId) {
-    final ArrayList<WikidataItem> depictedItems = new ArrayList<>(contribution.getDepictedItems());
-    final WikidataPlace wikidataPlace = contribution.getWikidataPlace();
-    if (wikidataPlace != null) {
-      depictedItems.add(wikidataPlace);
-    }
-    return Observable.fromIterable(depictedItems)
+    return Observable.fromIterable(contribution.getDepictedItems())
         .concatMap(wikidataItem -> addDepictsProperty(fileEntityId.toString(), wikidataItem));
   }
 }


### PR DESCRIPTION
**Description (required)**

Fixes #3694

- Stop automatically adding `WikidataPlace` as a depiction in `WikidataEditService`, preventing duplication when the depiction is also manually selected on the depicts screen
- Refactor some logic out of `DepictModel.searchAllEntities()` to obtain `DepictedItem` instances directly from a list of places
- When `DepictsFragment` becomes visible, automatically select each unique place associated with an image in the set
    - Use the `Place` from each `UploadItem` returned by `UploadRepository.getUploads()`
    - Obtain `DepictedItem` instances via `DepictsClient`
    - Select each `DepictedItem`
- Add `areContentsTheSame` callback to `UploadDepictsAdapter` to make sure pre-selected depictions aren't unchecked in certain scenarios
- Scroll back to the top of the depicts list every time the list is updated to make sure pre-selected depictions are visible in certain scenarios

**Tests performed (required)**

Tested betaDebug on Pixel 4 XL with API level 30.