### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
     <uses-permission android:name="com.google.android.apps.photos.permission.GOOGLE_PHOTOS" />
     <uses-permission android:name="android.permission.SET_WALLPAPER"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
 
     <!-- Needed only if your app targets Android 5.0 (API level 21) or higher. -->


### PR DESCRIPTION
Added ACCESS_COARSE_LOCATION permission that Provides an estimate of the device's location, to within about 1 mile (1.6 km)

**Description (required)**

Fixes #4444 #4558 

Earlier app was able to get location up to 50 meters only but now it can access location upto 1.6km

**Tests performed 

Tested on Redmi 8A dual with API level 10.