### PR TITLE
[Enhancement] Add option to centre on GPS location for issue #5008

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -438,13 +438,13 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
      * Center the camera on the last saved location
      */
     private void addCenterOnGPSButton(){
-        fabCenterOnLocation = findViewById(R.id.centre_on_gps);
-        fabCenterOnLocation.setOnClickListener(view -> getCentre());
+        fabCenterOnLocation = findViewById(R.id.center_on_gps);
+        fabCenterOnLocation.setOnClickListener(view -> getCenter());
     }
     /**
      * Animate map to move to desired Latitude and Longitude
      */
-    void getCentre() {
+    void getCenter() {
         mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(location.getLatitude(),location.getLongitude()),15.0));
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -11,6 +11,7 @@ import static fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.
 
 import android.content.Intent;
 import android.graphics.BitmapFactory;
+import android.location.Location;
 import android.os.Bundle;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
@@ -29,6 +30,8 @@ import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.mapbox.android.core.location.LocationEngineCallback;
+import com.mapbox.android.core.location.LocationEngineResult;
 import com.mapbox.android.core.permissions.PermissionsManager;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
@@ -93,6 +96,10 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
      */
     private String activity;
     /**
+     * location : location
+     */
+    private Location location;
+    /**
      * modifyLocationButton : button for start editing location
      */
     Button modifyLocationButton;
@@ -105,6 +112,10 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
      */
     FloatingActionButton placeSelectedButton;
     /**
+     * cGPS: button for centre on location;
+     */
+    FloatingActionButton cGPS;
+    /**
      * droppedMarkerLayer : Layer for static screen
      */
     private Layer droppedMarkerLayer;
@@ -113,7 +124,7 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
      */
     private ImageView shadow;
     /**
-     * largeToolbarText : textView of shadow
+     * cGPS : textView of centre to location
      */
     private TextView largeToolbarText;
     /**
@@ -154,6 +165,7 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
         addPlaceSelectedButton();
         addCredits();
         getToolbarUI();
+        addCentreOnGPSButton();
 
         if ("UploadActivity".equals(activity)) {
             placeSelectedButton.setVisibility(View.GONE);
@@ -162,6 +174,7 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
             largeToolbarText.setText(getResources().getString(R.string.image_location));
             smallToolbarText.setText(getResources().
                 getString(R.string.check_whether_location_is_correct));
+            cGPS.setVisibility(View.GONE);
         }
 
         mapView.onCreate(savedInstanceState);
@@ -275,6 +288,7 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
         largeToolbarText.setText(getResources().getString(R.string.choose_a_location));
         smallToolbarText.setText(getResources().getString(R.string.pan_and_zoom_to_adjust));
         bindListeners();
+        cGPS.setVisibility(View.VISIBLE);
     }
 
     /**
@@ -338,6 +352,20 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
 
             // Set the component's render mode
             locationComponent.setRenderMode(RenderMode.NORMAL);
+
+            locationComponent.getLocationEngine().getLastLocation(
+                new LocationEngineCallback<LocationEngineResult>() {
+                    @Override
+                    public void onSuccess(LocationEngineResult result) {
+                        location = result.getLastLocation();
+                    }
+
+                    @Override
+                    public void onFailure(@NonNull Exception exception) {
+
+                    }
+                });
+
 
         }
     }
@@ -404,6 +432,16 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
             mapboxMap.getCameraPosition());
         setResult(AppCompatActivity.RESULT_OK, returningIntent);
         finish();
+    }
+    /**
+     * Centre the camera on the last saved location
+     */
+    private void addCentreOnGPSButton(){
+        cGPS = findViewById(R.id.centre_on_gps);
+        cGPS.setOnClickListener(view -> getCentre());
+    }
+    void getCentre() {
+        mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(location.getLatitude(),location.getLongitude()),15.0));
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -435,12 +435,15 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
         finish();
     }
     /**
-     * Centre the camera on the last saved location
+     * Center the camera on the last saved location
      */
     private void addCenterOnGPSButton(){
         fabCenterOnLocation = findViewById(R.id.centre_on_gps);
         fabCenterOnLocation.setOnClickListener(view -> getCentre());
     }
+    /**
+     * Animate map to move to desired Latitude and Longitude
+     */
     void getCentre() {
         mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(location.getLatitude(),location.getLongitude()),15.0));
     }

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -21,6 +21,7 @@ import android.view.animation.OvershootInterpolator;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
@@ -112,9 +113,9 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
      */
     FloatingActionButton placeSelectedButton;
     /**
-     * cGPS: button for centre on location;
+     * fabCenterOnLocation: button for center on location;
      */
