### PR TITLE
Fixes #4774  Leaderboard: Taping on avatar should open tip popup

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/profile/leaderboard/UserDetailAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/leaderboard/UserDetailAdapter.java
@@ -1,5 +1,6 @@
 package fr.free.nrw.commons.profile.leaderboard;
 
+import android.app.AlertDialog;
 import android.content.Context;
 import android.net.Uri;
 import android.view.LayoutInflater;
@@ -8,6 +9,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
+import butterknife.internal.DebouncingOnClickListener;
 import com.facebook.drawee.view.SimpleDraweeView;
 import fr.free.nrw.commons.R;
 
@@ -67,7 +69,7 @@ public class UserDetailAdapter extends RecyclerView.Adapter<UserDetailAdapter.Da
      * @param position
      */
     @Override
-    public void onBindViewHolder(@NonNull UserDetailAdapter.DataViewHolder holder, int position) {
+    public void onBindViewHolder(@NonNull DataViewHolder holder, int position) {
         TextView rank = holder.rank;
         SimpleDraweeView avatar = holder.avatar;
         TextView username = holder.username;
@@ -83,6 +85,17 @@ public class UserDetailAdapter extends RecyclerView.Adapter<UserDetailAdapter.Da
         count.setText(String.format("%s %d",
             holder.getContext().getResources().getString(R.string.count_prefix),
             leaderboardResponse.getCategoryCount()));
+
+        avatar.setOnClickListener(new DebouncingOnClickListener() {
+            @Override
+            public void doClick(final View v) {
+                new AlertDialog.Builder(v.getContext())
+                    .setMessage(R.string.leaderboard_avatar_setup)
+                    .setCancelable(false)
+                    .setPositiveButton(R.string.ok, (dialog, which) -> {})
+                    .show();
+            }
+        });
 
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -683,4 +683,5 @@ Upload your first media by tapping on the add button.</string>
   <string name="reset">Reset</string>
   <string name="location_message">Location data helps Wiki editors find your picture, making it much more useful.\nYour recent uploads have no location.\nWe suggest you turn on location in your camera app\'s settings.\nThank you for uploading!</string>
   <string name="feedback_sharing_data_alert">Please remove from this email any information that you are not comfortable sharing publicly. Also, please be aware that your email address with which you are posting, and the associated name and profile picture, will be visible publicly.</string>
+  <string name="leaderboard_avatar_setup">To set up your leaderboard avatar, tap \"Set as avatar\" in the three-dots menu of any image.</string>
 </resources>


### PR DESCRIPTION
Fixes #4774 
Setup an on-click listener on avatar image and show alert on click of an avatar with message on how to setup avatar.

