### PR TITLE
4664: Moved AdvanceQueryFragment to ViewBinding

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/AdvanceQueryFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/AdvanceQueryFragment.kt
@@ -6,52 +6,48 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
-import androidx.appcompat.widget.AppCompatButton
-import androidx.appcompat.widget.AppCompatEditText
 import androidx.fragment.app.Fragment
-import fr.free.nrw.commons.R
-import kotlinx.android.synthetic.main.fragment_advance_query.*
+import fr.free.nrw.commons.databinding.FragmentAdvanceQueryBinding
 
 class AdvanceQueryFragment : Fragment() {
 
+    private var _binding: FragmentAdvanceQueryBinding? = null
+    private val binding get() = _binding
     lateinit var originalQuery: String
     lateinit var callback: Callback
-    lateinit var etQuery: AppCompatEditText
-    lateinit var btnApply: AppCompatButton
-    lateinit var btnReset: AppCompatButton
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val view = inflater.inflate(R.layout.fragment_advance_query, container, false)
+        _binding = FragmentAdvanceQueryBinding.inflate(inflater, container, false)
         originalQuery = arguments?.getString("query")!!
         setHasOptionsMenu(false)
-        return view
+        return binding?.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        etQuery = view.findViewById(R.id.et_query)
-        btnApply = view.findViewById(R.id.btn_apply)
-        btnReset = view.findViewById(R.id.btn_reset)
 
-        etQuery.setText(originalQuery)
-        btnReset.setOnClickListener {
-            btnReset.post {
-                etQuery.setText(originalQuery)
-                etQuery.clearFocus()
-                hideKeyBoard()
-                callback.reset()
+        with(requireNotNull(binding)) {
+            etQuery.setText(originalQuery)
+            btnReset.setOnClickListener {
+                btnReset.post {
+                    etQuery.setText(originalQuery)
+                    etQuery.clearFocus()
+                    hideKeyBoard()
+                    callback.reset()
+                }
             }
-        }
 
-        btnApply.setOnClickListener {
-            btnApply.post {
-                etQuery.clearFocus()
-                hideKeyBoard()
-                callback.apply(etQuery.text.toString())
-                callback.close()
+            btnApply.setOnClickListener {
+                btnApply.post {
+                    etQuery.clearFocus()
+                    hideKeyBoard()
+                    callback.apply(etQuery.text.toString())
+                    callback.close()
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #4664 

What changes did you make and why?
- **Issue:** As per the information provided and work request on the ticket above, `AdvanceQueryFragment.kt ` is currently using `findViewById` which is tedious and not needed, and can cause runtime crashes.
- **Solution:** Hence migration was done by replacing `findViewById ` with `viewbinding`, which is always null safe, type-safe and supports both Java and Kotlin.