### PR TITLE
Main activity title is sometimes "Contributions", sometimes "Commons"

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -4,13 +4,12 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.FrameLayout;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
@@ -247,17 +246,23 @@ public class MainActivity  extends BaseActivity
     @Override
     protected void onRestoreInstanceState(Bundle savedInstanceState) {
         super.onRestoreInstanceState(savedInstanceState);
-        String currentFragmentName = savedInstanceState.getString("activeFragment");
-        if(currentFragmentName == ActiveFragment.CONTRIBUTIONS.name()) {
+        String activeFragmentName = savedInstanceState.getString("activeFragment");
+        if(activeFragmentName != null) {
+            restoreActiveFragment(activeFragmentName);
+        }
+    }
+
+    private void restoreActiveFragment(@NonNull String fragmentName) {
+        if(fragmentName.equals(ActiveFragment.CONTRIBUTIONS.name())) {
             setTitle(getString(R.string.contributions_fragment));
             loadFragment(ContributionsFragment.newInstance(),false);
-        }else if(currentFragmentName == ActiveFragment.NEARBY.name()) {
+        }else if(fragmentName.equals(ActiveFragment.NEARBY.name())) {
             setTitle(getString(R.string.nearby_fragment));
             loadFragment(NearbyParentFragment.newInstance(),false);
-        }else if(currentFragmentName == ActiveFragment.EXPLORE.name()) {
+        }else if(fragmentName.equals(ActiveFragment.EXPLORE.name())) {
             setTitle(getString(R.string.navigation_item_explore));
             loadFragment(ExploreFragment.newInstance(),false);
-        }else if(currentFragmentName == ActiveFragment.BOOKMARK.name()) {
+        }else if(fragmentName.equals(ActiveFragment.BOOKMARK.name())) {
             setTitle(getString(R.string.favorites));
             loadFragment(BookmarkFragment.newInstance(),false);
         }


### PR DESCRIPTION
**Description**

Fixes #4438 

**What changes did you make and why?**

Replaced == with equals() when checking for the active fragment restored from `savedInstanceState`.
Since == checks for reference, the checks were failing and the fragments were not being loaded.

**Tests performed**

Tested betaDebug manually on Google Pixel 5 emulator with API level 30.