### PR TITLE
Fixes issue #4469 selecting text doesn't always work in upload wizard

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
@@ -123,8 +123,6 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
                         eventListener.onPrimaryCaptionTextChange(value.length() != 0);
                     }
                 }));
-            captionItemEditText.setText(uploadMediaDetail.getCaptionText());
-            descItemEditText.setText(uploadMediaDetail.getDescriptionText());
 
             if (position == 0) {
                 removeButton.setVisibility(View.GONE);


### PR DESCRIPTION
**Description (required)**

Fixes #4469

What changes did you make and why?

- Removed the initial setText calls for the caption and description editText fields, since they seem to unneeded and set later on lines 148 and 152. This seems to have fixed the issue, where text was not selectable (and therefore copyable) when a user click the 'next' button and then returned to the screen with the caption and description.

**Tests performed (required)**

- Opened app and started upload wizard, after taking a picture and adding a caption and description
- Tested that selecting the text still works before pressing 'next'
- Clicked 'next' and then 'previous' and then confirmed that the text could now selected as expected
- Tested progressing to and then back from multiple steps during upload process (after adding 'depicts' and 'categories' etc.)
- Tested an upload with the change, the caption and description working as expected
- Tested ProdBeta on Google Pixel 4a (5G) with API level 30 (Android Version 11)
