### PR TITLE
Converted the WikipediaInstructionsDialogFragment to use viewbinding

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/WikipediaInstructionsDialogFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/WikipediaInstructionsDialogFragment.kt
@@ -5,40 +5,32 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
+import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
-import fr.free.nrw.commons.R
-import kotlinx.android.synthetic.main.dialog_add_to_wikipedia_instructions.*
+import fr.free.nrw.commons.databinding.DialogAddToWikipediaInstructionsBinding
 
 /**
  * Dialog fragment for displaying instructions for editing wikipedia
  */
 class WikipediaInstructionsDialogFragment : DialogFragment() {
 
-    var contribution: Contribution? = null
     var callback: Callback? = null
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.dialog_add_to_wikipedia_instructions, container)
-    }
+    ) = DialogAddToWikipediaInstructionsBinding.inflate(inflater, container, false).apply {
+        val contribution: Contribution? = arguments!!.getParcelable(ARG_CONTRIBUTION)
+        tvWikicode.setText(contribution?.media?.wikiCode)
+        instructionsCancel.setOnClickListener { dismiss() }
+        instructionsConfirm.setOnClickListener {
+            callback?.onConfirmClicked(contribution, checkboxCopyWikicode.isChecked)
+        }
+    }.root
 
-    override fun onViewCreated(
-        view: View,
-        savedInstanceState: Bundle?
-    ) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        contribution = arguments!!.getParcelable(ARG_CONTRIBUTION)
-        tv_wikicode.setText(contribution?.media?.wikiCode)
-        instructions_cancel.setOnClickListener {
-            dismiss()
-        }
-
-        instructions_confirm.setOnClickListener {
-            callback?.onConfirmClicked(contribution, checkbox_copy_wikicode.isChecked)
-        }
-
         dialog!!.window?.setSoftInputMode(
             WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN
         )
@@ -52,16 +44,11 @@ class WikipediaInstructionsDialogFragment : DialogFragment() {
     }
 
     companion object {
-
-        val ARG_CONTRIBUTION = "contribution"
+        const val ARG_CONTRIBUTION = "contribution"
 
         @JvmStatic
-        fun newInstance(contribution: Contribution): WikipediaInstructionsDialogFragment {
-            val frag = WikipediaInstructionsDialogFragment()
-            val args = Bundle()
-            args.putParcelable(ARG_CONTRIBUTION, contribution)
-            frag.arguments = args
-            return frag
+        fun newInstance(contribution: Contribution) = WikipediaInstructionsDialogFragment().apply {
+            arguments = bundleOf(ARG_CONTRIBUTION to contribution)
         }
     }
 }


### PR DESCRIPTION
Two main changes here
* Firstly the move to view binding for the GUI.  Moving code from `onViewCreated()` into the `onCreateView()` meant there was no need to keep a reference to the *binding* or the *contrinution* further cleaning things up.
* Secondly, using the more idiomatic `bundleOf` extension function for building the fragment arguments.