### PR TITLE
fixed issue #4590 fab of custom selector is still open after uploading

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -275,6 +275,7 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment impl
     @OnClick(R.id.fab_custom_gallery)
     void launchCustomSelector(){
         controller.initiateCustomGalleryPickWithPermission(getActivity());
+        animateFAB(isFabOpen);
     }
 
     private void animateFAB(final boolean isFabOpen) {


### PR DESCRIPTION
Description (required)
Fab list was still open after uploading photo through custom selector fab. It should be closed upon returning to ContributorListFragment.

Fixes #4590

What changes did you make and why?
Called the function which animates (open / closes) the fab list after the custom selector fab was clicked.

Tests performed (required)
Tested betaDebug on Pixel 4 with API level 30.