### PR TITLE
In app feedback name

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/feedback/FeedbackContentCreator.java
+++ b/app/src/main/java/fr/free/nrw/commons/feedback/FeedbackContentCreator.java
@@ -2,6 +2,7 @@ package fr.free.nrw.commons.feedback;
 
 import android.content.Context;
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.auth.AccountUtil;
 import fr.free.nrw.commons.feedback.model.Feedback;
 import fr.free.nrw.commons.utils.LangCodeUtils;
 import java.util.Locale;
@@ -29,7 +30,9 @@ public class FeedbackContentCreator {
 
         stringBuilder = new StringBuilder();
         stringBuilder.append("== ");
-        stringBuilder.append("Feedback from ~~~ for version ");
+        stringBuilder.append("Feedback from  ");
+        stringBuilder.append(AccountUtil.getUserName(context));
+        stringBuilder.append(" for version ");
         stringBuilder.append(feedback.getVersion());
         stringBuilder.append(" ==");
         stringBuilder.append("\n");

--- a/app/src/test/kotlin/fr/free/nrw/commons/feedback/FeedbackContentCreatorUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/feedback/FeedbackContentCreatorUnitTests.kt
@@ -24,14 +24,13 @@ class FeedbackContentCreatorUnitTests {
     private lateinit var creator: FeedbackContentCreator
     private lateinit var feedback: Feedback
 
-    @Mock
     private lateinit var context: Context
     
     @Before
     fun setup() {
         MockitoAnnotations.initMocks(this)
         AppAdapter.set(TestAppAdapter())
-        context = RuntimeEnvironment.application.applicationContext
+        context = FakeContextWrapper(RuntimeEnvironment.application.applicationContext)
     }
 
     @Test


### PR DESCRIPTION
**Description (required)**
In the feedback section, currently the app posts "~~~" which is transformed into something complex (username [talk].
Instead, the app should insert the username.

Fixes #4904 

What changes did you make and why?
removed ~~~ and fetched username instead using AccountUtils class.

**Tests performed (required)**

Tested on prodDebug
Device: Redmi 6 PRO
Android: 9 (API 28)