### PR TITLE
Fix bug #4959 by correctly setting previous db version number and updating the current db version

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/data/DBOpenHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/data/DBOpenHelper.java
@@ -4,9 +4,7 @@ import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteOpenHelper;
-
 import fr.free.nrw.commons.bookmarks.items.BookmarkItemsDao;
-import fr.free.nrw.commons.bookmarks.items.BookmarkItemsDao.Table;
 import fr.free.nrw.commons.bookmarks.locations.BookmarkLocationsDao;
 import fr.free.nrw.commons.bookmarks.pictures.BookmarkPicturesDao;
 import fr.free.nrw.commons.category.CategoryDao;
@@ -16,7 +14,7 @@ import fr.free.nrw.commons.recentlanguages.RecentLanguagesDao;
 public class DBOpenHelper  extends SQLiteOpenHelper {
 
     private static final String DATABASE_NAME = "commons.db";
-    private static final int DATABASE_VERSION = 19;
+    private static final int DATABASE_VERSION = 20;
     public static final String CONTRIBUTIONS_TABLE = "contributions";
     private final String DROP_TABLE_STATEMENT="DROP TABLE IF EXISTS %s";
 

--- a/app/src/main/java/fr/free/nrw/commons/recentlanguages/RecentLanguagesDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/recentlanguages/RecentLanguagesDao.java
@@ -185,23 +185,17 @@ public class RecentLanguagesDao {
             if (from == to) {
                 return;
             }
-            if (from < 6) {
+            if (from < 19) {
                 // doesn't exist yet
                 from++;
                 onUpdate(db, from, to);
                 return;
             }
-            if (from == 6) {
-                // table added in version 7
+            if (from == 19) {
+                // table added in version 20
                 onCreate(db);
                 from++;
                 onUpdate(db, from, to);
-                return;
-            }
-            if (from == 7) {
-                from++;
-                onUpdate(db, from, to);
-                return;
             }
         }
     }

--- a/app/src/test/kotlin/fr/free/nrw/commons/recentlanguages/RecentLanguagesDaoUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/recentlanguages/RecentLanguagesDaoUnitTest.kt
@@ -177,20 +177,103 @@ class RecentLanguagesDaoUnitTest {
     @Test
     fun migrateTableVersionFrom_v5_to_v6() {
         onUpdate(database, 5, 6)
-        // Table didnt exist before v7
+        // Table didnt exist in version 6
         verifyZeroInteractions(database)
     }
 
     @Test
     fun migrateTableVersionFrom_v6_to_v7() {
         onUpdate(database, 6, 7)
-        verify(database).execSQL(CREATE_TABLE_STATEMENT)
+        // Table didnt exist in version 7
+        verifyZeroInteractions(database)
     }
 
     @Test
     fun migrateTableVersionFrom_v7_to_v8() {
         onUpdate(database, 7, 8)
-        // Table didnt change in version 8
+        // Table didnt exist in version 8
+        verifyZeroInteractions(database)
+    }
+
+    @Test
+    fun migrateTableVersionFrom_v8_to_v9() {
+        onUpdate(database, 8, 9)
+        // Table didnt exist in version 9
+        verifyZeroInteractions(database)
+    }
+
+    @Test
+    fun migrateTableVersionFrom_v9_to_v10() {
+        onUpdate(database, 9, 10)
+        // Table didnt exist in version 10
+        verifyZeroInteractions(database)
+    }
+
+    @Test
+    fun migrateTableVersionFrom_v10_to_v11() {
+        onUpdate(database, 10, 11)
+        // Table didnt exist in version 11
+        verifyZeroInteractions(database)
+    }
+
+    @Test
+    fun migrateTableVersionFrom_v11_to_v12() {
+        onUpdate(database, 11, 12)
+        // Table didnt exist in version 12
+        verifyZeroInteractions(database)
+    }
+
+    @Test
+    fun migrateTableVersionFrom_v12_to_v13() {
+        onUpdate(database, 12, 13)
+        // Table didnt exist in version 13
+        verifyZeroInteractions(database)
+    }
+
+    @Test
+    fun migrateTableVersionFrom_v13_to_v14() {
+        onUpdate(database, 13, 14)
+        // Table didnt exist in version 14
+        verifyZeroInteractions(database)
+    }
+
+    @Test
+    fun migrateTableVersionFrom_v14_to_v15() {
+        onUpdate(database, 14, 15)
+        // Table didnt exist in version 15
+        verifyZeroInteractions(database)
+    }
+
+    @Test
+    fun migrateTableVersionFrom_v15_to_v16() {
+        onUpdate(database, 15, 16)
+        // Table didnt exist in version 16
+        verifyZeroInteractions(database)
+    }
+
+    @Test
+    fun migrateTableVersionFrom_v16_to_v17() {
+        onUpdate(database, 16, 17)
+        // Table didnt exist in version 17
+        verifyZeroInteractions(database)
+    }
+
+    @Test
+    fun migrateTableVersionFrom_v18_to_v19() {
+        onUpdate(database, 18, 19)
+        // Table didnt exist in version 18
+        verifyZeroInteractions(database)
+    }
+
+    @Test
+    fun migrateTableVersionFrom_v19_to_v20() {
+        onUpdate(database, 19, 20)
+        verify(database).execSQL(CREATE_TABLE_STATEMENT)
+    }
+
+    @Test
+    fun migrateTableVersionFrom_v20_to_v20() {
+        onUpdate(database, 20, 20)
         verifyZeroInteractions(database)
     }
 


### PR DESCRIPTION
**Description**
Fixes #4959

The previous version of DB was incorrectly set in the PR https://github.com/commons-app/apps-android-commons/pull/4515 due to which crash was happening for users who updated the app from 3.1-release to 4.0-release

Steps to test

- Uninstall app
- Install 3.1-release
- Go to Any Media Detail
- Click on Pencil Icon next to - `In all languages` in the Description
- Update to 4.0-release without uninstalling the app
- Click on Pencil Icon again

**Tests performed**
Tested betaDebug on Mi A2 with API level 29