### PR TITLE
Show progress when uploading image

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionViewHolder.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionViewHolder.java
@@ -123,6 +123,7 @@ public class ContributionViewHolder extends RecyclerView.ViewHolder {
                 if (transferred == 0 || transferred >= total) {
                     progressView.setIndeterminate(true);
                 } else {
+                    progressView.setIndeterminate(false);
                     progressView.setProgress((int) (((double) transferred / (double) total) * 100));
                 }
                 break;


### PR DESCRIPTION
**Description (required)**
 if one keeps on looking at the app during a picture upload, one just sees a fake progress bar imitation. If one wants to see a real progress bar one just has to pull down the notifications. So please use the same real progress bar that you have in notifications, also in the app.

Fixes #4679

What changes did you make and why?
added a single line that sets progress bar indeterminate to false

**Tests performed (required)**
Device Redmi 6 Pro
API level 28
build: Beta

**Screenshots (for UI changes only)**
![WhatsApp Image 2022-02-17 at 23 41 06](https://user-images.githubusercontent.com/55136047/154544835-a7689c93-8fa3-44da-b64b-11ac8c5c544d.jpeg)

