### PR TITLE
5204: Fix unit test UploadMediaPresenterTest.handleImageResult

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -326,6 +326,7 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
             view.showMessage(R.string.add_caption_toast, R.color.color_error);
         }
 
+        // If image with same file name exists check the bit in errorCode is set or not
         if ((errorCode & FILE_NAME_EXISTS) != 0) {
             Timber.d("Trying to show duplicate picture popup");
             view.showDuplicatePicturePopup(uploadItem);

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -8,6 +8,7 @@ import static fr.free.nrw.commons.utils.ImageUtils.FILE_NAME_EXISTS;
 import static fr.free.nrw.commons.utils.ImageUtils.FILE_NO_EXIF;
 import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_BLURRY;
 import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_DARK;
+import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_DUPLICATE;
 import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_GEOLOCATION_DIFFERENT;
 import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_KEEP;
 import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_OK;
@@ -325,7 +326,8 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
             view.showMessage(R.string.add_caption_toast, R.color.color_error);
         }
 
-        if (errorCode == FILE_NAME_EXISTS) {
+        if ((errorCode == FILE_NAME_EXISTS) || (errorCode == (FILE_NO_EXIF | FILE_NAME_EXISTS)) ||
+            (errorCode == (IMAGE_DUPLICATE | FILE_NAME_EXISTS))) {
             Timber.d("Trying to show duplicate picture popup");
             view.showDuplicatePicturePopup(uploadItem);
         }
@@ -333,7 +335,7 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
         // If image has some problems, show popup accordingly
         if ((errorCode == FILE_NO_EXIF) || (errorCode == IMAGE_DARK) ||
             (errorCode == FILE_FBMD) || (errorCode == IMAGE_GEOLOCATION_DIFFERENT) ||
-            (errorCode == IMAGE_BLURRY)) {
+            (errorCode == IMAGE_BLURRY) || errorCode == (FILE_NO_EXIF | FILE_NAME_EXISTS)) {
             view.showBadImagePopup(errorCode, uploadItem);
         }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -325,7 +325,7 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
             view.showMessage(R.string.add_caption_toast, R.color.color_error);
         }
 
-        else if (errorCode == FILE_NAME_EXISTS) {
+        if (errorCode == FILE_NAME_EXISTS) {
             Timber.d("Trying to show duplicate picture popup");
             view.showDuplicatePicturePopup(uploadItem);
         }

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -326,8 +326,7 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
             view.showMessage(R.string.add_caption_toast, R.color.color_error);
         }
 
-        if ((errorCode & (FILE_NAME_EXISTS | IMAGE_DUPLICATE | IMAGE_DARK | IMAGE_BLURRY
-            | IMAGE_GEOLOCATION_DIFFERENT | FILE_FBMD | FILE_NO_EXIF)) != 0) {
+        if ((errorCode & FILE_NAME_EXISTS) != 0) {
             Timber.d("Trying to show duplicate picture popup");
             view.showDuplicatePicturePopup(uploadItem);
         }

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -3,13 +3,7 @@ package fr.free.nrw.commons.upload.mediaDetails;
 import static fr.free.nrw.commons.di.CommonsApplicationModule.IO_THREAD;
 import static fr.free.nrw.commons.di.CommonsApplicationModule.MAIN_THREAD;
 import static fr.free.nrw.commons.utils.ImageUtils.EMPTY_CAPTION;
-import static fr.free.nrw.commons.utils.ImageUtils.FILE_FBMD;
 import static fr.free.nrw.commons.utils.ImageUtils.FILE_NAME_EXISTS;
-import static fr.free.nrw.commons.utils.ImageUtils.FILE_NO_EXIF;
-import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_BLURRY;
-import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_DARK;
-import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_DUPLICATE;
-import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_GEOLOCATION_DIFFERENT;
 import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_KEEP;
 import static fr.free.nrw.commons.utils.ImageUtils.IMAGE_OK;
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -325,17 +325,15 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
             view.showMessage(R.string.add_caption_toast, R.color.color_error);
         }
 
