### PR TITLE
fixing: Duplicate filename notification completely replaces image-found-on-internet warning #5180

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.upload.mediaDetails;
 
 import static android.app.Activity.RESULT_OK;
+import static fr.free.nrw.commons.utils.ImageUtils.FILE_NAME_EXISTS;
 import static fr.free.nrw.commons.utils.ImageUtils.getErrorMessageForResult;
 
 import android.annotation.SuppressLint;
@@ -403,13 +404,18 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
                 getString(R.string.upload),
                 getString(R.string.cancel),
                 () -> {
-                    uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
                     /*
                         User skipped the warning of low quality image, so we call
                         onImageValidationSuccess rather than onNextButtonClicked to avoid showing
                         other warning popups again.
                     */
-                    onImageValidationSuccess();
+
+                    // validate image only when same file name error does not occur
+                    // show the same file name error if exists.
+                    if ((errorCode & FILE_NAME_EXISTS) == 0) {
+                        uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
+                        onImageValidationSuccess();
+                    }
                 },
                 () -> deleteThisPicture()
             );

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -3,7 +3,12 @@ package fr.free.nrw.commons.upload.mediaDetails;
 import static fr.free.nrw.commons.di.CommonsApplicationModule.IO_THREAD;
 import static fr.free.nrw.commons.di.CommonsApplicationModule.MAIN_THREAD;
 import static fr.free.nrw.commons.utils.ImageUtils.EMPTY_CAPTION;
+import static fr.free.nrw.commons.utils.ImageUtils.FILE_FBMD;
 import static fr.free.nrw.commons.utils.ImageUtils.FILE_NAME_EXISTS;
+import static fr.free.nrw.commons.utils.ImageUtils.FILE_NO_EXIF;
+import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_BLURRY;
+import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_DARK;
+import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_GEOLOCATION_DIFFERENT;
 import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_KEEP;
 import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_OK;
 
@@ -314,18 +319,26 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
             uploadItem.setHasInvalidLocation(true);
         }
 
-        switch (errorCode) {
-            case EMPTY_CAPTION:
-                Timber.d("Captions are empty. Showing toast");
-                view.showMessage(R.string.add_caption_toast, R.color.color_error);
-                break;
-            case FILE_NAME_EXISTS:
-                Timber.d("Trying to show duplicate picture popup");
-                view.showDuplicatePicturePopup(uploadItem);
-                break;
-            default:
-                view.showBadImagePopup(errorCode, uploadItem);
+        // If errorCode is empty caption show message
+        if (errorCode == EMPTY_CAPTION) {
+            Timber.d("Captions are empty. Showing toast");
+            view.showMessage(R.string.add_caption_toast, R.color.color_error);
         }
+
+        // If image with same file name exists check the bit in errorCode is set or not
+        if ((errorCode & FILE_NAME_EXISTS) != 0) {
+            Timber.d("Trying to show duplicate picture popup");
+            view.showDuplicatePicturePopup(uploadItem);
+        }
+
+        // If image has some problems check if the bits are set in errorCode and
+        // show popup accordingly
+        if (((errorCode & FILE_NO_EXIF) != 0) || ((errorCode & IMAGE_DARK) != 0) ||
+            ((errorCode & FILE_FBMD) != 0) || ((errorCode & IMAGE_GEOLOCATION_DIFFERENT) != 0) ||
+            ((errorCode & IMAGE_BLURRY) != 0)) {
+            view.showBadImagePopup(errorCode, uploadItem);
+        }
+
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.java
@@ -45,7 +45,7 @@ public class ImageUtils {
     /**
      * Set 1st bit as 1 for blurry image ie. 0010
      */
-    static final int IMAGE_BLURRY = 1 << 1; // 2
+    public static final int IMAGE_BLURRY = 1 << 1; // 2
     /**
      * Set 2nd bit as 1 for duplicate image ie. 0100
      */
@@ -68,7 +68,7 @@ public class ImageUtils {
     public static final int IMAGE_KEEP = -1;
     public static final int IMAGE_WAIT = -2;
     public static final int EMPTY_CAPTION = -3;
-    public static final int FILE_NAME_EXISTS = -4;
+    public static final int FILE_NAME_EXISTS = 1 << 6;
     static final int NO_CATEGORY_SELECTED = -5;
 
     private static ProgressDialog progressDialogWallpaper;


### PR DESCRIPTION

**Description (required)**

Fixes #5180 

What changes did you make and why?
Changed the error code for file name exists. To check for the error effectively.
Replaced switch case with multiple if statements so that every condition is checked.

**Tests performed (required)**

Tested prodDebug on Pixel 4 with API level 28.

**Screenshots (for UI changes only)**

https://user-images.githubusercontent.com/77919824/228610180-16cca1ec-90d5-461e-8f70-cf9827e2befc.mp4


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
