### PR TITLE
Fix crash on content provider client already released

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesDao.java
@@ -80,11 +80,11 @@ public class RecentSearchesDao {
                     Timber.e(e, "query deleted");
                     throw new RuntimeException(e);
                 } finally {
-                    db.release();
+                    db.close();
                 }
             }
-        } catch (RemoteException e) {
-            throw new RuntimeException(e);
+        } catch (Exception e) {
+            Timber.e(e, "Error while clearing history");
         } finally {
             if (cursor != null) {
                 cursor.close();


### PR DESCRIPTION
**Description**
Fixes #4654 

**What changes did you make and why?**
This issue happens in a rare case when the content provider client is already released. I have added an expectation handling along with the replacement of the deprecated method `release()` with `close()`

**Tests performed**
Tested betaDebug on Mi A2  with API level 29