### PR TITLE
Show user current location

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -80,6 +80,7 @@ import fr.free.nrw.commons.description.DescriptionEditHelper;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.explore.depictions.WikidataItemDetailsActivity;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
+import fr.free.nrw.commons.location.LocationServiceManager;
 import fr.free.nrw.commons.nearby.Label;
 import fr.free.nrw.commons.profile.ProfileActivity;
 import fr.free.nrw.commons.ui.widget.HtmlTextView;
@@ -116,6 +117,9 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
     private boolean isDeleted = false;
     private boolean isWikipediaButtonDisplayed;
     private Callback callback;
+
+    @Inject
+    LocationServiceManager locationManager;
 
 
     public static MediaDetailFragment forMedia(int index, boolean editable, boolean isCategoryImage, boolean isWikipediaButtonDisplayed) {
@@ -826,9 +830,14 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             defaultLatitude = media.getCoordinates().getLatitude();
             defaultLongitude = media.getCoordinates().getLongitude();
         } else {
-            String[] lastLocation = applicationKvStore.getString(LAST_LOCATION,(defaultLatitude + "," + defaultLongitude)).split(",");
-            defaultLatitude = Double.parseDouble(lastLocation[0]);
-            defaultLongitude = Double.parseDouble(lastLocation[1]);
+            if(locationManager.getLastLocation()!=null) {
+                defaultLatitude = locationManager.getLastLocation().getLatitude();
+                defaultLongitude = locationManager.getLastLocation().getLongitude();
+            } else {
+                String[] lastLocation = applicationKvStore.getString(LAST_LOCATION,(defaultLatitude + "," + defaultLongitude)).split(",");
+                defaultLatitude = Double.parseDouble(lastLocation[0]);
+                defaultLongitude = Double.parseDouble(lastLocation[1]);
+            }
         }
 
         startActivityForResult(new LocationPicker.IntentBuilder()

--- a/app/src/test/kotlin/fr/free/nrw/commons/media/MediaDetailFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/media/MediaDetailFragmentUnitTests.kt
@@ -28,6 +28,7 @@ import fr.free.nrw.commons.category.CategoryEditSearchRecyclerViewAdapter
 import fr.free.nrw.commons.explore.SearchActivity
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import fr.free.nrw.commons.location.LatLng
+import fr.free.nrw.commons.location.LocationServiceManager
 import fr.free.nrw.commons.ui.widget.HtmlTextView
 import org.junit.Assert
 import org.junit.Before
@@ -65,6 +66,9 @@ class MediaDetailFragmentUnitTests {
     private lateinit var layoutInflater: LayoutInflater
     private lateinit var view: View
     private lateinit var context: Context
+
+    @Mock
+    private lateinit var locationManager: LocationServiceManager
 
     @Mock
     private lateinit var categoryEditSearchRecyclerViewAdapter: CategoryEditSearchRecyclerViewAdapter
@@ -180,6 +184,7 @@ class MediaDetailFragmentUnitTests {
         Whitebox.setInternalState(fragment, "categoryContainer", linearLayout)
         Whitebox.setInternalState(fragment, "categorySearchView", searchView)
         Whitebox.setInternalState(fragment, "mediaDiscussion", textView)
+        Whitebox.setInternalState(fragment, "locationManager", locationManager)
         Whitebox.setInternalState(
             fragment,
             "categoryEditSearchRecyclerViewAdapter",
@@ -239,11 +244,13 @@ class MediaDetailFragmentUnitTests {
 
     @Test
     @Throws(Exception::class)
-    fun testOnUpdateCoordinatesClicked() {
+    fun testOnUpdateCoordinatesClickedCurrentLocationNull() {
         `when`(media.coordinates).thenReturn(null)
+        `when`(locationManager.lastLocation).thenReturn(null)
         `when`(applicationKvStore.getString(LAST_LOCATION)).thenReturn("37.773972,-122.431297")
         fragment.onUpdateCoordinatesClicked()
         Mockito.verify(media, Mockito.times(1)).coordinates
+        Mockito.verify(locationManager, Mockito.times(1)).lastLocation
         val shadowActivity: ShadowActivity = shadowOf(activity)
         val startedIntent = shadowActivity.nextStartedActivity
         val shadowIntent: ShadowIntent = shadowOf(startedIntent)
@@ -257,6 +264,21 @@ class MediaDetailFragmentUnitTests {
         `when`(applicationKvStore.getString(LAST_LOCATION)).thenReturn("37.773972,-122.431297")
         fragment.onUpdateCoordinatesClicked()
         Mockito.verify(media, Mockito.times(3)).coordinates
+        val shadowActivity: ShadowActivity = shadowOf(activity)
+        val startedIntent = shadowActivity.nextStartedActivity
+        val shadowIntent: ShadowIntent = shadowOf(startedIntent)
+        Assert.assertEquals(shadowIntent.intentClass, LocationPickerActivity::class.java)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testOnUpdateCoordinatesClickedCurrentLocationNotNull() {
+        `when`(media.coordinates).thenReturn(null)
+        `when`(locationManager.lastLocation).thenReturn(LatLng(-0.000001, -0.999999, 0f))
+        `when`(applicationKvStore.getString(LAST_LOCATION)).thenReturn("37.773972,-122.431297")
+
+        fragment.onUpdateCoordinatesClicked()
+        Mockito.verify(locationManager, Mockito.times(3)).lastLocation
         val shadowActivity: ShadowActivity = shadowOf(activity)
         val startedIntent = shadowActivity.nextStartedActivity
         val shadowIntent: ShadowIntent = shadowOf(startedIntent)


### PR DESCRIPTION
**Description (required)**
when adding coordinates to a photo, the map should center on my location (if available) or at the last coordinates I provided. It is not very convenient to navigate from San Francisco to Germany every time

Fixes #4699

What changes did you make and why?
checked for users device location and if available then use that instead of default san Francisco location. 

**Tests performed (required)**

Device: Redmi 6 Pro
API Level: 28
Build Variant: Beta
