### PR TITLE
4671: Change the deprecated RuntimeEnvironment.application in all the Robolectric unit tests

### DIFF
--- a/app/src/test/kotlin/fr/free/nrw/commons/AboutActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/AboutActivityUnitTests.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.view.Menu
 import android.view.MenuItem
+import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -11,7 +12,6 @@ import org.junit.runner.RunWith
 import org.mockito.MockitoAnnotations
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.fakes.RoboMenu
@@ -33,7 +33,7 @@ class AboutActivityUnitTests {
 
         activity = Robolectric.buildActivity(AboutActivity::class.java).create().get()
 
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
     }
 
     @Test

--- a/app/src/test/kotlin/fr/free/nrw/commons/auth/AccountUtilUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/auth/AccountUtilUnitTest.kt
@@ -1,5 +1,6 @@
 package fr.free.nrw.commons.auth
 
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.FakeContextWrapper
 import fr.free.nrw.commons.FakeContextWrapperWithException
 import fr.free.nrw.commons.TestCommonsApplication
@@ -8,7 +9,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
@@ -21,7 +21,7 @@ class AccountUtilUnitTest {
     @Before
     @Throws(Exception::class)
     fun setUp() {
-        context = FakeContextWrapper(RuntimeEnvironment.application.applicationContext)
+        context = FakeContextWrapper(ApplicationProvider.getApplicationContext())
         accountUtil = AccountUtil()
     }
 
@@ -41,7 +41,7 @@ class AccountUtilUnitTest {
     @Throws(Exception::class)
     fun testGetUserNameWithException() {
         val context =
-            FakeContextWrapperWithException(RuntimeEnvironment.application.applicationContext)
+            FakeContextWrapperWithException(ApplicationProvider.getApplicationContext())
         Assert.assertEquals(AccountUtil.getUserName(context), null)
     }
 
@@ -55,7 +55,7 @@ class AccountUtilUnitTest {
     @Throws(Exception::class)
     fun testAccountWithException() {
         val context =
-            FakeContextWrapperWithException(RuntimeEnvironment.application.applicationContext)
+            FakeContextWrapperWithException(ApplicationProvider.getApplicationContext())
         Assert.assertEquals(AccountUtil.account(context), null)
     }
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/auth/LoginActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/auth/LoginActivityUnitTests.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.widget.Button
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestAppAdapter
 import fr.free.nrw.commons.TestCommonsApplication
@@ -24,7 +25,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.fakes.RoboMenuItem
 import org.wikipedia.AppAdapter
@@ -77,7 +77,7 @@ class LoginActivityUnitTests {
         MockitoAnnotations.initMocks(this)
         AppAdapter.set(TestAppAdapter())
         activity = Robolectric.buildActivity(LoginActivity::class.java).create().get()
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         menuItem = RoboMenuItem(null)
         Whitebox.setInternalState(activity, "progressDialog", progressDialog)
         Whitebox.setInternalState(activity, "applicationKvStore", applicationKvStore)

--- a/app/src/test/kotlin/fr/free/nrw/commons/auth/SessionManagerUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/auth/SessionManagerUnitTests.kt
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.auth
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.TestCommonsApplication
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import org.junit.Assert
@@ -13,7 +14,6 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.powermock.api.mockito.PowerMockito.`when`
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -44,10 +44,10 @@ class SessionManagerUnitTests {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        accountManager = AccountManager.get(RuntimeEnvironment.application)
+        accountManager = AccountManager.get(ApplicationProvider.getApplicationContext())
         shadowOf(accountManager).addAccount(account)
         sessionManager =
-            SessionManager(RuntimeEnvironment.application.applicationContext, defaultKvStore)
+            SessionManager(ApplicationProvider.getApplicationContext(), defaultKvStore)
     }
 
     @Test

--- a/app/src/test/kotlin/fr/free/nrw/commons/auth/WikiAccountAuthenticatorUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/auth/WikiAccountAuthenticatorUnitTest.kt
@@ -6,6 +6,7 @@ import android.accounts.AccountManager
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.BuildConfig
 import fr.free.nrw.commons.TestCommonsApplication
 import org.junit.Assert
@@ -15,7 +16,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 
@@ -36,7 +36,7 @@ class WikiAccountAuthenticatorUnitTest {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         authenticator = WikiAccountAuthenticator(context)
     }
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/BookmarkListRootFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/BookmarkListRootFragmentUnitTest.kt
@@ -8,6 +8,7 @@ import android.widget.ListAdapter
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.tabs.TabLayout
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.times
@@ -32,7 +33,6 @@ import org.powermock.api.mockito.PowerMockito.mock
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.wikipedia.AppAdapter
@@ -86,7 +86,7 @@ class BookmarkListRootFragmentUnitTest {
         MockitoAnnotations.initMocks(this)
         AppAdapter.set(TestAppAdapter())
         activity = Robolectric.buildActivity(MainActivity::class.java).create().get()
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         fragment = BookmarkListRootFragment()
         fragmentManager = activity.supportFragmentManager

--- a/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/items/BookmarkItemsFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/items/BookmarkItemsFragmentUnitTest.kt
@@ -10,6 +10,7 @@ import android.widget.TextView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.whenever
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestAppAdapter
@@ -25,7 +26,6 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.wikipedia.AppAdapter
@@ -77,7 +77,7 @@ class BookmarkItemsFragmentUnitTest {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         AppAdapter.set(TestAppAdapter())
         val activity = Robolectric.buildActivity(ProfileActivity::class.java).create().get()
         fragment = BookmarkItemsFragment.newInstance()

--- a/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/locations/BookmarkLocationFragmentUnitTests.kt
@@ -10,6 +10,7 @@ import android.widget.TextView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.whenever
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestAppAdapter
@@ -29,12 +30,10 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.wikipedia.AppAdapter
 import java.lang.reflect.Method
-import java.util.ArrayList
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [21], application = TestCommonsApplication::class)
@@ -98,7 +97,7 @@ class BookmarkLocationFragmentUnitTests {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         AppAdapter.set(TestAppAdapter())
         val activity = Robolectric.buildActivity(ProfileActivity::class.java).create().get()
         fragment = BookmarkLocationsFragment.newInstance()

--- a/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/pictures/BookmarkPicturesFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/pictures/BookmarkPicturesFragmentUnitTests.kt
@@ -14,6 +14,7 @@ import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
@@ -34,7 +35,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -88,7 +88,7 @@ class BookmarkPicturesFragmentUnitTests {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         AppAdapter.set(TestAppAdapter())
         val activity = Robolectric.buildActivity(ProfileActivity::class.java).create().get()
         fragment = BookmarkPicturesFragment.newInstance()

--- a/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryDetailsActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryDetailsActivityUnitTests.kt
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.category
 import android.content.Context
 import android.view.Menu
 import android.view.MenuItem
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.TestAppAdapter
 import fr.free.nrw.commons.TestCommonsApplication
 import fr.free.nrw.commons.explore.categories.media.CategoriesMediaFragment
@@ -14,7 +15,6 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.fakes.RoboMenu
 import org.robolectric.fakes.RoboMenuItem
@@ -43,7 +43,7 @@ class CategoryDetailsActivityUnitTests {
 
         AppAdapter.set(TestAppAdapter())
 
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         activity = Robolectric.buildActivity(CategoryDetailsActivity::class.java).create().get()
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryEditHelperUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/CategoryEditHelperUnitTests.kt
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.category
 
 import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestCommonsApplication
@@ -18,7 +19,6 @@ import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 
@@ -45,7 +45,7 @@ class CategoryEditHelperUnitTests {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         helper = CategoryEditHelper(notificationHelper, pageEditClient, viewUtilWrapper,
             "")
         Mockito.`when`(media.filename).thenReturn("File:Example.jpg")

--- a/app/src/test/kotlin/fr/free/nrw/commons/category/GridViewAdapterUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/GridViewAdapterUnitTest.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.soloader.SoLoader
 import fr.free.nrw.commons.Media
@@ -19,7 +20,6 @@ import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import java.lang.reflect.Method
 
@@ -51,7 +51,7 @@ class GridViewAdapterUnitTest {
         MockitoAnnotations.initMocks(this)
 
 
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         SoLoader.setInTestMode()
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionViewHolderUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionViewHolderUnitTests.kt
@@ -8,11 +8,10 @@ import android.widget.ImageButton
 import android.widget.ProgressBar
 import android.widget.RelativeLayout
 import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.drawee.view.SimpleDraweeView
-import com.facebook.imagepipeline.request.ImageRequest
 import com.facebook.soloader.SoLoader
-import com.nhaarman.mockitokotlin2.verify
 import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestCommonsApplication
@@ -24,17 +23,14 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.Mockito
 import org.mockito.Mockito.*
 import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import java.io.File
 import java.lang.reflect.Method
 
 @RunWith(RobolectricTestRunner::class)
@@ -79,7 +75,7 @@ class ContributionViewHolderUnitTests {
     fun setUp() {
         MockitoAnnotations.initMocks(this)
         SoLoader.setInTestMode()
-        Fresco.initialize(RuntimeEnvironment.application.applicationContext)
+        Fresco.initialize(ApplicationProvider.getApplicationContext())
         activity = Robolectric.buildActivity(ProfileActivity::class.java).create().get()
         parent = LayoutInflater.from(activity).inflate(R.layout.layout_contribution, null)
         contributionViewHolder = ContributionViewHolder(parent, callback, mediaClient)

--- a/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionsFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionsFragmentUnitTests.kt
@@ -8,17 +8,18 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestAppAdapter
 import fr.free.nrw.commons.TestCommonsApplication
-import fr.free.nrw.commons.campaigns.models.Campaign
 import fr.free.nrw.commons.campaigns.CampaignView
+import fr.free.nrw.commons.campaigns.models.Campaign
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import fr.free.nrw.commons.media.MediaDetailPagerFragment
 import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient
 import fr.free.nrw.commons.nearby.NearbyNotificationCardView
-import fr.free.nrw.commons.notification.models.Notification
 import fr.free.nrw.commons.notification.NotificationController
+import fr.free.nrw.commons.notification.models.Notification
 import fr.free.nrw.commons.notification.models.NotificationType
 import io.reactivex.Single
 import io.reactivex.disposables.CompositeDisposable
@@ -28,13 +29,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.*
 import org.mockito.Mock
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -101,7 +101,7 @@ class ContributionsFragmentUnitTests {
 
         AppAdapter.set(TestAppAdapter())
 
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         activity = Robolectric.buildActivity(MainActivity::class.java).create().get()
 
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionsListFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/contributions/ContributionsListFragmentUnitTests.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.TestAppAdapter
@@ -23,13 +24,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mock
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -105,7 +105,7 @@ class ContributionsListFragmentUnitTests {
         MockitoAnnotations.initMocks(this)
         AppAdapter.set(TestAppAdapter())
 
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         activity = Robolectric.buildActivity(MainActivity::class.java).create().get()
         layoutInflater = LayoutInflater.from(activity)
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/contributions/MainActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/contributions/MainActivityUnitTests.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.os.Looper
 import android.view.MenuItem
 import androidx.fragment.app.Fragment
+import androidx.test.core.app.ApplicationProvider
 import androidx.work.Configuration
 import androidx.work.testing.WorkManagerTestInitHelper
 import fr.free.nrw.commons.CommonsApplication
@@ -25,13 +26,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.powermock.api.mockito.PowerMockito
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -89,7 +89,7 @@ class MainActivityUnitTests {
 
         activity = Robolectric.buildActivity(MainActivity::class.java).create().get()
         activity.applicationKvStore = applicationKvStore
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         menuItem = RoboMenuItem(context)
         mockContext = PowerMockito.mock(Context::class.java)
         mainActivity = PowerMockito.mock(MainActivity::class.java)

--- a/app/src/test/kotlin/fr/free/nrw/commons/coordinates/CoordinateEditHelperUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/coordinates/CoordinateEditHelperUnitTest.kt
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.coordinates
 
 import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestCommonsApplication
@@ -19,7 +20,6 @@ import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.lang.reflect.Method
@@ -47,7 +47,7 @@ class CoordinateEditHelperUnitTest {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         helper = CoordinateEditHelper(notificationHelper, pageEditClient, viewUtilWrapper)
         `when`(media.filename).thenReturn("")
         `when`(pageEditClient.getCurrentWikiText(anyString())).thenReturn(Single.just(""))

--- a/app/src/test/kotlin/fr/free/nrw/commons/customselector/helper/OnSwipeTouchListenerTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/customselector/helper/OnSwipeTouchListenerTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.View
+import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.whenever
 import fr.free.nrw.commons.TestAppAdapter
 import fr.free.nrw.commons.TestCommonsApplication
@@ -14,7 +15,6 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wikipedia.AppAdapter
 
@@ -43,7 +43,7 @@ internal class OnSwipeTouchListenerTest {
         MockitoAnnotations.initMocks(this)
         AppAdapter.set(TestAppAdapter())
 
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         onSwipeTouchListener = OnSwipeTouchListener(context)
         gesListener = OnSwipeTouchListener(context).GestureListener()
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/customselector/ui/selector/FolderFragmentTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/customselector/ui/selector/FolderFragmentTest.kt
@@ -10,6 +10,7 @@ import android.widget.ProgressBar
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.soloader.SoLoader
 import fr.free.nrw.commons.R
@@ -26,7 +27,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -61,7 +61,7 @@ class FolderFragmentTest {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         AppAdapter.set(TestAppAdapter())
         SoLoader.setInTestMode()
         Fresco.initialize(context)

--- a/app/src/test/kotlin/fr/free/nrw/commons/customselector/ui/selector/ImageFragmentTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/customselector/ui/selector/ImageFragmentTest.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.soloader.SoLoader
 import com.nhaarman.mockitokotlin2.whenever
@@ -30,7 +31,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
@@ -73,7 +73,7 @@ class ImageFragmentTest {
     @Before
     fun setUp(){
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         AppAdapter.set(TestAppAdapter())
         SoLoader.setInTestMode()
         Fresco.initialize(context)

--- a/app/src/test/kotlin/fr/free/nrw/commons/description/DescriptionEditActivityUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/description/DescriptionEditActivityUnitTest.kt
@@ -10,6 +10,7 @@ import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestCommonsApplication
 import fr.free.nrw.commons.databinding.ActivityDescriptionEditBinding
@@ -24,13 +25,12 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -59,7 +59,7 @@ class DescriptionEditActivityUnitTest {
     @Throws(Exception::class)
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         uploadMediaDetails = mutableListOf(UploadMediaDetail("en", "desc"))
                 as ArrayList<UploadMediaDetail>
         val intent = Intent().putExtra("title", "read")

--- a/app/src/test/kotlin/fr/free/nrw/commons/explore/ExploreFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/explore/ExploreFragmentUnitTest.kt
@@ -5,6 +5,7 @@ import android.os.Looper.getMainLooper
 import android.view.*
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.tabs.TabLayout
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestAppAdapter
@@ -21,7 +22,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -54,7 +54,7 @@ class ExploreFragmentUnitTest {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         AppAdapter.set(TestAppAdapter())
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/explore/ExploreListRootFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/explore/ExploreListRootFragmentUnitTest.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.widget.FrameLayout
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.tabs.TabLayout
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.times
@@ -28,7 +29,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.wikipedia.AppAdapter
@@ -74,7 +74,7 @@ class ExploreListRootFragmentUnitTest {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         AppAdapter.set(TestAppAdapter())
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/explore/depictions/WikidataItemDetailsActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/explore/depictions/WikidataItemDetailsActivityUnitTests.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.FrameLayout
 import androidx.fragment.app.FragmentManager
+import androidx.test.core.app.ApplicationProvider
 import androidx.viewpager.widget.ViewPager
 import com.google.android.material.tabs.TabLayout
 import fr.free.nrw.commons.R
@@ -23,7 +24,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.robolectric.fakes.RoboMenu
@@ -67,7 +67,7 @@ class WikidataItemDetailsActivityUnitTests {
         MockitoAnnotations.initMocks(this)
         AppAdapter.set(TestAppAdapter())
         val intent = Intent(
-            RuntimeEnvironment.application.applicationContext,
+            ApplicationProvider.getApplicationContext(),
             WikidataItemDetailsActivity::class.java
         )
         intent.putExtra("wikidataItemName", "depictionName")

--- a/app/src/test/kotlin/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragmentUnitTest.kt
@@ -10,6 +10,7 @@ import android.widget.ListView
 import android.widget.TextView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.whenever
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestAppAdapter
@@ -24,7 +25,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.wikipedia.AppAdapter
@@ -65,7 +65,7 @@ class RecentSearchesFragmentUnitTest {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         AppAdapter.set(TestAppAdapter())
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/explore/search/SearchActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/explore/search/SearchActivityUnitTests.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.widget.SearchView
 import androidx.fragment.app.FragmentController
 import androidx.fragment.app.FragmentManager
+import androidx.test.core.app.ApplicationProvider
 import androidx.viewpager.widget.ViewPager
 import com.nhaarman.mockitokotlin2.verify
 import fr.free.nrw.commons.Media
@@ -31,7 +32,6 @@ import org.powermock.api.mockito.PowerMockito.mock
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.lang.reflect.Method
@@ -88,7 +88,7 @@ class SearchActivityUnitTests {
     fun setUp() {
         MockitoAnnotations.initMocks(this)
         activity = Robolectric.buildActivity(SearchActivity::class.java).create().get()
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
     }
 
     @Test

--- a/app/src/test/kotlin/fr/free/nrw/commons/feedback/FeedbackContentCreatorUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/feedback/FeedbackContentCreatorUnitTests.kt
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.feedback
 
 import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.FakeContextWrapper
 import fr.free.nrw.commons.TestAppAdapter
 import fr.free.nrw.commons.TestCommonsApplication
@@ -14,7 +15,6 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wikipedia.AppAdapter
 
@@ -30,7 +30,7 @@ class FeedbackContentCreatorUnitTests {
     fun setup() {
         MockitoAnnotations.initMocks(this)
         AppAdapter.set(TestAppAdapter())
-        context = FakeContextWrapper(RuntimeEnvironment.application.applicationContext)
+        context = FakeContextWrapper(ApplicationProvider.getApplicationContext())
     }
 
     @Test

--- a/app/src/test/kotlin/fr/free/nrw/commons/feedback/FeedbackDialogTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/feedback/FeedbackDialogTests.kt
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.feedback
 import android.content.Context
 import android.os.Looper.getMainLooper
 import android.text.Editable
+import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.doReturn
 import fr.free.nrw.commons.TestAppAdapter
 import fr.free.nrw.commons.TestCommonsApplication
@@ -20,7 +21,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -42,7 +42,7 @@ class FeedbackDialogTests {
     fun setUp() {
         MockitoAnnotations.initMocks(this)
 
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         AppAdapter.set(TestAppAdapter())
 
         val activity = Robolectric.buildActivity(MainActivity::class.java).create().get()

--- a/app/src/test/kotlin/fr/free/nrw/commons/filepicker/FilePickerTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/filepicker/FilePickerTest.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
 import androidx.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.verify
 import fr.free.nrw.commons.TestCommonsApplication
 import fr.free.nrw.commons.filepicker.Constants.RequestCodes
@@ -18,7 +19,6 @@ import org.mockito.*
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.lang.reflect.Method
@@ -52,7 +52,7 @@ class FilePickerTest {
     @Before
     fun setup() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
     }
 
     @Test

--- a/app/src/test/kotlin/fr/free/nrw/commons/leaderboard/LeaderboardFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/leaderboard/LeaderboardFragmentUnitTests.kt
@@ -12,6 +12,7 @@ import android.widget.Spinner
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestAppAdapter
 import fr.free.nrw.commons.TestCommonsApplication
@@ -32,7 +33,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
@@ -82,7 +82,7 @@ class LeaderboardFragmentUnitTests {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         AppAdapter.set(TestAppAdapter())
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/leaderboard/LeaderboardListAdapterUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/leaderboard/LeaderboardListAdapterUnitTests.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.widget.TextView
 import androidx.paging.PagedList
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.drawee.view.SimpleDraweeView
 import com.facebook.soloader.SoLoader
@@ -19,7 +20,6 @@ import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.lang.reflect.Field
@@ -43,7 +43,7 @@ class LeaderboardListAdapterUnitTests {
 
     @Before
     fun setUp() {
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         MockitoAnnotations.initMocks(this)
         SoLoader.setInTestMode()
         Fresco.initialize(context)

--- a/app/src/test/kotlin/fr/free/nrw/commons/login/LoginActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/login/LoginActivityUnitTests.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestAppAdapter
 import fr.free.nrw.commons.TestCommonsApplication
@@ -17,7 +18,6 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.fakes.RoboMenuItem
 import org.wikipedia.AppAdapter
@@ -53,7 +53,7 @@ class LoginActivityUnitTests {
 
         activity = Robolectric.buildActivity(LoginActivity::class.java).create().get()
 
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         val fieldProgressDialog: Field =
             LoginActivity::class.java.getDeclaredField("progressDialog")

--- a/app/src/test/kotlin/fr/free/nrw/commons/media/MediaDetailFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/media/MediaDetailFragmentUnitTests.kt
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.media
 
-import org.robolectric.shadows.ShadowActivity
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -15,28 +14,27 @@ import android.webkit.WebView
 import android.widget.*
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
-import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.drawee.generic.GenericDraweeHierarchy
 import com.facebook.drawee.view.SimpleDraweeView
 import com.facebook.soloader.SoLoader
 import com.nhaarman.mockitokotlin2.whenever
 import fr.free.nrw.commons.LocationPicker.LocationPickerActivity
-import org.robolectric.Shadows.shadowOf
+import fr.free.nrw.commons.Media
+import fr.free.nrw.commons.R
+import fr.free.nrw.commons.TestAppAdapter
+import fr.free.nrw.commons.TestCommonsApplication
+import fr.free.nrw.commons.delete.DeleteHelper
+import fr.free.nrw.commons.delete.ReasonBuilder
 import fr.free.nrw.commons.explore.SearchActivity
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import fr.free.nrw.commons.location.LatLng
 import fr.free.nrw.commons.location.LocationServiceManager
 import fr.free.nrw.commons.ui.widget.HtmlTextView
+import io.reactivex.Single
 import org.junit.Assert
 import org.junit.Before
-import fr.free.nrw.commons.TestCommonsApplication
-import fr.free.nrw.commons.R
-import fr.free.nrw.commons.TestAppAdapter
-import fr.free.nrw.commons.Media
-import fr.free.nrw.commons.delete.DeleteHelper
-import fr.free.nrw.commons.delete.ReasonBuilder
-import io.reactivex.Single
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.*
@@ -44,17 +42,16 @@ import org.mockito.Mockito.*
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowActivity
 import org.robolectric.shadows.ShadowIntent
 import org.wikipedia.AppAdapter
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.util.*
-import kotlin.collections.ArrayList
-import kotlin.collections.HashMap
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [21], application = TestCommonsApplication::class)
@@ -152,13 +149,13 @@ class MediaDetailFragmentUnitTests {
 
         MockitoAnnotations.initMocks(this)
 
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         AppAdapter.set(TestAppAdapter())
 
         SoLoader.setInTestMode()
 
-        Fresco.initialize(RuntimeEnvironment.application.applicationContext)
+        Fresco.initialize(ApplicationProvider.getApplicationContext())
 
         activity = Robolectric.buildActivity(SearchActivity::class.java).create().get()
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/media/MediaDetailPagerFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/media/MediaDetailPagerFragmentUnitTests.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.os.Looper
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import androidx.test.core.app.ApplicationProvider
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.soloader.SoLoader
 import fr.free.nrw.commons.Media
@@ -23,7 +24,6 @@ import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -57,7 +57,7 @@ class MediaDetailPagerFragmentUnitTests {
 
         MockitoAnnotations.initMocks(this)
 
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         AppAdapter.set(TestAppAdapter())
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/media/ZoomableActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/media/ZoomableActivityUnitTests.kt
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.media
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.soloader.SoLoader
 import fr.free.nrw.commons.TestAppAdapter
@@ -19,7 +20,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.wikipedia.AppAdapter
@@ -45,7 +45,7 @@ class ZoomableActivityUnitTests {
     fun setUp() {
         MockitoAnnotations.initMocks(this)
         AppAdapter.set(TestAppAdapter())
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         SoLoader.setInTestMode()
         Fresco.initialize(context)
         val intent = Intent().setData(uri)

--- a/app/src/test/kotlin/fr/free/nrw/commons/navtab/MoreBottomSheetFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/navtab/MoreBottomSheetFragmentUnitTests.kt
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.navtab
 
-import android.app.Dialog
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -13,33 +12,26 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.CommonsApplication
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestAppAdapter
 import fr.free.nrw.commons.TestCommonsApplication
 import fr.free.nrw.commons.actions.PageEditClient
-import fr.free.nrw.commons.feedback.FeedbackDialog
 import fr.free.nrw.commons.feedback.model.Feedback
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import fr.free.nrw.commons.profile.ProfileActivity
-import fr.free.nrw.commons.utils.ConfigUtils
-import fr.free.nrw.commons.utils.ConfigUtils.getVersionNameWithSha
 import io.reactivex.Observable
-import io.reactivex.Single
-import io.reactivex.SingleSource
-import io.reactivex.functions.Function
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers
 import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -48,7 +40,6 @@ import org.robolectric.shadows.ShadowAlertDialog
 import org.robolectric.shadows.ShadowDialog
 import org.wikipedia.AppAdapter
 import java.lang.reflect.Method
-import java.util.concurrent.Callable
 
 
 @RunWith(RobolectricTestRunner::class)
@@ -74,7 +65,7 @@ class MoreBottomSheetFragmentUnitTests {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         AppAdapter.set(TestAppAdapter())
 
         activity = Robolectric.buildActivity(ProfileActivity::class.java).create().get()

--- a/app/src/test/kotlin/fr/free/nrw/commons/navtab/MoreBottomSheetLoggedOutFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/navtab/MoreBottomSheetLoggedOutFragmentUnitTests.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Looper
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.TestCommonsApplication
 import fr.free.nrw.commons.profile.ProfileActivity
 import org.junit.Assert
@@ -12,7 +13,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -29,7 +29,7 @@ class MoreBottomSheetLoggedOutFragmentUnitTests {
     @Before
     fun setUp() {
 
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         val activity = Robolectric.buildActivity(ProfileActivity::class.java).create().get()
         fragment = MoreBottomSheetLoggedOutFragment()

--- a/app/src/test/kotlin/fr/free/nrw/commons/nearby/NearbyControllerTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/nearby/NearbyControllerTest.kt
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.nearby
 
 import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
@@ -18,7 +19,6 @@ import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.util.*
@@ -50,7 +50,7 @@ class NearbyControllerTest {
     fun setUp() {
         MockitoAnnotations.initMocks(this)
         nearbyController = NearbyController(nearbyPlaces)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
     }
 
     @Test

--- a/app/src/test/kotlin/fr/free/nrw/commons/nearby/NearbyFilterSearchRecyclerViewAdapterUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/nearby/NearbyFilterSearchRecyclerViewAdapterUnitTests.kt
@@ -5,6 +5,7 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.TestCommonsApplication
 import org.junit.Assert
 import org.junit.Before
@@ -13,7 +14,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.util.*
@@ -47,7 +47,7 @@ class NearbyFilterSearchRecyclerViewAdapterUnitTests {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         adapter = NearbyFilterSearchRecyclerViewAdapter(context, ArrayList<Label>(Label.valuesAsList()), recyclerView)
         viewHolder.placeTypeIcon = imageView
         viewHolder.placeTypeLabel = textView

--- a/app/src/test/kotlin/fr/free/nrw/commons/nearby/NearbyParentFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/nearby/NearbyParentFragmentUnitTest.kt
@@ -15,6 +15,7 @@ import androidx.appcompat.widget.AppCompatImageView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.mapbox.mapboxsdk.camera.CameraPosition
@@ -45,7 +46,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -128,7 +128,7 @@ class NearbyParentFragmentUnitTest {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         AppAdapter.set(TestAppAdapter())
         activity = Robolectric.buildActivity(MainActivity::class.java).create().get()

--- a/app/src/test/kotlin/fr/free/nrw/commons/notification/NotificationActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/notification/NotificationActivityUnitTests.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.view.Menu
 import android.view.MenuItem
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.ShadowActionBar
 import fr.free.nrw.commons.TestAppAdapter
@@ -21,7 +22,6 @@ import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.fakes.RoboMenu
 import org.robolectric.fakes.RoboMenuItem
@@ -65,7 +65,7 @@ class NotificationActivityUnitTests {
         activity =
             Robolectric.buildActivity(NotificationActivity::class.java, intent).create().get()
 
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         menuItemWithId = RoboMenuItem(R.id.archived)
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/notification/NotificationHelperUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/notification/NotificationHelperUnitTests.kt
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.notification
 import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.TestCommonsApplication
 import fr.free.nrw.commons.notification.models.Notification
 import fr.free.nrw.commons.notification.models.NotificationType
@@ -13,7 +14,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import java.lang.reflect.Field
 
@@ -33,7 +33,7 @@ class NotificationHelperUnitTests {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         notificationHelper = NotificationHelper(context)
 
         val fieldNotificationManager: Field =

--- a/app/src/test/kotlin/fr/free/nrw/commons/profile/ProfileActivityTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/profile/ProfileActivityTest.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.os.Looper
 import android.view.Menu
 import android.view.MenuItem
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestCommonsApplication
 import org.junit.Assert
@@ -15,7 +16,6 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.fakes.RoboMenu
@@ -40,7 +40,7 @@ class ProfileActivityTest {
     fun setUp() {
         MockitoAnnotations.initMocks(this)
         activity = Robolectric.buildActivity(ProfileActivity::class.java).create().get()
-        mockContext = RuntimeEnvironment.application.applicationContext
+        mockContext = ApplicationProvider.getApplicationContext()
     }
 
     @Test

--- a/app/src/test/kotlin/fr/free/nrw/commons/profile/achievements/AchievementsFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/profile/achievements/AchievementsFragmentUnitTests.kt
@@ -11,6 +11,7 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import androidx.test.core.app.ApplicationProvider
 import com.dinuscxj.progressbar.CircleProgressBar
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestAppAdapter
@@ -28,7 +29,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -106,7 +106,7 @@ class AchievementsFragmentUnitTests {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         menuItem = RoboMenuItem(context)
         AppAdapter.set(TestAppAdapter())
         val activity = Robolectric.buildActivity(ProfileActivity::class.java).create().get()

--- a/app/src/test/kotlin/fr/free/nrw/commons/quiz/QuizActivityUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/quiz/QuizActivityUnitTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.Button
+import androidx.test.core.app.ApplicationProvider
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.soloader.SoLoader
 import fr.free.nrw.commons.R
@@ -19,7 +20,6 @@ import org.powermock.api.mockito.PowerMockito.mock
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
@@ -42,7 +42,7 @@ class QuizActivityUnitTest {
     fun setUp() {
         MockitoAnnotations.initMocks(this)
         SoLoader.setInTestMode()
-        Fresco.initialize(RuntimeEnvironment.application.applicationContext)
+        Fresco.initialize(ApplicationProvider.getApplicationContext())
         activity = Robolectric.buildActivity(QuizActivity::class.java).create().get()
         context = mock(Context::class.java)
         view = LayoutInflater.from(activity)

--- a/app/src/test/kotlin/fr/free/nrw/commons/quiz/QuizCheckerUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/quiz/QuizCheckerUnitTest.kt
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.quiz
 
 import android.app.Activity
+import androidx.test.core.app.ApplicationProvider
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.soloader.SoLoader
 import com.nhaarman.mockitokotlin2.any
@@ -20,7 +21,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import java.lang.reflect.Method
 
@@ -47,7 +47,7 @@ class QuizCheckerUnitTest {
     fun setUp() {
         MockitoAnnotations.initMocks(this)
         SoLoader.setInTestMode()
-        Fresco.initialize(RuntimeEnvironment.application.applicationContext)
+        Fresco.initialize(ApplicationProvider.getApplicationContext())
         activity = Robolectric.buildActivity(QuizActivity::class.java).create().get()
         quizChecker = QuizChecker(sessionManager, okHttpJsonApiClient, jsonKvStore)
         Mockito.`when`(sessionManager.userName).thenReturn("")

--- a/app/src/test/kotlin/fr/free/nrw/commons/review/ReviewActivityTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/review/ReviewActivityTest.kt
@@ -5,6 +5,7 @@ import android.os.Looper.getMainLooper
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.Button
+import androidx.test.core.app.ApplicationProvider
 import butterknife.BindView
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.soloader.SoLoader
@@ -28,7 +29,6 @@ import org.mockito.Spy
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -68,7 +68,7 @@ class ReviewActivityTest {
     fun setUp() {
         MockitoAnnotations.initMocks(this)
 
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         AppAdapter.set(TestAppAdapter())
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/review/ReviewControllerTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/review/ReviewControllerTest.kt
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.review
 import android.app.Activity
 import android.content.Context
 import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.soloader.SoLoader
 import com.nhaarman.mockitokotlin2.verify
@@ -23,7 +24,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -57,7 +57,7 @@ class ReviewControllerTest {
     @Throws(Exception::class)
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         AppAdapter.set(TestAppAdapter())
         SoLoader.setInTestMode()
         Fresco.initialize(context)

--- a/app/src/test/kotlin/fr/free/nrw/commons/review/ReviewImageFragmentTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/review/ReviewImageFragmentTest.kt
@@ -9,6 +9,7 @@ import android.widget.Button
 import android.widget.TextView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import androidx.test.core.app.ApplicationProvider
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.soloader.SoLoader
 import com.nhaarman.mockitokotlin2.doReturn
@@ -28,7 +29,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -62,7 +62,7 @@ class ReviewImageFragmentTest {
     fun setUp() {
 
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         AppAdapter.set(TestAppAdapter())
         SoLoader.setInTestMode()
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/settings/SettingsActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/settings/SettingsActivityUnitTests.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Bundle
 import android.os.Looper
 import android.view.MenuItem
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.TestCommonsApplication
 import org.junit.Assert
 import org.junit.Before
@@ -13,7 +14,6 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -35,7 +35,7 @@ class SettingsActivityUnitTests {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         activity = Robolectric.buildActivity(SettingsActivity::class.java).create().get()
         menuItem = RoboMenuItem(null)
     }

--- a/app/src/test/kotlin/fr/free/nrw/commons/settings/SettingsFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/settings/SettingsFragmentUnitTests.kt
@@ -10,6 +10,7 @@ import android.widget.ListView
 import android.widget.TextView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
+import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
@@ -29,7 +30,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -64,7 +64,7 @@ class SettingsFragmentUnitTests {
     fun setUp() {
         MockitoAnnotations.initMocks(this)
         val activity = Robolectric.buildActivity(SettingsActivity::class.java).create().get()
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         fragment = SettingsFragment()
         fragmentManager = activity.supportFragmentManager

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/LanguagesAdapterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/LanguagesAdapterTest.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.ConfigurationCompat
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestCommonsApplication
 import org.junit.Assert
@@ -16,7 +17,6 @@ import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.wikipedia.language.AppLanguageLookUpTable
@@ -46,7 +46,7 @@ class LanguagesAdapterTest {
     @Throws(Exception::class)
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         language = AppLanguageLookUpTable(context)
         convertView = LayoutInflater.from(context)
             .inflate(R.layout.row_item_languages_spinner, null) as View

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadActivityUnitTests.kt
@@ -2,6 +2,7 @@ package fr.free.nrw.commons.upload
 
 import android.content.Context
 import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
 import androidx.work.Configuration
 import androidx.work.testing.WorkManagerTestInitHelper
 import fr.free.nrw.commons.CommonsApplication
@@ -23,7 +24,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.wikipedia.AppAdapter
@@ -59,7 +59,7 @@ class UploadActivityUnitTests {
         list.add(uploadableFile)
         intent.putParcelableArrayListExtra(UploadActivity.EXTRA_FILES, list)
         activity = Robolectric.buildActivity(UploadActivity::class.java, intent).create().get()
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
 
         Whitebox.setInternalState(activity, "fragments", mutableListOf(uploadBaseFragment))
         Whitebox.setInternalState(activity, "presenter", presenter)

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
@@ -7,6 +7,7 @@ import android.widget.AdapterView
 import android.widget.GridLayout
 import android.widget.ListView
 import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
@@ -26,7 +27,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.lang.reflect.Field
@@ -70,7 +70,7 @@ class UploadMediaDetailAdapterUnitTest {
         uploadMediaDetails = mutableListOf(uploadMediaDetail, uploadMediaDetail)
         activity = Robolectric.buildActivity(UploadActivity::class.java).get()
         adapter = UploadMediaDetailAdapter("", recentLanguagesDao)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         Whitebox.setInternalState(adapter, "uploadMediaDetails", uploadMediaDetails)
         Whitebox.setInternalState(adapter, "eventListener", eventListener)
         Whitebox.setInternalState(adapter, "recentLanguagesTextView", textView)

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/categories/UploadCategoriesFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/categories/UploadCategoriesFragmentUnitTests.kt
@@ -13,6 +13,7 @@ import android.widget.TextView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.textfield.TextInputLayout
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
@@ -35,7 +36,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -102,7 +102,7 @@ class UploadCategoriesFragmentUnitTests {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         AppAdapter.set(TestAppAdapter())
         val activity = Robolectric.buildActivity(UploadActivity::class.java).create().get()
         fragment = UploadCategoriesFragment()

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/depicts/DepictEditHelperUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/depicts/DepictEditHelperUnitTest.kt
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.upload.depicts
 
 import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.whenever
 import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.R
@@ -19,7 +20,6 @@ import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.lang.reflect.Method
@@ -47,7 +47,7 @@ class DepictEditHelperUnitTest {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         helper = DepictEditHelper(notificationHelper, wikidataEditService, viewUtilWrapper)
         Whitebox.setInternalState(helper, "viewUtilWrapper", viewUtilWrapper)
         Whitebox.setInternalState(helper, "notificationHelper", notificationHelper)

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/depicts/DepictsFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/depicts/DepictsFragmentUnitTests.kt
@@ -12,6 +12,7 @@ import android.widget.TextView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.textfield.TextInputLayout
 import com.nhaarman.mockitokotlin2.whenever
 import depictedItem
@@ -33,7 +34,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.wikipedia.AppAdapter
@@ -95,7 +95,7 @@ class DepictsFragmentUnitTests {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         AppAdapter.set(TestAppAdapter())
 
         val activity = Robolectric.buildActivity(UploadActivity::class.java).create().get()

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
@@ -16,6 +16,7 @@ import androidx.appcompat.widget.AppCompatImageButton
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import com.github.chrisbanes.photoview.PhotoView
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng
@@ -43,7 +44,6 @@ import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
@@ -109,7 +109,7 @@ class UploadMediaDetailFragmentUnitTest {
     fun setUp() {
         MockitoAnnotations.initMocks(this)
 
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         AppAdapter.set(TestAppAdapter())
 
         activity = Robolectric.buildActivity(UploadActivity::class.java).create().get()

--- a/app/src/test/kotlin/fr/free/nrw/commons/utils/ImageUtilsTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/utils/ImageUtilsTest.kt
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.utils
 import android.app.ProgressDialog
 import android.content.Context
 import android.graphics.Bitmap
+import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.TestCommonsApplication
 import fr.free.nrw.commons.location.LatLng
 import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient
@@ -12,11 +13,10 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.io.File
@@ -46,7 +46,7 @@ class ImageUtilsTest {
     @Before
     fun setup() {
         MockitoAnnotations.initMocks(this)
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
     }
 
     @Test

--- a/app/src/test/kotlin/fr/free/nrw/commons/widget/PicOfDayAppWidgetUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/widget/PicOfDayAppWidgetUnitTests.kt
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.widget
 import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.widget.RemoteViews
+import androidx.test.core.app.ApplicationProvider
 import com.facebook.imagepipeline.core.ImagePipelineFactory
 import com.facebook.soloader.SoLoader
 import fr.free.nrw.commons.Media
@@ -20,7 +21,6 @@ import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.powermock.reflect.Whitebox
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wikipedia.AppAdapter
 import java.lang.reflect.Method
@@ -47,7 +47,7 @@ class PicOfDayAppWidgetUnitTests {
     @Before
     fun setUp() {
         AppAdapter.set(TestAppAdapter())
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         SoLoader.setInTestMode()
         ImagePipelineFactory.initialize(context)
         MockitoAnnotations.initMocks(this)


### PR DESCRIPTION
**Description (required)**

Fixes #4671 

What changes did you make and why?

Changed the deprecated RuntimeEnvironment.application to ApplicationProvider.getApplicationContext() in all the robolectric unit tests and optimised the imports accordingly.

**Tests performed (required)**

Tested BetaDebug on Redmi 5A with API level 26.