### PR TITLE
Fixes #5187: Fix App crashes when you click on Author Name

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -57,6 +57,7 @@ import com.facebook.imagepipeline.image.ImageInfo;
 import com.facebook.imagepipeline.request.ImageRequest;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import fr.free.nrw.commons.BuildConfig;
 import fr.free.nrw.commons.LocationPicker.LocationPicker;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.MediaDataExtractor;
@@ -1233,7 +1234,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             return;
         }
         if (sessionManager.getUserName() == null) {
-            String userProfileLink = "https://commons.wikimedia.org/wiki/User:" + media.getUser();
+            String userProfileLink = BuildConfig.COMMONS_URL + "/wiki/User:" + media.getUser();
             Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(userProfileLink));
             startActivity(browserIntent);
             return;

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -1232,6 +1232,12 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         if (media == null || media.getUser() == null) {
             return;
         }
+        if (sessionManager.getUserName() == null) {
+            String userProfileLink = "https://commons.wikimedia.org/wiki/User:" + media.getAuthor();
+            Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(userProfileLink));
+            startActivity(browserIntent);
+            return;
+        }
         ProfileActivity.startYourself(getActivity(), media.getUser(), !Objects
             .equals(sessionManager.getUserName(), media.getUser()));
     }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -1233,7 +1233,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             return;
         }
         if (sessionManager.getUserName() == null) {
-            String userProfileLink = "https://commons.wikimedia.org/wiki/User:" + media.getAuthor();
+            String userProfileLink = "https://commons.wikimedia.org/wiki/User:" + media.getUser();
             Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(userProfileLink));
             startActivity(browserIntent);
             return;


### PR DESCRIPTION
**Description (required)**

Fixes #5187

What changes did you make and why?

Changed onAuthorViewClicked method so that it renders the author's profile on the browser. Previously it just crashed the application as showed on the issue this PR fixes.

![Screenshot 2023-04-03 at 11 43 52 AM](https://user-images.githubusercontent.com/37851094/229587392-51438c3f-e4ea-4cbb-bfb7-d6db0e9dea4f.jpeg)

**Tests performed (required)**

Tested ProdDebug on Pixel 5 with API level 31.

**Screenshots (for UI changes only)**

Before: 

![Screenshot 2023-04-03 at 12 03 21 PM](https://user-images.githubusercontent.com/37851094/229590930-8d3eb2e2-db15-4772-b643-b9954d4672e0.jpeg)

After:

![Screenshot 2023-04-03 at 12 03 20 PM](https://user-images.githubusercontent.com/37851094/229590963-7aa41b34-cee5-4d6b-b1e4-69cc380773b2.jpeg)



