### PR TITLE
Skip used images

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
@@ -166,26 +166,22 @@ public class ReviewActivity extends BaseActivity {
         compositeDisposable.add(reviewHelper.getRandomMedia()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(media -> {
-                    Log.e("Media Fetched : " , media.getFilename());
-                    getGlobalUsage(media);
-                }));
+                .subscribe(this::checkUsageOfMedia));
         return true;
     }
 
     /**
-     * Get The Global Usage
-     *
+     * Check whether media is used or not in any Wiki Page
      */
     @SuppressLint("CheckResult")
-    private void getGlobalUsage(final Media media) {
-        compositeDisposable.add(reviewHelper.getUsageOfFile(media.getFilename())
+    private void checkUsageOfMedia(final Media media) {
+        compositeDisposable.add(reviewHelper.checkFileUsage(media.getFilename())
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(result -> {
-                Log.e("Result : " , result+"");
-                // Finds non-hidden categories from Media instance
+                // result false indicates media is not used in any wiki
                 if (!result) {
+                    // Finds non-hidden categories from Media instance
                     findNonHiddenCategories(media);
                 } else {
                     runRandomizer();

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
@@ -166,7 +166,7 @@ public class ReviewActivity extends BaseActivity {
         compositeDisposable.add(reviewHelper.getRandomMedia()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(this::checkUsageOfMedia));
+                .subscribe(this::checkWhetherFileIsUsedInWikis));
         return true;
     }
 
@@ -174,7 +174,7 @@ public class ReviewActivity extends BaseActivity {
      * Check whether media is used or not in any Wiki Page
      */
     @SuppressLint("CheckResult")
-    private void checkUsageOfMedia(final Media media) {
+    private void checkWhetherFileIsUsedInWikis(final Media media) {
         compositeDisposable.add(reviewHelper.checkFileUsage(media.getFilename())
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -161,14 +162,35 @@ public class ReviewActivity extends BaseActivity {
         hasNonHiddenCategories = false;
         progressBar.setVisibility(View.VISIBLE);
         reviewPager.setCurrentItem(0);
+        // Finds non-hidden categories from Media instance
         compositeDisposable.add(reviewHelper.getRandomMedia()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(media -> {
-                    // Finds non-hidden categories from Media instance
-                    findNonHiddenCategories(media);
+                    Log.e("Media Fetched : " , media.getFilename());
+                    getGlobalUsage(media);
                 }));
         return true;
+    }
+
+    /**
+     * Get The Global Usage
+     *
+     */
+    @SuppressLint("CheckResult")
+    private void getGlobalUsage(final Media media) {
+        compositeDisposable.add(reviewHelper.getUsageOfFile(media.getFilename())
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(result -> {
+                Log.e("Result : " , result+"");
+                // Finds non-hidden categories from Media instance
+                if (!result) {
+                    findNonHiddenCategories(media);
+                } else {
+                    runRandomizer();
+                }
+            }));
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewHelper.java
@@ -101,13 +101,16 @@ public class ReviewHelper {
     }
 
     /**
-     * Get The Count of Global Usages Of file
+     * Checks Whether Given File is used in any Wiki page or not
+     * by calling api for given file
      *
+     * @param filename
      * @return
      */
-     Observable<Boolean> getUsageOfFile(final String filename) {
+     Observable<Boolean> checkFileUsage(final String filename) {
          return reviewInterface.getGlobalUsageInfo(filename)
-             .map(mwQueryResponse -> mwQueryResponse.query().firstPage().checkFileInUse());
+             .map(mwQueryResponse -> mwQueryResponse.query().firstPage()
+                 .checkWhetherFileIsUsedInWikis());
      }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewHelper.java
@@ -101,6 +101,16 @@ public class ReviewHelper {
     }
 
     /**
+     * Get The Count of Global Usages Of file
+     *
+     * @return
+     */
+     Observable<Boolean> getUsageOfFile(final String filename) {
+         return reviewInterface.getGlobalUsageInfo(filename)
+             .map(mwQueryResponse -> mwQueryResponse.query().firstPage().checkFileInUse());
+     }
+
+    /**
      * Checks if the change is reviewable or not.
      * - checks the type and revisionId of the change
      * - checks supported image extensions

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewInterface.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewInterface.java
@@ -15,4 +15,7 @@ public interface ReviewInterface {
 
     @GET("w/api.php?action=query&format=json&formatversion=2&prop=revisions&rvprop=timestamp|ids|user&rvdir=newer&rvlimit=1")
     Observable<MwQueryResponse> getFirstRevisionOfFile(@Query("titles") String titles);
+
+    @GET("w/api.php?action=query&format=json&formatversion=2&prop=fileusage|globalusage")
+    Observable<MwQueryResponse> getGlobalUsageInfo(@Query("titles") String title);
 }

--- a/data-client/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
+++ b/data-client/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
@@ -161,17 +161,16 @@ public class MwQueryPage extends BaseModel {
         }
 
         final int totalCount = fileUsages.size();
-        int ignoreCount = 0;
 
         /* Ignore usage under https://commons.wikimedia.org/wiki/User:Didym/Mobile_upload/
            which has been a gallery of all of our uploads since 2014 */
-        for (final FileUsage cur : fileUsages) {
-            if (cur.title().contains("User:Didym/Mobile upload")) {
-                ignoreCount++;
+        for (final FileUsage fileUsage : fileUsages) {
+            if ( ! fileUsage.title().contains("User:Didym/Mobile upload")) {
+                return true;
             }
         }
 
-        return !(ignoreCount == totalCount);
+        return false;
     }
 
     public static class Revision {

--- a/data-client/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
+++ b/data-client/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
@@ -151,29 +151,25 @@ public class MwQueryPage extends BaseModel {
         title += "#" + fragment;
     }
 
-    public boolean checkFileInUse() {
+    public boolean checkWhetherFileIsUsedInWikis() {
         if (globalUsages == null || globalUsages.size() == 0) {
-            return checkUseInFileUsage();
+            if (fileUsages == null || fileUsages.size() == 0) {
+                return false;
+            }
+
+            final int totalCount = fileUsages.size();
+            int ignoreCount = 0;
+
+            for (final FileUsage cur : fileUsages) {
+                if (cur.title().contains("User:Didym/Mobile upload")) {
+                    ignoreCount++;
+                }
+            }
+
+            return !(ignoreCount == totalCount);
         }
 
         return true;
-    }
-
-    public boolean checkUseInFileUsage() {
-        if (fileUsages == null || fileUsages.size() == 0) {
-            return false;
-        }
-
-        final int totalCount = fileUsages.size();
-        int ignoreCount = 0;
-
-        for (final FileUsage cur : fileUsages) {
-            if (cur.title().contains("User:Didym/Mobile upload")) {
-                ignoreCount++;
-            }
-        }
-
-        return !(ignoreCount == totalCount);
     }
 
     public static class Revision {

--- a/data-client/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
+++ b/data-client/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
@@ -25,6 +25,8 @@ public class MwQueryPage extends BaseModel {
     @SuppressWarnings("unused,NullableProblems") @NonNull private CategoryInfo categoryinfo;
     @SuppressWarnings("unused") @Nullable private List<LangLink> langlinks;
     @SuppressWarnings("unused") @Nullable private List<Revision> revisions;
+    @SuppressWarnings("unused") @SerializedName("fileusage") @Nullable private List<FileUsage> fileUsages;
+    @SuppressWarnings("unused") @SerializedName("globalusage") @Nullable private List<GlobalUsage> globalUsages;
     @SuppressWarnings("unused") @Nullable private List<Coordinates> coordinates;
     @SuppressWarnings("unused") @Nullable private List<Category> categories;
     @SuppressWarnings("unused") @Nullable private PageProps pageprops;
@@ -65,6 +67,14 @@ public class MwQueryPage extends BaseModel {
 
     @Nullable public List<Category> categories() {
         return categories;
+    }
+
+    @Nullable public List<GlobalUsage> globalUsages() {
+        return globalUsages;
+    }
+
+    @Nullable public List<FileUsage> fileUsages() {
+        return fileUsages;
     }
 
     @Nullable public List<Coordinates> coordinates() {
@@ -139,6 +149,31 @@ public class MwQueryPage extends BaseModel {
 
     public void appendTitleFragment(@Nullable String fragment) {
         title += "#" + fragment;
+    }
+
+    public boolean checkFileInUse() {
+        if (globalUsages == null || globalUsages.size() == 0) {
+            return checkUseInFileUsage();
+        }
+
+        return true;
+    }
+
+    public boolean checkUseInFileUsage() {
+        if (fileUsages == null || fileUsages.size() == 0) {
+            return false;
+        }
+
+        final int totalCount = fileUsages.size();
+        int ignoreCount = 0;
+
+        for (final FileUsage cur : fileUsages) {
+            if (cur.title().contains("User:Didym/Mobile upload")) {
+                ignoreCount++;
+            }
+        }
+
+        return !(ignoreCount == totalCount);
     }
 
     public static class Revision {
@@ -225,6 +260,44 @@ public class MwQueryPage extends BaseModel {
 
         public boolean isDisambiguation() {
             return disambiguation != null;
+        }
+    }
+
+    public static class GlobalUsage {
+        @SerializedName("title") private String title;
+        @SerializedName("wiki")private String wiki;
+        @SerializedName("url") private String url;
+
+        public String getTitle() {
+            return title;
+        }
+
+        public String getWiki() {
+            return wiki;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+
+    }
+
+    public static class FileUsage {
+        @SerializedName("pageid") private int pageid;
+        @SerializedName("ns") private int ns;
+        @SerializedName("title") private String title;
+
+        public int pageId() {
+            return pageid;
+        }
+
+        public int ns() {
+            return ns;
+        }
+
+        public String title() {
+            return title;
         }
     }
 

--- a/data-client/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
+++ b/data-client/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
@@ -152,24 +152,26 @@ public class MwQueryPage extends BaseModel {
     }
 
     public boolean checkWhetherFileIsUsedInWikis() {
-        if (globalUsages == null || globalUsages.size() == 0) {
-            if (fileUsages == null || fileUsages.size() == 0) {
-                return false;
-            }
-
-            final int totalCount = fileUsages.size();
-            int ignoreCount = 0;
-
-            for (final FileUsage cur : fileUsages) {
-                if (cur.title().contains("User:Didym/Mobile upload")) {
-                    ignoreCount++;
-                }
-            }
-
-            return !(ignoreCount == totalCount);
+        if (globalUsages != null && globalUsages.size() > 0) {
+            return true;
         }
 
-        return true;
+        if (fileUsages == null || fileUsages.size() == 0) {
+            return false;
+        }
+
+        final int totalCount = fileUsages.size();
+        int ignoreCount = 0;
+
+        /* Ignore usage under https://commons.wikimedia.org/wiki/User:Didym/Mobile_upload/
+           which has been a gallery of all of our uploads since 2014 */
+        for (final FileUsage cur : fileUsages) {
+            if (cur.title().contains("User:Didym/Mobile upload")) {
+                ignoreCount++;
+            }
+        }
+
+        return !(ignoreCount == totalCount);
     }
 
     public static class Revision {

--- a/data-client/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResponse.java
+++ b/data-client/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResponse.java
@@ -13,7 +13,7 @@ public class MwQueryResponse extends MwResponse {
 
     @SuppressWarnings("unused") @SerializedName("continue") @Nullable private Map<String, String> continuation;
 
-    @Nullable private MwQueryResult query;
+    @SerializedName("query") @Nullable private MwQueryResult query;
 
     public boolean batchComplete() {
         return batchComplete;

--- a/data-client/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.java
+++ b/data-client/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 @SuppressWarnings("unused")
 public class MwQueryResult extends BaseModel implements PostProcessingTypeAdapter.PostProcessable {
-    @Nullable private List<MwQueryPage> pages;
+    @SerializedName("pages") @Nullable private List<MwQueryPage> pages;
     @Nullable private List<Redirect> redirects;
     @Nullable private List<ConvertedTitle> converted;
     @SerializedName("userinfo") private UserInfo userInfo;


### PR DESCRIPTION
**Description (required)**

When retrieving a new image to review, skip to next if the image is in use in any article or user page

Fixes #5103

What changes did you make and why?

Calling An API for every image to check if it is in use or not

**Tests performed (required)**

Tested ProdDebug on Poco X4 Pro with API level 31.

I Only consider fileusage, not considered globalusage cause in review all images has globalusage zero, it's my observation from test it may be wrong, so please confirm.

Note : I need to remove unnecessary code and logs form this, I made this PR Just For Testing of feature