### PR TITLE
Fix #5151: Use DialogUtil methods instead of AlertDialog.Builder

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
@@ -1,7 +1,6 @@
 package fr.free.nrw.commons;
 
 import android.annotation.SuppressLint;
-import android.app.AlertDialog;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -16,6 +15,7 @@ import androidx.annotation.NonNull;
 import fr.free.nrw.commons.databinding.ActivityAboutBinding;
 import fr.free.nrw.commons.theme.BaseActivity;
 import fr.free.nrw.commons.utils.ConfigUtils;
+import fr.free.nrw.commons.utils.DialogUtil;
 import java.util.Collections;
 import java.util.List;
 
@@ -161,17 +161,20 @@ public class AboutActivity extends BaseActivity {
         spinner.setAdapter(languageAdapter);
         spinner.setGravity(17);
         spinner.setPadding(50,0,0,0);
-        AlertDialog.Builder builder = new AlertDialog.Builder(AboutActivity.this);
-        builder.setView(spinner);
-        builder.setTitle(R.string.about_translate_title)
-                .setMessage(R.string.about_translate_message)
-                .setPositiveButton(R.string.about_translate_proceed, (dialog, which) -> {
-                    String langCode = CommonsApplication.getInstance().getLanguageLookUpTable().getCodes().get(spinner.getSelectedItemPosition());
-                    Utils.handleWebUrl(AboutActivity.this, Uri.parse(Urls.TRANSLATE_WIKI_URL + langCode));
-                });
-        builder.setNegativeButton(R.string.about_translate_cancel, (dialog, which) -> dialog.cancel());
-        builder.create().show();
 
+        Runnable positiveButtonRunnable = () -> {
+            String langCode = CommonsApplication.getInstance().getLanguageLookUpTable().getCodes().get(spinner.getSelectedItemPosition());
+            Utils.handleWebUrl(AboutActivity.this, Uri.parse(Urls.TRANSLATE_WIKI_URL + langCode));
+        };
+        DialogUtil.showAlertDialog(this,
+            getString(R.string.about_translate_title),
+            getString(R.string.about_translate_message),
+            getString(R.string.about_translate_proceed),
+            getString(R.string.about_translate_cancel),
+            positiveButtonRunnable,
+            () -> {},
+            spinner,
+            true);
     }
 
 }

--- a/app/src/main/java/fr/free/nrw/commons/profile/ProfileActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/ProfileActivity.java
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.profile;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -14,11 +13,9 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
-import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.FileProvider;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
-import androidx.viewpager.widget.ViewPager;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import com.google.android.material.tabs.TabLayout;
@@ -27,11 +24,11 @@ import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.ViewPagerAdapter;
 import fr.free.nrw.commons.auth.SessionManager;
 import fr.free.nrw.commons.contributions.ContributionsFragment;
-import fr.free.nrw.commons.contributions.ContributionsListFragment;
 import fr.free.nrw.commons.explore.ParentViewPager;
 import fr.free.nrw.commons.profile.achievements.AchievementsFragment;
 import fr.free.nrw.commons.profile.leaderboard.LeaderboardFragment;
 import fr.free.nrw.commons.theme.BaseActivity;
