### PR TITLE
fix #4971 update description extraction algorithm

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -94,6 +94,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.commons.lang3.StringUtils;
@@ -914,19 +916,15 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
      * @return LinkedHashMap<LanguageCode,Description>
      */
     private LinkedHashMap<String,String> getDescriptions(String s) {
-        // trim spaces next to "=" and "|"
-        s = s.replace(" =", "=").replace(" |", "|").replace("= ","=").replace("| ","|");
-        int descriptionIndex = s.indexOf("description=");
-        if(descriptionIndex == -1){
-            descriptionIndex = s.indexOf("Description=");
+        final Pattern pattern = Pattern.compile("[dD]escription *=(.*?)\n *\\|", Pattern.DOTALL);
+        final Matcher matcher = pattern.matcher(s);
+        String description = null;
+        if (matcher.find()) {
+            description = matcher.group();
         }
-
-        if( descriptionIndex == -1 ){
+        if(description == null){
             return new LinkedHashMap<>();
         }
-        final String descriptionToEnd = s.substring(descriptionIndex+12);
-        final int descriptionEndIndex = descriptionToEnd.indexOf("\n|");
-        final String description = s.substring(descriptionIndex+12, descriptionIndex+12+descriptionEndIndex);
 
         final LinkedHashMap<String,String> descriptionList = new LinkedHashMap<>();
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/media/MediaDetailFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/media/MediaDetailFragmentUnitTests.kt
@@ -468,6 +468,25 @@ class MediaDetailFragmentUnitTests {
 
     @Test
     @Throws(Exception::class)
+    fun testGetDescriptionsWithLongSpaces() {
+        `when`(media.filename).thenReturn("")
+        val method: Method = MediaDetailFragment::class.java.getDeclaredMethod("getDescriptions", String::class.java)
+        method.isAccessible = true
+        val s = "=={{int:filedesc}}==\n" +
+                "{{Information\n" +
+                "|Description   ={{en|1=The interior of Sacred Heart RC Church, Wimbledon, London.}}\n" +
+                "|Source        ={{own}}\n" +
+                "|Author        =[[User:Diliff|Diliff]]\n" +
+                "|Date          =2015-02-17\n" +
+                "|Permission    ={{Diliff/Licensing}}\n" +
+                "|other_versions=\n" +
+                "}}"
+        val map = linkedMapOf("en" to "The interior of Sacred Heart RC Church, Wimbledon, London.")
+        Assert.assertEquals(map, method.invoke(fragment, s))
+    }
+
+    @Test
+    @Throws(Exception::class)
     fun testGetDescriptionList() {
         `when`(media.filename).thenReturn("")
         val method: Method = MediaDetailFragment::class.java.getDeclaredMethod(


### PR DESCRIPTION
**Description (required)**

Fixes #4971 

the original algorithm trims only one space next to `|` and `=` in wikitext, for the wikitext with multiple spaces between `description` and `=`, the algorithm fails to work.
I change the algorithm so that It can match descriptions in wikitext with long spaces.
Also, a related unit test is added.

**Tests performed (required)**

Tested {ProdDebug} on {HUAWEI HMA-AL00} with API level {API 29}.
