### PR TITLE
Fix bug #4984 Added queries for package name for Android API 30+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,16 @@
     <uses-permission android:name="android.permission.SET_WALLPAPER"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
+    <queries>
+        <!-- Browser -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+        <!-- Google Maps -->
+        <package android:name="com.google.android.apps.maps" />
+    </queries>
 
 
     <!-- Needed only if your app targets Android 5.0 (API level 21) or higher. -->


### PR DESCRIPTION
**Description**
Fixes #4984

Android 11+ will restrict package name visibility so we need to add the required package names manually.

**Tests performed**
Tested betaDebug on Google Pixel 4A with API level 32
