### PR TITLE
Fix issue with wrong language descriptions shown in Nearby map

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
@@ -7,7 +7,7 @@ public class Prefs {
     public static final String DEFAULT_LICENSE = "defaultLicense";
     public static final String UPLOADS_SHOWING = "uploadsshowing";
     public static final String MANAGED_EXIF_TAGS = "managed_exif_tags";
-    public static final String DESCRIPTION_LANGUAGE = "descriptionLanguage";
+    public static final String DESCRIPTION_LANGUAGE = "languageDescription";
     public static final String APP_UI_LANGUAGE = "appUiLanguage";
     public static final String KEY_THEME_VALUE = "appThemePref";
     public static final String TELEMETRY_PREFERENCE = "telemetryPref";


### PR DESCRIPTION
**Description**
Fixes #4583

Due to the incorrect pref key, the lang parameter for the query was `""` due to which random lang was fetched. This is a correction for a change made in the PR #4366

**Tests performed**
Tested betaDebug on Xiaomi Mi A2 with API level 29

![Screenshot 2021-08-29 015633](https://user-images.githubusercontent.com/30932899/131251926-c14e7a29-fb21-4213-83f1-a519846cbced.png)
![Screenshot 2021-08-29 023156](https://user-images.githubusercontent.com/30932899/131251928-f8ebe2eb-9225-4177-80ac-79283396d49d.png)
