### PR TITLE
Fix issue #4962, remove trailing whitespace in caption field when set to `uploadMediaDetails`

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
@@ -198,7 +198,7 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
 
             removeButton.setOnClickListener(v -> removeDescription(uploadMediaDetail, position));
             captionListener = new AbstractTextWatcher(
-                captionText -> uploadMediaDetails.get(position).setCaptionText(convertJapSpaceToEngSpace(removeTrailingWhitespace(captionText))));
+                captionText -> uploadMediaDetails.get(position).setCaptionText(convertIdeographicSpaceToLatinSpace(removeTrailingWhitespace(captionText))));
             descriptionListener = new AbstractTextWatcher(
                 descriptionText -> uploadMediaDetails.get(position).setDescriptionText(descriptionText));
             captionItemEditText.addTextChangedListener(captionListener);
@@ -446,11 +446,11 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
         }
 
         /**
-         * Convert Japanese spaces to English spaces
+         * Convert Ideographic space to Latin space
          * @param source the source text
-         * @return a string with English space instead of Japanese space
+         * @return a string with Latin spaces instead of Ideographic spaces
          */
-        public String convertJapSpaceToEngSpace(String source) {
+        public String convertIdeographicSpaceToLatinSpace(String source) {
             Pattern JapSpacePattern = Pattern.compile("\\x{3000}");
             return JapSpacePattern.matcher(source).replaceAll(" ");
         }

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import timber.log.Timber;
 
@@ -197,7 +198,7 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
 
             removeButton.setOnClickListener(v -> removeDescription(uploadMediaDetail, position));
             captionListener = new AbstractTextWatcher(
-                captionText -> uploadMediaDetails.get(position).setCaptionText(removeTrailingWhitespace(captionText)));
+                captionText -> uploadMediaDetails.get(position).setCaptionText(convertJapSpaceToEngSpace(removeTrailingWhitespace(captionText))));
             descriptionListener = new AbstractTextWatcher(
                 descriptionText -> uploadMediaDetails.get(position).setDescriptionText(descriptionText));
             captionItemEditText.addTextChangedListener(captionListener);
@@ -443,10 +444,20 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
             }
             return source;
         }
+
+        /**
+         * Convert Japanese spaces to English spaces
+         * @param source the source text
+         * @return a string with English space instead of Japanese space
+         */
+        public String convertJapSpaceToEngSpace(String source) {
+            Pattern JapSpacePattern = Pattern.compile("\\x{3000}");
+            return JapSpacePattern.matcher(source).replaceAll(" ");
+        }
+
     }
 
     public interface Callback {
-
         void showAlert(int mediaDetailDescription, int descriptionInfo);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
@@ -451,8 +451,8 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
          * @return a string with Latin spaces instead of Ideographic spaces
          */
         public String convertIdeographicSpaceToLatinSpace(String source) {
-            Pattern JapSpacePattern = Pattern.compile("\\x{3000}");
-            return JapSpacePattern.matcher(source).replaceAll(" ");
+            Pattern ideographicSpacePattern = Pattern.compile("\\x{3000}");
+            return ideographicSpacePattern.matcher(source).replaceAll(" ");
         }
 
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
@@ -197,7 +197,7 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
 
             removeButton.setOnClickListener(v -> removeDescription(uploadMediaDetail, position));
             captionListener = new AbstractTextWatcher(
-                captionText -> uploadMediaDetails.get(position).setCaptionText(captionText));
+                captionText -> uploadMediaDetails.get(position).setCaptionText(removeTrailingWhitespace(captionText)));
             descriptionListener = new AbstractTextWatcher(
                 descriptionText -> uploadMediaDetails.get(position).setDescriptionText(descriptionText));
             captionItemEditText.addTextChangedListener(captionListener);
@@ -417,6 +417,31 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
                         selectedLanguages);
                 languageHistoryListView.setAdapter(recentLanguagesAdapter);
             }
