### PR TITLE
Added vertical scrollbar to all instances of Scrollview

### DIFF
--- a/app/src/main/res/layout/activity_notification.xml
+++ b/app/src/main/res/layout/activity_notification.xml
@@ -28,7 +28,8 @@
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/listView"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"/>
+                android:layout_height="match_parent"
+                android:scrollbars="vertical"/>
 
         </RelativeLayout>
 

--- a/app/src/main/res/layout/activity_upload.xml
+++ b/app/src/main/res/layout/activity_upload.xml
@@ -73,6 +73,7 @@
           android:layout_height="wrap_content"
           android:layout_marginTop="@dimen/small_gap"
           android:padding="8px"
+          android:scrollbars="vertical"
           />
 
     </LinearLayout>

--- a/app/src/main/res/layout/bottom_sheet_nearby.xml
+++ b/app/src/main/res/layout/bottom_sheet_nearby.xml
@@ -26,6 +26,7 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_nearby_list"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        android:scrollbars="vertical"/>
     </RelativeLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_bookmarks_locations.xml
+++ b/app/src/main/res/layout/fragment_bookmarks_locations.xml
@@ -27,6 +27,7 @@
         android:id="@+id/listView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:scrollbars="vertical"
         />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_contributions_list.xml
+++ b/app/src/main/res/layout/fragment_contributions_list.xml
@@ -30,6 +30,7 @@
         android:id="@+id/contributionsList"
         android:layout_height="match_parent"
         android:layout_width="match_parent"
+        android:scrollbars="vertical"
         />
 
     <LinearLayout

--- a/app/src/main/res/layout/fragment_leaderboard.xml
+++ b/app/src/main/res/layout/fragment_leaderboard.xml
@@ -41,7 +41,8 @@
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/filters" />
+    app:layout_constraintTop_toBottomOf="@+id/filters"
+    android:scrollbars="vertical" />
 
   <Button
     android:text="@string/leaderboard_my_rank_button_text"

--- a/app/src/main/res/layout/fragment_nearby_list.xml
+++ b/app/src/main/res/layout/fragment_nearby_list.xml
@@ -9,6 +9,7 @@
         android:id="@+id/listView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:scrollbars="vertical"
         />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/layout_edit_categories.xml
+++ b/app/src/main/res/layout/layout_edit_categories.xml
@@ -86,7 +86,8 @@
         android:id="@+id/rv_categories"
         android:layout_width="match_parent"
         android:layout_height="@dimen/dimen_200"
-        android:background="?attr/mainBackground"/>
+        android:background="?attr/mainBackground"
+        android:scrollbars="vertical"/>
 
       <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/nearby_filter_list.xml
+++ b/app/src/main/res/layout/nearby_filter_list.xml
@@ -26,6 +26,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginVertical="@dimen/dimen_10"
+        android:scrollbars="vertical"
         />
 
 </LinearLayout>

--- a/app/src/main/res/layout/upload_categories_fragment.xml
+++ b/app/src/main/res/layout/upload_categories_fragment.xml
@@ -85,7 +85,8 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:layout_above="@+id/button_divider"
-      android:layout_below="@id/category_search_layout"/>
+      android:layout_below="@id/category_search_layout"
+      android:scrollbars="vertical"/>
 
   </LinearLayout>
 

--- a/app/src/main/res/layout/upload_depicts_fragment.xml
+++ b/app/src/main/res/layout/upload_depicts_fragment.xml
@@ -113,7 +113,8 @@
         android:layout_marginEnd="@dimen/standard_gap"
         android:layout_marginRight="@dimen/standard_gap"
         android:layout_above="@+id/button_divider"
-        android:layout_below="@id/depicts_search_layout" />
+        android:layout_below="@id/depicts_search_layout"
+        android:scrollbars="vertical" />
     </LinearLayout>
 
     <View


### PR DESCRIPTION
Added vertical scrollbar to all instances of Scrollview.

Fixes #4513 

What changes did you make and why? 
Added vertical scrollbar to all instances of Scrollview so that when the underlying list is populated and overflows the view a scrollbar temporarily appears indicating to the user that scrolling is possible.

Opened app and navigated to several fragments with a scrollview. Those with no or little data showed no scrollbar, those with larger amounts of data displayed a temporary scrollbar which reappeared when the user scrolled.  

Tested ProdBeta on Google Pixel 4a (5G) with API level 30 (Android Version 11)

Example screenshot:
![Screenshot_20210722-130600](https://user-images.githubusercontent.com/7031407/126636989-66f82728-a1bd-4303-9d1b-ad7c0b234572.png)

