### PR TITLE
5125: Fix LocationPickerActivityUnitTests

### DIFF
--- a/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
@@ -81,6 +81,9 @@ class LocationPickerActivityUnitTests {
     private lateinit var smallToolbarText: TextView
 
     @Mock
+    private lateinit var fabCenterOnLocation: FloatingActionButton
+
+    @Mock
     private lateinit var tvAttribution: AppCompatTextView
 
     @Mock
@@ -89,7 +92,7 @@ class LocationPickerActivityUnitTests {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = RuntimeEnvironment.getApplication().applicationContext
         activity = Robolectric.buildActivity(LocationPickerActivity::class.java).get()
 
         Whitebox.setInternalState(activity, "mapboxMap", mapboxMap)
@@ -103,6 +106,7 @@ class LocationPickerActivityUnitTests {
         Whitebox.setInternalState(activity, "shadow", shadow)
         Whitebox.setInternalState(activity, "largeToolbarText", largeToolbarText)
         Whitebox.setInternalState(activity, "smallToolbarText", smallToolbarText)
+        Whitebox.setInternalState(activity, "fabCenterOnLocation", fabCenterOnLocation)
         Whitebox.setInternalState(activity, "tvAttribution", tvAttribution)
     }
 
@@ -206,6 +210,7 @@ class LocationPickerActivityUnitTests {
         verify(droppedMarkerLayer, times(1)).setProperties(any())
         verify(largeToolbarText, times(1)).text = "Choose a location"
         verify(smallToolbarText, times(1)).text = "Pan and zoom to adjust"
+        verify(fabCenterOnLocation, times(1)).visibility = View.VISIBLE
         verify(mapboxMap, times(1)).addOnCameraMoveStartedListener(activity)
         verify(mapboxMap, times(1)).addOnCameraIdleListener(activity)
     }

--- a/app/src/test/kotlin/fr/free/nrw/commons/nearby/AdvanceQueryFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/nearby/AdvanceQueryFragmentUnitTests.kt
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.nearby
 
-import android.content.Context
 import android.os.Bundle
 import android.os.Looper
 import android.view.LayoutInflater
@@ -26,7 +25,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -38,7 +36,6 @@ import org.wikipedia.AppAdapter
 class AdvanceQueryFragmentUnitTests {
 
     private lateinit var view: View
-    private lateinit var context: Context
     private lateinit var activity: MainActivity
     private lateinit var layoutInflater: LayoutInflater
     private lateinit var fragment: AdvanceQueryFragment
@@ -63,7 +60,6 @@ class AdvanceQueryFragmentUnitTests {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.getApplication().applicationContext
         AppAdapter.set(TestAppAdapter())
         activity = Robolectric.buildActivity(MainActivity::class.java).create().get()
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/recentlanguages/RecentLanguagesAdapterUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/recentlanguages/RecentLanguagesAdapterUnitTest.kt
@@ -1,10 +1,9 @@
 package fr.free.nrw.commons.recentlanguages
 
 import android.content.Context
+import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
-import com.nhaarman.mockitokotlin2.whenever
 import fr.free.nrw.commons.TestCommonsApplication
 import kotlinx.android.synthetic.main.row_item_languages_spinner.view.*
 import org.junit.Assert
@@ -12,8 +11,12 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
+import fr.free.nrw.commons.R
+import fr.free.nrw.commons.contributions.MainActivity
 import org.mockito.MockitoAnnotations
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.lang.reflect.Field
@@ -23,24 +26,25 @@ import java.lang.reflect.Field
 @LooperMode(LooperMode.Mode.PAUSED)
 class RecentLanguagesAdapterUnitTest {
 
+    private lateinit var context: Context
+    private lateinit var convertView: View
+    private lateinit var activity: MainActivity
     private lateinit var adapter: RecentLanguagesAdapter
     private lateinit var languages: List<Language>
 
     @Mock
-    private lateinit var context: Context
-
-    @Mock
-    private lateinit var viewGroup: ViewGroup
-
-    @Mock
-    private lateinit var convertView: View
-
-    @Mock
-    private lateinit var textView: TextView
+    private lateinit var parent: ViewGroup
 
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
+
+        context = RuntimeEnvironment.getApplication().applicationContext
+
+        activity = Robolectric.buildActivity(MainActivity::class.java).get()
+
+        convertView = LayoutInflater.from(context).inflate(R.layout.row_item_languages_spinner, null) as View
+
         languages = listOf(
             Language("English", "en"),
             Language("Bengali", "bn")
@@ -91,13 +95,7 @@ class RecentLanguagesAdapterUnitTest {
     @Test
     @Throws(Exception::class)
     fun testGetView() {
-        val list = languages
-        whenever(convertView.tv_language).thenReturn(textView)
-        val recentLanguagesAdapter: Field =
-            RecentLanguagesAdapter::class.java.getDeclaredField("recentLanguages")
-        recentLanguagesAdapter.isAccessible = true
-        recentLanguagesAdapter.set(adapter, list)
-        Assert.assertEquals(adapter.getView(0, convertView, viewGroup), convertView)
+        Assert.assertEquals(adapter.getView(0, convertView, parent), convertView)
     }
 
     @Test


### PR DESCRIPTION
Fixes #5125 

What changes did you make and why?

- Issue was method `testOnClickModifyLocation` was throwing `InvocationTargetException`, due to missing mock & visibility verification of `fabCenterOnLocation`. 
- The required changes are done, and all test cases passed.
