### PR TITLE
Fix bug #4950 back arrow still present on top-level activity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -662,7 +662,7 @@ public class ContributionsFragment
     }
 
     public boolean backButtonClicked() {
-        if (null != mediaDetailPagerFragment && mediaDetailPagerFragment.isVisible()) {
+        if (mediaDetailPagerFragment != null && mediaDetailPagerFragment.isVisible()) {
             if (store.getBoolean("displayNearbyCardView", true) && !isUserProfile) {
                 if (nearbyNotificationCardView.cardViewVisibilityState == NearbyNotificationCardView.CardViewVisibilityState.READY) {
                     nearbyNotificationCardView.setVisibility(View.VISIBLE);
@@ -679,9 +679,10 @@ public class ContributionsFragment
             }else {
                 fetchCampaigns();
             }
-            if(getActivity() instanceof MainActivity) {
+            if (getActivity() instanceof MainActivity) {
                 // Fragment is associated with MainActivity
-                ((MainActivity)getActivity()).showTabs();
+                ((BaseActivity) getActivity()).getSupportActionBar().setDisplayHomeAsUpEnabled(false);
+                ((MainActivity) getActivity()).showTabs();
             }
             return true;
         }


### PR DESCRIPTION
**Description**
Fixes #4950

`((BaseActivity) getActivity()).getSupportActionBar().setDisplayHomeAsUpEnabled(false);` was removed in #4736 due to which this bug occured

**Tests performed**
Tested ProdDebug on Mi A2 with API level 29