### PR TITLE
Fix notification bug #4547

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
@@ -301,13 +301,13 @@ class UploadWorker(var appContext: Context, workerParams: WorkerParameters) :
                                     "WikiDataEdit not required, upload success"
                                 )
                                 saveCompletedContribution(contribution,uploadResult)
-                                showSuccessNotification(contribution)
                             }else{
                                 Timber.d(
                                     "WikiDataEdit not required, making wikidata edit"
                                 )
                                 makeWikiDataEdit(uploadResult, contribution)
                             }
+                            showSuccessNotification(contribution)
 
                         } else {
                             Timber.e("Stash Upload failed")


### PR DESCRIPTION
**Description**
Fixes #4547

The upload notification was not dismissing automatically for any upload done for WLM via Nearby.

**Tests performed**
Tested betaDebug on Mi A2 with API level 29
