### PR TITLE
Handle possible erroneous DB migrations for BookmarksLocationDao

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationsDao.java
@@ -274,37 +274,26 @@ public class BookmarkLocationsDao {
                 onUpdate(db, from, to);
                 return;
             }
-            if (from == 10) {
-                //This is safe, and can be called clean, as we/I do not remember the appropriate version for this
-                //We are anyways switching to room, these things won't be necessary then
-                try {
-                    db.execSQL("ALTER TABLE bookmarksLocations ADD COLUMN location_pic STRING;");
-                }catch (SQLiteException exception){
-                    Timber.e(exception);//
-                }
-                return;
+
+            //We've been seeing many cases where one of these seem to have missed to added and its
+            // hard to find the exact version knowing which version the user is going to upgrade from,
+            //before until this version (18), we want to make sure that these column do exist
+            if (from <= 17) {
+                addColumn(db, "location_pic", "STRING");
+                addColumn(db, "location_destroyed", "STRING");
+                addColumn(db, "location_language", "STRING");
+                addColumn(db, "location_exists", "STRING");
             }
-            if (from >= 12) {
-                try {
-                    db.execSQL(
-                        "ALTER TABLE bookmarksLocations ADD COLUMN location_destroyed STRING;");
-                } catch (SQLiteException exception) {
-                    Timber.e(exception);
-                }
-            }
-            if (from >= 13){
-                try {
-                    db.execSQL("ALTER TABLE bookmarksLocations ADD COLUMN location_language STRING;");
-                } catch (SQLiteException exception){
-                    Timber.e(exception);
-                }
-            }
-            if (from >= 14){
-                try {
-                    db.execSQL("ALTER TABLE bookmarksLocations ADD COLUMN location_exists STRING;");
-                } catch (SQLiteException exception){
-                    Timber.e(exception);
-                }
+        }
+
+        private static void addColumn(final SQLiteDatabase db, final String columnName,
+            final String type){
+            try {
+                db.execSQL(
+                    String.format("ALTER TABLE bookmarksLocations ADD COLUMN %s %s;", columnName,
+                        type));
+            } catch (final SQLiteException exception) {
+                Timber.e(exception);
             }
         }
     }

--- a/app/src/main/java/fr/free/nrw/commons/data/DBOpenHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/data/DBOpenHelper.java
@@ -13,7 +13,7 @@ import fr.free.nrw.commons.explore.recentsearches.RecentSearchesDao;
 public class DBOpenHelper  extends SQLiteOpenHelper {
 
     private static final String DATABASE_NAME = "commons.db";
-    private static final int DATABASE_VERSION = 17;
+    private static final int DATABASE_VERSION = 18;
     public static final String CONTRIBUTIONS_TABLE = "contributions";
     private final String DROP_TABLE_STATEMENT="DROP TABLE IF EXISTS %s";
 


### PR DESCRIPTION
**Description (required)**

Fixes #4652

What changes did you make and why?

Attempt to include all possible missing columns in BookmarksLocationDao for DB versions <=17

**Tests performed (required)**

Tested betaDebug on API 27

Verified that onUpgrade is called and the DB tries to alter table to add possible missing columns
