### PR TITLE
Fix Wiki Love Monuments year

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -18,6 +18,7 @@ import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.core.content.ContextCompat;
 
 import fr.free.nrw.commons.kvstore.JsonKvStore;
+import java.util.Calendar;
 import java.util.Date;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.page.PageTitle;
@@ -243,4 +244,11 @@ public class Utils {
         return "30 Sep";
     }
 
+    public static int getWikiLovesMonumentsYear(Calendar calendar) {
+        int year = calendar.get(Calendar.YEAR);
+        if (calendar.get(Calendar.MONTH) < Calendar.SEPTEMBER) {
+            year -= 1;
+        }
+        return year;
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -244,6 +244,13 @@ public class Utils {
         return "30 Sep";
     }
 
+    /***
+     * Function to get the current WLM year
+     * It increments at the start of September in line with the other WLM functions
+     * (No consideration of locales for now)
+     * @param calendar
+     * @return
+     */
     public static int getWikiLovesMonumentsYear(Calendar calendar) {
         int year = calendar.get(Calendar.YEAR);
         if (calendar.get(Calendar.MONTH) < Calendar.SEPTEMBER) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/PageContentsCreator.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/PageContentsCreator.java
@@ -3,11 +3,13 @@ package fr.free.nrw.commons.upload;
 import android.content.Context;
 import androidx.annotation.NonNull;
 import fr.free.nrw.commons.Media;
+import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.contributions.Contribution;
 import fr.free.nrw.commons.filepicker.UploadableFile.DateTimeWithSource;
 import fr.free.nrw.commons.settings.Prefs.Licenses;
 import fr.free.nrw.commons.utils.ConfigUtils;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -61,10 +63,9 @@ class PageContentsCreator {
             buffer.append("{{Location|").append(decimalCoords).append("}}").append("\n");
         }
 
-        if (contribution.getWikidataPlace()!=null && contribution.getWikidataPlace().isMonumentUpload()) {
-            buffer.append("{{Wiki Loves Monuments 2021|1= ")
-                .append(contribution.getCountryCode())
-                .append("}}").append("\n");
+        if (contribution.getWikidataPlace() != null && contribution.getWikidataPlace().isMonumentUpload()) {
+            buffer.append(String.format(Locale.ENGLISH, "{{Wiki Loves Monuments %d|1= %s}}\n",
+                Utils.getWikiLovesMonumentsYear(Calendar.getInstance()), contribution.getCountryCode()));
         }
 
         buffer.append("== {{int:license-header}} ==\n")

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -673,7 +673,7 @@
   <string name="custom_selector_info_text2">Im Gegensatz zum Bild auf der linken Seite ist das Bild auf der rechten Seite mit dem Commons-Logo versehen, das anzeigt, dass es bereits hochgeladen wurde. Für die Bildvorschau berühren und halten.</string>
   <string name="welcome_custom_selector_ok">Großartig</string>
   <string name="custom_selector_already_uploaded_image_text">Dieses Bild ist bereits auf Commons hochgeladen worden.</string>
-  <string name="wlm_upload_info">Dieses Bild wird am Wettbewerb Wiki Loves Monuments 2021 teilnehmen</string>
+  <string name="wlm_upload_info">Dieses Bild wird am Wettbewerb Wiki Loves Monuments teilnehmen</string>
   <string name="display_monuments">Denkmäler anzeigen</string>
   <string name="wlm_month_message">Es ist der Wiki Loves Monuments Monat!</string>
   <string name="learn_more">MEHR ERFAHREN</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -654,7 +654,7 @@
   <string name="custom_selector_info_text2">A diferencia de la imagen de la izquierda, la imagen de la derecha tiene el logo de Commons que indica que ha sido cargado. \nPara previsualizar la imagen toca y mantén</string>
   <string name="welcome_custom_selector_ok">Magnífico</string>
   <string name="custom_selector_already_uploaded_image_text">Esta imagen ya se ha subido a Commons.</string>
-  <string name="wlm_upload_info">Esta imagen será introducida al concurso Wiki Loves Monuments 2021</string>
+  <string name="wlm_upload_info">Esta imagen será introducida al concurso Wiki Loves Monuments</string>
   <string name="display_monuments">Mostrar monumentos</string>
   <string name="wlm_month_message">¡Es el mes de Wiki Loves Monuments!</string>
   <string name="learn_more">APRENDE MÁS</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -651,7 +651,7 @@
   <string name="welcome_custom_selector_ok">Æðislegt</string>
   <string name="custom_selector_already_uploaded_image_text">Þessa mynd er þegar búið að senda inn í Commons.</string>
   <string name="place_state_wlm">WLM</string>
-  <string name="wlm_upload_info">Þessi mynd verður send inn í Wiki Loves Monuments 2021 keppnina</string>
+  <string name="wlm_upload_info">Þessi mynd verður send inn í Wiki Loves Monuments keppnina</string>
   <string name="display_monuments">Birta minnismerki</string>
   <string name="wlm_month_message">Núna er Wiki Loves Monuments mánuðurinn!</string>
   <string name="learn_more">KANNA NÁNAR</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -628,7 +628,7 @@
   <string name="back">Indietro</string>
   <string name="welcome_custom_selector_ok">Fantastico</string>
   <string name="custom_selector_already_uploaded_image_text">Questa immagine è già stata caricata su Commons.</string>
-  <string name="wlm_upload_info">Questa immagine sarà ammessa al concorso Wiki Loves Monuments 2021</string>
+  <string name="wlm_upload_info">Questa immagine sarà ammessa al concorso Wiki Loves Monuments</string>
   <string name="display_monuments">Mostra monumenti</string>
   <string name="wlm_month_message">È il mese di Wiki Loves Monuments!</string>
   <string name="learn_more">ULTERIORI INFORMAZIONI</string>

--- a/app/src/main/res/values-lb/strings.xml
+++ b/app/src/main/res/values-lb/strings.xml
@@ -369,7 +369,7 @@
   <string name="done">Fäerdeg</string>
   <string name="back">Zréck</string>
   <string name="welcome_custom_selector_ok">Genial</string>
-  <string name="wlm_upload_info">Dëst Bild wäert beim Concours Wiki Loves Monuments 2021 agereecht ginn.</string>
+  <string name="wlm_upload_info">Dëst Bild wäert beim Concours Wiki Loves Monuments agereecht ginn.</string>
   <string name="display_monuments">Monumenter weisen</string>
   <string name="learn_more">FIR MÉI ZE WËSSEN</string>
   <string name="need_permission">Autorisatioun gëtt gebraucht</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -645,7 +645,7 @@
   <string name="welcome_custom_selector_ok">Geweldig</string>
   <string name="custom_selector_already_uploaded_image_text">Deze afbeelding is al geüpload op Wikimedia Commons.</string>
   <string name="place_state_wlm">WLM</string>
-  <string name="wlm_upload_info">Deze afbeelding doet mee aan de wedstrijd Wiki Loves Monuments 2021</string>
+  <string name="wlm_upload_info">Deze afbeelding doet mee aan de wedstrijd Wiki Loves Monuments</string>
   <string name="display_monuments">Monumenten weergeven</string>
   <string name="wlm_month_message">Het is Wiki Houdt Van Monumenten maand!</string>
   <string name="learn_more">LEES MEER</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -674,7 +674,7 @@
   <string name="custom_selector_info_text2">W przeciwieństwie do zdjęcia po lewej, zdjęcie po prawej ma logo Commons wskazujące, że zostało już przesłane.\n  Dotknij i przytrzymaj, aby wyświetlić podgląd obrazu.</string>
   <string name="welcome_custom_selector_ok">Niesamowite</string>
   <string name="custom_selector_already_uploaded_image_text">Tez plik został już przesłany do Commons.</string>
-  <string name="wlm_upload_info">Ten obraz zostanie zgłoszony do konkursu Wiki Loves Monuments 2021</string>
+  <string name="wlm_upload_info">Ten obraz zostanie zgłoszony do konkursu Wiki Loves Monuments</string>
   <string name="display_monuments">Pokaż zabytki</string>
   <string name="wlm_month_message">To jest miesiąc Wiki Lovers Monuments!</string>
   <string name="learn_more">DOWIEDZ SIĘ WIĘCEJ</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -666,7 +666,7 @@
   <string name="custom_selector_info_text2">Diferente da imagem à esquerda, a da direita possui o logotipo do Commons, o que indica que o envio dela já está concluído.\n Toque e segure para pré-visualizar a imagem.</string>
   <string name="welcome_custom_selector_ok">Ótimo</string>
   <string name="custom_selector_already_uploaded_image_text">Esta imagem já foi enviada para Commons.</string>
-  <string name="wlm_upload_info">Essa imagem será enviada ao concurso Wiki Loves Monuments 2021</string>
+  <string name="wlm_upload_info">Essa imagem será enviada ao concurso Wiki Loves Monuments</string>
   <string name="display_monuments">Monumentos de exibição</string>
   <string name="wlm_month_message">Estamos no mês no Wiki Loves Monuments!</string>
   <string name="learn_more">SABER MAIS</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -664,7 +664,7 @@
   <string name="custom_selector_info_text2">Ao contrário da imagem à esquerda, a imagem à direita tem o logótipo da wiki Commons que indica que ela já foi carregada.\n Tocar e manter para uma antevisão da imagem.</string>
   <string name="welcome_custom_selector_ok">Excecional</string>
   <string name="custom_selector_already_uploaded_image_text">Esta imagem já foi carregada na wiki Commons.</string>
-  <string name="wlm_upload_info">Esta imagem será submetida ao concurso Wiki Loves Monuments 2021</string>
+  <string name="wlm_upload_info">Esta imagem será submetida ao concurso Wiki Loves Monuments</string>
   <string name="display_monuments">Mostrar monumentos</string>
   <string name="wlm_month_message">É o mês da Wiki Loves Monuments!</string>
   <string name="learn_more">SABER MAIS</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -656,7 +656,7 @@
   <string name="custom_selector_info_text2">Till skillnad från bilden till vänster har bilden till höger Commons-logotypen, vilket innebär att den redan är uppladdad.\n Tryck och håll ned för att förhandsgranska bilden.</string>
   <string name="welcome_custom_selector_ok">Häftigt</string>
   <string name="custom_selector_already_uploaded_image_text">Denna bild har redan laddats upp till Commons.</string>
-  <string name="wlm_upload_info">Denna bild kommer att skickas in till tävlingen Wiki Loves Monuments 2021</string>
+  <string name="wlm_upload_info">Denna bild kommer att skickas in till tävlingen Wiki Loves Monuments</string>
   <string name="display_monuments">Visa monument</string>
   <string name="wlm_month_message">Det är Wiki Loves Monuments-månaden!</string>
   <string name="learn_more">LÄS MER</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -684,7 +684,7 @@
   <string name="custom_selector_info_text2">На відміну від зображення зліва, зображення праворуч має логотип Commons, яке вказує, що воно вже завантажене.\n  Натисніть і утримуйте для попереднього перегляду зображення.</string>
   <string name="welcome_custom_selector_ok">Чудово</string>
   <string name="custom_selector_already_uploaded_image_text">Це зображення вже завантажено на Спільний ресурс.</string>
-  <string name="wlm_upload_info">Це зображення буде брати участь у конкурсі Wiki Loves Monuments 2021</string>
+  <string name="wlm_upload_info">Це зображення буде брати участь у конкурсі Wiki Loves Monuments</string>
   <string name="display_monuments">Показати пам’ятники</string>
   <string name="wlm_month_message">Цей місяць Wiki Loves Monuments!</string>
   <string name="learn_more">ДОСЛІДИТИ БІЛЬШЕ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -696,7 +696,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="welcome_custom_selector_ok">Awesome</string>
   <string name="custom_selector_already_uploaded_image_text">This image has already been uploaded to Commons.</string>
   <string name="place_state_wlm">WLM</string>
-  <string name="wlm_upload_info">This image will be entered into the Wiki Loves Monuments 2021 contest</string>
+  <string name="wlm_upload_info">This image will be entered into the Wiki Loves Monuments contest</string>
   <string name="display_monuments">Display monuments</string>
   <string name="wlm_month_message">It\'s Wiki Loves Monuments month!</string>
   <string name="learn_more">LEARN MORE</string>

--- a/app/src/test/kotlin/fr/free/nrw/commons/UtilsTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/UtilsTest.kt
@@ -1,0 +1,28 @@
+package fr.free.nrw.commons
+
+import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import java.util.*
+
+class UtilsTest {
+    @Test
+    fun wikiLovesMonumentsYearBeforeSeptember() {
+        val cal = Calendar.getInstance()
+        cal.set(2022, Calendar.FEBRUARY, 1)
+        Assertions.assertEquals(2021, Utils.getWikiLovesMonumentsYear(cal))
+    }
+
+    @Test
+    fun wikiLovesMonumentsYearInSeptember() {
+        val cal = Calendar.getInstance()
+        cal.set(2022, Calendar.SEPTEMBER, 1)
+        Assertions.assertEquals(2022, Utils.getWikiLovesMonumentsYear(cal))
+    }
+
+    @Test
+    fun wikiLovesMonumentsYearAfterSeptember() {
+        val cal = Calendar.getInstance()
+        cal.set(2022, Calendar.DECEMBER, 1)
+        Assertions.assertEquals(2022, Utils.getWikiLovesMonumentsYear(cal))
+    }
+}


### PR DESCRIPTION
**Description (required)**

Fixes #5043

- Removes year from messages and just say "Wiki Loves Monuments" (I only changed obvious ones; the rest would need to be fixed by translators)
- Retrieve current year instead of the hard-coded "2021".

**Tests performed (required)**

Tested the betaDebug variant by going to the nearby map, jumping to a WLM country and find a monument to upload (using emulator only).

I selected [Rengstorff House](https://www.wikidata.org/wiki/Q7313211#Q7313211$6C6D76BE-BAE8-4A92-B66E-E5664E3F00F0) and uploaded https://commons.wikimedia.beta.wmflabs.org/wiki/File:Test_WLM_7.jpg . The file page contains "{{Wiki Loves Monuments 2022|".


**Screenshots (for UI changes only)**

![Screenshot_20220910_170116](https://user-images.githubusercontent.com/10674/189477812-cfcae30e-b793-4155-83e9-dee620cb9335.png)
