### PR TITLE
5157: Fix longer questions not visible completely in Peer Review

### DIFF
--- a/app/src/main/res/layout/fragment_review_image.xml
+++ b/app/src/main/res/layout/fragment_review_image.xml
@@ -21,7 +21,7 @@
       <TextView
         android:id="@+id/tv_review_question"
         android:layout_width="match_parent"
-        android:layout_height="80dp"
+        android:layout_height="wrap_content"
         android:gravity="center_vertical"
         tools:text="testing1"
         android:textAlignment="center"


### PR DESCRIPTION
**Description (required)**

Fixes #5157 

What changes did you make and why?

Changed the layout height to `wrap_content` as longer questions were not visible completely even on scrolling.

**Tests performed (required)**

Tested ProdDebug on Redmi 5A with API level 27.

**Screenshots (for UI changes only)**

Longer question about copyright

Earlier:
![earlier](https://user-images.githubusercontent.com/83745993/222673744-21e62f29-8903-41e0-b338-ec8ab85730ea.jpeg)

Now:

![now](https://user-images.githubusercontent.com/83745993/222673770-d1c39599-537e-4bb5-b139-b51532b2ceb2.jpeg)