+import fr.free.nrw.commons.utils.DialogUtil;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -196,17 +193,21 @@ public class ProfileActivity extends BaseActivity {
      * @param screenshot screenshot of the present screen
      */
     public void showAlert(final Bitmap screenshot) {
-        final AlertDialog.Builder alert = new AlertDialog.Builder(this);
         final LayoutInflater factory = LayoutInflater.from(this);
         final View view = factory.inflate(R.layout.image_alert_layout, null);
         final ImageView screenShotImage = view.findViewById(R.id.alert_image);
         screenShotImage.setImageBitmap(screenshot);
         final TextView shareMessage = view.findViewById(R.id.alert_text);
         shareMessage.setText(R.string.achievements_share_message);
-        alert.setView(view);
-        alert.setPositiveButton(R.string.about_translate_proceed, (dialog, which) -> shareScreen(screenshot));
-        alert.setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.cancel());
-        alert.show();
+        DialogUtil.showAlertDialog(this,
+            "",
+            getString(R.string.achievements_share_message),
+            getString(R.string.about_translate_proceed),
+            getString(R.string.cancel),
+            () -> shareScreen(screenshot),
+            () -> {},
+            view,
+            true);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/profile/ProfileActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/ProfileActivity.java
@@ -201,7 +201,7 @@ public class ProfileActivity extends BaseActivity {
         shareMessage.setText(R.string.achievements_share_message);
         DialogUtil.showAlertDialog(this,
             "",
-            getString(R.string.achievements_share_message),
+            "",
             getString(R.string.about_translate_proceed),
             getString(R.string.cancel),
             () -> shareScreen(screenshot),

--- a/app/src/main/java/fr/free/nrw/commons/profile/ProfileActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/ProfileActivity.java
@@ -200,8 +200,8 @@ public class ProfileActivity extends BaseActivity {
         final TextView shareMessage = view.findViewById(R.id.alert_text);
         shareMessage.setText(R.string.achievements_share_message);
         DialogUtil.showAlertDialog(this,
-            "",
-            "",
+            null,
+            null,
             getString(R.string.about_translate_proceed),
             getString(R.string.cancel),
             () -> shareScreen(screenshot),

--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -376,7 +376,7 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
                 getString(R.string.no_achievements_yet, userName) :
                 getString(R.string.you_have_no_achievements_yet);
         DialogUtil.showAlertDialog(getActivity(),
-            "",
+            null,
             message,
             getString(R.string.ok),
             () -> {},

--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -1,8 +1,6 @@
 package fr.free.nrw.commons.profile.achievements;
 
 import android.accounts.Account;
-import android.app.AlertDialog;
-import android.app.AlertDialog.Builder;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
@@ -32,6 +30,7 @@ import fr.free.nrw.commons.auth.SessionManager;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient;
 import fr.free.nrw.commons.utils.ConfigUtils;
+import fr.free.nrw.commons.utils.DialogUtil;
 import fr.free.nrw.commons.utils.ViewUtil;
 import fr.free.nrw.commons.profile.ProfileActivity;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -373,16 +372,15 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
     }
 
     private void setZeroAchievements() {
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
-            .setMessage(
-                !Objects.equals(sessionManager.getUserName(), userName) ?
-                    getString(R.string.no_achievements_yet, userName) :
-                    getString(R.string.you_have_no_achievements_yet)
-            )
-            .setPositiveButton(getString(R.string.ok), (dialog, which) -> {
-            });
-        AlertDialog dialog = builder.create();
-        dialog.show();
+        String message = !Objects.equals(sessionManager.getUserName(), userName) ?
+                getString(R.string.no_achievements_yet, userName) :
+                getString(R.string.you_have_no_achievements_yet);
+        DialogUtil.showAlertDialog(getActivity(),
+            "",
+            message,
+            getString(R.string.ok),
+            () -> {},
+            true);
         imagesUploadedProgressbar.setVisibility(View.INVISIBLE);
         imageRevertsProgressbar.setVisibility(View.INVISIBLE);
         imagesUsedByWikiProgressBar.setVisibility(View.INVISIBLE);
@@ -391,7 +389,6 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
         imageRevertedText.setText(R.string.no_image_reverted);
         imageUploadedText.setText(R.string.no_image_uploaded);
         imageView.setVisibility(View.INVISIBLE);
-
     }
 
     /**
@@ -507,29 +504,27 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
      * @param message
      */
     private void launchAlert(String title, String message){
-        new AlertDialog.Builder(getActivity())
-                .setTitle(title)
-                .setMessage(message)
-                .setCancelable(true)
-                .setPositiveButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
-                .create()
-                .show();
+        DialogUtil.showAlertDialog(getActivity(),
+            title,
+            message,
+            getString(R.string.ok),
+            () -> {},
+            true);
     }
 
     /**
      *  Launch Alert with a READ MORE button and clicking it open a custom webpage
      */
-    private void launchAlertWithHelpLink(String title, String message, String helpLinkUrl){
-        new Builder(getActivity())
-            .setTitle(title)
-            .setMessage(message)
-            .setCancelable(true)
-            .setPositiveButton(android.R.string.ok, (dialog, id) -> dialog.cancel())
-            .setNegativeButton(R.string.read_help_link, (dialog ,id) ->{
-                Utils.handleWebUrl(requireContext(), Uri.parse(helpLinkUrl));;
-            })
-            .create()
-            .show();
+    private void launchAlertWithHelpLink(String title, String message, String helpLinkUrl) {
+        DialogUtil.showAlertDialog(getActivity(),
+            title,
+            message,
+            getString(R.string.ok),
+            getString(R.string.read_help_link),
+            () -> {},
+            () -> Utils.handleWebUrl(requireContext(), Uri.parse(helpLinkUrl)),
+            null,
+            true);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/utils/DialogUtil.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/DialogUtil.kt
@@ -34,8 +34,8 @@ object DialogUtil {
     @JvmStatic
     fun showAlertDialog(
         activity: Activity,
-        title: String,
-        message: String,
+        title: String?,
+        message: String?,
         onPositiveBtnClick: Runnable?,
         onNegativeBtnClick: Runnable?
     ) {
@@ -53,8 +53,8 @@ object DialogUtil {
     @JvmStatic
     fun showAlertDialog(
         activity: Activity,
-        title: String,
-        message: String,
+        title: String?,
+        message: String?,
         positiveButtonText: String?,
         negativeButtonText: String?,
         onPositiveBtnClick: Runnable?,
@@ -74,8 +74,8 @@ object DialogUtil {
     @JvmStatic
     fun showAlertDialog(
         activity: Activity,
-        title: String,
-        message: String,
+        title: String?,
+        message: String?,
         onPositiveBtnClick: Runnable?,
         onNegativeBtnClick: Runnable?,
         customView: View?,
@@ -97,8 +97,8 @@ object DialogUtil {
     @JvmStatic
     fun showAlertDialog(
         activity: Activity,
-        title: String,
-        message: String,
+        title: String?,
+        message: String?,
         positiveButtonText: String?,
         negativeButtonText: String?,
         onPositiveBtnClick: Runnable?,
@@ -122,8 +122,8 @@ object DialogUtil {
     @JvmStatic
     fun showAlertDialog(
         activity: Activity,
-        title: String,
-        message: String,
+        title: String?,
+        message: String?,
         positiveButtonText: String?,
         onPositiveBtnClick: Runnable?,
         cancelable: Boolean
@@ -152,8 +152,8 @@ object DialogUtil {
      */
     private fun createAndShowDialogSafely(
         activity: Activity,
-        title: String,
-        message: String,
+        title: String?,
+        message: String?,
         positiveButtonText: String? = null,
         negativeButtonText: String? = null,
         onPositiveBtnClick: Runnable? = null,
@@ -171,8 +171,8 @@ object DialogUtil {
         }
 
         showSafely(activity, AlertDialog.Builder(activity).apply {
-            setTitle(title)
-            setMessage(message)
+            title?.also{setTitle(title)}
+            title?.also{setMessage(message)}
             setView(customView)
             setCancelable(cancelable)
             positiveButtonText?.let {


### PR DESCRIPTION
**Description (required)**

Fixes #5151

What changes did you make and why?
Changed all except 2 uses of `AlertDialog.Builder` to be more in-line with the rest of the code base that uses `DialogUtil` methods wherever possible. The remaining 2 cases are in `MediaDetailFragment` and are not quite as easily substituted and are not covered here.

I also made the choice of accepting nulls in title and string in DialogUtil as I found out that an empty string functions differently from a null. I believe an empty string title causes the box to be larger instead of a null one where the title is not set at all.

**Tests performed (required)**

Tested betaDebug on Pixel XL with API level 30.
Also ran `testbetaDebugUnitTestCoverage` and seems to pass all test cases.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