-    FloatingActionButton cGPS;
+    FloatingActionButton fabCenterOnLocation;
     /**
      * droppedMarkerLayer : Layer for static screen
      */
@@ -124,7 +125,7 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
      */
     private ImageView shadow;
     /**
-     * cGPS : textView of centre to location
+     * largeToolbarText : textView of shadow
      */
     private TextView largeToolbarText;
     /**
@@ -165,7 +166,7 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
         addPlaceSelectedButton();
         addCredits();
         getToolbarUI();
-        addCentreOnGPSButton();
+        addCenterOnGPSButton();
 
         if ("UploadActivity".equals(activity)) {
             placeSelectedButton.setVisibility(View.GONE);
@@ -174,7 +175,7 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
             largeToolbarText.setText(getResources().getString(R.string.image_location));
             smallToolbarText.setText(getResources().
                 getString(R.string.check_whether_location_is_correct));
-            cGPS.setVisibility(View.GONE);
+            fabCenterOnLocation.setVisibility(View.GONE);
         }
 
         mapView.onCreate(savedInstanceState);
@@ -288,7 +289,7 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
         largeToolbarText.setText(getResources().getString(R.string.choose_a_location));
         smallToolbarText.setText(getResources().getString(R.string.pan_and_zoom_to_adjust));
         bindListeners();
-        cGPS.setVisibility(View.VISIBLE);
+        fabCenterOnLocation.setVisibility(View.VISIBLE);
     }
 
     /**
@@ -353,6 +354,7 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
             // Set the component's render mode
             locationComponent.setRenderMode(RenderMode.NORMAL);
 
+            // Get the component's location engine to receive user's last location
             locationComponent.getLocationEngine().getLastLocation(
                 new LocationEngineCallback<LocationEngineResult>() {
                     @Override
@@ -362,7 +364,6 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
 
                     @Override
                     public void onFailure(@NonNull Exception exception) {
-
                     }
                 });
 
@@ -436,9 +437,9 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
     /**
      * Centre the camera on the last saved location
      */
-    private void addCentreOnGPSButton(){
-        cGPS = findViewById(R.id.centre_on_gps);
-        cGPS.setOnClickListener(view -> getCentre());
+    private void addCenterOnGPSButton(){
+        fabCenterOnLocation = findViewById(R.id.centre_on_gps);
+        fabCenterOnLocation.setOnClickListener(view -> getCentre());
     }
     void getCentre() {
         mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(location.getLatitude(),location.getLongitude()),15.0));

--- a/app/src/main/res/layout/bottom_container_location_picker.xml
+++ b/app/src/main/res/layout/bottom_container_location_picker.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:layout_gravity="bottom">
@@ -18,6 +19,19 @@
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:srcCompat="@drawable/ic_check_black_24dp" />
+
+  <com.google.android.material.floatingactionbutton.FloatingActionButton
+    android:id="@+id/centre_on_gps"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="20dp"
+    android:contentDescription="@string/select_location_location_picker"
+    app:backgroundTint="@color/white"
+    app:elevation="3dp"
+    app:layout_anchorGravity="bottom|end"
+    app:layout_constraintBottom_toTopOf="@+id/location_chosen_button"
+    app:layout_constraintEnd_toEndOf="@id/location_chosen_button"
+    app:srcCompat="@drawable/ic_my_location_black_24dp" />
 
   <androidx.appcompat.widget.AppCompatTextView
     android:id="@+id/tv_attribution"

--- a/app/src/main/res/layout/bottom_container_location_picker.xml
+++ b/app/src/main/res/layout/bottom_container_location_picker.xml
@@ -21,7 +21,7 @@
     app:srcCompat="@drawable/ic_check_black_24dp" />
 
   <com.google.android.material.floatingactionbutton.FloatingActionButton
-    android:id="@+id/centre_on_gps"
+    android:id="@+id/center_on_gps"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginBottom="20dp"


### PR DESCRIPTION
**Description (required)**

[Enhancement] Add option to center on GPS location from issue #5008 

In layout, add floatactionbutton and add new method addCentreOnGPSButton() in LocationPickerActivity. Users can click the button to be redirected to the device's current location.

**Tests performed (required)**

Tested {LocationPickerActivity} on {Pixel 2} with API level {API level 30}.
No change to LocationPickerActivityUnitTests due to a lack of understanding of the test file format. When performing the test, a NullException error occurred.

**Screenshots (for UI changes only)**
![Screenshot 2022-10-26 155455](https://user-images.githubusercontent.com/45113399/197938509-0690a5be-ae10-4499-8980-3a9c4fa32f9b.png)


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
