### PR TITLE
fix: Width of Rank has been increased so that it can accommodate rank…

### DIFF
--- a/app/src/main/res/layout/leaderboard_list_element.xml
+++ b/app/src/main/res/layout/leaderboard_list_element.xml
@@ -15,7 +15,7 @@
       style="?android:textAppearanceMedium"
       android:gravity="center_vertical|center_horizontal"
       android:layout_width="0dp"
-      android:layout_weight="0.1"
+      android:layout_weight="0.15"
       android:layout_height="match_parent"
       android:maxLines="1"
       android:inputType="text"
@@ -39,7 +39,7 @@
       style="?android:textAppearanceMedium"
       android:gravity="center_vertical|start"
       android:layout_width="0dp"
-      android:layout_weight="0.6"
+      android:layout_weight="0.55"
       android:layout_height="match_parent"/>
 
     <TextView


### PR DESCRIPTION
**Description (required)**

Fixes #4680 

What changes did you make and why?
Increased layout_weight of rank so that rank above 999 can be shown.

Screenshots:

<img src="https://user-images.githubusercontent.com/58620100/139643846-53d62511-adde-4379-a254-514bb8616a76.png" height="550" /><img src="https://user-images.githubusercontent.com/58620100/139643463-dcfa29b0-77db-44e0-afaa-8b98a3342151.png" height="550" />

