### PR TITLE
4664: Moved FolderFragment to ViewBinding

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/FolderFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/FolderFragment.kt
@@ -5,28 +5,31 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ProgressBar
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import fr.free.nrw.commons.R
 import fr.free.nrw.commons.customselector.helper.ImageHelper
 import fr.free.nrw.commons.customselector.model.Result
 import fr.free.nrw.commons.customselector.listeners.FolderClickListener
 import fr.free.nrw.commons.customselector.model.CallbackStatus
 import fr.free.nrw.commons.customselector.model.Folder
 import fr.free.nrw.commons.customselector.ui.adapter.FolderAdapter
+import fr.free.nrw.commons.databinding.FragmentCustomSelectorBinding
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment
 import fr.free.nrw.commons.media.MediaClient
 import fr.free.nrw.commons.upload.FileProcessor
-import kotlinx.android.synthetic.main.fragment_custom_selector.*
-import kotlinx.android.synthetic.main.fragment_custom_selector.view.*
 import javax.inject.Inject
 
 /**
  * Custom selector folder fragment.
  */
 class FolderFragment : CommonsDaggerSupportFragment() {
+
+    /**
+     * ViewBinding
+     */
+    private var _binding: FragmentCustomSelectorBinding? = null
+    private val binding get() = _binding
 
     /**
      * View Model for images.
@@ -89,20 +92,20 @@ class FolderFragment : CommonsDaggerSupportFragment() {
      * Inflate Layout, init adapter, init gridLayoutManager, setUp recycler view, observe the view model for result.
      */
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val root = inflater.inflate(R.layout.fragment_custom_selector, container, false)
+        _binding = FragmentCustomSelectorBinding.inflate(inflater, container, false)
         folderAdapter = FolderAdapter(activity!!, activity as FolderClickListener)
         gridLayoutManager = GridLayoutManager(context, columnCount())
-        selectorRV = root.selector_rv
-        loader = root.loader
-        with(root.selector_rv){
-            this.layoutManager = gridLayoutManager
-            setHasFixedSize(true)
-            this.adapter = folderAdapter
+        selectorRV = binding?.selectorRv
+        loader = binding?.loader
+        with(binding?.selectorRv){
+            this?.layoutManager = gridLayoutManager
+            this?.setHasFixedSize(true)
+            this?.adapter = folderAdapter
         }
-        viewModel?.result?.observe(viewLifecycleOwner, Observer {
+        viewModel?.result?.observe(viewLifecycleOwner) {
             handleResult(it)
-        })
-        return root
+        }
+        return binding?.root
     }
 
     /**
@@ -115,7 +118,7 @@ class FolderFragment : CommonsDaggerSupportFragment() {
             val images = result.images
             if(images.isNullOrEmpty())
             {
-                empty_text?.let {
+                binding?.emptyText?.let {
                     it.visibility = View.VISIBLE
                 }
             }
@@ -138,6 +141,15 @@ class FolderFragment : CommonsDaggerSupportFragment() {
     override fun onResume() {
         folderAdapter.notifyDataSetChanged()
         super.onResume()
+    }
+
+    /**
+     * onDestroyView
+     * clearing view binding
+     */
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 
     /**


### PR DESCRIPTION
Fixes #4664 

What changes did you make and why?
- **Issue:** As per the information provided and work request on the ticket above, `FolderFragment.kt` is currently using Kotlin Synthetic which creates auto-generated class, and has been alread deprecated.
- **Solution:** Hence migration was done by replacing `kotlin-synthetic` with `viewbinding`, which is always null safe, type-safe and supports both Java and Kotlin.

NB: During migration, removed a redundant SAM constructor & moved out its lambda constructor out of parenthesis.
