### PR TITLE
fixes #4529 Bug on getting thumb URL when media is null

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -546,8 +546,8 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         image.getHierarchy().setFailureImage(R.drawable.image_placeholder);
 
         DraweeController controller = Fresco.newDraweeControllerBuilder()
-                .setLowResImageRequest(ImageRequest.fromUri(media.getThumbUrl()))
-                .setImageRequest(ImageRequest.fromUri(media.getImageUrl()))
+                .setLowResImageRequest(ImageRequest.fromUri(media != null ? media.getThumbUrl() : null))
+                .setImageRequest(ImageRequest.fromUri(media != null ? media.getImageUrl() : null))
                 .setControllerListener(aspectRatioListener)
                 .setOldController(image.getController())
                 .build();


### PR DESCRIPTION
**Description (required)**

Fixes #4529

