### PR TITLE
Fixes #4524 Kotlin NPE on fetch contributions

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionBoundaryCallback.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionBoundaryCallback.kt
@@ -70,7 +70,9 @@ class ContributionBoundaryCallback @Inject constructor(
                     }
             )
         }else {
-            compositeDisposable.clear()
+            if (compositeDisposable != null){
+                compositeDisposable.clear()
+            }
         }
     }
 


### PR DESCRIPTION
**Description (required)**
This error seemed to occur on compositeDisposable.clear() so null checked there

Fixes #4524

