### PR TITLE
5074: Fix cropped numbers in Leaderboard

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -78,8 +78,14 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
     @BindView(R.id.images_uploaded_progressbar)
     CircleProgressBar imagesUploadedProgressbar;
 
+    @BindView(R.id.tv_uploaded_images)
+    AppCompatTextView uploadedImagesTextview;
+
     @BindView(R.id.images_used_by_wiki_progress_bar)
     CircleProgressBar imagesUsedByWikiProgressBar;
+
+    @BindView(R.id.tv_wiki_pb)
+    AppCompatTextView imagesUsedByWikiTextview;
 
     @BindView(R.id.image_reverts_progressbar)
     CircleProgressBar imageRevertsProgressbar;
@@ -366,8 +372,8 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
             imagesUploadedProgressbar.setVisibility(View.VISIBLE);
             imagesUploadedProgressbar.setProgress
                     (100*uploadCount/levelInfo.getMaxUploadCount());
-            imagesUploadedProgressbar.setProgressTextFormatPattern
-                    (uploadCount +"/" + levelInfo.getMaxUploadCount() );
+            uploadedImagesTextview.setText
+                (uploadCount + "/" + levelInfo.getMaxUploadCount());
         }
 
     }
@@ -416,8 +422,8 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
         thanksReceived.setText(String.valueOf(achievements.getThanksReceived()));
         imagesUsedByWikiProgressBar.setProgress
                 (100 * achievements.getUniqueUsedImages() / levelInfo.getMaxUniqueImages());
-        imagesUsedByWikiProgressBar.setProgressTextFormatPattern
-                (achievements.getUniqueUsedImages() + "/" + levelInfo.getMaxUniqueImages());
+        imagesUsedByWikiTextview.setText
+            (achievements.getUniqueUsedImages() + "/" + levelInfo.getMaxUniqueImages());
         imagesFeatured.setText(String.valueOf(achievements.getFeaturedImages()));
         tvQualityImages.setText(String.valueOf(achievements.getQualityImages()));
         String levelUpInfoString = getString(R.string.level).toUpperCase();

--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -422,8 +422,10 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
         thanksReceived.setText(String.valueOf(achievements.getThanksReceived()));
         imagesUsedByWikiProgressBar.setProgress
                 (100 * achievements.getUniqueUsedImages() / levelInfo.getMaxUniqueImages());
-        imagesUsedByWikiTextview.setText
-            (achievements.getUniqueUsedImages() + "/" + levelInfo.getMaxUniqueImages());
+        if(imagesUsedByWikiTextview != null) {
+            imagesUsedByWikiTextview.setText
+                (achievements.getUniqueUsedImages() + "/" + levelInfo.getMaxUniqueImages());
+        }
         imagesFeatured.setText(String.valueOf(achievements.getFeaturedImages()));
         tvQualityImages.setText(String.valueOf(achievements.getQualityImages()));
         String levelUpInfoString = getString(R.string.level).toUpperCase();

--- a/app/src/main/res/layout/fragment_achievements.xml
+++ b/app/src/main/res/layout/fragment_achievements.xml
@@ -128,25 +128,48 @@
 
             </LinearLayout>
 
-
-
-            <com.dinuscxj.progressbar.CircleProgressBar
+            <FrameLayout
               android:layout_width="@dimen/dimen_40"
               android:layout_height="@dimen/dimen_40"
-              android:layout_alignParentRight="true"
               android:layout_alignParentEnd="true"
-              android:layout_marginEnd="@dimen/large_gap"
-              android:layout_marginRight="@dimen/large_gap"
-              android:id="@+id/images_uploaded_progressbar"
-              android:progress="50"
-              app:progress_text_size="@dimen/progressbar_text"
-              app:progress_end_color="#8C8B98"
-              app:progress_start_color="#3A3381"
-              app:progress_stroke_width="@dimen/progressbar_stroke"
-              app:progress_text_format_pattern="573/110"
-              android:visibility="gone"
-              app:progress_text_color="@color/secondaryColor"
-              app:style="solid_line" />
+              android:layout_alignParentRight="true"
+              android:layout_marginEnd="32dp"
+              android:layout_marginRight="32dp">
+
+              <com.dinuscxj.progressbar.CircleProgressBar
+                android:layout_width="@dimen/dimen_40"
+                android:layout_height="@dimen/dimen_40"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentEnd="true"
+                android:layout_marginEnd="@dimen/large_gap"
+                android:layout_marginRight="@dimen/large_gap"
+                android:id="@+id/images_uploaded_progressbar"
+                android:progress="50"
+                app:progress_text_size="@dimen/progressbar_text"
+                app:progress_end_color="#8C8B98"
+                app:progress_start_color="#3A3381"
+                app:progress_stroke_width="@dimen/progressbar_stroke"
+                app:progress_text_format_pattern=""
+                android:visibility="gone"
+                app:progress_text_color="@color/secondaryColor"
+                app:style="solid_line" />
+
+              <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tv_uploaded_images"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="@dimen/progressbar_padding"
+                android:gravity="center"
+                android:maxLines="1"
+                android:textColor="@color/secondaryColor"
+                app:autoSizeMaxTextSize="@dimen/progressbar_text"
+                app:autoSizeMinTextSize="2sp"
+                app:autoSizeStepGranularity="1sp"
+                app:autoSizeTextType="uniform" />
+
+            </FrameLayout>
+
+
 
           </RelativeLayout>
 
