### PR TITLE
Fix #4930 : change the nearby bookmark icon color

### DIFF
--- a/app/src/main/res/drawable/ic_filled_star_24dp.xml
+++ b/app/src/main/res/drawable/ic_filled_star_24dp.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="#EDA33F"
         android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
 </vector>


### PR DESCRIPTION
**Description (required)**

Fixes #4930

The original black icon cannot be seen in the dark theme. The icon color is then changed to orange so that it is visible in both themes.

**Tests performed (required)**


**Screenshots (for UI changes only)**
Light theme:
<img src="https://user-images.githubusercontent.com/73240868/162859714-0ed5a19e-7ece-4a4b-81ed-7f0f074650c1.png" width="30%">
Dark theme:
<img src="https://user-images.githubusercontent.com/73240868/162859788-7188058e-c71f-42d3-a131-088089f3276d.png" width="30%">


