### PR TITLE
Fixed 4794 : Added a functionality of remembering zoom level on map

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -7,6 +7,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacem
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
 import static fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.LAST_LOCATION;
+import static fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.LAST_ZOOM;
 
 import android.content.Intent;
 import android.graphics.BitmapFactory;
@@ -382,6 +383,7 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
                 mapboxMap.getCameraPosition().target.getLatitude()
                     + ","
                     + mapboxMap.getCameraPosition().target.getLongitude());
+            applicationKvStore.putString(LAST_ZOOM,mapboxMap.getCameraPosition().zoom + "");
         }
         final Intent returningIntent = new Intent();
         returningIntent.putExtra(LocationPickerConstants.MAP_CAMERA_POSITION,

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -383,7 +383,7 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
                 mapboxMap.getCameraPosition().target.getLatitude()
                     + ","
                     + mapboxMap.getCameraPosition().target.getLongitude());
-            applicationKvStore.putString(LAST_ZOOM,mapboxMap.getCameraPosition().zoom + "");
+            applicationKvStore.putString(LAST_ZOOM, mapboxMap.getCameraPosition().zoom + "");
         }
         final Intent returningIntent = new Intent();
         returningIntent.putExtra(LocationPickerConstants.MAP_CAMERA_POSITION,

--- a/app/src/main/java/fr/free/nrw/commons/upload/ImageCoordinates.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ImageCoordinates.kt
@@ -18,6 +18,10 @@ class ImageCoordinates internal constructor(exif: ExifInterface?) {
      * @return string of `"[decLatitude]|[decLongitude]"` or null if coordinates do not exist
      */
     var decimalCoords: String? = null
+    var zoomLevel : Double = 16.0
+    /**
+     *  @return double value of zoom or 16.0 by default
+     */
 
     /**
      * Construct from a stream.

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -60,6 +60,7 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
      * from applicationKvStore.
      */
     public static final String LAST_LOCATION = "last_location_while_uploading";
+    public static final String LAST_ZOOM = "last_zoom_level_while_uploading";
     @BindView(R.id.tv_title)
     TextView tvTitle;
     @BindView(R.id.ib_map)
@@ -424,17 +425,19 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
         editableUploadItem = uploadItem;
         double defaultLatitude = 37.773972;
         double defaultLongitude = -122.431297;
+        double defaultZoom = 16.0;
 
         if (uploadItem.getGpsCoords()
             .getDecLatitude() != 0.0 && uploadItem.getGpsCoords().getDecLongitude() != 0.0) {
             defaultLatitude = uploadItem.getGpsCoords()
                 .getDecLatitude();
             defaultLongitude = uploadItem.getGpsCoords().getDecLongitude();
+            defaultZoom = uploadItem.getGpsCoords().getZoomLevel();
             startActivityForResult(new LocationPicker.IntentBuilder()
                 .defaultLocation(new CameraPosition.Builder()
                     .target(
                         new com.mapbox.mapboxsdk.geometry.LatLng(defaultLatitude, defaultLongitude))
-                    .zoom(16).build())
+                    .zoom(defaultZoom).build())
                 .activityKey("UploadActivity")
                 .build(getActivity()), REQUEST_CODE);
         } else {
@@ -444,11 +447,14 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
                 defaultLatitude = Double.parseDouble(locationLatLng[0]);
                 defaultLongitude = Double.parseDouble(locationLatLng[1]);
             }
+            if(defaultKvStore.getString(LAST_ZOOM) != null){
+                defaultZoom = Double.parseDouble(defaultKvStore.getString(LAST_ZOOM));
+            }
             startActivityForResult(new LocationPicker.IntentBuilder()
                 .defaultLocation(new CameraPosition.Builder()
                     .target(
                         new com.mapbox.mapboxsdk.geometry.LatLng(defaultLatitude, defaultLongitude))
-                    .zoom(16).build())
+                    .zoom(defaultZoom).build())
                 .activityKey("NoLocationUploadActivity")
                 .build(getActivity()), REQUEST_CODE);
         }
@@ -474,8 +480,9 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
 
                 final String latitude = String.valueOf(cameraPosition.target.getLatitude());
                 final String longitude = String.valueOf(cameraPosition.target.getLongitude());
+                final double zoom = cameraPosition.zoom;
 
