### PR TITLE
fixed issue #4500 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -109,7 +109,6 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
 
     public static MediaDetailFragment forMedia(int index, boolean editable, boolean isCategoryImage, boolean isWikipediaButtonDisplayed) {
         MediaDetailFragment mf = new MediaDetailFragment();
-
         Bundle state = new Bundle();
         state.putBoolean("editable", editable);
         state.putBoolean("isCategoryImage", isCategoryImage);
@@ -117,7 +116,6 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         state.putInt("listIndex", 0);
         state.putInt("listTop", 0);
         state.putBoolean("isWikipediaButtonDisplayed", isWikipediaButtonDisplayed);
-
         mf.setArguments(state);
 
         return mf;
@@ -201,6 +199,8 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
     RecyclerView categoryRecyclerView;
     @BindView(R.id.update_categories_button)
     Button updateCategoriesButton;
+    @BindView(R.id.coordinate_edit)
+    Button coordinateEditButton;
     @BindView(R.id.dummy_category_edit_container)
     LinearLayout dummyCategoryEditContainer;
     @BindView(R.id.pb_categories)
@@ -320,6 +320,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
 
         if(applicationKvStore.getBoolean("login_skipped")){
             delete.setVisibility(GONE);
+            coordinateEditButton.setVisibility(GONE);
         }
 
         handleBackEvent(view);


### PR DESCRIPTION


**Description (required)**
Coordinate edit button should be hidden if user not logged in (user skips login)
Fixes #4500 

What changes did you make and why?
created a reference to the edit button, and set its visibility to GONE if value for "login_skipped" is true
**Tests performed (required)**

Tested ProdDebug on Pixel 5 with API level 30.

**Screenshots (for UI changes only)**
![coordiantes_edit_button](https://user-images.githubusercontent.com/24782183/135951907-7e01b50a-2e68-4b16-8300-0c443c914110.PNG)

Need help? See https://support.google.com/android/answer/9075928

---



_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
