### PR TITLE
Fixes #4953: remove misleading dialog 'Unable to get descriptions'

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -1052,10 +1052,6 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         } else if (requestCode == REQUEST_CODE_EDIT_DESCRIPTION && resultCode == RESULT_CANCELED) {
             progressBarEditDescription.setVisibility(GONE);
             editDescription.setVisibility(VISIBLE);
-
-            viewUtil.showShortToast(getContext(),
-                Objects.requireNonNull(getContext())
-                    .getString(R.string.descriptions_picking_unsuccessful));
         }
     }
 


### PR DESCRIPTION
**Description (required)**

Fixes #4953 

In the `onActivityResult` method of `MediaDetailFragment`, a dialog 'Unable to get descriptions' will be displayed if the `DescriptionEditActivity` returns with result code `RESULT_CANCELED` which is the default return value when an activity exit.
I deleted the codes which display the misleading dialog when `DescriptionEditActivity` exits with result code `RESULT_CANCELED` and the issue is solved.
I think the same issue happens for the activity that edits coordinates.

**Tests performed (required)**

Tested ProdDebug on HUAWEI HMA-AL00 with API level 29.