-        // If image with same file name exists check the bit in errorCode is set or not
-        if ((errorCode & FILE_NAME_EXISTS) != 0) {
+        else if (errorCode == FILE_NAME_EXISTS) {
             Timber.d("Trying to show duplicate picture popup");
             view.showDuplicatePicturePopup(uploadItem);
         }
 
-        // If image has some problems check if the bits are set in errorCode and
-        // show popup accordingly
-        if (((errorCode & FILE_NO_EXIF) != 0) || ((errorCode & IMAGE_DARK) != 0) ||
-            ((errorCode & FILE_FBMD) != 0) || ((errorCode & IMAGE_GEOLOCATION_DIFFERENT) != 0) ||
-            ((errorCode & IMAGE_BLURRY) != 0)) {
+        // If image has some problems, show popup accordingly
+        if ((errorCode == FILE_NO_EXIF) || (errorCode == IMAGE_DARK) ||
+            (errorCode == FILE_FBMD) || (errorCode == IMAGE_GEOLOCATION_DIFFERENT) ||
+            (errorCode == IMAGE_BLURRY)) {
             view.showBadImagePopup(errorCode, uploadItem);
         }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -326,16 +326,14 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
             view.showMessage(R.string.add_caption_toast, R.color.color_error);
         }
 
-        if ((errorCode == FILE_NAME_EXISTS) || (errorCode == (FILE_NO_EXIF | FILE_NAME_EXISTS)) ||
-            (errorCode == (IMAGE_DUPLICATE | FILE_NAME_EXISTS))) {
+        if ((errorCode & (FILE_NAME_EXISTS | IMAGE_DUPLICATE | IMAGE_DARK | IMAGE_BLURRY
+            | IMAGE_GEOLOCATION_DIFFERENT | FILE_FBMD | FILE_NO_EXIF)) != 0) {
             Timber.d("Trying to show duplicate picture popup");
             view.showDuplicatePicturePopup(uploadItem);
         }
 
-        // If image has some problems, show popup accordingly
-        if ((errorCode == FILE_NO_EXIF) || (errorCode == IMAGE_DARK) ||
-            (errorCode == FILE_FBMD) || (errorCode == IMAGE_GEOLOCATION_DIFFERENT) ||
-            (errorCode == IMAGE_BLURRY) || errorCode == (FILE_NO_EXIF | FILE_NAME_EXISTS)) {
+        // If image has some other problems, show popup accordingly
+        if (errorCode != EMPTY_CAPTION && errorCode != FILE_NAME_EXISTS) {
             view.showBadImagePopup(errorCode, uploadItem);
         }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -326,16 +326,16 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
             view.showMessage(R.string.add_caption_toast, R.color.color_error);
         }
 
-        if ((errorCode & FILE_NAME_EXISTS) == FILE_NAME_EXISTS) {
+        if ((errorCode == FILE_NAME_EXISTS) || (errorCode == (FILE_NO_EXIF | FILE_NAME_EXISTS)) ||
+            (errorCode == (IMAGE_DUPLICATE | FILE_NAME_EXISTS))) {
             Timber.d("Trying to show duplicate picture popup");
             view.showDuplicatePicturePopup(uploadItem);
         }
 
         // If image has some problems, show popup accordingly
-        if ((errorCode & FILE_NO_EXIF) == FILE_NO_EXIF || (errorCode & IMAGE_DARK) == IMAGE_DARK ||
-            (errorCode & FILE_FBMD) == FILE_FBMD ||
-            (errorCode & IMAGE_GEOLOCATION_DIFFERENT) == IMAGE_GEOLOCATION_DIFFERENT ||
-            (errorCode & IMAGE_BLURRY) == IMAGE_BLURRY) {
+        if ((errorCode == FILE_NO_EXIF) || (errorCode == IMAGE_DARK) ||
+            (errorCode == FILE_FBMD) || (errorCode == IMAGE_GEOLOCATION_DIFFERENT) ||
+            (errorCode == IMAGE_BLURRY) || errorCode == (FILE_NO_EXIF | FILE_NAME_EXISTS)) {
             view.showBadImagePopup(errorCode, uploadItem);
         }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -326,16 +326,16 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
             view.showMessage(R.string.add_caption_toast, R.color.color_error);
         }
 
-        if ((errorCode == FILE_NAME_EXISTS) || (errorCode == (FILE_NO_EXIF | FILE_NAME_EXISTS)) ||
-            (errorCode == (IMAGE_DUPLICATE | FILE_NAME_EXISTS))) {
+        if ((errorCode & FILE_NAME_EXISTS) == FILE_NAME_EXISTS) {
             Timber.d("Trying to show duplicate picture popup");
             view.showDuplicatePicturePopup(uploadItem);
         }
 
         // If image has some problems, show popup accordingly
-        if ((errorCode == FILE_NO_EXIF) || (errorCode == IMAGE_DARK) ||
-            (errorCode == FILE_FBMD) || (errorCode == IMAGE_GEOLOCATION_DIFFERENT) ||
-            (errorCode == IMAGE_BLURRY) || errorCode == (FILE_NO_EXIF | FILE_NAME_EXISTS)) {
+        if ((errorCode & FILE_NO_EXIF) == FILE_NO_EXIF || (errorCode & IMAGE_DARK) == IMAGE_DARK ||
+            (errorCode & FILE_FBMD) == FILE_FBMD ||
+            (errorCode & IMAGE_GEOLOCATION_DIFFERENT) == IMAGE_GEOLOCATION_DIFFERENT ||
+            (errorCode & IMAGE_BLURRY) == IMAGE_BLURRY) {
             view.showBadImagePopup(errorCode, uploadItem);
         }
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaPresenterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaPresenterTest.kt
@@ -154,14 +154,8 @@ class UploadMediaPresenterTest {
         uploadMediaPresenter.handleImageResult(EMPTY_CAPTION, uploadItem)
         verify(view).showMessage(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
 
-        /**
-         * Bad Picture Test
-         * Handle any error code corresponding to:
-         * FILE_NO_EXIF, IMAGE_DARK, FILE_FBMD, IMAGE_GEOLOCATION_DIFFERENT, IMAGE_BLURRY
-         * FILE_NO_EXIF | FILE_NAME_EXISTS
-         */
-        val badImageErrorCodes = listOf(1, 2, 8, 16, 32, 96)
-        uploadMediaPresenter.handleImageResult(badImageErrorCodes.random(), uploadItem)
+        // Bad Picture Test
+        uploadMediaPresenter.handleImageResult(-7, uploadItem)
         verify(view)?.showBadImagePopup(ArgumentMatchers.anyInt(), ArgumentMatchers.eq(uploadItem))
     }
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaPresenterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaPresenterTest.kt
@@ -158,10 +158,10 @@ class UploadMediaPresenterTest {
          * Bad Picture Test
          * Handle any error code corresponding to:
          * FILE_NO_EXIF, IMAGE_DARK, FILE_FBMD, IMAGE_GEOLOCATION_DIFFERENT, IMAGE_BLURRY
+         * FILE_NO_EXIF | FILE_NAME_EXISTS
          */
-        val errorCodes = listOf(1, 2, 8, 16, 32)
-        val randomErrorCode = errorCodes.random()
-        uploadMediaPresenter.handleImageResult(randomErrorCode, uploadItem)
+        val badImageErrorCodes = listOf(1, 2, 8, 16, 32, 96)
+        uploadMediaPresenter.handleImageResult(badImageErrorCodes.random(), uploadItem)
         verify(view)?.showBadImagePopup(ArgumentMatchers.anyInt(), ArgumentMatchers.eq(uploadItem))
     }
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaPresenterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaPresenterTest.kt
@@ -154,10 +154,15 @@ class UploadMediaPresenterTest {
         uploadMediaPresenter.handleImageResult(EMPTY_CAPTION, uploadItem)
         verify(view).showMessage(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
 
-        //Bad Picture test
-        //Empty Caption test
-        uploadMediaPresenter.handleImageResult(-7, uploadItem)
-        // TODO https://github.com/commons-app/apps-android-commons/issues/5204 verify(view)?.showBadImagePopup(ArgumentMatchers.anyInt(), ArgumentMatchers.eq(uploadItem))
+        /**
+         * Bad Picture Test
+         * Handle any error code corresponding to:
+         * FILE_NO_EXIF, IMAGE_DARK, FILE_FBMD, IMAGE_GEOLOCATION_DIFFERENT, IMAGE_BLURRY
+         */
+        val errorCodes = listOf(1, 2, 8, 16, 32)
+        val randomErrorCode = errorCodes.random()
+        uploadMediaPresenter.handleImageResult(randomErrorCode, uploadItem)
+        verify(view)?.showBadImagePopup(ArgumentMatchers.anyInt(), ArgumentMatchers.eq(uploadItem))
     }
 
     @Test
@@ -229,7 +234,7 @@ class UploadMediaPresenterTest {
      */
     @Test
     fun handleBadImageBaseTestFileNameExists() {
-        uploadMediaPresenter.handleBadImage(-4, uploadItem)
+        uploadMediaPresenter.handleBadImage(64, uploadItem)
         verify(view).showDuplicatePicturePopup(uploadItem)
     }
 


### PR DESCRIPTION
**Description (required)**

Fixes #5204 

What changes did you make and why?

The function `handleBadImage()` was getting invoked twice because the error code for `EMPTY_CAPTION` (-3) was also satisfying the condition for bad image as it was giving a non-zero bitwise AND (&) in both the cases. Used `==` instead of bitwise AND (&). Moreover, the unit test was checking against error code -7, which corresponds to none of the bad image options. So, modified the unit test to randomly pick one of the eligible error codes. 

After fixing the above unit test, I observed that `handleBadImageBaseTestFileNameExists()` was failing too because the error code -4 was recently modified to 64 and usage of bitwise AND (&) had the same effect as in the case of `EMPTY_CAPTION`. Fixed that too so that `UploadMediaPresenterTest` does not fail.

**Tests performed (required)**

Tested prodDebug on Redmi 5A with API level 27.
