### PR TITLE
Fix warnings for ImageFileLoader.kt #4786

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/CustomSelectorViewModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/CustomSelectorViewModel.kt
@@ -45,7 +45,7 @@ class CustomSelectorViewModel(var context: Context,var imageFileLoader: ImageFil
             override fun onFailed(throwable: Throwable) {
                 result.postValue(Result(CallbackStatus.SUCCESS, arrayListOf()))
             }
-        },scope)
+        })
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/ImageFileLoader.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/ImageFileLoader.kt
@@ -33,7 +33,7 @@ class ImageFileLoader(val context: Context) : CoroutineScope{
     /**
      * Load Device Images under coroutine.
      */
-    fun loadDeviceImages(listener: ImageLoaderListener, scope: CoroutineScope) {
+    fun loadDeviceImages(listener: ImageLoaderListener) {
         launch(Dispatchers.Main) {
             withContext(Dispatchers.IO) {
                 getImages(listener)
@@ -82,7 +82,7 @@ class ImageFileLoader(val context: Context) : CoroutineScope{
 
 
                 if (file != null && file.exists()) {
-                    if (id != null && name != null && path != null && bucketId != null && bucketName != null) {
+                    if (name != null && path != null && bucketName != null) {
                         val uri = ContentUris.withAppendedId(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, id)
                         val image = Image(id, name, uri, path, bucketId, bucketName)
                         images.add(image)

--- a/app/src/test/kotlin/fr/free/nrw/commons/customselector/ui/selector/ImageFileLoaderTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/customselector/ui/selector/ImageFileLoaderTest.kt
@@ -75,7 +75,7 @@ class ImageFileLoaderTest {
      */
     @Test
     fun testLoadDeviceImages() {
-        imageFileLoader.loadDeviceImages(imageLoaderListener, coroutineScope)
+        imageFileLoader.loadDeviceImages(imageLoaderListener)
     }
 
     /**


### PR DESCRIPTION
Fix warnings for ImageFileLoader.kt #4786 

All warning solved except :- 'DATA: String' is deprecated. Deprecated in Java 

because solveing this will require major code changes which is probably not necessary at this point of time
