### PR TITLE
Fix #5058

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.kt
@@ -115,9 +115,9 @@ class FileProcessor @Inject constructor(
         Timber.d("Checking for tag: %s", tag)
         exifInterface?.getAttribute(tag)
             ?.takeIf { it.isNotEmpty() }
-            ?.let {
+            ?.let { attributeName ->
                 exifInterface.setAttribute(tag, null).also {
-                    Timber.d("Exif tag $tag with value $it redacted.")
+                    Timber.d("Exif tag $tag with value $attributeName redacted.")
                 }
             }
     }


### PR DESCRIPTION
**Description (required)**

Fixes #5058 by specifying a variable name instead of usign `it`.

**Tests performed (required)**

Tested {build variant, e.g. ProdDebug} on {name of device or emulator} with API level {API level}.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
