### PR TITLE
Fixes #4747 - When uploading many pictures, the top thumbnails strip do not show the current picture

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -469,6 +469,8 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
         if (index < fragments.size() - 1) {
             vpUpload.setCurrentItem(index + 1, false);
             fragments.get(index + 1).onBecameVisible();
+            ((LinearLayoutManager) rvThumbnails.getLayoutManager())
+                .scrollToPositionWithOffset((index > 0) ? index-1 : 0, 0);
         } else {
             if(defaultKvStore.getInt(COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES, 0) >= 10){
                 DialogUtil.showAlertDialog(this,
@@ -490,6 +492,8 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
         if (index != 0) {
             vpUpload.setCurrentItem(index - 1, true);
             fragments.get(index - 1).onBecameVisible();
+            ((LinearLayoutManager) rvThumbnails.getLayoutManager())
+                .scrollToPositionWithOffset((index > 3) ? index-2 : 0, 0);
         }
     }
 


### PR DESCRIPTION
**Description (required)**

Fixes #4747 

What changes did you make and why?

- Thumbnail Recyclerview scrolls corresponding with UploadImageViewPager. As the next/ previous button is clicked, it scrolls to the corresponding picture index.

**Tests performed (required)**

Tested ProdDebug on Pixel 3 with API level 29.