### PR TITLE
Fixes 4760 : Clicking the back button in Contribution Tab after uploading an image, exit the app

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -248,8 +248,6 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
 
     @Override
     public void returnToMainActivity() {
-        Intent intent = new Intent(this, MainActivity.class);
-        startActivity(intent);
         finish();
     }
 


### PR DESCRIPTION
**Description (required)**

Fixes #4760

What changes did you make and why?

Removed recreation of MainActivity.

**Tests performed (required)**

Tested ProdDebug master on Pixel 3 with API level 30.
