### PR TITLE
Fix #5148: Use DialogUtil method in Uploadactivity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -225,9 +225,13 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .filter(result -> result)
-                .subscribe(result -> showInfoAlert(R.string.block_notification_title,
-                        R.string.block_notification, UploadActivity.this::finish)
-                ));
+                .subscribe(result -> DialogUtil.showAlertDialog(
+                    this,
+                    getString(R.string.block_notification_title),
+                    getString(R.string.block_notification),
+                    getString(R.string.ok),
+                    this::finish,
+                    true)));
     }
 
     private void checkStoragePermissions() {
@@ -457,18 +461,6 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
         finish();
     }
 
-    private void showInfoAlert(int titleStringID, int messageStringId, Runnable positive, String... formatArgs) {
-        new AlertDialog.Builder(this)
-                .setTitle(titleStringID)
-                .setMessage(getString(messageStringId, (Object[]) formatArgs))
-                .setCancelable(true)
-                .setPositiveButton(android.R.string.ok, (dialog, id) -> {
-                    positive.run();
-                    dialog.cancel();
-                })
-                .create()
-                .show();
-    }
 
     @Override
     public void showAlertDialog(int messageResourceId, Runnable onPositiveClick) {

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadActivityUnitTests.kt
@@ -235,26 +235,6 @@ class UploadActivityUnitTests {
 
     @Test
     @Throws(Exception::class)
-    fun testShowInfoAlert() {
-        val method: Method = UploadActivity::class.java.getDeclaredMethod(
-            "showInfoAlert",
-            Int::class.java,
-            Int::class.java,
-            Runnable::class.java,
-            Array<String>::class.java
-        )
-        method.isAccessible = true
-        method.invoke(
-            activity,
-            R.string.block_notification_title,
-            R.string.block_notification,
-            mock(Runnable::class.java),
-            arrayOf("")
-        )
-    }
-
-    @Test
-    @Throws(Exception::class)
     fun testOnNextButtonClicked() {
         activity.onNextButtonClicked(-1)
     }


### PR DESCRIPTION
**Description (required)**

Fixes #5148 

What changes did you make and why?
Removed the `showInfoAlert` method from `UploadActivity` and replaced its use with `DialogUtil.showAlertDialog`. I believe this reduces code duplication as `DialogUtil` has some methods that can be used to set up alert dialogs that can be reused without each class needing to implement their own variants.  

The unit test that tests for the existence of such a `showInfoAlert` method has also been removed as I believe it is not relevant anymore.

From what I've gathered, `AlertDialog` automatically calls `dialog.dismiss()` after running whatever method is tagged to its buttons so the `dialog.cancel()` which does almost the same thing can be safely removed. 

**Tests performed (required)**

Tested betaDebug on Pixel XL with API level 30.
Also ran `testbetaDeubgUnitTestCoverage` and seems to pass all test cases.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
