### PR TITLE
Fix #3792 Missing Column Issue

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
@@ -274,7 +274,7 @@ public class BookmarkLocationsDao {
                 onUpdate(db, from, to);
                 return;
             }
-            if (from >= 10) {
+            if (from == 10) {
                 //This is safe, and can be called clean, as we/I do not remember the appropriate version for this
                 //We are anyways switching to room, these things won't be necessary then
                 try {

--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
@@ -274,7 +274,7 @@ public class BookmarkLocationsDao {
                 onUpdate(db, from, to);
                 return;
             }
-            if (from == 10) {
+            if (from >= 10) {
                 //This is safe, and can be called clean, as we/I do not remember the appropriate version for this
                 //We are anyways switching to room, these things won't be necessary then
                 try {
@@ -284,7 +284,7 @@ public class BookmarkLocationsDao {
                 }
                 return;
             }
-            if (from == 12) {
+            if (from >= 12) {
                 try {
                     db.execSQL(
                         "ALTER TABLE bookmarksLocations ADD COLUMN location_destroyed STRING;");
@@ -292,14 +292,14 @@ public class BookmarkLocationsDao {
                     Timber.e(exception);
                 }
             }
-            if (from == 13){
+            if (from >= 13){
                 try {
                     db.execSQL("ALTER TABLE bookmarksLocations ADD COLUMN location_language STRING;");
                 } catch (SQLiteException exception){
                     Timber.e(exception);
                 }
             }
-            if (from == 14){
+            if (from >= 14){
                 try {
                     db.execSQL("ALTER TABLE bookmarksLocations ADD COLUMN location_exists STRING;");
                 } catch (SQLiteException exception){


### PR DESCRIPTION
**Description**
Fix #3792 Missing Column Issue

**What changes did you make and why?**
After noticing the logs carefully I see that `D/BookmarkLocationsDao$Table: bookmarksLocations db is updated from:14, to:15` was done, this issue was likely caused due to missing columns which were added in previous migrations, so I call all ifs which add new columns to the table, this will ensure that no column is missed and try-catch should prevent the same column to be added twice exception.

**Tests performed**
Tested betaDebug on Mi A2 with API level 29