### PR TITLE
fixes the bug regarding copy to subsequent media when near a wikidata place.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -274,7 +274,7 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
     public void onNearbyPlaceFound(UploadItem uploadItem, Place place) {
         nearbyPlace = place;
         this.uploadItem = uploadItem;
-        showNearbyFound = true;
+        showNearbyFound = false;
         if(callback.getIndexInViewFlipper(this) == 0) {
             if (UploadActivity.nearbyPopupAnswers.containsKey(nearbyPlace)) {
                 final boolean response = UploadActivity.nearbyPopupAnswers.get(nearbyPlace);


### PR DESCRIPTION
**Description (required)**

Fixes #5057

What changes did you make and why?
Changed the value of "showNearbyFound"(in the method onNearbyPlaceFound) from true to false that may have been conflicting with the method "onBecameVisible" whenever next/previous button was clicked.

**Tests performed (required)**

Tested  ProdDebug on Xiaomi Redmi 9 with API level 29.