### PR TITLE
fixed issue #4500 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -109,7 +109,6 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
 
     public static MediaDetailFragment forMedia(int index, boolean editable, boolean isCategoryImage, boolean isWikipediaButtonDisplayed) {
         MediaDetailFragment mf = new MediaDetailFragment();
-
         Bundle state = new Bundle();
         state.putBoolean("editable", editable);
         state.putBoolean("isCategoryImage", isCategoryImage);
@@ -117,7 +116,6 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         state.putInt("listIndex", 0);
         state.putInt("listTop", 0);
         state.putBoolean("isWikipediaButtonDisplayed", isWikipediaButtonDisplayed);
-
         mf.setArguments(state);
 
         return mf;
@@ -201,6 +199,8 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
     RecyclerView categoryRecyclerView;
     @BindView(R.id.update_categories_button)
     Button updateCategoriesButton;
+    @BindView(R.id.coordinate_edit)
+    Button coordinateEditButton;
     @BindView(R.id.dummy_category_edit_container)
     LinearLayout dummyCategoryEditContainer;
     @BindView(R.id.pb_categories)
@@ -320,6 +320,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
 
         if(applicationKvStore.getBoolean("login_skipped")){
             delete.setVisibility(GONE);
+            coordinateEditButton.setVisibility(GONE);
         }
 
         handleBackEvent(view);


### PR DESCRIPTION

**Description (required)**
Coordinate edit button should be hidden if login skipped (user not logged in)
Fixes #4500

What changes did you make and why?
Created reference to coordinate edit button and then set view to _GONE_ if "login_skipped" value is _true_

**Tests performed (required)**
Tested ProdDebug on Pixel 5 with API level 30.

**Screenshots (for UI changes only)**
![coordiantes_edit_button](https://user-images.githubusercontent.com/24782183/136005213-1700f81e-7af0-4617-8f85-c10e6c2bdeea.PNG)

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
