### PR TITLE
Remove network type information from NetworkUtils

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/utils/NetworkUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/NetworkUtils.java
@@ -49,6 +49,8 @@ public class NetworkUtils {
             return NetworkConnectionType.WIFI;
         }
 
+        // TODO for Android 12+ request permission from user is mandatory
+        /*
         int mobileNetwork = telephonyManager.getNetworkType();
         switch (mobileNetwork) {
             case TelephonyManager.NETWORK_TYPE_GPRS:
@@ -71,6 +73,8 @@ public class NetworkUtils {
             default:
                 return NetworkConnectionType.UNKNOWN;
         }
+         */
+        return NetworkConnectionType.UNKNOWN;
     }
 
     /**

--- a/app/src/test/kotlin/fr/free/nrw/commons/utils/NetworkUtilsTest.java
+++ b/app/src/test/kotlin/fr/free/nrw/commons/utils/NetworkUtilsTest.java
@@ -8,6 +8,7 @@ import android.telephony.TelephonyManager;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import fr.free.nrw.commons.utils.model.NetworkConnectionType;
@@ -97,6 +98,7 @@ public class NetworkUtilsTest {
     }
 
     @Test
+    @Ignore("Fix these test with telemetry permission")
     public void testCellular2GNetwork() {
         Context mockContext = mock(Context.class);
         Application mockApplication = mock(Application.class);
@@ -123,6 +125,7 @@ public class NetworkUtilsTest {
     }
 
     @Test
+    @Ignore("Fix these test with telemetry permission")
     public void testCellular3GNetwork() {
         Context mockContext = mock(Context.class);
         Application mockApplication = mock(Application.class);
@@ -149,6 +152,7 @@ public class NetworkUtilsTest {
     }
 
     @Test
+    @Ignore("Fix these test with telemetry permission")
     public void testCellular4GNetwork() {
         Context mockContext = mock(Context.class);
         Application mockApplication = mock(Application.class);


### PR DESCRIPTION
**Description**
Fixes #4988 

Remove network type information from NetworkUtils, starting from API 30 and above permission to get network type should be explicitly granted by the user. We only use this information for logs so this does not seem extremely important for now so I have commented it out for now and we should ideally add an option for this in the settings.

**Tests performed**
Tested prodDebug on Mi A2 with API level 29