### PR TITLE
Remove unnecessary imports and fix type error

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -56,8 +56,6 @@ import java.util.Collections;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Named;
-import kotlin.reflect.jvm.internal.impl.load.kotlin.JvmType.Object;
-import kotlin.reflect.jvm.internal.impl.util.Checks;
 import timber.log.Timber;
 
 public class UploadActivity extends BaseActivity implements UploadContract.View, UploadBaseFragment.Callback {


### PR DESCRIPTION
**Description (required)**

Fixes the travis error happened right after #4022 is merged. The issue was having an extra import of 
```
import kotlin.reflect.jvm.internal.impl.load.kotlin.JvmType.Object;
```

What changes did you make and why?

**Tests performed (required)**

Tested prod Debug, API 10