### PR TITLE
Update CI with latest versions, artifacts and caching

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out code
       - uses: actions/checkout@v2.4.0
+      - name: Check out code
 
       - name: Set up JDK
         uses: actions/setup-java@v2.5.0

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,7 +13,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Check out code
 
       - name: Set up JDK
         uses: actions/setup-java@v2.5.0

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Upload betaDebug APK
         uses: actions/upload-artifact@v2.3.1
         with:
-          name: betaDebugAPK-PR${{ github.event.pull_request.number || github.ref }}
+          name: betaDebugAPK
           path: app/build/outputs/apk/beta/debug/app-*.apk
 
       - name: Generate prodDebug APK
@@ -54,5 +54,5 @@ jobs:
       - name: Upload prodDebug APK
         uses: actions/upload-artifact@v2.3.1
         with:
-          name: prodDebugAPK-PR${{ github.event.pull_request.number || github.ref }}
+          name: prodDebugAPK
           path: app/build/outputs/apk/prod/debug/app-*.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,11 +12,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Check out code
+      - uses: actions/checkout@v2.4.0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2.5.0
         with:
-          java-version: 1.8
+          distribution: "temurin"
+          java-version: 8
+
+      - name: Cache packages
+        id: cache-packages
+        uses: actions/cache@v2.1.7
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-packages-${{ runner.os }}-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', 'gradle.properties') }}
+          restore-keys: gradle-packages-${{ runner.os }}
 
       - name: Build with Gradle and run Unit Tests
         run: ./gradlew -Pcoverage testBetaDebugUnitTestCoverage --stacktrace
@@ -27,20 +40,20 @@ jobs:
           chmod +x codecov
           ./codecov -f "app/build/reports/jacoco/testBetaDebugUnitTestCoverage/testBetaDebugUnitTestCoverage.xml" -Z
 
-      - name: Build betaDebug APK
+      - name: Generate betaDebug APK
         run: bash ./gradlew assembleBetaDebug --stacktrace
 
       - name: Upload betaDebug APK
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.3.1
         with:
-          name: betaDebugAPK-PR${{ github.event.pull_request.number }}
-          path: app/build/outputs/apk/debug/app-*.apk
+          name: betaDebugAPK-PR${{ github.event.pull_request.number || github.ref }}
+          path: app/build/outputs/apk/beta/debug/app-*.apk
 
-      - name: Build prodDebug APK
+      - name: Generate prodDebug APK
         run: bash ./gradlew assembleProdDebug --stacktrace
 
       - name: Upload prodDebug APK
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.3.1
         with:
-          name: prodDebugAPK-PR${{ github.event.pull_request.number }}
-          path: app/build/outputs/apk/prod/app-*.apk
+          name: prodDebugAPK-PR${{ github.event.pull_request.number || github.ref }}
+          path: app/build/outputs/apk/prod/debug/app-*.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,18 +8,39 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    name: Build APK and Run Unit Tests
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8 
-    - name: Build with Gradle
-      run: ./gradlew -Pcoverage testBetaDebugUnitTestCoverage
-    - name: Upload Test Report
-      run: |
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        chmod +x codecov
-        ./codecov -f "app/build/reports/jacoco/testBetaDebugUnitTestCoverage/testBetaDebugUnitTestCoverage.xml" -Z
+      - uses: actions/checkout@v2
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Build with Gradle and run Unit Tests
+        run: ./gradlew -Pcoverage testBetaDebugUnitTestCoverage --stacktrace
+
+      - name: Upload Test Report to Codecov
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -f "app/build/reports/jacoco/testBetaDebugUnitTestCoverage/testBetaDebugUnitTestCoverage.xml" -Z
+
+      - name: Build betaDebug APK
+        run: bash ./gradlew assembleBetaDebug --stacktrace
+
+      - name: Upload betaDebug APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: betaDebugAPK-PR${{ github.event.pull_request.number }}
+          path: app/build/outputs/apk/debug/app-*.apk
+
+      - name: Build prodDebug APK
+        run: bash ./gradlew assembleProdDebug --stacktrace
+
+      - name: Upload prodDebug APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: prodDebugAPK-PR${{ github.event.pull_request.number }}
+          path: app/build/outputs/apk/prod/app-*.apk


### PR DESCRIPTION
**Description**
Fixes #4770

What changes did you make and why?
Update CI with latest versions, artifacts and caching

After every build two apks are generated prodDebug and betaDebug, maintainers no longer need to manually build apk, they can simply download them to test✌️😀

Download link - https://github.com/madhurgupta10/apps-android-commons/actions/runs/1783540419

