### PR TITLE
Fixed #4793 : Remove the need to tap "Next" again

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -96,9 +96,10 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
     private boolean isExpanded = true;
 
     /**
-     * isNoLocationDialog will be true, if user add location through add location dialog
+     * True if location is added via the "missing location" popup dialog (which appears after tapping
+     * "Next" if the picture has no geographical coordinates).
      */
-    private boolean isNoLocationDialog;
+    private boolean isMissingLocationDialog;
 
     /**
      * showNearbyFound will be true, if any nearby location found that needs pictures and the nearby popup is yet to be shown
@@ -489,11 +490,11 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
 
                 editLocation(latitude, longitude,zoom);
                 /*
-                       if isNoLocationDialog is true then the user will redirect to the next screen
-                       otherwise user will redirect back to the upload screen
+                       If isMissingLocationDialog is true, it means that the user has already tapped the
+                       "Next" button, so go directly to the next step.
                  */
-                if(isNoLocationDialog){
-                    isNoLocationDialog = false;
+                if(isMissingLocationDialog){
+                    isMissingLocationDialog = false;
                     onNextButtonClicked();
                 }
             }
@@ -528,7 +529,7 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
      */
     @Override
     public void displayAddLocationDialog(final Runnable onSkipClicked) {
-        isNoLocationDialog = true;
+        isMissingLocationDialog = true;
         DialogUtil.showAlertDialog(Objects.requireNonNull(getActivity()),
             getString(R.string.no_location_found_title),
             getString(R.string.no_location_found_message),

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -94,6 +94,7 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
     private Place place;
 
     private boolean isExpanded = true;
+    public boolean isNoLocationDialog;
 
     /**
      * showNearbyFound will be true, if any nearby location found that needs pictures and the nearby popup is yet to be shown
@@ -483,6 +484,11 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
                 final double zoom = cameraPosition.zoom;
 
                 editLocation(latitude, longitude,zoom);
+
+                if(isNoLocationDialog){
+                    isNoLocationDialog = false;
+                    onNextButtonClicked();
+                }
             }
         }
     }
@@ -515,6 +521,7 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
      */
     @Override
     public void displayAddLocationDialog(final Runnable onSkipClicked) {
+        isNoLocationDialog = true;
         DialogUtil.showAlertDialog(Objects.requireNonNull(getActivity()),
             getString(R.string.no_location_found_title),
             getString(R.string.no_location_found_message),

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -94,7 +94,11 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
     private Place place;
 
     private boolean isExpanded = true;
-    public boolean isNoLocationDialog;
+
+    /**
+     * isNoLocationDialog will be true, if user add location through add location dialog
+     */
+    private boolean isNoLocationDialog;
 
     /**
      * showNearbyFound will be true, if any nearby location found that needs pictures and the nearby popup is yet to be shown
@@ -484,7 +488,10 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
                 final double zoom = cameraPosition.zoom;
 
                 editLocation(latitude, longitude,zoom);
-
+                /*
+                       if isNoLocationDialog is true then the user will redirect to the next screen
+                       otherwise user will redirect back to the upload screen
+                 */
                 if(isNoLocationDialog){
                     isNoLocationDialog = false;
                     onNextButtonClicked();

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
@@ -388,7 +388,7 @@ class UploadMediaDetailFragmentUnitTest {
 
         Whitebox.setInternalState(cameraPosition, "target", latLng)
         Whitebox.setInternalState(fragment, "editableUploadItem", uploadItem)
-        Whitebox.setInternalState(fragment,"isNoLocationDialog",true)
+        Whitebox.setInternalState(fragment,"isMissingLocationDialog",true)
         Whitebox.setInternalState(fragment, "presenter", presenter)
 
         `when`(LocationPicker.getCameraPosition(intent)).thenReturn(cameraPosition)

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
@@ -359,8 +359,8 @@ class UploadMediaDetailFragmentUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun testOnActivityResult() {
-        Shadows.shadowOf(Looper.getMainLooper()).idle()
+    fun testOnActivityResultOnMapIconClicked() {
+        shadowOf(Looper.getMainLooper()).idle()
         Mockito.mock(LocationPicker::class.java)
         val intent = Mockito.mock(Intent::class.java)
         val cameraPosition = Mockito.mock(CameraPosition::class.java)
@@ -374,6 +374,29 @@ class UploadMediaDetailFragmentUnitTest {
         `when`(latLng.longitude).thenReturn(0.0)
         `when`(uploadItem.gpsCoords).thenReturn(imageCoordinates)
         fragment.onActivityResult(1211, Activity.RESULT_OK, intent)
+        Mockito.verify(presenter, Mockito.times(0)).verifyImageQuality(0)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testOnActivityResultAddLocationDialog() {
+        shadowOf(Looper.getMainLooper()).idle()
+        Mockito.mock(LocationPicker::class.java)
+        val intent = Mockito.mock(Intent::class.java)
+        val cameraPosition = Mockito.mock(CameraPosition::class.java)
+        val latLng = Mockito.mock(LatLng::class.java)
+
+        Whitebox.setInternalState(cameraPosition, "target", latLng)
+        Whitebox.setInternalState(fragment, "editableUploadItem", uploadItem)
+        Whitebox.setInternalState(fragment,"isNoLocationDialog",true)
+        Whitebox.setInternalState(fragment, "presenter", presenter)
+
+        `when`(LocationPicker.getCameraPosition(intent)).thenReturn(cameraPosition)
+        `when`(latLng.latitude).thenReturn(0.0)
+        `when`(latLng.longitude).thenReturn(0.0)
+        `when`(uploadItem.gpsCoords).thenReturn(imageCoordinates)
+        fragment.onActivityResult(1211, Activity.RESULT_OK, intent)
+        Mockito.verify(presenter, Mockito.times(1)).verifyImageQuality(0)
     }
 
     @Test


### PR DESCRIPTION
**Description**
- After tapping "Next", the "No location found" popup appears.

- Problem: After choosing a location, I am still at the caption/description step, so I have to tap "Next" again.

- Goal: After choosing a location, I should be sent directly to the next step (depictions, or next media in the case of a multi-upload)

Fixes #4793

What changes did you make and why?

-  when <b>add location dialog</b> appears, flag become true and once the user selected the location they will redirect to the next screen and flag become false 

- Also add and update the required test

Tests performed

Tested on ASUS_X00TD with API level 28.
