### PR TITLE
#5030 Bug fix "Author field shows HTML tags when template used"

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Media.kt
+++ b/app/src/main/java/fr/free/nrw/commons/Media.kt
@@ -115,6 +115,28 @@ class Media constructor(
                 ""
 
     /**
+     * Gets media display title
+     * @return Media title
+     */
+    fun getDisplayAuthor(): String{
+        if (author == null)
+            return ""
+
+        val completeHtmlTagCheck = "<.*>(.*)<.*>".toRegex() // Detect if complete html tags present
+        var completeCheckResult = completeHtmlTagCheck.findAll(author!!) // Find matching cases, return text between tag
+        if(completeCheckResult.count()==1) return completeCheckResult.toList().get(0).groupValues.get(1) // Get matching result and return text between tag - text between tag is inside a capture group
+        else if (completeCheckResult.count()>1) return "" // If there are multiple cases we return nothing --> can multiple cases occur?
+
+        val hrefTagCheck = "<.*>(.*)".toRegex() // Detect if half html tags present -> <a href= XXX> case
+        var hrefTagCheckResult = hrefTagCheck.findAll(author!!) // Find matching cases, return text between tag
+        if(hrefTagCheckResult.count()==1) return hrefTagCheckResult.toList().get(0).groupValues.get(1) // Get matching result and return text between tag
+        else if (hrefTagCheckResult.count()>1) return "" // If there are multiple cases we return nothing --> can multiple cases occur?
+
+        return author!! // If this is reached then html tags are not present, return author text as is
+
+    }
+
+    /**
      * Gets file page title
      * @return New media page title
      */

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -643,10 +643,11 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         categoryNames.clear();
         categoryNames.addAll(media.getCategories());
 
-        if (media.getAuthor() == null || media.getAuthor().equals("")) {
+        if (media.getDisplayAuthor() == "") {
+            author.setText("");
             authorLayout.setVisibility(GONE);
         } else {
-            author.setText(media.getAuthor());
+            author.setText(media.getDisplayAuthor());
         }
     }
 


### PR DESCRIPTION
Added specific display author function in Media.kt that parses the author string with Regex

Fixes #5030 

Added new Author function in Media.kt, with Regex checks for two types of Author, complete html tag:
<>[Some author text]<>

And incomplete
<>[Some author text]

For any author strings with formats not falling into these categories it returns the author as before
