### PR TITLE
4664: Moved CustomSelectorActivity to ViewBinding

### DIFF
--- a/app/src/main/res/layout/activity_custom_selector.xml
+++ b/app/src/main/res/layout/activity_custom_selector.xml
@@ -1,24 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  xmlns:app="http://schemas.android.com/apk/res-auto">
+  android:layout_height="match_parent">
 
-    <include
-      layout="@layout/custom_selector_toolbar"
-      android:id="@+id/toolbar"
-      />
+  <include layout="@layout/custom_selector_toolbar" />
 
-    <androidx.fragment.app.FragmentContainerView
-      android:id="@+id/fragment_container"
-      android:layout_width="match_parent"
-      android:layout_height="0dp"
-      app:layout_constraintBottom_toTopOf="@id/bottom_layout"
-      app:layout_constraintTop_toBottomOf="@+id/toolbar_layout"/>
+  <androidx.fragment.app.FragmentContainerView
+    android:id="@+id/fragment_container"
+    android:layout_width="match_parent"
+    android:layout_height="0dp"
+    app:layout_constraintBottom_toTopOf="@id/bottom_layout"
+    app:layout_constraintTop_toBottomOf="@+id/toolbar_layout" />
 
-    <include
-      layout="@layout/custom_selector_bottom_layout"
-      android:id="@+id/bottom_sheet"
-      />
+  <include layout="@layout/custom_selector_bottom_layout" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #4664 

What changes did you make and why?
- **Issue:** As per the information provided and work request on the ticket above, `CustomSelectorActivity.kt` is currently using Kotlin Synthetic which creates auto-generated class, and has been alread deprecated.
- **Solution:** Hence migration was done by replacing `kotlin-synthetic` with `viewbinding`, which is always null safe, type-safe and supports both Java and Kotlin.

NB: During migration unnecessary `id`s of included layouts  were removed from `activity_custom_selector.xml` which was showing error before the fix.
