### PR TITLE
Fixes #4607: Copied description, caption and language structure removed after canceling upload of one media 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.java
@@ -117,6 +117,13 @@ public class UploadModel {
                 createdTimestampSource,
                 uploadableFile.getContentUri(),
                 fileCreatedDateString);
+
+        // If an uploadItem of the same uploadableFile has been created before, we return that.
+        // This is to avoid multiple instances of uploadItem of same file passed around.
+        if (items.contains(uploadItem)) {
+            return items.get(items.indexOf(uploadItem));
+        }
+
         if (place != null) {
             uploadItem.getUploadMediaDetails().set(0, new UploadMediaDetail(place));
         }


### PR DESCRIPTION
**Description (required)**

Fixes #4607
### What changes did you make and why?
#### Cause of bug:
On start of an upload activity, each `uploadableFile` has a `UploadMediaDetailFragment` and its own `UploadMediaPresenter`. The fragment calls `init()` which calls `presenter.receiveImage(uploadableFile, place)`. The side effect of this is to create an `uploadItem` for this `uploadableFile` and add to the repository which acts as the 'master copy' of uploadItem if one is not already present. However, the new `uploadItem` is always used in `receiveImage` even if one already exists. 

On removal of an item from the upload list as happens when it is flagged and 'cancel' is clicked, the current presenter seems to be destroyed and a new one is created for the fragment. This calls `init` again which proceeds to attempt to call `receiveImage` again. A new `uploadItem` is created for the same file (which has none of the caption & description details) and runs the same code to eventually get displayed, thus showing the empty one. Notably, this `uploadItem` is not in the `repository` and thus any changes to it makes no actual difference to the final uploads. 

#### Proposed fix:
If the newly created UploadItem already has an older 'master copy' of it available, `UploadItem::createAndAddUploadItem`changes to return the old copy instead of not adding it but still returning the new copy.

### **Tests performed (required)**

Tested Build Variant: Tested BetaDebug on Pixel XL with API level 30.

Additionally, the following testing was performed:
I used https://commons.wikimedia.org/wiki/File:Bergtocht_van_Guarda_via_Ardez_en_Ftan_naar_Scuol._20-09-2019._(actm.)_27.jpg as the image that would be flagged as problematic. 

1. Upload 3 images in the order of normal 1, flagged, normal 2
2. Add caption and description and change language structure for first image, copy to remaining.
3. Go to image 2, press next, get flagged and press cancel. This should remove the image.
4. Third image, which is normal 2 will immediately appear. This correctly contains the caption, description and language structure of image 1. 
5. Edited all three fields and continue to upload all images. The final images shown in the home page correctly records the latest values. 

I also redid the above test but at step 3, before pressing next, I edited all 3 fields and copied them to the remaining (so only the last image has it). Then continued and the behavior was as expected.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
