### PR TITLE
Fix: user reset for Thanks after Review

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
@@ -127,13 +127,8 @@ public class ReviewImageFragment extends CommonsDaggerSupportFragment {
                 enableButtons();
                 question = getString(R.string.review_thanks);
 
-                // Get existing user name if it is already saved using savedInstanceState else get from reviewController
-                if (savedInstanceState == null) {
-                    if (getReviewActivity().reviewController.firstRevision != null) {
-                        user = getReviewActivity().reviewController.firstRevision.getUser();
-                    }
-                } else {
-                    user = savedInstanceState.getString(SAVED_USER);
+                if (getReviewActivity().reviewController.firstRevision != null) {
+                    user = getReviewActivity().reviewController.firstRevision.getUser();
                 }
 
                 //if the user is null because of whatsoever reason, review will not be sent anyways


### PR DESCRIPTION
Fixes #5174 

In the ReviewImageFragment.java file, the "THANKS" case got the username through an if statement. This if saved the username from the previously reviewed image in "savedInstanceState" and kept using it whenever the review screen was loaded again (wether or not it was the same image being reviewed).

I believe this was added in order to avoid the app crashing whenever the app got rotated while on that screen (since "user" could have been null). However, it meant showing the same username even with the next image.

By removing the if statement, The app does not crash while it is rotated on that screen, but the message that includes the user disappears. Still, it doesn't affect the next user displayed. I do believe it is better this way for now, while this new "disappearing message issue" is dealt with.

https://user-images.githubusercontent.com/108767897/226074991-4cd5d990-be45-4b7e-99f5-b4d1835b31fa.mov
https://user-images.githubusercontent.com/108767897/226075288-031fca1d-f8c4-4773-a25a-e870bc3318bc.mov