### PR TITLE
unformatted search text field for depicts and categories search field of upload wizard

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.java
@@ -3,7 +3,6 @@ package fr.free.nrw.commons.upload.categories;
 import android.app.Activity;
 import android.os.Bundle;
 import android.text.Editable;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -18,12 +17,12 @@ import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
-import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 import com.jakewharton.rxbinding2.view.RxView;
 import com.jakewharton.rxbinding2.widget.RxTextView;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.category.CategoryItem;
+import fr.free.nrw.commons.ui.PasteSensitiveTextInputEditText;
 import fr.free.nrw.commons.upload.UploadActivity;
 import fr.free.nrw.commons.upload.UploadBaseFragment;
 import fr.free.nrw.commons.utils.DialogUtil;
@@ -44,7 +43,7 @@ public class UploadCategoriesFragment extends UploadBaseFragment implements Cate
     @BindView(R.id.til_container_search)
     TextInputLayout tilContainerEtSearch;
     @BindView(R.id.et_search)
-    TextInputEditText etSearch;
+    PasteSensitiveTextInputEditText etSearch;
     @BindView(R.id.pb_categories)
     ProgressBar pbCategories;
     @BindView(R.id.rv_categories)

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
@@ -15,11 +15,11 @@ import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
-import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 import com.jakewharton.rxbinding2.view.RxView;
 import com.jakewharton.rxbinding2.widget.RxTextView;
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.ui.PasteSensitiveTextInputEditText;
 import fr.free.nrw.commons.upload.UploadActivity;
 import fr.free.nrw.commons.upload.UploadBaseFragment;
 import fr.free.nrw.commons.upload.structure.depictions.DepictedItem;
@@ -45,7 +45,7 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
     @BindView(R.id.depicts_search_container)
     TextInputLayout depictsSearchContainer;
     @BindView(R.id.depicts_search)
-    TextInputEditText depictsSearch;
+    PasteSensitiveTextInputEditText depictsSearch;
     @BindView(R.id.depictsSearchInProgress)
     ProgressBar depictsSearchInProgress;
     @BindView(R.id.depicts_recycler_view)

--- a/app/src/main/res/layout/upload_categories_fragment.xml
+++ b/app/src/main/res/layout/upload_categories_fragment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:id="@+id/rl_container_categories"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
@@ -56,14 +57,15 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <com.google.android.material.textfield.TextInputEditText
+        <fr.free.nrw.commons.ui.PasteSensitiveTextInputEditText
           android:id="@+id/et_search"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:hint="@string/categories_search_text_hint"
           android:imeOptions="actionSearch"
           android:inputType="text"
-          android:maxLines="1"/>
+          android:maxLines="1"
+          app:allowFormatting="false"/>
       </com.google.android.material.textfield.TextInputLayout>
 
       <ProgressBar

--- a/app/src/main/res/layout/upload_depicts_fragment.xml
+++ b/app/src/main/res/layout/upload_depicts_fragment.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_marginBottom="8dp"
     android:orientation="vertical"
     tools:showIn="@layout/activity_upload">
@@ -81,13 +82,14 @@
             android:layout_marginTop="@dimen/standard_gap"
             android:layout_height="wrap_content">
 
-            <com.google.android.material.textfield.TextInputEditText
+              <fr.free.nrw.commons.ui.PasteSensitiveTextInputEditText
                 android:id="@+id/depicts_search"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:imeOptions="actionSearch"
                 android:inputType="text"
-                android:maxLines="1" />
+                android:maxLines="1"
+              app:allowFormatting="false" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <ProgressBar

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/categories/UploadCategoriesFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/categories/UploadCategoriesFragmentUnitTests.kt
@@ -11,11 +11,11 @@ import android.widget.TextView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestAppAdapter
 import fr.free.nrw.commons.TestCommonsApplication
+import fr.free.nrw.commons.ui.PasteSensitiveTextInputEditText
 import fr.free.nrw.commons.upload.UploadActivity
 import fr.free.nrw.commons.upload.UploadBaseFragment
 import io.reactivex.disposables.Disposable
@@ -57,7 +57,7 @@ class UploadCategoriesFragmentUnitTests {
     private lateinit var tilContainerEtSearch: TextInputLayout
 
     @Mock
-    private lateinit var etSearch: TextInputEditText
+    private lateinit var etSearch: PasteSensitiveTextInputEditText
 
     @Mock
     private lateinit var rvCategories: RecyclerView

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/depicts/DepictsFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/depicts/DepictsFragmentUnitTests.kt
@@ -10,11 +10,11 @@ import android.widget.TextView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestAppAdapter
 import fr.free.nrw.commons.TestCommonsApplication
+import fr.free.nrw.commons.ui.PasteSensitiveTextInputEditText
 import fr.free.nrw.commons.upload.UploadActivity
 import fr.free.nrw.commons.upload.UploadBaseFragment
 import io.reactivex.disposables.Disposable
@@ -57,7 +57,7 @@ class DepictsFragmentUnitTests {
     private lateinit var recyclerView: RecyclerView
 
     @Mock
-    private lateinit var textInputEditText: TextInputEditText
+    private lateinit var textInputEditText: PasteSensitiveTextInputEditText
 
     @Mock
     private lateinit var progressBar: ProgressBar


### PR DESCRIPTION
**Pasted text into the ```` depicts ```` and ```` categories ```` search field is unformatted**

Fixes #4722 

Replaced the ```` TextEditInputText ```` widget with ```` PasteSensitiveTextInputEditText ```` 
(PasteSensitiveTextInputEditText widget: [pull request](https://github.com/commons-app/apps-android-commons/pull/4667))
<br>
Tested on Realme Narzo 20 with API level 30.
