### PR TITLE
4664: Moved PageableMediaFragment to ViewBinding

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/media/PageableMediaFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/media/PageableMediaFragment.kt
@@ -2,16 +2,23 @@ package fr.free.nrw.commons.explore.media
 
 import android.content.Context
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.category.CategoryImagesCallback
+import fr.free.nrw.commons.databinding.FragmentSearchPaginatedBinding
 import fr.free.nrw.commons.explore.paging.BasePagingFragment
 import fr.free.nrw.commons.media.MediaDetailPagerFragment.MediaDetailProvider
-import kotlinx.android.synthetic.main.fragment_search_paginated.*
-
 
 abstract class PageableMediaFragment : BasePagingFragment<Media>(), MediaDetailProvider {
+
+    /**
+     * ViewBinding
+     */
+    private var _binding: FragmentSearchPaginatedBinding? = null
+    private val binding get() = _binding
 
     override val pagedListAdapter by lazy {
         PagedMediaAdapter(categoryImagesCallback::onMediaClicked)
@@ -32,6 +39,15 @@ abstract class PageableMediaFragment : BasePagingFragment<Media>(), MediaDetailP
         }
     }
 
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentSearchPaginatedBinding.inflate(inflater, container, false)
+        return binding?.root
+    }
+
     private val simpleDataObserver =
         SimpleDataObserver { categoryImagesCallback.viewPagerNotifyDataSetChanged() }
 
@@ -41,6 +57,7 @@ abstract class PageableMediaFragment : BasePagingFragment<Media>(), MediaDetailP
     }
 
     override fun onDestroyView() {
+        _binding = null
         super.onDestroyView()
         pagedListAdapter.unregisterAdapterDataObserver(simpleDataObserver)
     }
@@ -49,7 +66,7 @@ abstract class PageableMediaFragment : BasePagingFragment<Media>(), MediaDetailP
         pagedListAdapter.currentList?.get(position)?.takeIf { it.filename != null }
             .also {
                 pagedListAdapter.currentList?.loadAround(position)
-                paginatedSearchResultsList.scrollToPosition(position)
+                binding?.paginatedSearchResultsList?.scrollToPosition(position)
             }
 
     override fun getTotalMediaCount(): Int = pagedListAdapter.itemCount


### PR DESCRIPTION
Fixes #4664 

What changes did you make and why?
- **Issue:** As per the information provided and work request on the ticket above, `PageableMediaFragment .kt` is currently using Kotlin Synthetic which creates auto-generated class, and has been alread deprecated.
- **Solution:** Hence migration was done by replacing `kotlin-synthetic` with `viewbinding`, which is always null safe, type-safe and supports both Java and Kotlin.