### PR TITLE
Tap to view fails issue resolved

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
@@ -533,14 +533,10 @@ class UploadWorker(var appContext: Context, workerParams: WorkerParameters) :
     /**
      * Method used to get Pending intent for opening different screen after clicking on notification
      * @param toClass
-     * @param params
      */
-    private fun getPendingIntent(toClass:Class<out BaseActivity> ,params:ArrayList<String>? = null):PendingIntent
+    private fun getPendingIntent(toClass:Class<out BaseActivity>):PendingIntent
     {
-        val intent=Intent(appContext,toClass)
-        params.let {
-            intent.putStringArrayListExtra("params",params)
-        }
+        val intent = Intent(appContext,toClass)
         return TaskStackBuilder.create(appContext).run {
              addNextIntentWithParentStack(intent)
              getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT)

--- a/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
@@ -1,13 +1,11 @@
 package fr.free.nrw.commons.upload.worker
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.app.PendingIntent
 import android.app.TaskStackBuilder
 import android.content.Context
 import android.content.Intent
 import android.graphics.BitmapFactory
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.work.CoroutineWorker

--- a/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
@@ -1,9 +1,13 @@
 package fr.free.nrw.commons.upload.worker
 
 import android.annotation.SuppressLint
+import android.app.Activity
+import android.app.PendingIntent
+import android.app.TaskStackBuilder
 import android.content.Context
+import android.content.Intent
 import android.graphics.BitmapFactory
-import android.location.Geocoder
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.work.CoroutineWorker
@@ -18,11 +22,12 @@ import fr.free.nrw.commons.auth.SessionManager
 import fr.free.nrw.commons.contributions.ChunkInfo
 import fr.free.nrw.commons.contributions.Contribution
 import fr.free.nrw.commons.contributions.ContributionDao
+import fr.free.nrw.commons.contributions.MainActivity
 import fr.free.nrw.commons.customselector.database.UploadedStatus
 import fr.free.nrw.commons.customselector.database.UploadedStatusDao
 import fr.free.nrw.commons.di.ApplicationlessInjection
-import fr.free.nrw.commons.location.LatLng
 import fr.free.nrw.commons.media.MediaClient
+import fr.free.nrw.commons.theme.BaseActivity
 import fr.free.nrw.commons.upload.StashUploadResult
 import fr.free.nrw.commons.upload.FileUtilsWrapper
 import fr.free.nrw.commons.upload.StashUploadState
@@ -37,7 +42,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
-import java.io.IOException
 import java.util.*
 import java.util.regex.Pattern
 import javax.inject.Inject
@@ -491,6 +495,7 @@ class UploadWorker(var appContext: Context, workerParams: WorkerParameters) :
     @SuppressLint("StringFormatInvalid")
     private fun showFailedNotification(contribution: Contribution) {
         val displayTitle = contribution.media.displayTitle
+        curentNotification.setContentIntent(getPendingIntent(MainActivity::class.java))
         curentNotification.setContentTitle(
             appContext.getString(
                 R.string.upload_failed_notification_title,
@@ -526,4 +531,17 @@ class UploadWorker(var appContext: Context, workerParams: WorkerParameters) :
             curentNotification.build()
         )
     }
+
+    private fun getPendingIntent(classType:Class<out BaseActivity> ,params:ArrayList<String>? = null):PendingIntent
+    {
+        val intent=Intent(appContext,classType)
+        params.let {
+            intent.putStringArrayListExtra("params",params)
+        }
+        return TaskStackBuilder.create(appContext).run {
+             addNextIntentWithParentStack(intent)
+             getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT)
+         };
+    }
+
 }

--- a/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
@@ -530,9 +530,14 @@ class UploadWorker(var appContext: Context, workerParams: WorkerParameters) :
         )
     }
 
-    private fun getPendingIntent(classType:Class<out BaseActivity> ,params:ArrayList<String>? = null):PendingIntent
+    /**
+     * Method used to get Pending intent for opening different screen after clicking on notification
+     * @param toClass
+     * @param params
+     */
+    private fun getPendingIntent(toClass:Class<out BaseActivity> ,params:ArrayList<String>? = null):PendingIntent
     {
-        val intent=Intent(appContext,classType)
+        val intent=Intent(appContext,toClass)
         params.let {
             intent.putStringArrayListExtra("params",params)
         }


### PR DESCRIPTION
**When upload fails the notification was coming tap to view but nothing was happening  **

Fixes #4604 

assigned pending intent to failed notification which will open MainActivity screen

**Tests performed **

Tested on Redmi note 5 pro.

attached video:
https://user-images.githubusercontent.com/43309120/135708444-aac8845b-ec37-433c-8668-b64e5cd18551.mp4

