### PR TITLE
Fixed #5181 Misleading warning title for duplicate file name

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -374,7 +374,7 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
                 }
             });
             DialogUtil.showAlertDialog(getActivity(),
-                getString(R.string.duplicate_image_found),
+                getString(R.string.duplicate_file_name),
                 String.format(Locale.getDefault(),
                     uploadTitleFormat,
                     uploadItem.getFileName()),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,7 +193,6 @@
   <string name="ok">OK</string>
   <string name="warning">Warning</string>
   <string name="duplicate_file_name">Duplicate File Name found</string>
-  <string name="duplicate_image_found">Duplicate Image Found</string>
   <string name="upload">Upload</string>
   <string name="yes">Yes</string>
   <string name="no">No</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,6 +192,7 @@
   <string name="location_permission_title">Requesting Location Permission</string>
   <string name="ok">OK</string>
   <string name="warning">Warning</string>
+  <string name="duplicate_file_name">Duplicate File Name found</string>
   <string name="duplicate_image_found">Duplicate Image Found</string>
   <string name="upload">Upload</string>
   <string name="yes">Yes</string>


### PR DESCRIPTION


**Description (required)**

Fixes #5181 

What changes did you make and why?
Added a new string resource to display in the alertdialog

**Tests performed (required)**

Tested locally on my device POCO X2, API Level 30

**Screenshots (for UI changes only)**

| Before | After |
| --- | --- |
|![image](https://user-images.githubusercontent.com/75121767/226958528-37a77796-f628-4e08-ac7d-83f24c4006c0.png) | ![image](https://user-images.githubusercontent.com/75121767/226957328-ce7e66d4-265e-4714-b255-0aa8cf1a5e7d.png)

---


