### PR TITLE
[WIP] Fix both timezone problem and saved date problem

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/Contribution.kt
@@ -38,6 +38,7 @@ data class Contribution constructor(
     val localUri: Uri? = null,
     var dataLength: Long = 0,
     var dateCreated: Date? = null,
+    var dateCreatedString: String? = null,
     var dateModified: Date? = null,
     var hasInvalidLocation : Int =  0,
     var contentUri: Uri? = null,
@@ -67,7 +68,8 @@ data class Contribution constructor(
         dateCreatedSource = "",
         depictedItems = depictedItems,
         wikidataPlace = from(item.place),
-        contentUri = item.contentUri
+        contentUri = item.contentUri,
+        dateCreatedString = item.fileCreatedDateString
     )
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/db/AppDatabase.kt
+++ b/app/src/main/java/fr/free/nrw/commons/db/AppDatabase.kt
@@ -14,7 +14,7 @@ import fr.free.nrw.commons.upload.depicts.DepictsDao
  * The database for accessing the respective DAOs
  *
  */
-@Database(entities = [Contribution::class, Depicts::class, UploadedStatus::class], version = 12, exportSchema = false)
+@Database(entities = [Contribution::class, Depicts::class, UploadedStatus::class], version = 13, exportSchema = false)
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun contributionDao(): ContributionDao

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
@@ -126,15 +126,16 @@ public class UploadableFile implements Parcelable {
     private DateTimeWithSource getDateTimeFromExif() {
         try {
             ExifInterface exif = new ExifInterface(file.getAbsolutePath());
+            // TAG_DATETIME returns the last edited date, we need TAG_DATETIME_ORIGINAL for creation date
             String dateTimeSubString = exif.getAttribute(ExifInterface.TAG_DATETIME_ORIGINAL);
 
-            dateTimeSubString = "2022:ss:33";
             String year = dateTimeSubString.substring(0,4);
-            Integer.parseInt(year);
+            Integer.parseInt(year); //Parsing integers to just verify no NumberFormatException is thrown means strings are numbers
             String month = dateTimeSubString.substring(5,7);
             Integer.parseInt(month);
             String day = dateTimeSubString.substring(8,10);
             Integer.parseInt(day);
+            // This date is stored as a string (not as a date), the rason is we don't want to include timezones
             String dateCreatedString = year+":"+month+":"+day;
             @SuppressLint("RestrictedApi") Long dateTime = exif.getDateTimeOriginal();
             if(dateTime != null){

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
@@ -12,6 +12,8 @@ import androidx.exifinterface.media.ExifInterface;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import fr.free.nrw.commons.upload.FileUtils;
@@ -124,12 +126,26 @@ public class UploadableFile implements Parcelable {
     private DateTimeWithSource getDateTimeFromExif() {
         try {
             ExifInterface exif = new ExifInterface(file.getAbsolutePath());
-            @SuppressLint("RestrictedApi") Long dateTime = exif.getDateTime();
+            String dateTimeSubString = exif.getAttribute(ExifInterface.TAG_DATETIME_ORIGINAL);
+
+            dateTimeSubString = "2022:ss:33";
+            String year = dateTimeSubString.substring(0,4);
+            Integer.parseInt(year);
+            String month = dateTimeSubString.substring(5,7);
+            Integer.parseInt(month);
+            String day = dateTimeSubString.substring(8,10);
+            Integer.parseInt(day);
+            String dateCreatedString = year+":"+month+":"+day;
+            @SuppressLint("RestrictedApi") Long dateTime = exif.getDateTimeOriginal();
             if(dateTime != null){
                 Date date = new Date(dateTime);
-                return new DateTimeWithSource(date, DateTimeWithSource.EXIF_SOURCE);
+                return new DateTimeWithSource(date, dateCreatedString, DateTimeWithSource.EXIF_SOURCE);
             }
         } catch (IOException e) {
+            e.printStackTrace();
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+        } catch (IndexOutOfBoundsException e) {
             e.printStackTrace();
         }
         return null;
@@ -149,6 +165,7 @@ public class UploadableFile implements Parcelable {
         public static final String EXIF_SOURCE = "exif";
 
         private final long epochDate;
+        private String dateString; // this does not includes timezone information
         private final String source;
 
         public DateTimeWithSource(long epochDate, String source) {
@@ -161,8 +178,18 @@ public class UploadableFile implements Parcelable {
             this.source = source;
         }
 
+        public DateTimeWithSource(Date date, String dateString, String source) {
+            this.epochDate = date.getTime();
+            this.dateString = dateString;
+            this.source = source;
+        }
+
         public long getEpochDate() {
             return epochDate;
+        }
+
+        public String getDateString() {
+            return dateString;
         }
 
         public String getSource() {

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
@@ -129,20 +129,21 @@ public class UploadableFile implements Parcelable {
             // TAG_DATETIME returns the last edited date, we need TAG_DATETIME_ORIGINAL for creation date
             // See issue https://github.com/commons-app/apps-android-commons/issues/1971
             String dateTimeSubString = exif.getAttribute(ExifInterface.TAG_DATETIME_ORIGINAL);
-
-            String year = dateTimeSubString.substring(0,4);
-            Integer.parseInt(year); //Parsing integers to just verify no NumberFormatException is thrown means strings are numbers
-            String month = dateTimeSubString.substring(5,7);
-            Integer.parseInt(month);
-            String day = dateTimeSubString.substring(8,10);
-            Integer.parseInt(day);
-            // This date is stored as a string (not as a date), the rason is we don't want to include timezones
-            String dateCreatedString = year+":"+month+":"+day;
-            @SuppressLint("RestrictedApi") Long dateTime = exif.getDateTimeOriginal();
-            if(dateTime != null){
-                Date date = new Date(dateTime);
-                return new DateTimeWithSource(date, dateCreatedString, DateTimeWithSource.EXIF_SOURCE);
+            if (dateTimeSubString!=null) { //getAttribute may return null
+                String year = dateTimeSubString.substring(0,4);
+                String month = dateTimeSubString.substring(5,7);
+                String day = dateTimeSubString.substring(8,10);
+                // This date is stored as a string (not as a date), the rason is we don't want to include timezones
+                String dateCreatedString = String.format("%04d-%02d-%02d", Integer.parseInt(year), Integer.parseInt(month), Integer.parseInt(day));
+                if (dateCreatedString.length() == 10) { //yyyy-MM-dd format of date is expected
+                    @SuppressLint("RestrictedApi") Long dateTime = exif.getDateTimeOriginal();
+                    if(dateTime != null){
+                        Date date = new Date(dateTime);
+                        return new DateTimeWithSource(date, dateCreatedString, DateTimeWithSource.EXIF_SOURCE);
+                    }
+                }
             }
+
         } catch (IOException e) {
             e.printStackTrace();
         } catch (NumberFormatException e) {

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
@@ -127,6 +127,7 @@ public class UploadableFile implements Parcelable {
         try {
             ExifInterface exif = new ExifInterface(file.getAbsolutePath());
             // TAG_DATETIME returns the last edited date, we need TAG_DATETIME_ORIGINAL for creation date
+            // See issue https://github.com/commons-app/apps-android-commons/issues/1971
             String dateTimeSubString = exif.getAttribute(ExifInterface.TAG_DATETIME_ORIGINAL);
 
             String year = dateTimeSubString.substring(0,4);

--- a/app/src/main/java/fr/free/nrw/commons/upload/PageContentsCreator.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/PageContentsCreator.java
@@ -48,7 +48,7 @@ class PageContentsCreator {
             .append(media.getAuthor()).append("]]\n");
 
         final String templatizedCreatedDate = getTemplatizedCreatedDate(
-            contribution.getDateCreated(), contribution.getDateCreatedSource());
+            contribution.getDateCreatedString(), contribution.getDateCreated(), contribution.getDateCreatedSource());
         if (!StringUtils.isBlank(templatizedCreatedDate)) {
             buffer.append("|date=").append(templatizedCreatedDate);
         }
@@ -90,12 +90,12 @@ class PageContentsCreator {
      * @param dateCreatedSource
      * @return
      */
-    private String getTemplatizedCreatedDate(Date dateCreated, String dateCreatedSource) {
+    private String getTemplatizedCreatedDate(String dateCreatedString, Date dateCreated, String dateCreatedSource) {
         if (dateCreated != null) {
             SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
             return String.format(Locale.ENGLISH,
                 isExif(dateCreatedSource) ? TEMPLATE_DATE_ACC_TO_EXIF : TEMPLATE_DATA_OTHER_SOURCE,
-                dateFormat.format(dateCreated)
+                isExif(dateCreatedSource) ? dateCreatedString: dateFormat.format(dateCreated)
             ) + "\n";
         }
         return "";

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadItem.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadItem.java
@@ -25,6 +25,7 @@ public class UploadItem {
     private boolean hasInvalidLocation;
     private boolean isWLMUpload = false;
     private String countryCode;
+    private String fileCreatedDateString; //according to EXIF data
 
     /**
      * Uri of uploadItem
@@ -40,7 +41,8 @@ public class UploadItem {
         final Place place,
         final long createdTimestamp,
         final String createdTimestampSource,
-        final Uri contentUri) {
+        final Uri contentUri,
+        final String fileCreatedDateString) {
         this.createdTimestampSource = createdTimestampSource;
         uploadMediaDetails = new ArrayList<>(Collections.singletonList(new UploadMediaDetail()));
         this.place = place;
@@ -50,6 +52,7 @@ public class UploadItem {
         this.createdTimestamp = createdTimestamp;
         this.contentUri = contentUri;
         imageQuality = BehaviorSubject.createDefault(ImageUtils.IMAGE_WAIT);
+        this.fileCreatedDateString = fileCreatedDateString;
     }
 
     public String getCreatedTimestampSource() {
@@ -82,6 +85,8 @@ public class UploadItem {
      * Uri points to image location or name, eg content://media/external/images/camera/10495 (Android 10)
      */
     public Uri getContentUri() { return contentUri; }
+
+    public String getFileCreatedDateString() { return fileCreatedDateString; }
 
     public void setImageQuality(final int imageQuality) {
       this.imageQuality.onNext(imageQuality);

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
@@ -102,8 +102,10 @@ public class UploadModel {
                 .getFileCreatedDate(context);
         long fileCreatedDate = -1;
         String createdTimestampSource = "";
+        String fileCreatedDateString = "";
         if (dateTimeWithSource != null) {
             fileCreatedDate = dateTimeWithSource.getEpochDate();
+            fileCreatedDateString = dateTimeWithSource.getDateString();
             createdTimestampSource = dateTimeWithSource.getSource();
         }
         Timber.d("File created date is %d", fileCreatedDate);
@@ -113,7 +115,8 @@ public class UploadModel {
             Uri.parse(uploadableFile.getFilePath()),
                 uploadableFile.getMimeType(context), imageCoordinates, place, fileCreatedDate,
                 createdTimestampSource,
-                uploadableFile.getContentUri());
+                uploadableFile.getContentUri(),
+                fileCreatedDateString);
         if (place != null) {
             uploadItem.getUploadMediaDetails().set(0, new UploadMediaDetail(place));
         }


### PR DESCRIPTION
**Description (required)**

Fixes #1971

- ExifInterface.TAG_DATETIME_ORIGINAL used instead of getDateTime() so that we will reach to date of creation of file 
- Date is stored in string form instead of Date data type, so timezones are never involved

**Tests performed (required)**

Tested ProdDebug on Pixel 5 with API level 31

Here is the test upload: https://commons.wikimedia.org/wiki/File%3ACommons_app_exif_issue.jpg

The same upload without changes in this PR: https://commons.wikimedia.org/w/index.php?title=File:Vinkeveen,_Heilig_Hart_van_Jezus_(32).jpg

Auto added categories is not tested yet.