### PR TITLE
Fixed #4750 : "Exists" is enabled by default for map view

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFilterState.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFilterState.java
@@ -15,7 +15,7 @@ public class NearbyFilterState {
      * Define initial filter values here
      */
     private NearbyFilterState() {
-        existsSelected = false;
+        existsSelected = true;
         needPhotoSelected = true;
         wlmSelected = true;
         checkBoxTriState = -1; // Unknown


### PR DESCRIPTION
**Description**

-  Filtering locations to only existing one would be much better user experience.

- In general sane default are a good idea.

- Looking for objects where no trace may exist anymore should be opt-in.

Fixes #4750

What changes did you make and why?

Just changed the default value of exists filter at NearByFilterState to true

Tested build variant on ASUS_X00TD with API level 28.

**Screenshots**

- Video of Changes:

https://user-images.githubusercontent.com/61725413/154792540-b7710476-fd67-455b-aa66-45944ecb1453.mp4


