### PR TITLE
Fixes #4601 - 1. Handle possible exceptions in the upload flow

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadClient.java
@@ -218,13 +218,13 @@ public class UploadClient {
                     CommonsApplication.DEFAULT_EDIT_SUMMARY,
                     uniqueFileName,
                     fileKey).map(uploadResponse -> {
-                    UploadResponse uploadResult = gson
+                    final UploadResponse uploadResult = gson
                         .fromJson(uploadResponse, UploadResponse.class);
                     if (uploadResult.getUpload() == null) {
                         final MwException exception = gson
                             .fromJson(uploadResponse, MwException.class);
                         Timber.e(exception, "Error in uploading file from stash");
-                        throw new RuntimeException(exception.getErrorCode());
+                        throw new Exception(exception.getErrorCode());
                     }
                     return uploadResult.getUpload();
                 });

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadResponse.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadResponse.kt
@@ -1,3 +1,3 @@
 package fr.free.nrw.commons.upload
 
-class UploadResponse(val upload: UploadResult)
+class UploadResponse(val upload: UploadResult?)

--- a/data-client/src/main/java/org/wikipedia/dataclient/mwapi/MwException.java
+++ b/data-client/src/main/java/org/wikipedia/dataclient/mwapi/MwException.java
@@ -31,11 +31,20 @@ public class MwException extends RuntimeException {
         return error;
     }
 
-    @Nullable public String getTitle() {
-        return error.getTitle();
+    @Nullable
+    public String getTitle() {
+        if (error != null) {
+            return error.getTitle();
+        }
+        return errors != null ? errors.get(0).getTitle() : null;
     }
 
-    @Override @Nullable public String getMessage() {
-        return error.getDetails();
+    @Override
+    @Nullable
+    public String getMessage() {
+        if (error != null) {
+            return error.getDetails();
+        }
+        return errors != null ? errors.get(0).getDetails() : null;
     }
 }


### PR DESCRIPTION
**Description (required)**

Fixes #4601

What changes did you make and why?
1. Handle possible exceptions in the upload file from stash
2. Modify MWException, as the error is nullable, update getTitle and getMessage to rever that


**Tests performed (required)**

Tested betaDebug on API 29 for the following cases
1. Single upload works as expected.
2. Multiple uploads works as expected.
3. In multiple uploads, make the first upload fail (manually make the upload result null), we see a failure notification for this upload and the second upload succeeds as expected.
4. In single upload make the upload result null, failure notification is shown

In all of these cases, the continuous progress bar is not shown.

