### PR TITLE
fix #4940 : store imageSHA1 before upload activity terminates

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.kt
@@ -41,7 +41,8 @@ data class Contribution constructor(
     var dateModified: Date? = null,
     var hasInvalidLocation : Int =  0,
     var contentUri: Uri? = null,
-    var countryCode : String? = null
+    var countryCode : String? = null,
+    var imageSHA1 : String? = null
 ) : Parcelable {
 
     fun completeWith(media: Media): Contribution {
@@ -52,7 +53,8 @@ data class Contribution constructor(
         item: UploadItem,
         sessionManager: SessionManager,
         depictedItems: List<DepictedItem>,
-        categories: List<String>
+        categories: List<String>,
+        imageSHA1: String
     ) : this(
         Media(
             formatCaptions(item.uploadMediaDetails),
@@ -67,7 +69,8 @@ data class Contribution constructor(
         dateCreatedSource = "",
         depictedItems = depictedItems,
         wikidataPlace = from(item.place),
-        contentUri = item.contentUri
+        contentUri = item.contentUri,
+        imageSHA1 = imageSHA1
     )
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/db/AppDatabase.kt
+++ b/app/src/main/java/fr/free/nrw/commons/db/AppDatabase.kt
@@ -14,7 +14,7 @@ import fr.free.nrw.commons.upload.depicts.DepictsDao
  * The database for accessing the respective DAOs
  *
  */
-@Database(entities = [Contribution::class, Depicts::class, UploadedStatus::class], version = 11, exportSchema = false)
+@Database(entities = [Contribution::class, Depicts::class, UploadedStatus::class], version = 12, exportSchema = false)
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun contributionDao(): ContributionDao

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
@@ -147,8 +147,10 @@ public class UploadModel {
     public Observable<Contribution> buildContributions() {
         return Observable.fromIterable(items).map(item ->
         {
+            String imageSHA1 = FileUtils.getSHA1(context.getContentResolver().openInputStream(item.getContentUri()));
+
             final Contribution contribution = new Contribution(
-                item, sessionManager, newListOf(selectedDepictions), newListOf(selectedCategories));
+                item, sessionManager, newListOf(selectedDepictions), newListOf(selectedCategories), imageSHA1);
 
             contribution.setHasInvalidLocation(item.hasInvalidLocation());
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
@@ -418,7 +418,7 @@ class UploadWorker(var appContext: Context, workerParams: WorkerParameters) :
      */
     private fun saveIntoUploadedStatus(contribution: Contribution) {
         contribution.contentUri?.let {
-            val imageSha1 = fileUtilsWrapper.getSHA1(appContext.contentResolver.openInputStream(it))
+            val imageSha1 = contribution.imageSHA1.toString()
             val modifiedSha1 = fileUtilsWrapper.getSHA1(fileUtilsWrapper.getFileInputStream(contribution.localUri?.path))
             MainScope().launch {
                 uploadedStatusDao.insertUploaded(


### PR DESCRIPTION
Description (required)

Fixes https://github.com/commons-app/apps-android-commons/issues/4940

When uploading photos from other apps, the UploadWorker tries to open the input stream after the UploadActivity terminates, triggering a security exception.
The issue is fixed by first storing the hash value of the image into the database before the UploadActivity ends.

Tests performed (required)

Tested {BetaDebug} on {Pixel 2} with API level {28}.