### PR TITLE
Bump github actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,17 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
 
       - name: Set up JDK
-        uses: actions/setup-java@v2.5.0
+        uses: actions/setup-java@v3
         with:
           distribution: "temurin"
           java-version: 11
 
       - name: Cache packages
         id: cache-packages
-        uses: actions/cache@v2.1.7
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -37,7 +37,7 @@ jobs:
 
       - name: AVD cache
         if: github.event_name != 'pull_request'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: avd-cache
         with:
           path: |
@@ -89,7 +89,7 @@ jobs:
         run: bash ./gradlew assembleBetaDebug --stacktrace
 
       - name: Upload betaDebug APK
-        uses: actions/upload-artifact@v2.3.1
+        uses: actions/upload-artifact@v3
         with:
           name: betaDebugAPK
           path: app/build/outputs/apk/beta/debug/app-*.apk
@@ -98,7 +98,7 @@ jobs:
         run: bash ./gradlew assembleProdDebug --stacktrace
 
       - name: Upload prodDebug APK
-        uses: actions/upload-artifact@v2.3.1
+        uses: actions/upload-artifact@v3
         with:
           name: prodDebugAPK
           path: app/build/outputs/apk/prod/debug/app-*.apk


### PR DESCRIPTION
**Description (required)**

This PR update github actions:
- Bump [checkout to v3](https://github.com/actions/checkout/releases)
- Bump [setup-java to v3](https://github.com/actions/setup-java/releases)
- Bump [cache to v3](https://github.com/actions/cache/releases)
- Bump [upload artifact to v3](https://github.com/actions/upload-artifact/releases)

Some older actions used node12 and this version is deprecated -> more information here https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

**Tests performed (required)**

Don't have impact of performance of app, this changes can speed up a little bit CI

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
