### PR TITLE
Cancel previous ongoing runs in the PR/branch when you push new commits 

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,6 +2,10 @@ name: Android CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-18.04
@@ -12,11 +16,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-        
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: ${{ github.token }}    
+ 
         
     - name: Build with Gradle
       run: ./gradlew -Pcoverage testBetaDebugUnitTestCoverage

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,9 +15,7 @@ jobs:
     - name: set up JDK 1.8
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
- 
-        
+        java-version: 1.8 
     - name: Build with Gradle
       run: ./gradlew -Pcoverage testBetaDebugUnitTestCoverage
     - name: Upload Test Report

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,7 +14,7 @@ jobs:
         java-version: 1.8
         
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.8.0
+      uses: styfle/cancel-workflow-action@0.9.1
       with:
         access_token: ${{ github.token }}    
         

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,6 +12,12 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+        
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}    
+        
     - name: Build with Gradle
       run: ./gradlew -Pcoverage testBetaDebugUnitTestCoverage
     - name: Upload Test Report


### PR DESCRIPTION
**Description (required)**

Fixes #4781 

What changes did you make?
Adding this to cancel any previous ongoing builds when you push new commits to a PR or branch. This will ensure that we don't run out of free build mins.

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
