### PR TITLE
Add constants file for map styles used across various fragments

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -53,6 +53,7 @@ import com.mapbox.mapboxsdk.maps.UiSettings;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+import fr.free.nrw.commons.MapStyle;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
@@ -248,8 +249,7 @@ public class LocationPickerActivity extends BaseActivity implements OnMapReadyCa
     @Override
     public void onMapReady(final MapboxMap mapboxMap) {
         this.mapboxMap = mapboxMap;
-        mapboxMap.setStyle(isDarkTheme ? LocationPickerConstants.DARK_MAP_STYLE :
-            LocationPickerConstants.STREETS_MAP_STYLE, this::onStyleLoaded);
+        mapboxMap.setStyle(isDarkTheme ? MapStyle.DARK : MapStyle.STREETS, this::onStyleLoaded);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerConstants.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerConstants.java
@@ -13,12 +13,6 @@ public final class LocationPickerConstants {
     public static final String MAP_CAMERA_POSITION
         = "location.picker.cameraPosition";
 
-    public static final String DARK_MAP_STYLE
-        = Style.getPredefinedStyle("Dark");
-
-    public static final String STREETS_MAP_STYLE
-        = Style.getPredefinedStyle("Streets");
-
 
     private LocationPickerConstants() {
     }

--- a/app/src/main/java/fr/free/nrw/commons/MapStyle.java
+++ b/app/src/main/java/fr/free/nrw/commons/MapStyle.java
@@ -1,0 +1,12 @@
+package fr.free.nrw.commons;
+
+import com.mapbox.mapboxsdk.maps.Style;
+
+/**
+ * Constants for various map styles
+ */
+public final class MapStyle {
+    public static final String DARK = Style.getPredefinedStyle("Dark");
+    public static final String OUTDOORS = Style.getPredefinedStyle("Outdoors");
+    public static final String STREETS = Style.getPredefinedStyle("Streets");
+}

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
@@ -54,6 +54,7 @@ import com.mapbox.mapboxsdk.maps.UiSettings;
 import com.mapbox.pluginscalebar.ScaleBarOptions;
 import com.mapbox.pluginscalebar.ScaleBarPlugin;
 import fr.free.nrw.commons.MapController;
+import fr.free.nrw.commons.MapStyle;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
@@ -190,8 +191,8 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
             mapBox = mapBoxMap;
             initViews();
             presenter.setActionListeners(applicationKvStore);
-            mapBoxMap.setStyle(isDarkTheme? Style.getPredefinedStyle("Dark"):
-                Style.getPredefinedStyle("Outdoors"), style -> {
+            mapBoxMap.setStyle(isDarkTheme? MapStyle.DARK :
+                MapStyle.OUTDOORS, style -> {
                 final UiSettings uiSettings = mapBoxMap.getUiSettings();
                 uiSettings.setCompassGravity(Gravity.BOTTOM | Gravity.LEFT);
                 uiSettings.setCompassMargins(12, 0, 0, 24);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -82,6 +82,7 @@ import com.mapbox.pluginscalebar.ScaleBarOptions;
 import com.mapbox.pluginscalebar.ScaleBarPlugin;
 import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.MapController.NearbyPlacesInfo;
+import fr.free.nrw.commons.MapStyle;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.auth.LoginActivity;
@@ -316,7 +317,8 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             initViews();
             presenter.setActionListeners(applicationKvStore);
             initNearbyFilter();
-            mapBoxMap.setStyle(isDarkTheme?Style.getPredefinedStyle("Dark"):Style.getPredefinedStyle("Outdoors"), style -> {
+            mapBoxMap.setStyle(isDarkTheme? MapStyle.DARK :
+                MapStyle.OUTDOORS, style -> {
                 final UiSettings uiSettings = mapBoxMap.getUiSettings();
                 uiSettings.setCompassGravity(Gravity.BOTTOM | Gravity.LEFT);
                 uiSettings.setCompassMargins(12, 0, 0, 24);


### PR DESCRIPTION
**Description (required)**

As discussed [here](https://github.com/commons-app/apps-android-commons/pull/5193#pullrequestreview-1368307148), map styles have many usages in the app. 

What changes did you make and why?

Added constants for all the map styles used in the app.

**Tests performed (required)**

Tested prodDebug on Redmi 5A with API level 27.

