### PR TITLE
targetSdkVersion updated

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -155,7 +155,7 @@ android {
         setProperty("archivesBaseName", "app-commons-v$versionName-" + getBranchName())
 
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 30
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
 

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/BookmarkListRootFragment.java
@@ -196,16 +196,38 @@ public class BookmarkListRootFragment extends CommonsDaggerSupportFragment imple
     }
   }
 
-  public void backPressed() {
-    if (null != mediaDetails && mediaDetails.isVisible()) {
-      // todo add get list fragment
-      ((BookmarkFragment) getParentFragment()).tabLayout.setVisibility(View.VISIBLE);
-      removeFragment(mediaDetails);
-      setFragment(listFragment, mediaDetails);
+  public boolean backPressed() {
+    //check mediaDetailPage fragment is not null then we check mediaDetail.is Visible or not to avoid NullPointerException
+    if(mediaDetails!=null) {
+      if (mediaDetails.isVisible()) {
+        if(mediaDetails.backButtonClicked()) {
+          // mediaDetails handled the back clicked , no further action required.
+          return true;
+        }
+        // todo add get list fragment
+        ((BookmarkFragment) getParentFragment()).setupTabLayout();
+        ArrayList<Integer> removed=mediaDetails.getRemovedItems();
+        removeFragment(mediaDetails);
+        ((BookmarkFragment) getParentFragment()).setScroll(true);
+        setFragment(listFragment, mediaDetails);
+        ((MainActivity) getActivity()).showTabs();
+        if(listFragment instanceof BookmarkPicturesFragment){
+          GridViewAdapter adapter=((GridViewAdapter)((BookmarkPicturesFragment)listFragment).getAdapter());
+          Iterator i = removed.iterator();
+          while (i.hasNext()) {
+            adapter.remove(adapter.getItem((int)i.next()));
+          }
+          mediaDetails.clearRemoved();
+
+        }
+      } else {
+        moveToContributionsFragment();
+      }
     } else {
-      ((MainActivity) getActivity()).setSelectedItemId(NavTab.CONTRIBUTIONS.code());
+      moveToContributionsFragment();
     }
-    ((MainActivity) getActivity()).showTabs();
+    // notify mediaDetails did not handled the backPressed further actions required.
+    return false;
   }
 
   void moveToContributionsFragment(){

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -339,11 +339,7 @@ public class ContributionsFragment
         getChildFragmentManager().executePendingTransactions();
     }
 
-    public Intent getUploadServiceIntent(){
-        Intent intent = new Intent(getActivity(), UploadService.class);
-        intent.setAction(UploadService.ACTION_START_SERVICE);
-        return intent;
-    }
+
 
     @SuppressWarnings("ConstantConditions")
     private void setUploadCount() {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/model/NearbyResultItem.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/model/NearbyResultItem.kt
@@ -61,6 +61,7 @@ class NearbyResultItem(private val item: ResultTuple?,
 
     fun getDescription(): ResultTuple {
         return description ?: ResultTuple()
+    }
 
     fun getEndTime(): ResultTuple {
         return endTime ?: ResultTuple()


### PR DESCRIPTION
target SDK version has been updated to 30.

Fixes #4447 

Changed target SDK version from 29 to 30

**Tests performed (required)**

Tested betaDebug on vivo-y15 with API level 30.

Encountered some major problem on changing the sdk version:
->The contribution , explore and favorite fragments worked fine but the app crashed due to memory leak as soon as the nearby and more fragment was clicked.


https://user-images.githubusercontent.com/68495725/121788808-f9965a00-cbed-11eb-8f63-d52e0a940bca.mp4

![WhatsApp Image 2021-06-13 at 2 23 06 AM](https://user-images.githubusercontent.com/68495725/121788840-6ad60d00-cbee-11eb-832c-59336fd108ca.jpeg)

![WhatsApp Image 2021-06-13 at 2 23 05 AM](https://user-images.githubusercontent.com/68495725/121788841-70335780-cbee-11eb-87dc-c690544b7c17.jpeg)

https://user-images.githubusercontent.com/68495725/121788897-ef289000-cbee-11eb-8e6b-a767b1dfed9e.mp4







