### PR TITLE
Fix#5084: Tapping on GitHub icon opens app when installed

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/AboutActivity.java
@@ -101,7 +101,14 @@ public class AboutActivity extends BaseActivity {
     }
 
     public void launchGithub(View view) {
-        Utils.handleWebUrl(this, Uri.parse(Urls.GITHUB_REPO_URL));
+        Intent intent;
+        try {
+            intent = new Intent(Intent.ACTION_VIEW, Uri.parse(Urls.GITHUB_REPO_URL));
+            intent.setPackage(Urls.GITHUB_PACKAGE_NAME);
+            startActivity(intent);
+        } catch (Exception e) {
+            Utils.handleWebUrl(this, Uri.parse(Urls.GITHUB_REPO_URL));
+        }
     }
 
     public void launchWebsite(View view) {

--- a/app/src/main/java/fr/free/nrw/commons/Urls.kt
+++ b/app/src/main/java/fr/free/nrw/commons/Urls.kt
@@ -3,6 +3,7 @@ package fr.free.nrw.commons
 internal object Urls {
     const val NEW_ISSUE_URL = "https://github.com/commons-app/apps-android-commons/issues"
     const val GITHUB_REPO_URL = "https://github.com/commons-app/apps-android-commons"
+    const val GITHUB_PACKAGE_NAME = "com.github.android"
     const val WEBSITE_URL = "https://commons-app.github.io"
     const val CREDITS_URL = "https://github.com/commons-app/apps-android-commons/blob/master/CREDITS"
     const val USER_GUIDE_URL = "https://commons-app.github.io/docs.html"


### PR DESCRIPTION
**Description (required)**

Fixes #5084 

What changes did you make and why?

When pressing the Github icon on the About page, it tries to open the Github repo link on the application if it is installed. For that it uses the `Context.getPackageManager()` function, but since Android 11 the package manager doesn't have access to all the applications installed on the device, because of that the application doesn't find the Github application and it throws a toast saying that "No web browser found to open URL".
The solution is specifying the name of the package of the third party application (in this case the GitHub app) on the intent, using the `Intent.setPackage()` function, and try to open the link on the application, starting a new activity. If the application is not found, the link is opened on the web browser.

**Tests performed (required)**

Tested ProdDebug on Pixel 4 with API level 27 & 30.

Need help? See https://support.google.com/android/answer/9075928
