### PR TITLE
Added Materialized Icon in DialogBox

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -173,6 +173,7 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     @OnClick(R.id.skip_login)
     void skipLogin() {
         new AlertDialog.Builder(this).setTitle(R.string.skip_login_title)
+                .setIcon(R.drawable.ic_skip)
                 .setMessage(R.string.skip_login_message)
                 .setCancelable(false)
                 .setPositiveButton(R.string.yes, (dialog, which) -> {

--- a/app/src/main/res/drawable/ic_skip.xml
+++ b/app/src/main/res/drawable/ic_skip.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/primaryColor">
+  <path
+      android:fillColor="@color/primaryColor"
+      android:pathData="M6,18l8.5,-6L6,6v12zM16,6v12h2V6h-2z"/>
+</vector>


### PR DESCRIPTION
**Description**

Fixes #4577.

Added Materialized Icon to the Skip login DialogBox with the primarycolor of the application.

**Tests performed**

Tested `3.0.2-debug-master` on `Realme XT` with API level `28`.

**Screenshots (for UI changes only)**

**Screenshot of current DialogBox:**

![WhatsApp Image 2021-08-25 at 3 52 15 AM](https://user-images.githubusercontent.com/54937640/130699253-7b496f20-aa65-4fb7-be79-876d07e04f98.jpeg)

**Screenshot of improved DialogBox:**

![WhatsApp Image 2021-08-25 at 3 58 18 AM](https://user-images.githubusercontent.com/54937640/130699438-9df2229e-ccad-4db2-9285-f714ba7c0a88.jpeg)