### PR TITLE
Added Changes for bottom_sheet

### DIFF
--- a/app/src/main/res/layout/fragment_more_bottom_sheet_logged_out.xml
+++ b/app/src/main/res/layout/fragment_more_bottom_sheet_logged_out.xml
@@ -21,9 +21,11 @@
               android:layout_height="wrap_content"
               android:layout_margin="12dp"
               android:drawableStart="@drawable/ic_settings_black_24dp"
+              android:drawableTint="@color/primaryColor"
               android:drawablePadding="12dp"
               android:padding="8dp"
               android:text="@string/menu_settings"
+              android:textColor="@color/primaryColor"
               android:textSize="18sp" />
 
             <TextView
@@ -32,9 +34,11 @@
               android:layout_height="wrap_content"
               android:layout_margin="12dp"
               android:drawableLeft="@drawable/ic_feedback_black_24dp"
+              android:drawableTint="@color/primaryColor"
               android:drawablePadding="12dp"
               android:padding="8dp"
               android:text="@string/navigation_item_feedback"
+              android:textColor="@color/primaryColor"
               android:textSize="18sp" />
 
             <TextView
@@ -43,9 +47,11 @@
               android:layout_height="wrap_content"
               android:layout_margin="12dp"
               android:drawableStart="@drawable/ic_info_outline_24dp"
+              android:drawableTint="@color/primaryColor"
               android:drawablePadding="12dp"
               android:padding="8dp"
               android:text="@string/navigation_item_about"
+              android:textColor="@color/primaryColor"
               android:textSize="18sp" />
 
             <TextView
@@ -54,9 +60,11 @@
               android:layout_height="wrap_content"
               android:layout_margin="12dp"
               android:drawableStart="@drawable/ic_baseline_person_24"
+              android:drawableTint="@color/primaryColor"
               android:drawablePadding="12dp"
               android:padding="8dp"
               android:text="@string/navigation_item_login"
+              android:textColor="@color/primaryColor"
               android:textSize="18sp" />
 
         </LinearLayout>


### PR DESCRIPTION
**Description**

Fixes #4597.

Changed the drawables tint and the text color to the primary color of the android application to improve the themability and the user interface of the android application.

**Tests performed**

Tested 3.0.2-debug-master on Realme XT with API level 28.

**Screenshots**

**Current bottom sheet:**

![WhatsApp Image 2021-08-31 at 8 11 45 PM](https://user-images.githubusercontent.com/54937640/131525544-e7d70117-7564-43a2-b267-528c39027a45.jpeg)

**Improved bottom sheet:**

![WhatsApp Image 2021-08-31 at 8 14 33 PM](https://user-images.githubusercontent.com/54937640/131525599-df8df6df-e03d-411e-bf18-8742b69ebae5.jpeg)
