### PR TITLE
Avoid ambiguity in a string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -589,7 +589,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="title_for_parent_classes">PARENT CLASSES</string>
 
   <string name="upload_nearby_place_found_title">Nearby Place Found</string>
-  <string name="upload_nearby_place_found_description">Is this a photo of Place %1$s?</string>
+  <string name="upload_nearby_place_found_description">Is this a photo of %1$s?</string>
   <string name="title_app_shortcut_bookmark">Bookmarks</string>
   <string name="title_app_shortcut_setting">Settings</string>
   <string name="remove_bookmark">Removed from bookmarks</string>


### PR DESCRIPTION
**Description (required)**

The phrase "Is this a photo of Place ...?" when placed along with an actual place name could get confusing. For instance, "Is this a photo of Place More London?"

The casing of "Place" is especially confusing.

What changes did you make and why?

So, I tweaked the phrase to avoid this ambiguity.

**Tests performed (required)**

OnePlus Nord running Android 12

**Screenshots (for UI changes only)**

![Screenshot_2023-04-16-19-07-53-80_d5db3f3edc380047609fe9c266f7c566](https://user-images.githubusercontent.com/12448084/232315211-f37977d9-3703-4160-9a68-2acad720ff3f.jpg)


---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
