### PR TITLE
Fix disappearing context on changing device orientation

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
@@ -129,6 +129,10 @@ public class ReviewImageFragment extends CommonsDaggerSupportFragment {
 
                 if (getReviewActivity().reviewController.firstRevision != null) {
                     user = getReviewActivity().reviewController.firstRevision.getUser();
+                } else {
+                    if(savedInstanceState != null) {
+                        user = savedInstanceState.getString(SAVED_USER);
+                    }
                 }
 
                 //if the user is null because of whatsoever reason, review will not be sent anyways


### PR DESCRIPTION
**Description (required)**

As discussed [here](https://github.com/commons-app/apps-android-commons/pull/5183#issuecomment-1509724798) (related issue: #5174) , the context disappears on changing orientation.

What changes did you make and why?

The context disappears in the Peer Review on rotating the device. Used `savedInstanceState` to handle orientation changes.

**Tests performed (required)**

Tested prodDebug on Redmi 5A with API level 27.