### PR TITLE
Viewbinding welcome activity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.java
@@ -6,22 +6,18 @@ import android.os.Bundle;
 import android.view.View;
 
 import androidx.viewpager.widget.ViewPager;
+import fr.free.nrw.commons.databinding.ActivityWelcomeBinding;
+import fr.free.nrw.commons.utils.ConfigUtils;
 
 import com.viewpagerindicator.CirclePageIndicator;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
+
 import fr.free.nrw.commons.quiz.QuizActivity;
 import fr.free.nrw.commons.theme.BaseActivity;
-import fr.free.nrw.commons.utils.ConfigUtils;
 
 public class WelcomeActivity extends BaseActivity {
 
-    @BindView(R.id.welcomePager)
-    ViewPager pager;
-    @BindView(R.id.welcomePagerIndicator)
-    CirclePageIndicator indicator;
+    private ActivityWelcomeBinding binding;
 
     private WelcomePagerAdapter adapter = new WelcomePagerAdapter();
     private boolean isQuiz;
@@ -34,7 +30,10 @@ public class WelcomeActivity extends BaseActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_welcome);
+
+        binding = ActivityWelcomeBinding.inflate(getLayoutInflater());
+        final View view = binding.getRoot();
+        setContentView(view);
 
         if (getIntent() != null) {
             Bundle bundle = getIntent().getExtras();
@@ -50,10 +49,7 @@ public class WelcomeActivity extends BaseActivity {
             findViewById(R.id.finishTutorialButton).setVisibility(View.VISIBLE);
         }
 
-        ButterKnife.bind(this);
 
-        pager.setAdapter(adapter);
-        indicator.setViewPager(pager);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.java
@@ -19,6 +19,9 @@ public class WelcomeActivity extends BaseActivity {
 
     private ActivityWelcomeBinding binding;
 
+    ViewPager pager;
+    CirclePageIndicator indicator;
+
     private WelcomePagerAdapter adapter = new WelcomePagerAdapter();
     private boolean isQuiz;
 
@@ -30,10 +33,6 @@ public class WelcomeActivity extends BaseActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        binding = ActivityWelcomeBinding.inflate(getLayoutInflater());
-        final View view = binding.getRoot();
-        setContentView(view);
 
         if (getIntent() != null) {
             Bundle bundle = getIntent().getExtras();
@@ -49,7 +48,17 @@ public class WelcomeActivity extends BaseActivity {
             findViewById(R.id.finishTutorialButton).setVisibility(View.VISIBLE);
         }
 
+        binding = ActivityWelcomeBinding.inflate(getLayoutInflater());
+        final View view = binding.getRoot();
+        setContentView(view);
 
+        pager = binding.welcomePager;
+        indicator = binding.welcomePagerIndicator;
+
+        pager.setAdapter(adapter);
+        indicator.setViewPager(pager);
+
+        pager.setOnClickListener(this::finishTutorial);
     }
 
     /**
@@ -90,8 +99,7 @@ public class WelcomeActivity extends BaseActivity {
         }
     }
 
-    @OnClick(R.id.finishTutorialButton)
-    public void finishTutorial() {
+    public void finishTutorial(View view) {
         defaultKvStore.putBoolean("firstrun", false);
         finish();
     }

--- a/app/src/main/java/fr/free/nrw/commons/WelcomePagerAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/WelcomePagerAdapter.java
@@ -55,7 +55,7 @@ public class WelcomePagerAdapter extends PagerAdapter {
 
             // Handle click of finishTutorialButton ("YES!" button) inside layout
             layout.findViewById(R.id.finishTutorialButton)
-                    .setOnClickListener(view -> ((WelcomeActivity) container.getContext()).finishTutorial());
+                    .setOnClickListener(view -> ((WelcomeActivity) container.getContext()).finishTutorial(view));
         }
 
         container.addView(layout);


### PR DESCRIPTION
**Description**

A small step toward completing #4664. Attempt at converting the WelcomeActivity to use view binding.

**What changes did you make and why?**

I just followed the example as best as I could. 

I ended up adding a parameter to the finishTutorial method in WelcomeActivity.java, so now it's finishTutorial(View view). I don't know why, but pager.setOnClickListener(this::finishTutorial) was giving an error if I didn't add that parameter. I updated the call to finishTutorial in WelcomePagerAdapter.java accordingly.

**Tests performed**

Manually tested ProdDebug on Android 9.0 with API level 28 (I'm not sure how to run a suite of automated tests if that's how we do it).


---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
