### PR TITLE
Refactor: move recent search model to data.models

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/data/models/RecentSearch.kt
+++ b/app/src/main/java/fr/free/nrw/commons/data/models/RecentSearch.kt
@@ -1,4 +1,4 @@
-package fr.free.nrw.commons.explore.recentsearches
+package fr.free.nrw.commons.data.models
 
 import android.net.Uri
 import java.util.*

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -23,7 +23,7 @@ import fr.free.nrw.commons.category.CategoryImagesCallback;
 import fr.free.nrw.commons.explore.categories.search.SearchCategoryFragment;
 import fr.free.nrw.commons.explore.depictions.search.SearchDepictionsFragment;
 import fr.free.nrw.commons.explore.media.SearchMediaFragment;
-import fr.free.nrw.commons.explore.recentsearches.RecentSearch;
+import fr.free.nrw.commons.data.models.RecentSearch;
 import fr.free.nrw.commons.explore.recentsearches.RecentSearchesDao;
 import fr.free.nrw.commons.explore.recentsearches.RecentSearchesFragment;
 import fr.free.nrw.commons.media.MediaDetailPagerFragment;

--- a/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesDao.java
@@ -9,6 +9,7 @@ import android.os.RemoteException;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import fr.free.nrw.commons.data.models.RecentSearch;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;

--- a/app/src/test/kotlin/fr/free/nrw/commons/explore/recentsearches/RecentSearchesDaoTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/explore/recentsearches/RecentSearchesDaoTest.kt
@@ -7,8 +7,8 @@ import android.database.MatrixCursor
 import android.database.sqlite.SQLiteDatabase
 import android.os.RemoteException
 import com.nhaarman.mockitokotlin2.*
-import fr.free.nrw.commons.BuildConfig
 import fr.free.nrw.commons.TestCommonsApplication
+import fr.free.nrw.commons.data.models.RecentSearch
 import fr.free.nrw.commons.explore.recentsearches.RecentSearchesContentProvider.BASE_URI
 import fr.free.nrw.commons.explore.recentsearches.RecentSearchesContentProvider.uriForId
 import fr.free.nrw.commons.explore.recentsearches.RecentSearchesDao.Table.*

--- a/app/src/test/kotlin/fr/free/nrw/commons/explore/search/SearchActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/explore/search/SearchActivityUnitTests.kt
@@ -13,7 +13,7 @@ import fr.free.nrw.commons.explore.SearchActivity
 import fr.free.nrw.commons.explore.categories.search.SearchCategoryFragment
 import fr.free.nrw.commons.explore.depictions.search.SearchDepictionsFragment
 import fr.free.nrw.commons.explore.media.SearchMediaFragment
-import fr.free.nrw.commons.explore.recentsearches.RecentSearch
+import fr.free.nrw.commons.data.models.RecentSearch
 import fr.free.nrw.commons.explore.recentsearches.RecentSearchesDao
 import fr.free.nrw.commons.explore.recentsearches.RecentSearchesFragment
 import fr.free.nrw.commons.media.MediaDetailPagerFragment


### PR DESCRIPTION
Part of an ongoing code refactoring to move all models to a common models package.

Fixes #4782

Moved RecentSearch to data.models package.

Tested debug on Pixel 4 (Emulator) with API level 30.