### PR TITLE
Fixed: After canceling a sharing, application goes back to the search menu #2296

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -222,7 +222,6 @@ public class SearchActivity extends BaseActivity
         if (mediaDetails == null || !mediaDetails.isVisible()) {
             // set isFeaturedImage true for featured images, to include author field on media detail
             mediaDetails = new MediaDetailPagerFragment(false, true);
-            FragmentManager supportFragmentManager = getSupportFragmentManager();
             supportFragmentManager
                     .beginTransaction()
                     .hide(supportFragmentManager.getFragments().get(supportFragmentManager.getBackStackEntryCount()))
@@ -261,7 +260,6 @@ public class SearchActivity extends BaseActivity
         //Remove the backstack entry that gets added when share button is clicked
         //fixing:https://github.com/commons-app/apps-android-commons/issues/2296
         if (getSupportFragmentManager().getBackStackEntryCount() == 2) {
-            FragmentManager supportFragmentManager = getSupportFragmentManager();
             supportFragmentManager
                 .beginTransaction()
                 .remove(mediaDetails)

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -258,13 +258,23 @@ public class SearchActivity extends BaseActivity
      */
     @Override
     public void onBackPressed() {
-        if (getSupportFragmentManager().getBackStackEntryCount() == 1){
+        //Remove the backstack entry that gets added when share button is clicked
+        //fixing:https://github.com/commons-app/apps-android-commons/issues/2296
+        if (getSupportFragmentManager().getBackStackEntryCount() == 2) {
+            FragmentManager supportFragmentManager = getSupportFragmentManager();
+            supportFragmentManager
+                .beginTransaction()
+                .remove(mediaDetails)
+                .commit();
+            supportFragmentManager.popBackStack();
+            supportFragmentManager.executePendingTransactions();
+        } else if (getSupportFragmentManager().getBackStackEntryCount() == 1) {
             // back to search so show search toolbar and hide navigation toolbar
             searchView.setVisibility(View.VISIBLE);//set the searchview
             tabLayout.setVisibility(View.VISIBLE);
             viewPager.setVisibility(View.VISIBLE);
             mediaContainer.setVisibility(View.GONE);
-        }else {
+        } else {
             toolbar.setVisibility(View.GONE);
         }
         super.onBackPressed();

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -227,7 +227,7 @@ public class SearchActivity extends BaseActivity
                     .beginTransaction()
                     .hide(supportFragmentManager.getFragments().get(supportFragmentManager.getBackStackEntryCount()))
                     .add(R.id.mediaContainer, mediaDetails)
-                    .addToBackStack(null)
+                    .addToBackStack(searchMediaFragment.getClass().getName())
                     .commit();
             // Reason for using hide, add instead of replace is to maintain scroll position after
             // coming back to the search activity. See https://github.com/commons-app/apps-android-commons/issues/1631

--- a/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/SearchActivity.java
@@ -227,7 +227,7 @@ public class SearchActivity extends BaseActivity
                     .beginTransaction()
                     .hide(supportFragmentManager.getFragments().get(supportFragmentManager.getBackStackEntryCount()))
                     .add(R.id.mediaContainer, mediaDetails)
-                    .addToBackStack(searchMediaFragment.getClass().getName())
+                    .addToBackStack(null)
                     .commit();
             // Reason for using hide, add instead of replace is to maintain scroll position after
             // coming back to the search activity. See https://github.com/commons-app/apps-android-commons/issues/1631
@@ -268,7 +268,8 @@ public class SearchActivity extends BaseActivity
                 .commit();
             supportFragmentManager.popBackStack();
             supportFragmentManager.executePendingTransactions();
-        } else if (getSupportFragmentManager().getBackStackEntryCount() == 1) {
+        }
+        if (getSupportFragmentManager().getBackStackEntryCount() == 1) {
             // back to search so show search toolbar and hide navigation toolbar
             searchView.setVisibility(View.VISIBLE);//set the searchview
             tabLayout.setVisibility(View.VISIBLE);

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -192,7 +192,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                 //Add media detail to backstack when the share button is clicked
                 //So that when the share is cancelled or completed the media detail page is on top
                 // of back stack fixing:https://github.com/commons-app/apps-android-commons/issues/2296
-                final FragmentManager supportFragmentManager = getActivity().getSupportFragmentManager();
+                FragmentManager supportFragmentManager = getActivity().getSupportFragmentManager();
                 if (supportFragmentManager.getBackStackEntryCount() < 2) {
                     supportFragmentManager
                         .beginTransaction()

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -188,6 +188,18 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                 shareIntent.setType("text/plain");
                 shareIntent.putExtra(Intent.EXTRA_TEXT, m.getDisplayTitle() + " \n" + m.getPageTitle().getCanonicalUri());
                 startActivity(Intent.createChooser(shareIntent, "Share image via..."));
+
+                //Add media detail to backstack when the share button is clicked
+                //So that when the share is cancelled or completed the media detail page is on top
+                // of back stack fixing:https://github.com/commons-app/apps-android-commons/issues/2296
+                final FragmentManager supportFragmentManager = getActivity().getSupportFragmentManager();
+                if (supportFragmentManager.getBackStackEntryCount() < 2) {
+                    supportFragmentManager
+                        .beginTransaction()
+                        .addToBackStack(MediaDetailPagerFragment.class.getName())
+                        .commit();
+                    supportFragmentManager.executePendingTransactions();
+                }
                 return true;
             case R.id.menu_browser_current_image:
                 // View in browser

--- a/app/src/test/kotlin/fr/free/nrw/commons/explore/search/SearchActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/explore/search/SearchActivityUnitTests.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.Mockito.times
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.powermock.api.mockito.PowerMockito.mock
@@ -124,7 +125,7 @@ class SearchActivityUnitTests {
         `when`(mFragments.supportFragmentManager).thenReturn(supportFragmentManager)
         `when`(supportFragmentManager.backStackEntryCount).thenReturn(0)
         activity.onBackPressed()
-        verify(supportFragmentManager).backStackEntryCount
+        verify(supportFragmentManager, times(2)).backStackEntryCount
     }
 
     @Test


### PR DESCRIPTION
**Description (required)**

Fixes #2296 

What changes did you make and why?
Added a media detail fragment in backstack in MediaDetailPagerFragment also removed the entry from the backstack when the user presses back button. When user cancelled while sharing or completed the sharing it directly jumped to previous screen so to avoid this a entry in backstack was needed.

**Tests performed (required)**

Tested prodDebug on Pixel 5 with API level 31.

**Screenshots (for UI changes only)**

https://user-images.githubusercontent.com/77919824/221420888-2a639040-103d-4797-a9e1-58089d3b8c56.mp4


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
