### PR TITLE
Added Update App Prompt

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -119,6 +119,7 @@ dependencies {
     implementation "androidx.exifinterface:exifinterface:1.3.2"
     implementation "androidx.core:core-ktx:$CORE_KTX_VERSION"
     implementation "androidx.multidex:multidex:2.0.1"
+    implementation 'com.github.javiersantos:AppUpdater:2.7'
 
     //swipe_layout
     implementation 'com.daimajia.swipelayout:library:1.2.0@aar'

--- a/app/src/main/java/fr/free/nrw/commons/explore/ExploreFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/ExploreFragment.java
@@ -12,6 +12,9 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import com.github.javiersantos.appupdater.AppUpdater;
+import com.github.javiersantos.appupdater.enums.Display;
+import com.github.javiersantos.appupdater.enums.UpdateFrom;
 import com.google.android.material.tabs.TabLayout;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.ViewPagerAdapter;
@@ -69,8 +72,23 @@ public class ExploreFragment extends CommonsDaggerSupportFragment {
         viewPager.setId(R.id.viewPager);
         tabLayout.setupWithViewPager(viewPager);
         setTabs();
+        setUpUpdatePrompt();
         setHasOptionsMenu(true);
         return view;
+    }
+
+    public void setUpUpdatePrompt() {
+        AppUpdater appUpdater = new AppUpdater(getContext());
+
+        new AppUpdater(getContext())
+            .setUpdateFrom(UpdateFrom.GOOGLE_PLAY)
+            .setDisplay(Display.DIALOG)
+            .setTitleOnUpdateAvailable("Update available")//Title of the Dialog Prompt
+            .setContentOnUpdateAvailable("Check out the latest version available of Commons Android App!")//Description of the Dialog Prompt
+            .setButtonUpdate("Update")//Updates the App
+            .setButtonDoNotShowAgain("Don't show again");//Never shows the prompt again until next release
+
+        appUpdater.start();
     }
 
     /**


### PR DESCRIPTION
**Description**

Fixes #4586.

Added In-App Update Prompt feature. Whenever a new update is released in the Play Store, a prompt  will be displayed. If the "Update" button is clicked, it will start to update the app, and if "Don't show again" button is clicked, the Prompt won't show up until the next update is released on the Play Store.

**Tests performed**

Tested `3.0.2-debug-master` on `Realme XT` with API level `28`.