### PR TITLE
Fix wrong import of Test

### DIFF
--- a/app/src/test/kotlin/fr/free/nrw/commons/customselector/helper/ImageHelperTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/customselector/helper/ImageHelperTest.kt
@@ -5,7 +5,7 @@ import fr.free.nrw.commons.customselector.model.Folder
 import fr.free.nrw.commons.customselector.model.Image
 import org.junit.jupiter.api.Assertions.*
 
-import org.junit.jupiter.api.Test
+import org.junit.Test
 import org.mockito.Mockito.mock
 
 /**


### PR DESCRIPTION
**Description (required)**

Fixes some of #5033

**Tests performed (required)**

Running ` ./gradlew :app:testBetaDebugUnitTest` will create ``build/reports/tests/testBetaDebugUnitTest/index.html`` and it should say 1528 tests, 100% successful. (It was previously 1524 tests.)

