### PR TITLE
ImageAdapter: fixed issue where selected count showed the size of the…

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/adapter/ImageAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/adapter/ImageAdapter.kt
@@ -151,7 +151,7 @@ class ImageAdapter(
 
             val isSelected = selectedIndex != -1
             if (isSelected) {
-                holder.itemSelected(selectedImages.size)
+                holder.itemSelected(selectedIndex + 1)
             } else {
                 holder.itemUnselected()
             }


### PR DESCRIPTION
fixed issue where selected count showed the size of the selectedImages (arrayList) instead of the image index.


I passed the correct parameter to the itemSelected function. Instead of the number of total images in the list, the index of every image.

Tested debug-master on Samsung s22 with API level Android 13.
