### PR TITLE
Fix invalid latitude value in android.yml

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -67,7 +67,7 @@ jobs:
           script: |
             adb shell content insert --uri content://settings/system --bind name:s:accelerometer_rotation --bind value:i:0
             adb shell content insert --uri content://settings/system --bind name:s:user_rotation --bind value:i:0
-            adb emu geo fix 37.422131 -122.084801
+            adb emu geo fix 37.422131 40.084801
             ./gradlew connectedBetaDebugAndroidTest --stacktrace
 
       - name: Run Unit tests with unified coverage

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -67,7 +67,7 @@ jobs:
           script: |
             adb shell content insert --uri content://settings/system --bind name:s:accelerometer_rotation --bind value:i:0
             adb shell content insert --uri content://settings/system --bind name:s:user_rotation --bind value:i:0
-            adb emu geo fix 37.422131 40.084801
+            adb emu geo fix 50.44299 30.51594
             ./gradlew connectedBetaDebugAndroidTest --stacktrace
 
       - name: Run Unit tests with unified coverage


### PR DESCRIPTION
Should fix this error:
```
/usr/bin/sh -c adb emu geo fix 37.422131 -122.084801
KO: invalid latitude value. Should be in [-90,+90] range
```
Outputted by CI on master: https://github.com/commons-app/apps-android-commons/actions/runs/3066734506/jobs/4952241619

**Description (required)**

Fixes #INSERT_ISSUE_NUMBER_HERE

What changes did you make and why?

**Tests performed (required)**

Tested {build variant, e.g. ProdDebug} on {name of device or emulator} with API level {API level}.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
