### PR TITLE
Bugfix #4653 - Fix UnknownFormatConversionException in MediaLicenseFragment

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/license/MediaLicenseFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/license/MediaLicenseFragment.java
@@ -161,13 +161,12 @@ public class MediaLicenseFragment extends UploadBaseFragment implements MediaLic
     }
 
     @Override
-    public void updateLicenseSummary(String licenseSummary, int numberOfItems) {
+    public void updateLicenseSummary(final String licenseSummary, final int numberOfItems) {
         String licenseHyperLink = "<a href='" + Utils.licenseUrlFor(licenseSummary) + "'>" +
                 getString(Utils.licenseNameFor(licenseSummary)) + "</a><br>";
 
-        setTextViewHTML(tvShareLicenseSummary, getResources()
-                .getQuantityString(R.plurals.share_license_summary, numberOfItems,
-                        licenseHyperLink));
+        setTextViewHTML(tvShareLicenseSummary, String.format("%s%s", getResources()
+            .getQuantityString(R.plurals.share_license_summary, numberOfItems), licenseHyperLink));
     }
 
     private void setTextViewHTML(TextView textView, String text) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,8 +18,8 @@
     <item quantity="other">%d uploads</item>
   </plurals>
   <plurals name="share_license_summary">
-    <item quantity="one">This image will be licensed under %1$s</item>
-    <item quantity="other">These images will be licensed under %1$s</item>
+    <item quantity="one">This image will be licensed under</item>
+    <item quantity="other">These images will be licensed under</item>
   </plurals>
   <plurals name="upload_count_title">
     <item quantity="one">%1$d Upload</item>


### PR DESCRIPTION
**Description (required)**

Fixes #4653

What changes did you make and why?
Special characters in this language (Myanmar) seems to be confused with positional argument's holder, extracted out the positional argument outside of quantity string for a possible fix

**Tests performed (required)**

Tested betaDebug on API 30
Have not been able to test in Myanmar language- would be able to test only after translate wiki translates it for every language.