### PR TITLE
4664: Moved ImageFragment to ViewBinding

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/ImageFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/ImageFragment.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import fr.free.nrw.commons.R
 import fr.free.nrw.commons.customselector.database.NotForUploadStatusDao
 import fr.free.nrw.commons.customselector.database.UploadedStatusDao
 import fr.free.nrw.commons.customselector.helper.ImageHelper
@@ -27,13 +26,12 @@ import fr.free.nrw.commons.customselector.model.CallbackStatus
 import fr.free.nrw.commons.customselector.model.Image
 import fr.free.nrw.commons.customselector.model.Result
 import fr.free.nrw.commons.customselector.ui.adapter.ImageAdapter
+import fr.free.nrw.commons.databinding.FragmentCustomSelectorBinding
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment
 import fr.free.nrw.commons.media.MediaClient
 import fr.free.nrw.commons.theme.BaseActivity
 import fr.free.nrw.commons.upload.FileProcessor
 import fr.free.nrw.commons.upload.FileUtilsWrapper
-import kotlinx.android.synthetic.main.fragment_custom_selector.*
-import kotlinx.android.synthetic.main.fragment_custom_selector.view.*
 import java.util.*
 import javax.inject.Inject
 import kotlin.collections.ArrayList
@@ -42,6 +40,9 @@ import kotlin.collections.ArrayList
  * Custom Selector Image Fragment.
  */
 class ImageFragment: CommonsDaggerSupportFragment(), RefreshUIListener, PassDataListener {
+
+    private var _binding: FragmentCustomSelectorBinding? = null
+    private val binding get() = _binding
 
     /**
      * Current bucketId.
@@ -64,7 +65,7 @@ class ImageFragment: CommonsDaggerSupportFragment(), RefreshUIListener, PassData
     private var selectorRV: RecyclerView? = null
     private var loader: ProgressBar? = null
     private var switch: Switch? = null
-    lateinit var filteredImages: ArrayList<Image>;
+    lateinit var filteredImages: ArrayList<Image>
 
     /**
      * Stores all images
@@ -171,33 +172,32 @@ class ImageFragment: CommonsDaggerSupportFragment(), RefreshUIListener, PassData
      * SetUp recycler view.
      */
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-
-        val root = inflater.inflate(R.layout.fragment_custom_selector, container, false)
+        _binding = FragmentCustomSelectorBinding.inflate(inflater, container, false)
         imageAdapter = ImageAdapter(requireActivity(), activity as ImageSelectListener, imageLoader!!)
         gridLayoutManager = GridLayoutManager(context,getSpanCount())
-        with(root.selector_rv){
-            this.layoutManager = gridLayoutManager
-            setHasFixedSize(true)
-            this.adapter = imageAdapter
+        with(binding?.selectorRv){
+            this?.layoutManager = gridLayoutManager
+            this?.setHasFixedSize(true)
+            this?.adapter = imageAdapter
         }
 
         viewModel?.result?.observe(viewLifecycleOwner, Observer{
             handleResult(it)
         })
 
-        switch = root.switchWidget
+        switch = binding?.switchWidget
         switch?.visibility = View.VISIBLE
         switch?.setOnCheckedChangeListener { _, isChecked -> onChangeSwitchState(isChecked) }
-        selectorRV = root.selector_rv
-        loader = root.loader
-        progressLayout = root.progressLayout
+        selectorRV = binding?.selectorRv
+        loader = binding?.loader
+        progressLayout = binding?.progressLayout
 
         val sharedPreferences: SharedPreferences =
             requireContext().getSharedPreferences(CUSTOM_SELECTOR_PREFERENCE_KEY, MODE_PRIVATE)
         showAlreadyActionedImages = sharedPreferences.getBoolean(SHOW_ALREADY_ACTIONED_IMAGES_PREFERENCE_KEY, true)
         switch?.isChecked = showAlreadyActionedImages
 
-        return root
+        return binding?.root
     }
 
     private fun onChangeSwitchState(checked: Boolean) {
@@ -252,7 +252,7 @@ class ImageFragment: CommonsDaggerSupportFragment(), RefreshUIListener, PassData
                 }
             }
             else{
-                empty_text?.let {
+                binding?.emptyText?.let {
                     it.visibility = View.VISIBLE
                 }
                 selectorRV?.let{
@@ -309,6 +309,11 @@ class ImageFragment: CommonsDaggerSupportFragment(), RefreshUIListener, PassData
             }
         }
         super.onDestroy()
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 
     override fun refresh() {


### PR DESCRIPTION
Fixes #4664 

What changes did you make and why?
- **Issue:** As per the information provided and work request on the ticket above, `ImageFragment.kt` is currently using Kotlin Synthetic which creates auto-generated class, and has been alread deprecated.
- **Solution:** Hence migration was done by replacing `kotlin-synthetic` with `viewbinding`, which is always null safe, type-safe and supports both Java and Kotlin.

NB: During migration a redundant semicolon was removed.
