### PR TITLE
fixed: When the coordinates have been copied from another picture, explain it in description #4700

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -246,6 +246,13 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
             public void onPositiveResponse() {
                 Timber.d("positive response from similar image fragment");
                 presenter.useSimilarPictureCoordinates(similarImageCoordinates, callback.getIndexInViewFlipper(UploadMediaDetailFragment.this));
+
+                // set the description text when user selects to use coordinate from the other image
+                // which was taken within 20s
+                // fixing: https://github.com/commons-app/apps-android-commons/issues/4700
+                uploadMediaDetailAdapter.getItems().get(0).setDescriptionText(
+                    getString(R.string.similar_coordinate_description_auto_set));
+                updateMediaDetails(uploadMediaDetailAdapter.getItems());
             }
 
             @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -750,4 +750,5 @@ Upload your first media by tapping on the add button.</string>
   <string name="full_screen_mode_zoom_info">Use two fingers to zoom in and out.</string>
   <string name="full_screen_mode_features_info">Swipe fast and long to perform these actions: \n- Left/Right: Go to previous/next \n- Up: Select\n- Down: Mark as not for upload.</string>
   <string name="set_up_avatar_toast_string">To set up your leaderboard avatar, tap \"Set as avatar\" in the three-dots menu of any image.</string>
+  <string name="similar_coordinate_description_auto_set">The coordinates are not the exact coordinates, but the person who uploaded this picture thinks they are close enough.</string>
 </resources>


### PR DESCRIPTION
**Description (required)**

Fixes #4700 

What changes did you make and why?
When the user was asked to use similar coordinate if the response was positive then added the string in description.

**Tests performed (required)**

Tested prodDebug on Pixel 4 with API level 28.

**Screenshots (for UI changes only)**

https://user-images.githubusercontent.com/77919824/223653281-971a0f84-47ef-498f-97e8-e829a117d7f8.mp4


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
