### PR TITLE
Fixed #4978 change caption upload algorithm

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
@@ -114,8 +114,16 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
      */
     public void removeDescription(final UploadMediaDetail uploadMediaDetail, final int position) {
         selectedLanguages.remove(position);
-        this.uploadMediaDetails.remove(uploadMediaDetail);
+        final int ListPosition =
+            (int) selectedLanguages.keySet().stream().filter(e -> e < position).count();
+        this.uploadMediaDetails.remove(uploadMediaDetails.get(ListPosition));
+        int i = position + 1;
+        while (selectedLanguages.containsKey(i)) {
+            selectedLanguages.remove(i);
+            i++;
+        }
         notifyItemRemoved(position);
+        notifyItemRangeChanged(position, uploadMediaDetails.size() - position);
     }
 
     public class ViewHolder extends RecyclerView.ViewHolder {
@@ -139,6 +147,10 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
         @BindView(R.id.btn_remove)
         ImageView removeButton;
 
+        AbstractTextWatcher captionListener;
+
+        AbstractTextWatcher descriptionListener;
+
         public ViewHolder(View itemView) {
             super(itemView);
             ButterKnife.bind(this, itemView);
@@ -156,6 +168,8 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
                         eventListener.onPrimaryCaptionTextChange(value.length() != 0);
                     }
                 }));
+            captionItemEditText.removeTextChangedListener(captionListener);
+            descItemEditText.removeTextChangedListener(descriptionListener);
             captionItemEditText.setText(uploadMediaDetail.getCaptionText());
             descItemEditText.setText(uploadMediaDetail.getDescriptionText());
 
@@ -178,13 +192,14 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
             }
 
             removeButton.setOnClickListener(v -> removeDescription(uploadMediaDetail, position));
-
-            captionItemEditText.addTextChangedListener(new AbstractTextWatcher(
-                    captionText -> uploadMediaDetails.get(position).setCaptionText(captionText)));
+            captionListener = new AbstractTextWatcher(
+                captionText -> uploadMediaDetails.get(position).setCaptionText(captionText));
+            descriptionListener = new AbstractTextWatcher(
+                descriptionText -> uploadMediaDetails.get(position).setDescriptionText(descriptionText));
+            captionItemEditText.addTextChangedListener(captionListener);
             initLanguage(position, uploadMediaDetail);
 
-            descItemEditText.addTextChangedListener(new AbstractTextWatcher(
-                    descriptionText -> uploadMediaDetails.get(position).setDescriptionText(descriptionText)));
+            descItemEditText.addTextChangedListener(descriptionListener);
             initLanguage(position, uploadMediaDetail);
 
             //If the description was manually added by the user, it deserves focus, if not, let the user decide


### PR DESCRIPTION
**Description (required)**
Fixes https://github.com/commons-app/apps-android-commons/issues/4978 :App crashed after edit multiple caption several time

At removeDescription()method at UploadMediaDetailAdapter.java. This method will remove the caption at position. This method will use 
```
notifyItemRemoved(position);
```
However, after using this method, the item will not be refreshed, that is, the data will not be rebound, .and the position corresponding to each item is the same as the original one, there will be problems. For example, there are only three items left. When we click to delete the last item, its position is the original position4, so it is actually called notifyItemRemoved (4), the boundary is exceeded.
  
**Tests performed (required)**

Tested ProdDebug on Pixel 4 with API level 28.

