### PR TITLE
Fixes #4455 - Warning when pressing "back" in upload wizard

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -6,6 +6,7 @@ import static fr.free.nrw.commons.wikidata.WikidataConstants.PLACE_OBJECT;
 import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.ProgressDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
@@ -45,6 +46,7 @@ import fr.free.nrw.commons.upload.license.MediaLicenseFragment;
 import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment;
 import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.UploadMediaDetailFragmentCallback;
 import fr.free.nrw.commons.upload.worker.UploadWorker;
+import fr.free.nrw.commons.utils.DialogUtil;
 import fr.free.nrw.commons.utils.PermissionUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -502,4 +504,20 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
             uploadCategoriesFragment.setCallback(null);
         }
     }
+
+    /**
+     * Overrides the back button to make sure the user is prepared to lose their progress
+     */
+    @Override
+    public void onBackPressed() {
+        DialogUtil.showAlertDialog(this,
+            getString(R.string.back_button_warning),
+            getString(R.string.back_button_warning_desc),
+            getString(R.string.back_button_continue),
+            getString(R.string.back_button_warning),
+            null,
+            this::finish
+        );
+    }
+
 }

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -6,7 +6,6 @@ import static fr.free.nrw.commons.wikidata.WikidataConstants.PLACE_OBJECT;
 import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.ProgressDialog;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.DisplayMetrics;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -391,11 +391,15 @@
 Upload your first media by tapping on the add button.</string>
 
   <string name="no_categories_selected">No Categories Selected</string>
-
   <string name="no_categories_selected_warning_desc">Images without categories are rarely usable. Are you sure you want to continue without selecting categories?</string>
-  <string name="no_depictions_selected">No Depictions Selected</string>
 
+  <string name="no_depictions_selected">No Depictions Selected</string>
   <string name="no_depictions_selected_warning_desc">Images with depictions are more easily found and more likely to be used. Are you sure you want to continue without selecting depictions?</string>
+
+  <string name="back_button_warning">Cancel Upload</string>
+  <string name="back_button_warning_desc">Using the back button will cancel this upload and you will lose your progress</string>
+  <string name="back_button_continue">Continue Upload</string>
+
   <string name="upload_flow_all_images_in_set">(For all image(s) in set)</string>
   <string name="search_this_area">Search this area</string>
   <string name="nearby_card_permission_title">Permission Request</string>


### PR DESCRIPTION
**Description (required)
Fixes #4455 

**What changes did you make and why?
- Added override for when the back button is pressed, which launches a dialog box confirming that the user wishes to cancel the upload. Added corresponding string resources, which might need checking over and then translating.

Tests performed (required)
- Opened app and navigated around, pressing the back button to confirm other activities were not affected
- Opened app and started upload wizard, after taking a picture and adding a caption click back to get the dialog
- Tested both 'Cancel Upload' which returned to home screen, and 'Continue Upload' which removes the dialog
- Tested on multiple steps during upload process (after adding 'depicts' and 'categories' etc.) 
- Tested ProdBeta on Google Pixel 4a (5G) with API level 30 (Android Version 11)

Screenshots (for UI changes only)

![Screenshot_20210722-144351](https://user-images.githubusercontent.com/7031407/126651276-2016d723-dae0-41cc-abc4-ce4613e369f8.png)