-                editLocation(latitude, longitude);
+                editLocation(latitude, longitude,zoom);
             }
         }
     }
@@ -485,12 +492,13 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
      * @param latitude new latitude
      * @param longitude new longitude
      */
-    public void editLocation(final String latitude, final String longitude){
+    public void editLocation(final String latitude, final String longitude, final double zoom){
 
         editableUploadItem.getGpsCoords().setDecLatitude(Double.parseDouble(latitude));
         editableUploadItem.getGpsCoords().setDecLongitude(Double.parseDouble(longitude));
         editableUploadItem.getGpsCoords().setDecimalCoords(latitude+"|"+longitude);
         editableUploadItem.getGpsCoords().setImageCoordsExists(true);
+        editableUploadItem.getGpsCoords().setZoomLevel(zoom);
         Toast.makeText(getContext(), "Location Updated", Toast.LENGTH_LONG).show();
 
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -117,6 +117,8 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
         this.callback = callback;
     }
 
+    private double defaultZoom = 16.0;
+
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -425,7 +427,6 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
         editableUploadItem = uploadItem;
         double defaultLatitude = 37.773972;
         double defaultLongitude = -122.431297;
-        double defaultZoom = 16.0;
 
         if (uploadItem.getGpsCoords()
             .getDecLatitude() != 0.0 && uploadItem.getGpsCoords().getDecLongitude() != 0.0) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -117,8 +117,6 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
         this.callback = callback;
     }
 
-    private double defaultZoom = 16.0;
-
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -427,8 +425,9 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
         editableUploadItem = uploadItem;
         double defaultLatitude = 37.773972;
         double defaultLongitude = -122.431297;
+        double defaultZoom = 16.0;
 
