### PR TITLE
#5030 Bug fix  "Author field shows HTML tags when template used"

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Media.kt
+++ b/app/src/main/java/fr/free/nrw/commons/Media.kt
@@ -115,6 +115,30 @@ class Media constructor(
                 ""
 
     /**
+     * Gets media display title
+     * @return Media title
+     */
+
+    fun getDisplayAuthor(): String{
+        if (author == null)
+            return ""
+
+        val completeHtmlTagCheck = "<.*>(.*)<.*>".toRegex() // Detect if complete html tags present
+        var completeCheckResult = completeHtmlTagCheck.findAll(author!!) // Find matching cases, return text between tag
+        if(completeCheckResult.count()==1) return completeCheckResult.toList().get(0).groupValues.get(1) // Get matching result and return text between tag - text between tag is inside a capture group
+        else if (completeCheckResult.count()>1) return "" // If there are multiple cases we return nothing --> can multiple cases occur?
+
+        val hrefTagCheck = "<.*>(.*)".toRegex() // Detect if half html tags present -> <a href= XXX> case
+        var hrefTagCheckResult = hrefTagCheck.findAll(author!!) // Find matching cases, return text between tag
+        if(hrefTagCheckResult.count()==1) return hrefTagCheckResult.toList().get(0).groupValues.get(1) // Get matching result and return text between tag
+        else if (hrefTagCheckResult.count()>1) return "" // If there are multiple cases we return nothing --> can multiple cases occur?
+
+        return author!! // If this is reached then html tags are not present, return author text as is
+
+    }
+
+
+    /**
      * Gets file page title
      * @return New media page title
      */

--- a/app/src/main/java/fr/free/nrw/commons/Media.kt
+++ b/app/src/main/java/fr/free/nrw/commons/Media.kt
@@ -118,25 +118,34 @@ class Media constructor(
      * Gets media display title
      * @return Media title
      */
-
     fun getDisplayAuthor(): String{
+
         if (author == null)
             return ""
 
         val completeHtmlTagCheck = "<.*>(.*)<.*>".toRegex() // Detect if complete html tags present
         var completeCheckResult = completeHtmlTagCheck.findAll(author!!) // Find matching cases, return text between tag
-        if(completeCheckResult.count()==1) return completeCheckResult.toList().get(0).groupValues.get(1) // Get matching result and return text between tag - text between tag is inside a capture group
-        else if (completeCheckResult.count()>1) return "" // If there are multiple cases we return nothing --> can multiple cases occur?
+
+        // Get matching result and return text between tag - text between tag is inside a capture group
+        if(completeCheckResult.count()==1)
+            return completeCheckResult.toList().get(0).groupValues.get(1)
+
+        // If there are multiple cases we return nothing --> can multiple cases occur?
+        else if (completeCheckResult.count()>1)
+            return ""
 
         val hrefTagCheck = "<.*>(.*)".toRegex() // Detect if half html tags present -> <a href= XXX> case
         var hrefTagCheckResult = hrefTagCheck.findAll(author!!) // Find matching cases, return text between tag
-        if(hrefTagCheckResult.count()==1) return hrefTagCheckResult.toList().get(0).groupValues.get(1) // Get matching result and return text between tag
-        else if (hrefTagCheckResult.count()>1) return "" // If there are multiple cases we return nothing --> can multiple cases occur?
+
+        // Get matching result and return text between tag
+        if(hrefTagCheckResult.count()==1)
+            return hrefTagCheckResult.toList().get(0).groupValues.get(1) // Get matching result and return text between tag
+
+        // If there are multiple cases we return nothing --> can multiple cases occur?
+        else if (hrefTagCheckResult.count()>1) return ""
 
         return author!! // If this is reached then html tags are not present, return author text as is
-
     }
-
 
     /**
      * Gets file page title

--- a/app/src/main/java/fr/free/nrw/commons/Media.kt
+++ b/app/src/main/java/fr/free/nrw/commons/Media.kt
@@ -118,7 +118,7 @@ class Media constructor(
      * Gets media display title
      * @return Media title
      */
-    fun getDisplayAuthor(): String{
+    fun getDisplayAuthor(): String {
 
         if (author == null)
             return ""
@@ -127,22 +127,22 @@ class Media constructor(
         var completeCheckResult = completeHtmlTagCheck.findAll(author!!) // Find matching cases, return text between tag
 
         // Get matching result and return text between tag - text between tag is inside a capture group
-        if(completeCheckResult.count()==1)
+        if (completeCheckResult.count() == 1)
             return completeCheckResult.toList().get(0).groupValues.get(1)
 
         // If there are multiple cases we return nothing --> can multiple cases occur?
-        else if (completeCheckResult.count()>1)
+        else if (completeCheckResult.count() > 1)
             return ""
 
         val hrefTagCheck = "<.*>(.*)".toRegex() // Detect if half html tags present -> <a href= XXX> case
         var hrefTagCheckResult = hrefTagCheck.findAll(author!!) // Find matching cases, return text between tag
 
         // Get matching result and return text between tag
-        if(hrefTagCheckResult.count()==1)
+        if (hrefTagCheckResult.count() == 1)
             return hrefTagCheckResult.toList().get(0).groupValues.get(1) // Get matching result and return text between tag
 
         // If there are multiple cases we return nothing --> can multiple cases occur?
-        else if (hrefTagCheckResult.count()>1) return ""
+        else if (hrefTagCheckResult.count() > 1) return ""
 
         return author!! // If this is reached then html tags are not present, return author text as is
     }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -674,10 +674,10 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         categoryNames.clear();
         categoryNames.addAll(media.getCategories());
 
-        if (media.getAuthor() == null || media.getAuthor().equals("")) {
+        if (media.getDisplayAuthor().equals("")) {
             authorLayout.setVisibility(GONE);
         } else {
-            author.setText(media.getAuthor());
+            author.setText(media.getDisplayAuthor());
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -674,7 +674,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         categoryNames.clear();
         categoryNames.addAll(media.getCategories());
 
-        if (media.getDisplayAuthor().equals("")) {
+        if (media.getDisplayAuthor() == null || media.getDisplayAuthor().equals("")) {
             authorLayout.setVisibility(GONE);
         } else {
             author.setText(media.getDisplayAuthor());

--- a/app/src/test/kotlin/fr/free/nrw/commons/MediaTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/MediaTest.kt
@@ -21,6 +21,7 @@ class MediaTest {
         val m = media(filename = "File:Example 1_2.jpg")
         assertEquals("Example 1 2", m.displayTitle)
     }
+
     @Test
     fun testGetDisplayAuthorWithCompleteHtmlTags() {
         // Test with author containing complete html tags
@@ -40,6 +41,13 @@ class MediaTest {
         // Test with author containing no html tags
         val media = media(author = "John Doe")
         assertEquals("John Doe", media.getDisplayAuthor())
+    }
+
+    @Test
+    fun testGetDisplayAuthorWithMultipleHtmlTags() {
+        // Test with author containing multiple html tags
+        val media = media(author = "<b><i>John Doe</i></b>")
+        assertEquals("", media.getDisplayAuthor())
     }
 
     @Test

--- a/app/src/test/kotlin/fr/free/nrw/commons/MediaTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/MediaTest.kt
@@ -21,6 +21,33 @@ class MediaTest {
         val m = media(filename = "File:Example 1_2.jpg")
         assertEquals("Example 1 2", m.displayTitle)
     }
+    @Test
+    fun testGetDisplayAuthorWithCompleteHtmlTags() {
+        // Test with author containing complete html tags
+        val media = media(author = "<b>John Doe</b>")
+        assertEquals("John Doe", media.getDisplayAuthor())
+    }
+
+    @Test
+    fun testGetDisplayAuthorWithHalfHtmlTag() {
+        // Test with author containing half html tag
+        val media = media(author = "<a href='example.com'>John Doe")
+        assertEquals("John Doe", media.getDisplayAuthor())
+    }
+
+    @Test
+    fun testGetDisplayAuthorWithoutHtmlTags() {
+        // Test with author containing no html tags
+        val media = media(author = "John Doe")
+        assertEquals("John Doe", media.getDisplayAuthor())
+    }
+
+    @Test
+    fun testGetDisplayAuthorWithEmptyAuthor() {
+        // Test with empty author
+        val media = media(author = null)
+        assertEquals("", media.getDisplayAuthor())
+    }
 }
 
 


### PR DESCRIPTION
Added a new function getDisplayAuthor in Media.kt that parses the author string with Regex, also added some tests for it

**Description (required)**
Fixes #5030

Just added a few tests to the changes made in #5069 
