### PR TITLE
Fix callback null crash #4644

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -145,19 +145,21 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
         presenter.receiveImage(uploadableFile, place);
         initRecyclerView();
 
-        if (callback.getIndexInViewFlipper(this) == 0) {
-            btnPrevious.setEnabled(false);
-            btnPrevious.setAlpha(0.5f);
-        } else {
-            btnPrevious.setEnabled(true);
-            btnPrevious.setAlpha(1.0f);
-        }
+        if (callback != null) {
+            if (callback.getIndexInViewFlipper(this) == 0) {
+                btnPrevious.setEnabled(false);
+                btnPrevious.setAlpha(0.5f);
+            } else {
+                btnPrevious.setEnabled(true);
+                btnPrevious.setAlpha(1.0f);
+            }
 
-        //If this is the last media, we have nothing to copy, lets not show the button
-        if (callback.getIndexInViewFlipper(this) == callback.getTotalNumberOfSteps()-4) {
-            btnCopyToSubsequentMedia.setVisibility(View.GONE);
-        } else {
-            btnCopyToSubsequentMedia.setVisibility(View.VISIBLE);
+            //If this is the last media, we have nothing to copy, lets not show the button
+            if (callback.getIndexInViewFlipper(this) == callback.getTotalNumberOfSteps() - 4) {
+                btnCopyToSubsequentMedia.setVisibility(View.GONE);
+            } else {
+                btnCopyToSubsequentMedia.setVisibility(View.VISIBLE);
+            }
         }
 
         attachImageViewScaleChangeListener();


### PR DESCRIPTION
**Description**
Fixes #4644 

**What changes did you make and why?**
`setCallback` is called by `UploadActivity` but when the fragment is destroyed and created again  `setCallback` is not called and callback seems to become `null`, this happens occasionally and the best way to solve is to add a null check.

**Tests performed**
Tested betaDebug on Mi A2 with API level 29