### PR TITLE
Fixes #53 - Suggest depicted country based on EXIF latitude/longitude

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -148,6 +148,8 @@ dependencies {
     //Glide
     implementation 'com.github.bumptech.glide:glide:4.12.0'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
+
+    implementation("io.github.coordinates2country:coordinates2country-android:1.2") {  exclude group: 'com.google.android', module: 'android' }
 }
 
 android {

--- a/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
+++ b/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
@@ -255,7 +255,7 @@ public class UploadRepository {
      */
 
     public Flowable<List<DepictedItem>> searchAllEntities(String query) {
-        return depictModel.searchAllEntities(query);
+        return depictModel.searchAllEntities(query, this);
     }
 
     /**
@@ -265,14 +265,14 @@ public class UploadRepository {
      * @return a single that provides the depictions
      */
     public Single<List<DepictedItem>> getPlaceDepictions() {
-        final Set<Place> places = new HashSet<>();
+        final Set<String> qids = new HashSet<>();
         for (final UploadItem item : getUploads()) {
             final Place place = item.getPlace();
             if (place != null) {
-                places.add(place);
+                qids.add(place.getWikiDataEntityId());
             }
         }
-        return depictModel.getPlaceDepictions(new ArrayList<>(places));
+        return depictModel.getPlaceDepictions(new ArrayList<>(qids));
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/structure/depictions/DepictModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/structure/depictions/DepictModel.kt
@@ -31,14 +31,14 @@ class DepictModel @Inject constructor(private val depictsClient: DepictsClient) 
         return if (query.isBlank()) {
             nearbyPlaces.switchMap { places: List<Place> ->
                 val qids = mutableSetOf<String>()
-                repository.uploads.forEach {
-                    if(it.gpsCoords != null && it.gpsCoords.imageCoordsExists) {
-                        qids.add("Q"+ Coordinates2Country.countryQID(it.gpsCoords.decLatitude,
-                            it.gpsCoords.decLongitude))
-                    }
-                }
                 for(place in  places) {
                     place.wikiDataEntityId?.let { qids.add(it) }
+                }
+                repository.uploads.forEach { item ->
+                    if(item.gpsCoords != null && item.gpsCoords.imageCoordsExists) {
+                        Coordinates2Country.countryQID(item.gpsCoords.decLatitude,
+                            item.gpsCoords.decLongitude)?.let { qids.add("Q$it") }
+                    }
                 }
                 getPlaceDepictions(ArrayList(qids)).toFlowable()
             }


### PR DESCRIPTION
**Description (required)**

Fixes #53

What changes did you make and why?

- Added [coordinates2country](https://github.com/coordinates2country/coordinates2country) Library to get Country Qid from its Coordinates.
-  When the search query is blank, check for each upload item that has non-null `gpsCoords` and use that to get the country's Qid.
- Passed the Qid to get the depiction item and added it to the initial list. 

**Tests performed (required)**

Tested ProdDebug on Pixel 3 with API level 29.