### PR TITLE
Show alert dialog card for sharing personal detail submission via email when clicking on the feedback menu.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetFragment.java
@@ -104,6 +104,27 @@ public class MoreBottomSheetFragment extends BottomSheetDialogFragment {
 
     @OnClick(R.id.more_feedback)
     public void onFeedbackClicked() {
+        showAlertDialog();
+    }
+
+    /**
+     * This method shows the alert dialog when a user wants to send feedback about the app.
+     */
+    private void showAlertDialog() {
+        new AlertDialog.Builder(getActivity())
+            .setMessage(R.string.feedback_sharing_data_alert)
+            .setCancelable(false)
+            .setPositiveButton(R.string.ok, (dialog, which) -> {
+                sendFeedback();
+            })
+            .show();
+    }
+
+    /**
+     * This method collects the feedback message and starts the activity with implicit intent
+     * to available email client.
+     */
+    private void sendFeedback() {
         final String technicalInfo = commonsLogSender.getExtraInfo();
 
         final Intent feedbackIntent = new Intent(Intent.ACTION_SENDTO);

--- a/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetLoggedOutFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetLoggedOutFragment.java
@@ -40,8 +40,7 @@ public class MoreBottomSheetLoggedOutFragment extends BottomSheetDialogFragment 
     public View onCreateView(@NonNull final LayoutInflater inflater,
         @Nullable final ViewGroup container, @Nullable final Bundle savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
-        final View view = inflater
-            .inflate(R.layout.fragment_more_bottom_sheet_logged_out, container, false);
+        final View view = inflater.inflate(R.layout.fragment_more_bottom_sheet_logged_out, container, false);
         ButterKnife.bind(this, view);
         return view;
     }
@@ -68,6 +67,9 @@ public class MoreBottomSheetLoggedOutFragment extends BottomSheetDialogFragment 
         showAlertDialog();
     }
 
+    /**
+     * This method shows the alert dialog when a user wants to send feedback about the app.
+     */
     private void showAlertDialog() {
         new AlertDialog.Builder(getActivity())
             .setMessage(R.string.feedback_sharing_data_alert)
@@ -78,6 +80,10 @@ public class MoreBottomSheetLoggedOutFragment extends BottomSheetDialogFragment 
             .show();
     }
 
+    /**
+     * This method collects the feedback message and starts and activity with implicit intent
+     * to available email client.
+     */
     private void sendFeedback() {
         final String technicalInfo = commonsLogSender.getExtraInfo();
 

--- a/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetLoggedOutFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetLoggedOutFragment.java
@@ -11,13 +11,13 @@ import android.view.ViewGroup;
 import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import fr.free.nrw.commons.AboutActivity;
 import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.R;
-import fr.free.nrw.commons.WelcomeActivity;
 import fr.free.nrw.commons.auth.LoginActivity;
 import fr.free.nrw.commons.di.ApplicationlessInjection;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
@@ -40,7 +40,8 @@ public class MoreBottomSheetLoggedOutFragment extends BottomSheetDialogFragment 
     public View onCreateView(@NonNull final LayoutInflater inflater,
         @Nullable final ViewGroup container, @Nullable final Bundle savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
-        final View view = inflater.inflate(R.layout.fragment_more_bottom_sheet_logged_out, container, false);
+        final View view = inflater
+            .inflate(R.layout.fragment_more_bottom_sheet_logged_out, container, false);
         ButterKnife.bind(this, view);
         return view;
     }
@@ -64,6 +65,20 @@ public class MoreBottomSheetLoggedOutFragment extends BottomSheetDialogFragment 
 
     @OnClick(R.id.more_feedback)
     public void onFeedbackClicked() {
+        showAlertDialog();
+    }
+
+    private void showAlertDialog() {
+        new AlertDialog.Builder(getActivity())
+            .setMessage(R.string.feedback_sharing_data_alert)
+            .setCancelable(false)
+            .setPositiveButton(R.string.ok, (dialog, which) -> {
+                sendFeedback();
+            })
+            .show();
+    }
+
+    private void sendFeedback() {
         final String technicalInfo = commonsLogSender.getExtraInfo();
 
         final Intent feedbackIntent = new Intent(Intent.ACTION_SENDTO);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -682,4 +682,5 @@ Upload your first media by tapping on the add button.</string>
   <string name="apply">Apply</string>
   <string name="reset">Reset</string>
   <string name="location_message">Location data helps Wiki editors find your picture, making it much more useful.\nYour recent uploads have no location.\nWe suggest you turn on location in your camera app\'s settings.\nThank you for uploading!</string>
+  <string name="feedback_sharing_data_alert">Please remove from this email any information that you are not comfortable sharing publicly</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -682,5 +682,5 @@ Upload your first media by tapping on the add button.</string>
   <string name="apply">Apply</string>
   <string name="reset">Reset</string>
   <string name="location_message">Location data helps Wiki editors find your picture, making it much more useful.\nYour recent uploads have no location.\nWe suggest you turn on location in your camera app\'s settings.\nThank you for uploading!</string>
-  <string name="feedback_sharing_data_alert">Please remove from this email any information that you are not comfortable sharing publicly</string>
+  <string name="feedback_sharing_data_alert">Please remove from this email any information that you are not comfortable sharing publicly. Also, please be aware that your email address with which you are posting, and the associated name and profile picture, will be visible publicly.</string>
 </resources>


### PR DESCRIPTION
Show alert dialog card for sharing personal detail submission via email when clicking on the feedback menu.

**Description (required)**

Fixes #4732 

What changes did you make and why?

Add alert dialog card for sharing the personal detail submission via email client when clicking on feedback menu.

**Screenshots (for UI changes only)**

![alert](https://user-images.githubusercontent.com/4018792/151589601-53de654e-c551-42a7-bd8a-0ff1a021cee6.png)

