### PR TITLE
Made media details caption & description copyable

### DIFF
--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -177,6 +177,7 @@
                       android:layout_width="@dimen/widget_margin"
                       android:layout_height="match_parent"
                       style="@style/MediaDetailTextBody"
+                      android:textIsSelectable="true"
                       tools:text="Captions of the media" />
                 </LinearLayout>
 
@@ -201,6 +202,7 @@
                       android:padding="@dimen/small_gap"
                       android:textColor="?attr/mediaDetailsText"
                       android:textSize="@dimen/description_text_size"
+                      android:textIsSelectable="true"
                       tools:text="Description of the media goes here. This can potentially be fairly long, and will need to wrap across multiple lines. We hope it looks nice though." />
                 </LinearLayout>
 


### PR DESCRIPTION
**Description**

caption & description is copyable now

Fixes #4480 

**Tests performed (required)**

Tested lastest master on Pixel 4 with API level 27.

**Screenshots (for UI changes only)**

<img src=https://user-images.githubusercontent.com/71203077/123502357-705d3980-d669-11eb-9384-b0a278b84bec.png width=300/>