### PR TITLE
fixed 4731: Nearby banner appearing in Media Details

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -498,7 +498,9 @@ public class ContributionsFragment
             // Means that no close nearby place is found
             nearbyNotificationCardView.setVisibility(View.GONE);
         }
-        if(mediaDetailPagerFragment!=null && !contributionsListFragment.isVisible()) {
+
+        // Prevent Nearby banner from appearing in Media Details, fixing bug https://github.com/commons-app/apps-android-commons/issues/4731
+        if (mediaDetailPagerFragment != null && !contributionsListFragment.isVisible()) {
             nearbyNotificationCardView.setVisibility(View.GONE);
         }
     }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -498,6 +498,9 @@ public class ContributionsFragment
             // Means that no close nearby place is found
             nearbyNotificationCardView.setVisibility(View.GONE);
         }
+        if(mediaDetailPagerFragment!=null && !contributionsListFragment.isVisible()) {
+            nearbyNotificationCardView.setVisibility(View.GONE);
+        }
     }
 
     @Override


### PR DESCRIPTION
**Description (required)**

Fixes #4731 

What changes did you make and why?
Added a condition where the nearby banner was updating and rendering again. When the detail page was opened before the banner rendered/updated after updating the banner was displayed in media detail activity. 

So to avoid that added a check whether it is media detail activity and if it is after updating location I set the nearby banner visibility to gone. 

**Tests performed (required)**
Tested prodDebug on Pixel 5 with API level 31.

**Screenshots (for UI changes only)**
![Screenshot_20230221_020208](https://user-images.githubusercontent.com/77919824/220194438-5306c412-ee32-4387-902f-cc8b520c2468.png)
![image](https://user-images.githubusercontent.com/77919824/220194624-f57de136-48d8-41f3-8db7-40fbd69deced.png)


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
