### PR TITLE
review: exclude images not uploaded from the app

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewInterface.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewInterface.java
@@ -10,7 +10,7 @@ import retrofit2.http.Query;
  * Interface class for peer review calls
  */
 public interface ReviewInterface {
-    @GET("w/api.php?action=query&format=json&formatversion=2&list=recentchanges&rcprop=title|ids&rctype=new|log&rctoponly=1&rcnamespace=6")
+    @GET("w/api.php?action=query&format=json&formatversion=2&list=recentchanges&rcprop=title|ids&rctype=new|log&rctoponly=1&rcnamespace=6&rctag=android%20app%20edit")
     Observable<MwQueryResponse> getRecentChanges(@Query("rcstart") String rcStart);
 
     @GET("w/api.php?action=query&format=json&formatversion=2&prop=revisions&rvprop=timestamp|ids|user&rvdir=newer&rvlimit=1")


### PR DESCRIPTION
**Description (required)**
The Review feature (in the app's menu) was originally thought as a way to improve our app's overall upload quality, it is not really adapted to the wide variety of pictures uploaded via other upload tools.


Fixes #5101 

What changes did you make and why?
* update the Review API call to request only images with the `android app edit` tag.
**Tests performed (required)**

Tested ProdDebug on Galaxy Nexus with API level 30.