@@ -267,23 +290,46 @@
 
             </LinearLayout>
 
-            <com.dinuscxj.progressbar.CircleProgressBar
+            <FrameLayout
               android:layout_width="@dimen/dimen_40"
               android:layout_height="@dimen/dimen_40"
-              android:layout_alignParentRight="true"
               android:layout_alignParentEnd="true"
-              android:layout_marginRight="@dimen/large_gap"
-              android:layout_marginEnd="@dimen/large_gap"
-              android:progress="50"
-              app:progress_text_size="@dimen/progressbar_text"
-              android:id="@+id/images_used_by_wiki_progress_bar"
-              app:progress_end_color="#8C8B98"
-              app:progress_start_color="#3A3381"
-              app:progress_stroke_width="2.5dp"
-              android:visibility="gone"
-              app:progress_text_color="@color/secondaryColor"
-              app:progress_text_format_pattern="12/24"
-              app:style="solid_line" />
+              android:layout_alignParentRight="true"
+              android:layout_marginEnd="32dp"
+              android:layout_marginRight="32dp">
+
+              <com.dinuscxj.progressbar.CircleProgressBar
+                android:layout_width="@dimen/dimen_40"
+                android:layout_height="@dimen/dimen_40"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentEnd="true"
+                android:layout_marginRight="@dimen/large_gap"
+                android:layout_marginEnd="@dimen/large_gap"
+                android:progress="50"
+                app:progress_text_size="@dimen/progressbar_text"
+                android:id="@+id/images_used_by_wiki_progress_bar"
+                app:progress_end_color="#8C8B98"
+                app:progress_start_color="#3A3381"
+                app:progress_stroke_width="2.5dp"
+                android:visibility="gone"
+                app:progress_text_color="@color/secondaryColor"
+                app:progress_text_format_pattern=""
+                app:style="solid_line" />
+
+              <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tv_wiki_pb"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="@dimen/progressbar_padding"
+                android:gravity="center"
+                android:maxLines="1"
+                android:textColor="@color/secondaryColor"
+                app:autoSizeMaxTextSize="@dimen/progressbar_text"
+                app:autoSizeMinTextSize="2sp"
+                app:autoSizeStepGranularity="1sp"
+                app:autoSizeTextType="uniform" />
+
+            </FrameLayout>
 
           </RelativeLayout>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -32,6 +32,7 @@
     <dimen name="very_large_height">240dp</dimen>
     <dimen name="fragment_height">48dp</dimen>
     <dimen name="filter_padding">15dp</dimen>
+    <dimen name="progressbar_padding">3.5dp</dimen>
 
     <!-- Component sizes -->
     <dimen name="overflow_icon_dimen">56dp</dimen>
@@ -52,7 +53,7 @@
     <dimen name="first_fab">15dp</dimen>
     <dimen name="second_fab">25dp</dimen>
     <dimen name="subtitle_text">12sp</dimen>
-    <dimen name="progressbar_text">9dp</dimen>
+    <dimen name="progressbar_text">9sp</dimen>
 
     <!-- App widget margin -->
     <dimen name="widget_margin">0dp</dimen>


### PR DESCRIPTION
**Description (required)**

Fixes #5074 

What changes did you make and why?

Fix without indentation changes:

Enabled auto-scaling of text

The numbers in the Achievements fragment are getting cropped as the app is currently using a hard-coded text size value of `9dp` and the text is of the form "xxx/xxx", that is, the circular progress bar can accommodate at most 6 digits and one '/' as of now. Increasing the size of the progress bar might disturb the nearby elements and so, I enabled auto-scaling of the text.

For defining the UI, Commons makes use of the dependency: com.dinuscxj:circleprogressbar:1.1.1 (Available [here](https://github.com/dinuscxj/CircleProgressBar.git)). 

Since this library does not handle larger numbers even in the latest version, they get cropped in the Achievements fragment. Even though we can programatically scale the text size, a more reliable method is to make use of the [official Android UI guide for autoscaling text](https://developer.android.com/develop/ui/views/text-and-emoji/autosizing-textview). Modifying the library might introduce an additional maintenance overhead for the app and so, I added a frame layout to make use of the official auto-sizeable TextView. Since the circular progress bar takes up a very small portion of the activity, the GPU considerations are negligible here. 

I also changed the unit for progress bar text size from`dp` to `sp` (for [text scaling](https://support.google.com/accessibility/android/answer/12159181?hl=en)) in the `dimens` file as this dimension would not impact any other component except the fix. 

**Tests performed (required)**

Tested ProdDebug on Redmi 5A with API level 26.

**Screenshots (for UI changes only)**

Since I haven't uploaded many pictures on the Commons app, I cannot reproduce the issue directly. However, this is how the XML design shows changes in Android Studio on adding large numbers:

![achievements](https://user-images.githubusercontent.com/83745993/218317838-f4ffdb7e-e1d6-49dc-b699-b5b2383fbe88.png)
