### PR TITLE
Include author info in the Thanks toast

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewController.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewController.java
@@ -146,7 +146,7 @@ public class ReviewController {
                 .getInstance(context)
                 .getCommonsApplicationComponent()
                 .inject(this);
-        ViewUtil.showShortToast(context, context.getString(R.string.send_thank_toast, media.getDisplayTitle()));
+        ViewUtil.showShortToast(context, context.getString(R.string.send_thank_toast, media.getAuthor(), media.getDisplayTitle()));
 
         if (firstRevision == null) {
             return;
@@ -166,7 +166,7 @@ public class ReviewController {
         final String title;
         if (result) {
             title = context.getString(R.string.send_thank_success_title);
-            message = context.getString(R.string.send_thank_success_message, media.getDisplayTitle());
+            message = context.getString(R.string.send_thank_success_message, media.getAuthor(), media.getDisplayTitle());
         } else {
             title = context.getString(R.string.send_thank_failure_title);
             message = context.getString(R.string.send_thank_failure_message, media.getDisplayTitle());

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -455,11 +455,11 @@ Upload your first media by tapping on the add button.</string>
   <string name="check_category_toast">Requesting category check for %1$s</string>
   <string name="nominate_for_deletion_done">Done</string>
   <string name="send_thank_success_title">Sending Thanks: Success</string>
-  <string name="send_thank_success_message">Successfully sent thanks to %1$s</string>
+  <string name="send_thank_success_message">Successfully sent thanks to %1$s for %2$s</string>
   <string name="send_thank_failure_message">Failed to send thanks %1$s</string>
   <string name="send_thank_failure_title">Sending Thanks: Failure</string>
 
-  <string name="send_thank_toast">Sending Thanks for %1$s</string>
+  <string name="send_thank_toast">Sending thanks to %1$s for %2$s</string>
   <string name="review_copyright">Does this follow the rules of copyright?</string>
   <string name="review_category">Is this correctly categorized?</string>
   <string name="review_spam">Is this in-scope?</string>


### PR DESCRIPTION
**Description (required)**

The toast shown when thanking an author during review did not include the author's name in it. It is important to show the same since the thank is explicitly sent to the author.

What changes did you make and why?

Included the author info in the thank related toasts.

**Tests performed (required)**

OnePlus Nord running Android 12

**Screenshots (for UI changes only)**

Successful thank toast
![Screenshot_2023-04-16-22-54-19-16_d5db3f3edc380047609fe9c266f7c566](https://user-images.githubusercontent.com/12448084/232330330-c565cef6-1c12-4c82-8c20-3be2d653ecca.jpg)

### Draft status reason

I'm not really sure what to do about the corresponding strings in other languages. I suppose the app would be handling them incorrectly since they only take one parameter. Do let me know your thoughts about the same.

**Update**: I just checked and it seems to be showing the author name in place of the media file name. So, the meaning of the text seems to change unexpectedly. We could shuffle the params around to fix this like `Sending thanks for $filename to $authorname` but the sentence does not seem to read well to me.

I could think of another alternative too. Anyways, let me hear other's thoughts before that.

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
