### PR TITLE
Fixes #4964: ordered images by timestamp

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -426,6 +426,14 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
 
     private void receiveExternalSharedItems() {
         uploadableFiles = contributionController.handleExternalImagesPicked(this, getIntent());
+
+        try {
+            Collections.sort(uploadableFiles, (f1, f2) -> (int) (
+                f2.getFileCreatedDate(this).getEpochDate() -
+                    f1.getFileCreatedDate(this).getEpochDate()));
+        }catch (NullPointerException e){
+            e.printStackTrace();
+        }
     }
 
     private void receiveInternalSharedItems() {


### PR DESCRIPTION
Fixes #4964 

Ordered the images by timestamp when they come from external sources (share button)