### PR TITLE
Fix #4992 invert the equals condition to be null safe

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -155,7 +155,7 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
         addCredits();
         getToolbarUI();
 
-        if (activity.equals("UploadActivity")) {
+        if ("UploadActivity".equals(activity)) {
             placeSelectedButton.setVisibility(View.GONE);
             modifyLocationButton.setVisibility(View.VISIBLE);
             showInMapButton.setVisibility(View.VISIBLE);


### PR DESCRIPTION
**Description**
Fixes #4992 

Inverted the equals condition to be null safe, this way if the activity is null then there would be no crash.

**Tests performed**
Tested prodDebug on Mi A2 with API level 29