### PR TITLE
Fixes #4503 Send log button on settings doesn't work

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/logging/LogsSender.java
+++ b/app/src/main/java/fr/free/nrw/commons/logging/LogsSender.java
@@ -1,5 +1,7 @@
 package fr.free.nrw.commons.logging;
 
+import static org.acra.ACRA.getErrorReporter;
+
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -62,6 +64,8 @@ public abstract class LogsSender implements ReportSender {
         final Uri logFileUri = getZippedLogFileUri(context, report);
         if (logFileUri != null) {
             sendEmail(context, logFileUri);
+        } else {
+            getErrorReporter().handleSilentException(null);
         }
     }
 


### PR DESCRIPTION
**Description (required)**

Fixes #4503 

What changes did you make and why?
Add an else case where crash logs are null means there is no crash

**Tests performed (required)**

Tested ProdDebug on with API level 10.
