### PR TITLE
Fixes #4571 - Nearby: Save last known location and show it immediately without waiting for GPS

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -118,9 +118,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -322,12 +320,12 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
                     nearbyParentFragmentInstanceReadyCallback.onReady();
                 }
                 performMapReadyActions();
-                List<String> locationLatLng =  new ArrayList<>(applicationKvStore.getStringSet("LastLocation"));
                 final CameraPosition cameraPosition;
-                if(!locationLatLng.isEmpty()) { // Checking for last searched location
+                if(applicationKvStore.getString("LastLocation")!=null) { // Checking for last searched location
+                    String[] locationLatLng = applicationKvStore.getString("LastLocation").split(",");
                     cameraPosition = new CameraPosition.Builder()
-                        .target(new LatLng(Double.valueOf(locationLatLng.get(0)),
-                            Double.valueOf(locationLatLng.get(1))))
+                        .target(new LatLng(Double.valueOf(locationLatLng[0]),
+                            Double.valueOf(locationLatLng[1])))
                         .zoom(ZOOM_LEVEL)
                         .build();
                 }else {
@@ -455,9 +453,9 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
         applicationKvStore.putBoolean("doNotAskForLocationPermission", true);
         final CameraPosition position;
-        List<String> locationLatLng =  new ArrayList<>(applicationKvStore.getStringSet("LastLocation"));
-        if(!locationLatLng.isEmpty()) { // Checking for last searched location
-            lastKnownLocation = new fr.free.nrw.commons.location.LatLng(Double.valueOf(locationLatLng.get(0)), Double.valueOf(locationLatLng.get(1)), 1f);
+        if(applicationKvStore.getString("LastLocation")!=null) { // Checking for last searched location
+            String[] locationLatLng = applicationKvStore.getString("LastLocation").split(",");
+            lastKnownLocation = new fr.free.nrw.commons.location.LatLng(Double.valueOf(locationLatLng[0]), Double.valueOf(locationLatLng[1]), 1f);
             position = new CameraPosition.Builder()
                 .target(LocationUtils.commonsLatLngToMapBoxLatLng(lastKnownLocation))
                 .zoom(ZOOM_LEVEL)
@@ -1002,7 +1000,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(nearbyPlacesInfo -> {
                     // Updating last searched location
-                    applicationKvStore.putStringSet("LastLocation", new HashSet<>(Arrays.asList(Double.toString(searchLatLng.getLatitude()), Double.toString(searchLatLng.getLongitude()))));
+                    applicationKvStore.putString("LastLocation", searchLatLng.getLatitude() + "," + searchLatLng.getLongitude());
                     updateMapMarkers(nearbyPlacesInfo, false);
                     lastFocusLocation=searchLatLng;
                 },

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1093,7 +1093,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         compositeDisposable.add(nearbyPlacesInfoObservable
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribe(nearbyPlacesInfo -> {                    
+            .subscribe(nearbyPlacesInfo -> {
                     if (nearbyPlacesInfo.placeList == null || nearbyPlacesInfo.placeList.isEmpty()) {
                         showErrorMessage(getString(R.string.no_nearby_places_around));
                     } else {


### PR DESCRIPTION
**Description (required)**

Fixes #4571 

What changes did you make and why?

- Saved the last known location in `applicationKvStore`, which will get updated each time when a user searches the new location

- Added condition for checking the last location, if available then the map will open at this location.

- Also resolved the issue of Mapbox getting null when using it without location permission.



**Tests performed (required)**

Tested betaDebug on Pixel 3 with API level 29.
