### PR TITLE
Fixes #4215 - Swiping on the last item in explore featured tab takes you to uploaded via mobile

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.java
@@ -112,6 +112,7 @@ public class ExploreListRootFragment extends CommonsDaggerSupportFragment implem
         container.setVisibility(View.VISIBLE);
         ((ExploreFragment) getParentFragment()).tabLayout.setVisibility(View.GONE);
         mediaDetails = new MediaDetailPagerFragment(false, true);
+        ((ExploreFragment) getParentFragment()).setScroll(false);
         setFragment(mediaDetails, listFragment);
         mediaDetails.showImage(position);
     }


### PR DESCRIPTION
**Description (required)**

Fixes #4215 

What changes did you make and why?

- Disabled the ParentViewPager scrolling on clicking the media.

**Tests performed (required)**

Tested betaDebug on Pixel 3 with API level 29.