### PR TITLE
5120: Fix image item loading in ExploreFragment

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/OkHttpConnectionFactory.java
+++ b/app/src/main/java/fr/free/nrw/commons/OkHttpConnectionFactory.java
@@ -3,7 +3,6 @@ package fr.free.nrw.commons;
 import androidx.annotation.NonNull;
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -20,30 +19,34 @@ import org.wikipedia.dataclient.okhttp.HttpStatusException;
 import timber.log.Timber;
 
 public final class OkHttpConnectionFactory {
+
     private static final String CACHE_DIR_NAME = "okhttp-cache";
     private static final long NET_CACHE_SIZE = 64 * 1024 * 1024;
-    @NonNull private static final Cache NET_CACHE = new Cache(new File(CommonsApplication.getInstance().getCacheDir(),
+    @NonNull
+    private static final Cache NET_CACHE = new Cache(
+        new File(CommonsApplication.getInstance().getCacheDir(),
             CACHE_DIR_NAME), NET_CACHE_SIZE);
 
     @NonNull
     private static final OkHttpClient CLIENT = createClient();
 
-    @NonNull public static OkHttpClient getClient() {
+    @NonNull
+    public static OkHttpClient getClient() {
         return CLIENT;
     }
 
     @NonNull
     private static OkHttpClient createClient() {
         return new OkHttpClient.Builder()
-                .cookieJar(SharedPreferenceCookieManager.getInstance())
-                .cache(NET_CACHE)
-                .connectTimeout(120, TimeUnit.SECONDS)
-                .writeTimeout(120, TimeUnit.SECONDS)
-                .readTimeout(120, TimeUnit.SECONDS)
-                .addInterceptor(getLoggingInterceptor())
-                .addInterceptor(new UnsuccessfulResponseInterceptor())
-                .addInterceptor(new CommonHeaderRequestInterceptor())
-                .build();
+            .cookieJar(SharedPreferenceCookieManager.getInstance())
+            .cache(NET_CACHE)
+            .connectTimeout(120, TimeUnit.SECONDS)
+            .writeTimeout(120, TimeUnit.SECONDS)
+            .readTimeout(120, TimeUnit.SECONDS)
+            .addInterceptor(getLoggingInterceptor())
+            .addInterceptor(new UnsuccessfulResponseInterceptor())
+            .addInterceptor(new CommonHeaderRequestInterceptor())
+            .build();
     }
 
     private static HttpLoggingInterceptor getLoggingInterceptor() {
@@ -62,13 +65,14 @@ public final class OkHttpConnectionFactory {
         @NonNull
         public Response intercept(@NonNull final Chain chain) throws IOException {
             final Request request = chain.request().newBuilder()
-                    .header("User-Agent", CommonsApplication.getInstance().getUserAgent())
-                    .build();
+                .header("User-Agent", CommonsApplication.getInstance().getUserAgent())
+                .build();
             return chain.proceed(request);
         }
     }
 
     public static class UnsuccessfulResponseInterceptor implements Interceptor {
+
         private static final List<String> DO_NOT_INTERCEPT = Collections.singletonList(
             "api.php?format=json&formatversion=2&errorformat=plaintext&action=upload&ignorewarnings=1");
 
@@ -80,15 +84,13 @@ public final class OkHttpConnectionFactory {
             final Response rsp = chain.proceed(chain.request());
 
             // Do not intercept certain requests and let the caller handle the errors
-            if(isExcludedUrl(chain.request())) {
+            if (isExcludedUrl(chain.request())) {
                 return rsp;
             }
             if (rsp.isSuccessful()) {
                 try (final ResponseBody responseBody = rsp.peekBody(ERRORS_PREFIX.length())) {
                     if (ERRORS_PREFIX.equals(responseBody.string())) {
-                        try (final ResponseBody body = rsp.body()) {
-                            throw new IOException(body.string());
-                        }
+                        throw new IOException(responseBody.string());
                     }
                 } catch (final IOException e) {
                     Timber.e(e);
@@ -100,8 +102,8 @@ public final class OkHttpConnectionFactory {
 
         private boolean isExcludedUrl(final Request request) {
             final String requestUrl = request.url().toString();
-            for(final String url: DO_NOT_INTERCEPT) {
-                if(requestUrl.contains(url)) {
+            for (final String url : DO_NOT_INTERCEPT) {
+                if (requestUrl.contains(url)) {
                     return true;
                 }
             }


### PR DESCRIPTION
Fixes #5120

What changes did you make and why?
- Removed redundant try block containing checker with `rsp.body` instead of using `peekBody`, resulting in closing the connection before even reading it.