### PR TITLE
Bug fix- current location marker

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1184,7 +1184,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     public void addCurrentLocationMarker(final fr.free.nrw.commons.location.LatLng curLatLng) {
         if (null != curLatLng && !isPermissionDenied) {
             ExecutorUtils.get().submit(() -> {
-                removeCurrentLocationMarker();
+                mapView.post(() -> removeCurrentLocationMarker());
                 Timber.d("Adds current location marker");
 
                 final Icon icon = IconFactory.getInstance(getContext())
@@ -1194,7 +1194,8 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
                         .position(new LatLng(curLatLng.getLatitude(),
                                 curLatLng.getLongitude()));
                 currentLocationMarkerOptions.setIcon(icon); // Set custom icon
-                currentLocationMarker = mapBox.addMarker(currentLocationMarkerOptions);
+                mapView.post(
+                    () -> currentLocationMarker = mapBox.addMarker(currentLocationMarkerOptions));
 
                 final List<LatLng> circle = UiUtils
                         .createCircleArray(curLatLng.getLatitude(), curLatLng.getLongitude(),
@@ -1204,8 +1205,9 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
                         .addAll(circle)
                         .strokeColor(getResources().getColor(R.color.current_marker_stroke))
                         .fillColor(getResources().getColor(R.color.current_marker_fill));
-                currentLocationPolygon = mapBox.addPolygon(currentLocationPolygonOptions);
-
+                mapView.post(
+                    () -> currentLocationPolygon = mapBox
+                        .addPolygon(currentLocationPolygonOptions));
             });
         } else {
             Timber.d("not adding current location marker..current location is null");


### PR DESCRIPTION
**Description (required)**
The current location marker was not visible, because updates in the map view were not done on the main thread
What changes did you make and why?

Moved the updates for the current location marker on the main thread

**Tests performed (required)**

Tested betaDebug on API 29 for the following cases
1. By default the current location marker is visible
2. After performing search this area for some other location, clicking on navigate to current location, takes and shows the current location marker

**Screenshots (for UI changes only)**

![image](https://user-images.githubusercontent.com/17375274/130717490-50aa01d6-715a-4b77-99c2-ccfea612d402.png)![image](https://user-images.githubusercontent.com/17375274/130717561-e4e4dd68-7e8d-4110-b74d-8279bd399ae0.png)

