### PR TITLE
App downloads too many of my contributions, without reason

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionBoundaryCallback.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionBoundaryCallback.kt
@@ -36,11 +36,10 @@ class ContributionBoundaryCallback @Inject constructor(
     }
 
     /**
-     * It is triggered when the user scrolls to the top of the list User's Contributions are then
-     * fetched from the network
+     * It is triggered when the user scrolls to the top of the list
      * */
     override fun onItemAtFrontLoaded(itemAtFront: Contribution) {
-        fetchContributions()
+
     }
 
     /**

--- a/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionBoundaryCallbackTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionBoundaryCallbackTest.kt
@@ -85,8 +85,6 @@ class ContributionBoundaryCallbackTest {
         whenever(mediaClient.getMediaListForUser(anyString()))
             .thenReturn(Single.just(listOf(media())))
         contributionBoundaryCallback.onItemAtFrontLoaded(mock(Contribution::class.java))
-        verify(repository).save(anyList());
-        verify(mediaClient).getMediaListForUser(anyString());
     }
 
     @Test


### PR DESCRIPTION
**Description (required)**
App downloads all the contributions at once by making lot's of subsequent requests to API. Instead the contributions should be downloaded as users scrolls rather than all at once.

Fixes #4900

What changes did you make and why?
I removed the fetchContributions call inside of onItemAtFrontLoaded . this will prevent function calling when user is not at the end.

**Tests performed (required)**
prodDebug

