### PR TITLE
Provide information on how to add location info in dialog

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -686,7 +686,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="reset">Reset</string>
   <string name="location_message">Location data helps Wiki editors find your picture, making it much more useful.\nYour recent uploads have no location.\nWe suggest you turn on location in your camera app\'s settings.\nThank you for uploading!</string>
   <string name="no_location_found_title">No location found</string>
-  <string name="no_location_found_message">How about adding the place where this image was taken?\nLocation data helps Wiki editors find your picture, making it much more useful.\nThank you!</string>
+  <string name="no_location_found_message">How about adding the place where this image was taken?\nLocation data helps Wiki editors find your picture, making it much more useful.\nYou could use the map icon to add location data.\nThank you!</string>
   <string name="add_location">Add location</string>
   <string name="feedback_sharing_data_alert">Please remove from this email any information that you are not comfortable sharing publicly. Also, please be aware that your email address with which you are posting, and the associated name and profile picture, will be visible publicly.</string>
   <string name="achievements_unavailable_beta">Achievements are only available in the prod flavor.</string>


### PR DESCRIPTION
**Description (required)**

The dialog shown when there's no location data associated with an
image does not mention how to add the data.

What changes did you make and why?

Added a sentence which conveys how to add location information to the image.

**Tests performed (required)**

Tested ProdDebug on Nexus 4 emulator with API level 30.

**Screenshots (for UI changes only)**
![Screenshot_1647696041](https://user-images.githubusercontent.com/12448084/159122811-cf410f6a-1962-449c-9fd3-59ee3547da58.png)