-        if (uploadItem.getGpsCoords()
+        if (uploadItem.getGpsCoords() != null && uploadItem.getGpsCoords()
             .getDecLatitude() != 0.0 && uploadItem.getGpsCoords().getDecLongitude() != 0.0) {
             defaultLatitude = uploadItem.getGpsCoords()
                 .getDecLatitude();

--- a/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityTest.kt
@@ -1,0 +1,67 @@
+package fr.free.nrw.commons.locationpicker
+
+import android.os.Looper
+import com.mapbox.mapboxsdk.camera.CameraPosition
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import fr.free.nrw.commons.LocationPicker.LocationPickerActivity
+import fr.free.nrw.commons.TestCommonsApplication
+import fr.free.nrw.commons.kvstore.JsonKvStore
+import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.LAST_ZOOM
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.powermock.reflect.Whitebox
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import java.lang.reflect.Method
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [21], application = TestCommonsApplication::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+class LocationPickerActivityTest {
+
+    private lateinit var activityLocationPicker : LocationPickerActivity
+
+    @Mock
+    private lateinit var applicationKvStore: JsonKvStore
+
+    @Mock
+    private lateinit var mapboxMap : MapboxMap
+
+
+    @Before
+    fun setup(){
+        MockitoAnnotations.initMocks(this)
+        activityLocationPicker = Robolectric.buildActivity(LocationPickerActivity::class.java).get()
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testRememberZoomLevel(){
+        shadowOf(Looper.getMainLooper()).idle()
+        Whitebox.setInternalState(activityLocationPicker,"mapboxMap",mapboxMap)
+        Whitebox.setInternalState(activityLocationPicker,"activity", "NoLocationUploadActivity")
+        Whitebox.setInternalState(activityLocationPicker,"applicationKvStore",applicationKvStore)
+        val position = CameraPosition.Builder().target(LatLng(
+                51.50550,
+                -0.07520, 0.0
+            )
+        ).zoom(15.0).build()
+        `when`(mapboxMap.cameraPosition).thenReturn(position)
+        val method: Method = LocationPickerActivity::class.java.getDeclaredMethod(
+            "placeSelected"
+        )
+        method.isAccessible = true
+        method.invoke(activityLocationPicker)
+        Mockito.verify(applicationKvStore,Mockito.times(1))
+            .putString(LAST_ZOOM,position.zoom.toString())
+    }
+}

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
@@ -31,6 +31,7 @@ import fr.free.nrw.commons.upload.ImageCoordinates
 import fr.free.nrw.commons.upload.UploadActivity
 import fr.free.nrw.commons.upload.UploadItem
 import fr.free.nrw.commons.upload.UploadMediaDetailAdapter
+import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.LAST_ZOOM
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -44,11 +45,13 @@ import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowActivity
+import org.robolectric.shadows.ShadowIntent
 import org.wikipedia.AppAdapter
 import java.lang.reflect.Method
-import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.LAST_ZOOM
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [21], application = TestCommonsApplication::class)
@@ -100,6 +103,8 @@ class UploadMediaDetailFragmentUnitTest {
     @Mock
     private lateinit var imageCoordinates: ImageCoordinates
 
+    private lateinit var activity: UploadActivity
+
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
@@ -107,7 +112,7 @@ class UploadMediaDetailFragmentUnitTest {
         context = RuntimeEnvironment.application.applicationContext
         AppAdapter.set(TestAppAdapter())
 
-        val activity = Robolectric.buildActivity(UploadActivity::class.java).create().get()
+        activity = Robolectric.buildActivity(UploadActivity::class.java).create().get()
         layoutInflater = LayoutInflater.from(activity)
 
         view = LayoutInflater.from(activity)
@@ -344,7 +349,7 @@ class UploadMediaDetailFragmentUnitTest {
     @Test
     @Throws(Exception::class)
     fun testShowExternalMap() {
-        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        shadowOf(Looper.getMainLooper()).idle()
         `when`(uploadItem.gpsCoords).thenReturn(imageCoordinates)
         `when`(imageCoordinates.decLatitude).thenReturn(0.0)
         `when`(imageCoordinates.decLongitude).thenReturn(0.0)
@@ -436,12 +441,35 @@ class UploadMediaDetailFragmentUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun testRememberedZoomLevel(){
-        Shadows.shadowOf(Looper.getMainLooper()).idle()
-        `when`(uploadItem.gpsCoords).thenReturn(imageCoordinates)
-        `when`(defaultKvStore.getString(LAST_ZOOM)).thenReturn("16.0")
+    fun testRememberedZoomLevelOnNull(){
+        shadowOf(Looper.getMainLooper()).idle()
+        Whitebox.setInternalState(fragment, "defaultKvStore", defaultKvStore)
+        `when`(uploadItem.gpsCoords).thenReturn(null)
+        `when`(defaultKvStore.getString(LAST_ZOOM)).thenReturn("13.0")
         fragment.showExternalMap(uploadItem)
         Mockito.verify(uploadItem,Mockito.times(1)).gpsCoords
+        Mockito.verify(defaultKvStore,Mockito.times(2)).getString(LAST_ZOOM)
+        val shadowActivity: ShadowActivity = shadowOf(activity)
+        val startedIntent = shadowActivity.nextStartedActivity
+        val shadowIntent: ShadowIntent = shadowOf(startedIntent)
+        Assert.assertEquals(shadowIntent.intentClass, LocationPickerActivity::class.java)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testRememberedZoomLevelOnNotNull(){
+        shadowOf(Looper.getMainLooper()).idle()
+        `when`(uploadItem.gpsCoords).thenReturn(imageCoordinates)
+        `when`(imageCoordinates.decLatitude).thenReturn(8.0)
+        `when`(imageCoordinates.decLongitude).thenReturn(-8.0)
+        `when`(imageCoordinates.zoomLevel).thenReturn(14.0)
+        `when`(defaultKvStore.getString(LAST_ZOOM)).thenReturn(null)
+        fragment.showExternalMap(uploadItem)
+        Mockito.verify(uploadItem.gpsCoords,Mockito.times(1)).zoomLevel
+        val shadowActivity: ShadowActivity = shadowOf(activity)
+        val startedIntent = shadowActivity.nextStartedActivity
+        val shadowIntent: ShadowIntent = shadowOf(startedIntent)
+        Assert.assertEquals(shadowIntent.intentClass, LocationPickerActivity::class.java)
     }
 
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
@@ -48,6 +48,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.wikipedia.AppAdapter
 import java.lang.reflect.Method
+import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.LAST_ZOOM
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [21], application = TestCommonsApplication::class)
@@ -437,13 +438,10 @@ class UploadMediaDetailFragmentUnitTest {
     @Throws(Exception::class)
     fun testRememberedZoomLevel(){
         Shadows.shadowOf(Looper.getMainLooper()).idle()
-        Whitebox.setInternalState(fragment, "defaultKvStore", defaultKvStore)
-        Whitebox.setInternalState(fragment, "editableUploadItem", uploadItem)
-        imageCoordinates.zoomLevel = 11.0
-        defaultKvStore.putString("last_zoom_level_while_uploading","5.63")
-        `when`(defaultKvStore.getString("last_zoom_level_while_uploading","16.0"))
-            .thenReturn("5.63")
-        `when`(imageCoordinates.zoomLevel).thenReturn(11.0)
+        `when`(uploadItem.gpsCoords).thenReturn(imageCoordinates)
+        `when`(defaultKvStore.getString(LAST_ZOOM)).thenReturn("16.0")
+        fragment.showExternalMap(uploadItem)
+        Mockito.verify(uploadItem,Mockito.times(1)).gpsCoords
     }
 
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
@@ -21,6 +21,7 @@ import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.nhaarman.mockitokotlin2.mock
 import fr.free.nrw.commons.LocationPicker.LocationPicker
+import fr.free.nrw.commons.LocationPicker.LocationPickerActivity
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestAppAdapter
 import fr.free.nrw.commons.TestCommonsApplication
@@ -346,6 +347,7 @@ class UploadMediaDetailFragmentUnitTest {
         `when`(uploadItem.gpsCoords).thenReturn(imageCoordinates)
         `when`(imageCoordinates.decLatitude).thenReturn(0.0)
         `when`(imageCoordinates.decLongitude).thenReturn(0.0)
+        `when`(imageCoordinates.zoomLevel).thenReturn(16.0)
         fragment.showExternalMap(uploadItem)
     }
 
@@ -429,6 +431,14 @@ class UploadMediaDetailFragmentUnitTest {
         Shadows.shadowOf(Looper.getMainLooper()).idle()
         runnable = Runnable {  }
         fragment.displayAddLocationDialog(runnable)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testRememberedZoomLevel(){
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        Whitebox.setInternalState(fragment, "defaultKvStore", defaultKvStore)
+        `when`(defaultKvStore.getString("last_zoom_level_while_uploading", )).thenReturn("16.0")
     }
 
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
@@ -439,9 +439,11 @@ class UploadMediaDetailFragmentUnitTest {
         Shadows.shadowOf(Looper.getMainLooper()).idle()
         Whitebox.setInternalState(fragment, "defaultKvStore", defaultKvStore)
         Whitebox.setInternalState(fragment, "editableUploadItem", uploadItem)
-        `when`(defaultKvStore.getString("last_zoom_level_while_uploading"))
-            .thenReturn("16.0")
-        `when`(imageCoordinates.zoomLevel).thenReturn(16.0)
+        imageCoordinates.zoomLevel = 11.0
+        defaultKvStore.putString("last_zoom_level_while_uploading","5.63")
+        `when`(defaultKvStore.getString("last_zoom_level_while_uploading","16.0"))
+            .thenReturn("5.63")
+        `when`(imageCoordinates.zoomLevel).thenReturn(11.0)
     }
 
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
@@ -438,7 +438,10 @@ class UploadMediaDetailFragmentUnitTest {
     fun testRememberedZoomLevel(){
         Shadows.shadowOf(Looper.getMainLooper()).idle()
         Whitebox.setInternalState(fragment, "defaultKvStore", defaultKvStore)
-        `when`(defaultKvStore.getString("last_zoom_level_while_uploading", )).thenReturn("16.0")
+        Whitebox.setInternalState(fragment, "editableUploadItem", uploadItem)
+        `when`(defaultKvStore.getString("last_zoom_level_while_uploading"))
+            .thenReturn("16.0")
+        `when`(imageCoordinates.zoomLevel).thenReturn(16.0)
     }
 
 }


### PR DESCRIPTION
**Description (required)**

while selecting location in map during upload, remember the zoom level in addition of longitude & latitude. 

Fixes #4794

What changes did you make and why?
- Added new filed <b>zoomLevel</b> in <b>ImageCoordinates file</b> to store zoom level
- Storing the new key-value pair for <b>zoom level</b> in <b>LocationPickerActivity file</b>.
- Set the <b>zoom level</b> in <b>UploadMediaDetailFragment</b> also updating the zoom level in same file.

**Tests performed**

Tested build variant on ASUS_X00TD with API level 28.
