### PR TITLE
Fixes #5015 - custom image selector not identifying photo location

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <uses-permission android:name="com.google.android.apps.photos.permission.GOOGLE_PHOTOS" />
     <uses-permission android:name="android.permission.SET_WALLPAPER"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION"/>
 
     <queries>
         <!-- Browser -->

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
@@ -3,9 +3,12 @@ package fr.free.nrw.commons.contributions;
 import static fr.free.nrw.commons.wikidata.WikidataConstants.PLACE_OBJECT;
 
 import android.Manifest;
+import android.Manifest.permission;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import androidx.annotation.NonNull;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.filepicker.DefaultCallback;
@@ -66,7 +69,18 @@ public class ContributionController {
 
         PermissionUtils.checkPermissionsAndPerformAction(activity,
             Manifest.permission.WRITE_EXTERNAL_STORAGE,
-            () -> FilePicker.openCustomSelector(activity, 0),
+            () -> {
+                if (VERSION.SDK_INT >= VERSION_CODES.Q) {
+                    PermissionUtils.checkPermissionsAndPerformAction(
+                        activity,
+                        permission.ACCESS_MEDIA_LOCATION,
+                        () -> {},
+                        R.string.media_location_permission_denied,
+                        R.string.add_location_manually
+                    );
+                }
+                FilePicker.openCustomSelector(activity, 0);
+            },
             R.string.storage_permission_title,
             R.string.write_storage_permission_rationale);
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -511,6 +511,9 @@ Upload your first media by tapping on the add button.</string>
   <string name="exif_tag_name_serialNumbers">Serial Numbers</string>
   <string name="exif_tag_name_software">Software</string>
 
+  <string name="media_location_permission_denied">Media location access denied</string>
+  <string name="add_location_manually">We may not be able to automatically obtain location data from pictures you upload. Please add the appropriate location for each picture before submitting</string>
+
   <string name="share_text">Upload photos to Wikimedia Commons directly from your phone. Download the Commons App now: %1$s</string>
   <string name="share_via">Share app via...</string>
   <string name="image_info">Image Info</string>


### PR DESCRIPTION
Fixes #5015

**What changes did you make and why?**

1. AndroidManifest.xml - added permission ACCESS_MEDIA_LOCATION

2. ContributionController.java (line 72) - inside the onPermissionGranted lambda on checking WRITE_EXTERNAL_STORAGE permission, I added code to request ACCESS_MEDIA_LOCATION permission on devices running Android 10 or greater to obtain images without the exif data being redacted

3. Strings.xml - Added 2 string resources for displaying in the dialog box in case the user rejects ACCESS_MEDIA_LOCATION permission request

Why did I request ACCESS_MEDIA_LOCATION inside the onPermissionGranted lambda?

Case 1: Request ACCESS_MEDIA_LOCATION before WRITE_EXTERNAL_STORAGE

```
if (VERSION.SDK_INT >= VERSION_CODES.Q) {
                    PermissionUtils.checkPermissionsAndPerformAction(
                        activity,
                        permission.ACCESS_MEDIA_LOCATION,
                        () -> {},
                        R.string.media_location_permission_denied,
                        R.string.add_location_manually
                    );
                }

PermissionUtils.checkPermissionsAndPerformAction(activity,
            Manifest.permission.WRITE_EXTERNAL_STORAGE,
            () -> FilePicker.openCustomSelector(activity, 0),
            R.string.storage_permission_title,
            R.string.write_storage_permission_rationale);

```
Problem:

![image](https://user-images.githubusercontent.com/112970189/228470661-47df5187-c526-4a7e-997e-2459dce280f9.png)

This permission dialog is shown once but clicking "Allow" does not navigate to the custom picker screen, a second click needs to be made to get there.

Case 2: Request ACCESS_MEDIA_LOCATION after WRITE_EXTERNAL_STORAGE

```
PermissionUtils.checkPermissionsAndPerformAction(activity,
            Manifest.permission.WRITE_EXTERNAL_STORAGE,
            () -> FilePicker.openCustomSelector(activity, 0),
            R.string.storage_permission_title,
            R.string.write_storage_permission_rationale);

if (VERSION.SDK_INT >= VERSION_CODES.Q) {
                    PermissionUtils.checkPermissionsAndPerformAction(
                        activity,
                        permission.ACCESS_MEDIA_LOCATION,
                        () -> {},
                        R.string.media_location_permission_denied,
                        R.string.add_location_manually
                    );
                }

```

Problem: The permission dialog is shown once and clicking "allow" navigate to the custom picker screen, but the location is not detected. As FilePicker.openCustomSelector(activity, 0) is executed when "allow" Is clicked, the app navigates to the custom picker screen before the code to request ACCESS_MEDIA_LOCATION can be executed.

Case 3: Requesting ACCESS_MEDIA_LOCATION inside the onPermissionGranted lambda (as in this pull request)

When requesting ACCESS_MEDIA_LOCATION inside the onPermissionGranted lambda, the permission dialog is shown once, on clicking "allow" navigates to the custom picker screen, and the location is successfully detected from pictures.

**Tested betaDebug on**
1. Realme Narzo 30 5G  with API level 33 (Android 13)
2. OnePlus dn2101 with API level 31 (Android 12)
3. Realme 3 Pro with API level 30 (Android 11)

**Screenshots**

![Screenshot_commons_app_android_13](https://user-images.githubusercontent.com/112970189/228464041-b17897b8-a322-454f-8d86-b047340fe8ca.jpg)
Location successfully obtained from image picked using custom image picker [Realme Narzo 30 5G  with API level 33]
