### PR TITLE
Make caption field single line Issue#4795

### DIFF
--- a/app/src/main/res/layout/row_item_description.xml
+++ b/app/src/main/res/layout/row_item_description.xml
@@ -48,7 +48,7 @@
               android:layout_height="match_parent"
               android:hint="@string/share_caption_hint"
               android:imeOptions="actionNext|flagNoExtractUi"
-              android:inputType="textMultiLine"
+              android:inputType="text"
               app:allowFormatting="false" />
         </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
**Description (required)**
When uploading image the caption  must not be multiline.

Fixes #4795

What changes did you make and why?
I changed the caption field inputType to text. earlier it was textMultiLine. 

**Tests performed (required)**
Tested on Redmi 6 Pro 
Build variant Beta
API LEVEL 28

**Screenshots (for UI changes only)**
![WhatsApp Image 2022-02-13 at 13 46 33](https://user-images.githubusercontent.com/55136047/153751057-11452903-a6f4-4dd6-878d-0a52507201ae.jpeg)
