### PR TITLE
Fixes #4706 - "Images Used" profile metric not showing correct count

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
@@ -216,6 +216,8 @@ public class OkHttpJsonApiClient {
                 if (json == null) {
                     return 0;
                 }
+                // Extract JSON from response
+                json = json.substring(json.indexOf('{'));
                 GetWikidataEditCountResponse countResponse = gson
                     .fromJson(json, GetWikidataEditCountResponse.class);
                 if (null != countResponse) {
@@ -253,6 +255,8 @@ public class OkHttpJsonApiClient {
                 if (json == null) {
                     return null;
                 }
+                // Extract JSON from response
+                json = json.substring(json.indexOf('{'));
                 Timber.d("Response for achievements is %s", json);
                 try {
                     return gson.fromJson(json, FeedbackResponse.class);


### PR DESCRIPTION
**Description (required)**

Fixes #4706 

What changes did you make and why?

- Extracted and Parse the JSON substring from the response string, as the API returns response in invalid JSON format.

**Tests performed (required)**

Tested ProdDebug on Pixel 3 with API level 29.