+        }
+
+        /**
+         * Checks if the source text contains trailing whitespace
+         * @param source input text
+         * @return contains trailing whitespace
+         */
+        public Boolean checkTrailingWhitespace(String source) {
+            int len = source.length();
+            if (len == 0) {
+                return false;
+            }
+            return Character.isWhitespace(source.charAt(len - 1));
+        }
+
+        /**
+         * Removes any trailing whitespace from the source text.
+         * @param source input text
+         * @return a character sequence without trailing whitespace
+         */
+        public String removeTrailingWhitespace(String source) {
+            while (checkTrailingWhitespace(source)) {
+                source = source.substring(0, source.length() - 1);
+            }
+            return source;
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
@@ -420,9 +420,9 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
         }
 
         /**
-         * Checks if the source text contains trailing whitespace
-         * @param source input text
-         * @return contains trailing whitespace
+         * Checks if the source string contains trailing whitespace
+         * @param source input string
+         * @return true if contains trailing whitespace and false otherwise
          */
         public Boolean checkTrailingWhitespace(String source) {
             int len = source.length();
@@ -434,8 +434,8 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
 
         /**
          * Removes any trailing whitespace from the source text.
-         * @param source input text
-         * @return a character sequence without trailing whitespace
+         * @param source input string
+         * @return a string without trailing whitespace
          */
         public String removeTrailingWhitespace(String source) {
             while (checkTrailingWhitespace(source)) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailInputFilter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailInputFilter.java
@@ -17,7 +17,7 @@ public class UploadMediaDetailInputFilter implements InputFilter {
      */
     public UploadMediaDetailInputFilter() {
         patterns = new Pattern[]{
-            Pattern.compile("[\\x{00A0}\\x{1680}\\x{180E}\\x{2000}-\\x{200B}\\x{2028}\\x{2029}\\x{202F}\\x{205F}\\x{3000}]"),
+            Pattern.compile("[\\x{00A0}\\x{1680}\\x{180E}\\x{2000}-\\x{200B}\\x{2028}\\x{2029}\\x{202F}\\x{205F}]"),
             Pattern.compile("[\\x{202A}-\\x{202E}]"),
             Pattern.compile("\\p{Cc}"),
             Pattern.compile("\\x{FEFF}"),

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailInputFilter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailInputFilter.java
@@ -56,6 +56,31 @@ public class UploadMediaDetailInputFilter implements InputFilter {
     }
 
     /**
+     * Checks if the source text contains trailing whitespace
+     * @param source input text
+     * @return contains trailing whitespace
+     */
+    private Boolean checkTrailingWhitespace(final CharSequence source) {
+        int len = source.length();
+        if (len == 0) {
+            return false;
+        }
+        return Character.isWhitespace(source.charAt(len - 1));
+    }
+
+    /**
+     * Removes any trailing whitespace from the source text.
+     * @param source input text
+     * @return a character sequence without trailing whitespace
+     */
+    private CharSequence removeTrailingWhitespace(CharSequence source) {
+        while (checkTrailingWhitespace(source)) {
+            source = source.subSequence(0, source.length());
+        }
+        return source;
+    }
+
+    /**
      * Filters out any blocklisted characters.
      * @param source {@inheritDoc}
      * @param start {@inheritDoc}
@@ -74,6 +99,12 @@ public class UploadMediaDetailInputFilter implements InputFilter {
             }
 
             return removeBlocklisted(source);
+        }
+        if (checkTrailingWhitespace(source)) {
+            if (start == dstart) {
+                return dest;
+            }
+            return removeTrailingWhitespace(source);
         }
         return null;
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailInputFilter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailInputFilter.java
@@ -56,32 +56,7 @@ public class UploadMediaDetailInputFilter implements InputFilter {
     }
 
     /**
-     * Checks if the source text contains trailing whitespace
-     * @param source input text
-     * @return contains trailing whitespace
-     */
-    private Boolean checkTrailingWhitespace(final CharSequence source) {
-        int len = source.length();
-        if (len == 0) {
-            return false;
-        }
-        return Character.isWhitespace(source.charAt(len - 1));
-    }
-
-    /**
-     * Removes any trailing whitespace from the source text.
-     * @param source input text
-     * @return a character sequence without trailing whitespace
-     */
-    private CharSequence removeTrailingWhitespace(CharSequence source) {
-        while (checkTrailingWhitespace(source)) {
-            source = source.subSequence(0, source.length() - 1);
-        }
-        return source;
-    }
-
-    /**
-     * Filters out any blocklisted characters and trailing white spaces.
+     * Filters out any blocklisted characters.
      * @param source {@inheritDoc}
      * @param start {@inheritDoc}
      * @param end {@inheritDoc}
@@ -93,16 +68,12 @@ public class UploadMediaDetailInputFilter implements InputFilter {
     @Override
     public CharSequence filter(CharSequence source, int start, int end, Spanned dest, int dstart,
         int dend) {
-        if (checkBlocklisted(source) || checkTrailingWhitespace(source)) {
-
-            if (checkBlocklisted(source)) {
-                if (start == dstart) {
-                    return dest;
-                }
-                source = removeBlocklisted(source);
+        if (checkBlocklisted(source)) {
+            if (start == dstart) {
+                return dest;
             }
 
-            return removeTrailingWhitespace(source);
+            return removeBlocklisted(source);
         }
         return null;
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailInputFilter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailInputFilter.java
@@ -98,13 +98,11 @@ public class UploadMediaDetailInputFilter implements InputFilter {
                 return dest;
             }
 
-            return removeBlocklisted(source);
-        }
-        if (checkTrailingWhitespace(source)) {
-            if (start == dstart) {
-                return dest;
+            if (checkTrailingWhitespace(source)) {
+                source = removeTrailingWhitespace(source);
             }
-            return removeTrailingWhitespace(source);
+
+            return removeBlocklisted(source);
         }
         return null;
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailInputFilter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailInputFilter.java
@@ -81,7 +81,7 @@ public class UploadMediaDetailInputFilter implements InputFilter {
     }
 
     /**
-     * Filters out any blocklisted characters.
+     * Filters out any blocklisted characters and trailing white spaces.
      * @param source {@inheritDoc}
      * @param start {@inheritDoc}
      * @param end {@inheritDoc}
@@ -93,13 +93,12 @@ public class UploadMediaDetailInputFilter implements InputFilter {
     @Override
     public CharSequence filter(CharSequence source, int start, int end, Spanned dest, int dstart,
         int dend) {
+        if (checkTrailingWhitespace(source)) {
+            source = removeTrailingWhitespace(source);
+        }
         if (checkBlocklisted(source)) {
             if (start == dstart) {
                 return dest;
-            }
-
-            if (checkTrailingWhitespace(source)) {
-                source = removeTrailingWhitespace(source);
             }
 
             return removeBlocklisted(source);

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailInputFilter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailInputFilter.java
@@ -75,7 +75,7 @@ public class UploadMediaDetailInputFilter implements InputFilter {
      */
     private CharSequence removeTrailingWhitespace(CharSequence source) {
         while (checkTrailingWhitespace(source)) {
-            source = source.subSequence(0, source.length());
+            source = source.subSequence(0, source.length() - 1);
         }
         return source;
     }
@@ -93,15 +93,16 @@ public class UploadMediaDetailInputFilter implements InputFilter {
     @Override
     public CharSequence filter(CharSequence source, int start, int end, Spanned dest, int dstart,
         int dend) {
-        if (checkTrailingWhitespace(source)) {
-            source = removeTrailingWhitespace(source);
-        }
-        if (checkBlocklisted(source)) {
-            if (start == dstart) {
-                return dest;
+        if (checkBlocklisted(source) || checkTrailingWhitespace(source)) {
+
+            if (checkBlocklisted(source)) {
+                if (start == dstart) {
+                    return dest;
+                }
+                source = removeBlocklisted(source);
             }
 
-            return removeBlocklisted(source);
+            return removeTrailingWhitespace(source);
         }
         return null;
     }

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
@@ -287,7 +287,7 @@ class UploadMediaDetailAdapterUnitTest {
     fun testCaptionJapaneseCharacters() {
         val test1 = "テスト　テスト"
         val expected1 = "テスト テスト"
-        Assert.assertEquals(expected1, viewHolder.convertJapSpaceToEngSpace(test1));
+        Assert.assertEquals(expected1, viewHolder.convertIdeographicSpaceToLatinSpace(test1));
 
         val test2 = "テスト　\r　\t　"
         val expected2 = "テスト"

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
@@ -284,10 +284,14 @@ class UploadMediaDetailAdapterUnitTest {
     }
 
     @Test
-    fun testRemoveTrailingJapaneseWhitespace() {
-        val test = "テスト　\r　\t　"
-        val expected = "テスト"
-        Assert.assertTrue(viewHolder.checkTrailingWhitespace(test));
-        Assert.assertEquals(expected, viewHolder.removeTrailingWhitespace(test))
+    fun testCaptionJapaneseCharacters() {
+        val test1 = "テスト　テスト"
+        val expected1 = "テスト テスト"
+        Assert.assertEquals(expected1, viewHolder.convertJapSpaceToEngSpace(test1));
+
+        val test2 = "テスト　\r　\t　"
+        val expected2 = "テスト"
+        Assert.assertTrue(viewHolder.checkTrailingWhitespace(test2));
+        Assert.assertEquals(expected2, viewHolder.removeTrailingWhitespace(test2))
     }
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
@@ -247,4 +247,16 @@ class UploadMediaDetailAdapterUnitTest {
         verify(adapterView, times(3)).adapter
     }
 
+    @Test
+    fun testRemoveTrailingWhitespace() {
+        val test1 = "test  "
+        val expected1 = "test"
+        Assert.assertTrue(viewHolder.checkTrailingWhitespace(test1));
+        Assert.assertEquals(expected1, viewHolder.removeTrailingWhitespace(test1))
+
+        val test2 = "test test "
+        val expected2 = "test test"
+        Assert.assertTrue(viewHolder.checkTrailingWhitespace(test2));
+        Assert.assertEquals(expected2, viewHolder.removeTrailingWhitespace(test2))
+    }
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
@@ -249,6 +249,7 @@ class UploadMediaDetailAdapterUnitTest {
 
     @Test
     fun testRemoveTrailingWhitespace() {
+        // empty space
         val test1 = "test  "
         val expected1 = "test"
         Assert.assertTrue(viewHolder.checkTrailingWhitespace(test1));
@@ -258,5 +259,35 @@ class UploadMediaDetailAdapterUnitTest {
         val expected2 = "test test"
         Assert.assertTrue(viewHolder.checkTrailingWhitespace(test2));
         Assert.assertEquals(expected2, viewHolder.removeTrailingWhitespace(test2))
+
+        // No whitespace
+        val test3 = "No trailing space";
+        val expected3 = "No trailing space";
+        Assert.assertFalse(viewHolder.checkTrailingWhitespace(test3))
+        Assert.assertEquals(expected3, viewHolder.removeTrailingWhitespace(test3))
+    }
+
+    @Test
+    fun testRemoveTrailingInstanceTab() {
+        val test = "test\t"
+        val expected = "test"
+        Assert.assertTrue(viewHolder.checkTrailingWhitespace(test));
+        Assert.assertEquals(expected, viewHolder.removeTrailingWhitespace(test))
+    }
+
+    @Test
+    fun testRemoveTrailingCarriageReturn() {
+        val test = "test\r"
+        val expected = "test"
+        Assert.assertTrue(viewHolder.checkTrailingWhitespace(test));
+        Assert.assertEquals(expected, viewHolder.removeTrailingWhitespace(test))
+    }
+
+    @Test
+    fun testRemoveTrailingJapaneseWhitespace() {
+        val test = "テスト　\r　\t　"
+        val expected = "テスト"
+        Assert.assertTrue(viewHolder.checkTrailingWhitespace(test));
+        Assert.assertEquals(expected, viewHolder.removeTrailingWhitespace(test))
     }
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailInputFilterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailInputFilterTest.kt
@@ -33,7 +33,7 @@ class UploadMediaDetailInputFilterTest {
         builder.filters = arrayOf(UploadMediaDetailInputFilter())
 
         //All unusual space characters
-        val tests = intArrayOf(0x00A0, 0x1680, 0x180E, 0x2000, 0x2005, 0x200B, 0x2028, 0x2029, 0x202F, 0x205F, 0x3000)
+        val tests = intArrayOf(0x00A0, 0x1680, 0x180E, 0x2000, 0x2005, 0x200B, 0x2028, 0x2029, 0x202F, 0x205F)
         for (test: Int in tests) {
             builder.insert(0, String(Character.toChars(test)))
             Assert.assertEquals(builder.toString(), "")

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailInputFilterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailInputFilterTest.kt
@@ -125,4 +125,16 @@ class UploadMediaDetailInputFilterTest {
         }
         Assert.assertEquals(builder.toString(), expected.toString())
     }
+
+    @Test
+    fun testFilterTrailingWhitespace() {
+        val builder = SpannableStringBuilder("")
+        builder.filters = arrayOf(UploadMediaDetailInputFilter())
+
+        val test: CharSequence = "test  "
+        val expected = "test"
+        builder.insert(0, test)
+        Assert.assertEquals(expected, builder.toString())
+        builder.clear()
+    }
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailInputFilterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailInputFilterTest.kt
@@ -125,16 +125,4 @@ class UploadMediaDetailInputFilterTest {
         }
         Assert.assertEquals(builder.toString(), expected.toString())
     }
-
-    @Test
-    fun testFilterTrailingWhitespace() {
-        val builder = SpannableStringBuilder("")
-        builder.filters = arrayOf(UploadMediaDetailInputFilter())
-
-        val test: CharSequence = "test  "
-        val expected = "test"
-        builder.insert(0, test)
-        Assert.assertEquals(expected, builder.toString())
-        builder.clear()
-    }
 }


### PR DESCRIPTION
**Description (required)**

Fixes #4962

The caption field is used for the media filename and the MediaWiki has restrictions on the filename, thus the trailing whitespace causes the logcat error `titleblacklist-custom-space`. See [https://commons.wikimedia.org/wiki/MediaWiki:Titleblacklist](url).

This issue is fixed by checking and removing any trailing whitespace in the caption field. 
In `UploadMediaDetailAdapter.java`, any trailing space in`captionText` will be removed using `removeTrailingWhitespace` when set to `uploadMediaDetails`.

**Tests performed (required)**

Tested Build variant: BetaDebug on Pixel 2 with API level 30.

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
