### PR TITLE
Fixed #4758: "Info" tooltip not visible in Japanese because of long label 

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -370,7 +370,7 @@
 
   <string name="write_storage_permission_rationale_for_image_share">We need your permission to access the external storage of your device in order to upload images.</string>
   <string name="nearby_notification_dismiss_message">You won\'t see the nearest place that needs pictures anymore. However, you can re-enable this notification in Settings if you wish.</string>
-  <string name="step_count">Step %1$d of %2$d: %3$s</string>
+  <string name="step_count">%1$d/%2$d: %3$s</string>
   <string name="next">Next</string>
   <string name="previous">Previous</string>
   <string name="submit">Submit</string>


### PR DESCRIPTION
**Description (required)**

Fixes #4758 

What changes did you make and why?

Changed the Japanese translation of "Step %1$d to %2d"

Tested on:
samsung a20
API level 30

**Screenshots (for UI changes only)**
![image](https://user-images.githubusercontent.com/71180467/150118447-abb9ee0d-86e3-4f4d-8b52-b5f3090cedd3.png)
