### PR TITLE
Fix #5151: Use DialogUtil for MediaDetailFragment

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -1128,7 +1128,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
 
                 AlertDialog dialog = DialogUtil.showAlertDialog(getActivity(),
                     getString(R.string.nominate_delete),
-                    "",
+                    null,
                     getString(R.string.about_translate_proceed),
                     getString(R.string.about_translate_cancel),
                     () -> onDeleteClicked(spinner),

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -1143,19 +1143,20 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             //But how does this  if (delete.getVisibility() == View.VISIBLE) {
             //            enableDeleteButton(true);   makes sense ?
             else {
-                AlertDialog.Builder alert = new AlertDialog.Builder(getActivity());
-                alert.setMessage(
-                    getString(R.string.dialog_box_text_nomination, media.getDisplayTitle()));
                 final EditText input = new EditText(getActivity());
-                alert.setView(input);
                 input.requestFocus();
-                alert.setPositiveButton(R.string.ok, (dialog1, whichButton) -> {
-                    String reason = input.getText().toString();
-                    onDeleteClickeddialogtext(reason);
-                });
-                alert.setNegativeButton(R.string.cancel, (dialog12, whichButton) -> {
-                });
-                AlertDialog d = alert.create();
+                AlertDialog d = DialogUtil.showAlertDialog(getActivity(),
+                    null,
+                    getString(R.string.dialog_box_text_nomination, media.getDisplayTitle()),
+                    getString(R.string.ok),
+                    getString(R.string.cancel),
+                    () -> {
+                        String reason = input.getText().toString();
+                        onDeleteClickeddialogtext(reason);
+                    },
+                    () -> {},
+                    input,
+                    true);
                 input.addTextChangedListener(new TextWatcher() {
                     private void handleText() {
                         final Button okButton = d.getButton(AlertDialog.BUTTON_POSITIVE);
@@ -1179,7 +1180,6 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
                     public void onTextChanged(CharSequence s, int start, int before, int count) {
                     }
                 });
-                d.show();
                 d.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
             }
         }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -13,7 +13,6 @@ import static fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.
 import static fr.free.nrw.commons.utils.LangCodeUtils.getLocalizedResources;
 
 import android.Manifest;
-import android.Manifest.permission;
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.Context;
@@ -84,6 +83,7 @@ import fr.free.nrw.commons.ui.widget.HtmlTextView;
 import fr.free.nrw.commons.upload.categories.UploadCategoriesFragment;
 import fr.free.nrw.commons.upload.depicts.DepictsFragment;
 import fr.free.nrw.commons.upload.UploadMediaDetail;
+import fr.free.nrw.commons.utils.DialogUtil;
 import fr.free.nrw.commons.utils.PermissionUtils;
 import fr.free.nrw.commons.utils.ViewUtilWrapper;
 import io.reactivex.Single;
@@ -1126,15 +1126,15 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
                 spinner.setAdapter(languageAdapter);
                 spinner.setGravity(17);
 
-                AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-                builder.setView(spinner);
-                builder.setTitle(R.string.nominate_delete)
-                    .setPositiveButton(R.string.about_translate_proceed,
-                        (dialog, which) -> onDeleteClicked(spinner));
-                builder.setNegativeButton(R.string.about_translate_cancel,
-                    (dialog, which) -> dialog.dismiss());
-                AlertDialog dialog = builder.create();
-                dialog.show();
+                AlertDialog dialog = DialogUtil.showAlertDialog(getActivity(),
+                    getString(R.string.nominate_delete),
+                    "",
+                    getString(R.string.about_translate_proceed),
+                    getString(R.string.about_translate_cancel),
+                    () -> onDeleteClicked(spinner),
+                    () -> {},
+                    spinner,
+                    true);
                 if (isDeleted) {
                     dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
                 }

--- a/app/src/main/java/fr/free/nrw/commons/utils/DialogUtil.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/DialogUtil.kt
@@ -2,7 +2,6 @@ package fr.free.nrw.commons.utils
 
 import android.app.Activity
 import android.app.AlertDialog
-import android.app.Dialog
 import android.view.View
 import fr.free.nrw.commons.R
 import timber.log.Timber
@@ -13,22 +12,23 @@ object DialogUtil {
      * @param activity the activity
      * @param dialog the dialog to be shown
      */
-    private fun showSafely(activity: Activity?, dialog: Dialog?) {
+    private fun showSafely(activity: Activity?, dialog: AlertDialog?):AlertDialog? {
 
         if (activity == null || dialog == null) {
             Timber.d("Show called with null activity / dialog. Ignoring.")
-            return
+            return null
         }
 
         if (activity.isFinishing || activity.isDestroyed) {
             Timber.e("Activity is not running. Could not show dialog. ")
-            return
+            return dialog
         }
         try {
             dialog.show()
         } catch (e: IllegalStateException) {
             Timber.e(e, "Could not show dialog.")
         }
+        return dialog;
     }
 
     @JvmStatic
@@ -38,8 +38,8 @@ object DialogUtil {
         message: String,
         onPositiveBtnClick: Runnable?,
         onNegativeBtnClick: Runnable?
-    ) {
-        createAndShowDialogSafely(
+    ): AlertDialog? {
+        return createAndShowDialogSafely(
             activity = activity,
             title = title,
             message = message,
@@ -58,9 +58,9 @@ object DialogUtil {
         positiveButtonText: String?,
         negativeButtonText: String?,
         onPositiveBtnClick: Runnable?,
-        onNegativeBtnClick: Runnable?
-    ) {
-        createAndShowDialogSafely(
+        onNegativeBtnClick: Runnable?,
+    ): AlertDialog? {
+        return createAndShowDialogSafely(
             activity = activity,
             title = title,
             message = message,
@@ -80,8 +80,8 @@ object DialogUtil {
         onNegativeBtnClick: Runnable?,
         customView: View?,
         cancelable: Boolean
-    ) {
-        createAndShowDialogSafely(
+    ): AlertDialog? {
+        return createAndShowDialogSafely(
             activity = activity,
             title = title,
             message = message,
@@ -105,8 +105,8 @@ object DialogUtil {
         onNegativeBtnClick: Runnable?,
         customView: View?,
         cancelable: Boolean
-    ) {
-        createAndShowDialogSafely(
+    ): AlertDialog? {
+        return createAndShowDialogSafely(
             activity = activity,
             title = title,
             message = message,
@@ -127,8 +127,8 @@ object DialogUtil {
         positiveButtonText: String?,
         onPositiveBtnClick: Runnable?,
         cancelable: Boolean
-    ) {
-        createAndShowDialogSafely(
+    ): AlertDialog? {
+        return createAndShowDialogSafely(
             activity = activity,
             title = title,
             message = message,
@@ -160,17 +160,17 @@ object DialogUtil {
         onNegativeBtnClick: Runnable? = null,
         customView: View? = null,
         cancelable: Boolean = true
-    ) {
+    ): AlertDialog? {
 
         /* If the custom view already has a parent, there is already a dialog showing with the view
          * This happens for on resume - return to avoid creating a second dialog - the first one
          * will still show
          */
         if (customView?.parent != null) {
-            return
+            return null;
         }
 
-        showSafely(activity, AlertDialog.Builder(activity).apply {
+        return showSafely(activity, AlertDialog.Builder(activity).apply {
             setTitle(title)
             setMessage(message)
             setView(customView)
@@ -181,6 +181,6 @@ object DialogUtil {
             negativeButtonText?.let {
                 setNegativeButton(it) { _, _ -> onNegativeBtnClick?.run() }
             }
-        }.create())
+        }.create());
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/utils/DialogUtil.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/DialogUtil.kt
@@ -28,7 +28,7 @@ object DialogUtil {
         } catch (e: IllegalStateException) {
             Timber.e(e, "Could not show dialog.")
         }
-        return dialog;
+        return dialog
     }
 
     @JvmStatic
@@ -167,7 +167,7 @@ object DialogUtil {
          * will still show
          */
         if (customView?.parent != null) {
-            return null;
+            return null
         }
 
         return showSafely(activity, AlertDialog.Builder(activity).apply {
@@ -181,6 +181,6 @@ object DialogUtil {
             negativeButtonText?.let {
                 setNegativeButton(it) { _, _ -> onNegativeBtnClick?.run() }
             }
-        }.create());
+        }.create())
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/utils/DialogUtil.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/DialogUtil.kt
@@ -34,8 +34,8 @@ object DialogUtil {
     @JvmStatic
     fun showAlertDialog(
         activity: Activity,
-        title: String,
-        message: String,
+        title: String?,
+        message: String?,
         onPositiveBtnClick: Runnable?,
         onNegativeBtnClick: Runnable?
     ): AlertDialog? {
@@ -53,8 +53,8 @@ object DialogUtil {
     @JvmStatic
     fun showAlertDialog(
         activity: Activity,
-        title: String,
-        message: String,
+        title: String?,
+        message: String?,
         positiveButtonText: String?,
         negativeButtonText: String?,
         onPositiveBtnClick: Runnable?,
@@ -74,8 +74,8 @@ object DialogUtil {
     @JvmStatic
     fun showAlertDialog(
         activity: Activity,
-        title: String,
-        message: String,
+        title: String?,
+        message: String?,
         onPositiveBtnClick: Runnable?,
         onNegativeBtnClick: Runnable?,
         customView: View?,
@@ -97,8 +97,8 @@ object DialogUtil {
     @JvmStatic
     fun showAlertDialog(
         activity: Activity,
-        title: String,
-        message: String,
+        title: String?,
+        message: String?,
         positiveButtonText: String?,
         negativeButtonText: String?,
         onPositiveBtnClick: Runnable?,
@@ -122,8 +122,8 @@ object DialogUtil {
     @JvmStatic
     fun showAlertDialog(
         activity: Activity,
-        title: String,
-        message: String,
+        title: String?,
+        message: String?,
         positiveButtonText: String?,
         onPositiveBtnClick: Runnable?,
         cancelable: Boolean
@@ -152,8 +152,8 @@ object DialogUtil {
      */
     private fun createAndShowDialogSafely(
         activity: Activity,
-        title: String,
-        message: String,
+        title: String?,
+        message: String?,
         positiveButtonText: String? = null,
         negativeButtonText: String? = null,
         onPositiveBtnClick: Runnable? = null,
@@ -171,8 +171,8 @@ object DialogUtil {
         }
 
         return showSafely(activity, AlertDialog.Builder(activity).apply {
-            setTitle(title)
-            setMessage(message)
+            title?.also{setTitle(title)}
+            message?.also{setMessage(message)}
             setView(customView)
             setCancelable(cancelable)
             positiveButtonText?.let {


### PR DESCRIPTION
**Description (required)**

Part of #5151

What changes did you make and why?

DialogUtil methods show and return the dialog object as well to be used more flexibly. Additionally, this PR also has an overlapping change with #5152 with the DialogUtil accepting nulls in order to prevent abnormally large empty boxes when a title or message is set to an empty string. 

For the changes in MediaDetailFragment, there might be changes to the logical flow of the code but I tried to keep it as similar as possible. The main difference is that for the second case, it calls show before setting the `input` properly. But from my testing, it seems both cases still function identical to the master branch. 

I'm not entirely sure if this change is necessary as it might be better to leave the more specific Builder uses as is. 

**Tests performed (required)**

Tested betaDebug on Pixel XL with API level 30.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
