### PR TITLE
Removed duplicate INTERNET Permission in Manifest file

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="fr.free.nrw.commons">
-    <uses-permission android:name="android.permission.INTERNET"/>
-
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />


### PR DESCRIPTION
**Description (required)**

Fixes #4683 

Removed duplicate INTERNET Permission from `AndroidManifest.xml` file to improve the code quality.