### PR TITLE
Fix #493: Fix erroneous no location reminder

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -471,6 +471,16 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
     }
 
     @Override
+    public void showAlertDialog(int messageResourceId, Runnable onPositiveClick) {
+        DialogUtil.showAlertDialog(this,
+            "",
+            getString(messageResourceId),
+            getString(R.string.ok),
+            onPositiveClick,
+            false);
+    }
+
+    @Override
     public void onNextButtonClicked(int index) {
         if (index < fragments.size() - 1) {
             vpUpload.setCurrentItem(index + 1, false);

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -488,18 +488,7 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
             ((LinearLayoutManager) rvThumbnails.getLayoutManager())
                 .scrollToPositionWithOffset((index > 0) ? index-1 : 0, 0);
         } else {
-            if(defaultKvStore.getInt(COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES, 0) >= 10){
-                DialogUtil.showAlertDialog(this,
-                    "",
-                    getString(R.string.location_message),
-                    getString(R.string.ok),
-                    () -> {
-                        defaultKvStore.putInt(COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES, 0);
-                        presenter.handleSubmit();
-                    }, false);
-            } else {
-                presenter.handleSubmit();
-            }
+            presenter.handleSubmit();
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadContract.java
@@ -24,6 +24,12 @@ public interface UploadContract {
 
         void showMessage(int messageResourceId);
 
+        /**
+         * Displays an alert with message given by {@code messageResourceId}.
+         * {@code onPositiveClick} is run after acknowledgement.
+         */
+        void showAlertDialog(int messageResourceId, Runnable onPositiveClick);
+
         List<UploadableFile> getUploadableFiles();
 
         void showHideTopCard(boolean shouldShow);

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
@@ -35,7 +35,7 @@ public class UploadPresenter implements UploadContract.UserActionListener {
     public static final String COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES
         = "number_of_consecutive_uploads_without_coordinates";
 
-    public static final int CONSECUTIVE_UPLOADS_REMINDER_THRESHOLD = 10;
+    public static final int CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES_REMINDER_THRESHOLD = 10;
 
 
     @Inject
@@ -61,7 +61,7 @@ public class UploadPresenter implements UploadContract.UserActionListener {
         }
         boolean hasManyConsecutiveUploadsWithoutLocation = defaultKvStore.getInt(
             COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES, 0) >=
-            CONSECUTIVE_UPLOADS_REMINDER_THRESHOLD;
+            CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES_REMINDER_THRESHOLD;
 
         if (hasManyConsecutiveUploadsWithoutLocation && !hasLocationProvidedForNewUploads) {
             defaultKvStore.putInt(COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES, 0);

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
@@ -35,7 +35,7 @@ public class UploadPresenter implements UploadContract.UserActionListener {
     public static final String COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES
         = "number_of_consecutive_uploads_without_coordinates";
 
-    private static final int CONSECUTIVE_UPLOADS_REMINDER_THRESHOLD = 10;
+    public static final int CONSECUTIVE_UPLOADS_REMINDER_THRESHOLD = 10;
 
 
     @Inject

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
@@ -35,6 +35,8 @@ public class UploadPresenter implements UploadContract.UserActionListener {
     public static final String COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES
         = "number_of_consecutive_uploads_without_coordinates";
 
+    private static final int CONSECUTIVE_UPLOADS_REMINDER_THRESHOLD = 10;
+
 
     @Inject
     UploadPresenter(UploadRepository uploadRepository,
@@ -51,6 +53,31 @@ public class UploadPresenter implements UploadContract.UserActionListener {
     @SuppressLint("CheckResult")
     @Override
     public void handleSubmit() {
+        boolean hasLocationProvidedForNewUploads = false;
+        for (UploadItem item : repository.getUploads()) {
+            if (item.getGpsCoords().getImageCoordsExists()) {
+                hasLocationProvidedForNewUploads = true;
+            }
+        }
+        boolean hasManyConsecutiveUploadsWithoutLocation = defaultKvStore.getInt(
+            COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES, 0) >=
+            CONSECUTIVE_UPLOADS_REMINDER_THRESHOLD;
+
+        if (hasManyConsecutiveUploadsWithoutLocation && !hasLocationProvidedForNewUploads) {
+            defaultKvStore.putInt(COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES, 0);
+            view.showAlertDialog(
+                R.string.location_message,
+                () -> {defaultKvStore.putInt(
+                    COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES,
+                    0);
+                    processContributionsForSubmission();
+                });
+        } else {
+            processContributionsForSubmission();
+        }
+    }
+
+    private void processContributionsForSubmission() {
         if (view.isLoggedIn()) {
             view.showProgress(true);
             repository.buildContributions()
@@ -72,9 +99,8 @@ public class UploadPresenter implements UploadContract.UserActionListener {
 
                         @Override
                         public void onNext(Contribution contribution) {
-                            if(contribution.getDecimalCoords() == null){
-                                final int recentCount
-                                    = defaultKvStore.getInt(
+                            if (contribution.getDecimalCoords() == null) {
+                                final int recentCount = defaultKvStore.getInt(
                                     COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES, 0);
                                 defaultKvStore.putInt(
                                     COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES, recentCount + 1);

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadPresenterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadPresenterTest.kt
@@ -88,7 +88,7 @@ class UploadPresenterTest {
         // test 1 - insufficient count
         `when`(
             defaultKvStore.getInt(UploadPresenter.COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES, 0))
-                .thenReturn(UploadPresenter.CONSECUTIVE_UPLOADS_REMINDER_THRESHOLD - 1)
+                .thenReturn(UploadPresenter.CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES_REMINDER_THRESHOLD - 1)
         uploadPresenter.handleSubmit()
         // no alert dialog expected as insufficient consecutive count
         verify(view, times(0)).showAlertDialog(ArgumentMatchers.anyInt(), ArgumentMatchers.any<Runnable>())
@@ -96,7 +96,7 @@ class UploadPresenterTest {
         // test 2 - sufficient count
         `when`(
             defaultKvStore.getInt(UploadPresenter.COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES, 0))
-            .thenReturn(UploadPresenter.CONSECUTIVE_UPLOADS_REMINDER_THRESHOLD)
+            .thenReturn(UploadPresenter.CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES_REMINDER_THRESHOLD)
         uploadPresenter.handleSubmit()
         // alert dialog expected as consecutive count is at threshold
         verify(view).showAlertDialog(ArgumentMatchers.anyInt(), ArgumentMatchers.any<Runnable>())
@@ -106,7 +106,7 @@ class UploadPresenterTest {
     fun handleSubmitImagesWithLocationWithConsecutiveNoLocationUploads() {
         `when`(
             defaultKvStore.getInt(UploadPresenter.COUNTER_OF_CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES, 0))
-            .thenReturn(UploadPresenter.CONSECUTIVE_UPLOADS_REMINDER_THRESHOLD)
+            .thenReturn(UploadPresenter.CONSECUTIVE_UPLOADS_WITHOUT_COORDINATES_REMINDER_THRESHOLD)
         `when`(imageCoords.imageCoordsExists).thenReturn(true)
         `when`(uploadItem.getGpsCoords()).thenReturn(imageCoords)
         `when`(repository.uploads).thenReturn(uploadableItems)


### PR DESCRIPTION
**Description (required)**

Fixes #4936

What changes did you make and why?
Moved the logic of handling the decision to show the reminder from `UploadActivity` to `UploadPresenter`. If I understood the MVP pattern correctly, I believe that it would be more appropriate for `UploadPresenter` to make the decision to show the reminder given it has direct access to the items being uploaded to check for location. 

The above requires that the `UploadContract.View` also include a method to show the dialog. Two test cases were also added, one for when an image is uploaded without location and one when an image is uploaded with location.

**Tests performed (required)**

Tested Build Variant: Tested BetaDebug on Pixel XL with API level 30.
Additionally, did the following test on debug build:
1. Upload 10 images without location
2. Upload image without location. Correctly shows no location reminder
3. Upload another 10 images without location
4. Upload image with location. Correctly proceeds without location reminder.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
