### PR TITLE
Fixed #4793 : Remove the need to tap "Next" again

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -483,6 +483,9 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
                 final double zoom = cameraPosition.zoom;
 
                 editLocation(latitude, longitude,zoom);
+                if(editableUploadItem.getUploadMediaDetails().get(0).getCaptionText().length() != 0){
+                    onNextButtonClicked();
+                }
             }
         }
     }

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
@@ -27,10 +27,7 @@ import fr.free.nrw.commons.TestAppAdapter
 import fr.free.nrw.commons.TestCommonsApplication
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import fr.free.nrw.commons.nearby.Place
-import fr.free.nrw.commons.upload.ImageCoordinates
-import fr.free.nrw.commons.upload.UploadActivity
-import fr.free.nrw.commons.upload.UploadItem
-import fr.free.nrw.commons.upload.UploadMediaDetailAdapter
+import fr.free.nrw.commons.upload.*
 import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.LAST_ZOOM
 import org.junit.Assert
 import org.junit.Before
@@ -359,8 +356,8 @@ class UploadMediaDetailFragmentUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun testOnActivityResult() {
-        Shadows.shadowOf(Looper.getMainLooper()).idle()
+    fun testOnActivityResultOnEmptyCaption() {
+        shadowOf(Looper.getMainLooper()).idle()
         Mockito.mock(LocationPicker::class.java)
         val intent = Mockito.mock(Intent::class.java)
         val cameraPosition = Mockito.mock(CameraPosition::class.java)
@@ -373,7 +370,34 @@ class UploadMediaDetailFragmentUnitTest {
         `when`(latLng.latitude).thenReturn(0.0)
         `when`(latLng.longitude).thenReturn(0.0)
         `when`(uploadItem.gpsCoords).thenReturn(imageCoordinates)
+        val uploadMediaDetails : ArrayList<UploadMediaDetail> = ArrayList()
+        uploadMediaDetails.add(UploadMediaDetail())
+        `when`(uploadItem.uploadMediaDetails).thenReturn(uploadMediaDetails)
         fragment.onActivityResult(1211, Activity.RESULT_OK, intent)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testOnActivityResultOnNotEmptyCaption() {
+        shadowOf(Looper.getMainLooper()).idle()
+        Mockito.mock(LocationPicker::class.java)
+        val intent = Mockito.mock(Intent::class.java)
+        val cameraPosition = Mockito.mock(CameraPosition::class.java)
+        val latLng = Mockito.mock(LatLng::class.java)
+
+        Whitebox.setInternalState(cameraPosition, "target", latLng)
+        Whitebox.setInternalState(fragment, "editableUploadItem", uploadItem)
+        Whitebox.setInternalState(fragment, "presenter", presenter)
+
+        `when`(LocationPicker.getCameraPosition(intent)).thenReturn(cameraPosition)
+        `when`(latLng.latitude).thenReturn(0.0)
+        `when`(latLng.longitude).thenReturn(0.0)
+        `when`(uploadItem.gpsCoords).thenReturn(imageCoordinates)
+        val uploadMediaDetails : ArrayList<UploadMediaDetail> = ArrayList()
+        uploadMediaDetails.add(UploadMediaDetail("lan-en","desc","caption"))
+        `when`(uploadItem.uploadMediaDetails).thenReturn(uploadMediaDetails)
+        fragment.onActivityResult(1211, Activity.RESULT_OK, intent)
+        Mockito.verify(presenter,Mockito.times(1)).verifyImageQuality(0)
     }
 
     @Test


### PR DESCRIPTION
**Description**

- After tapping "Next", the "No location found" popup appears.

- Problem: After choosing a location, I am still at the caption/description step, so I have to tap "Next" again.

- Goal: After choosing a location, I should be sent directly to the next step (depictions, or next media in the case of a multi-upload).

Fixes #4793

What changes did you make and why?

- Once the location is selected then I checked for caption, if it not entered then I redirect the user back to the upload screen otherwise to the next screen.

- Also add and update the required test 

**Tests performed **

Tested  on ASUS_X00TD with API level 28.
