### PR TITLE
Increased number of leaderboard records fetched in a single request from API

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/profile/leaderboard/LeaderboardConstants.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/leaderboard/LeaderboardConstants.java
@@ -8,7 +8,7 @@ public class LeaderboardConstants {
     /**
      * This is the size of the page i.e. number items to load in a batch when pagination is performed
      */
-    public static final int PAGE_SIZE = 10;
+    public static final int PAGE_SIZE = 100;
 
     /**
      * This is the starting offset, we set it to 0 to start loading from rank 1


### PR DESCRIPTION
**Description (required)**

Fixes #4372

What changes did you make and why?
Increased number of leaderboard records fetched in a single request from API

**Tests performed (required)**

Tested ProdDebug on Pixel 4 XL with API level 31.
