### PR TITLE
Update library to new version that handles older Java VMs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -152,7 +152,7 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
 
-    implementation("io.github.coordinates2country:coordinates2country-android:1.2") {  exclude group: 'com.google.android', module: 'android' }
+    implementation("io.github.coordinates2country:coordinates2country-android:1.3") {  exclude group: 'com.google.android', module: 'android' }
 }
 
 task disableAnimations(type: Exec) {


### PR DESCRIPTION
Fixes #4972 I believe.

Built `assembleProd` fine, and the library gave expected results when testing after `installProdDebug`.