### PR TITLE
Reduce minsdk back 21

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -177,7 +177,7 @@ android {
         versionName '4.1.0'
         setProperty("archivesBaseName", "app-commons-v$versionName-" + getBranchName())
 
-        minSdkVersion 29
+        minSdkVersion 21
         targetSdkVersion 31
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'


### PR DESCRIPTION
Commit 0f0358f22 (Bump minSdk to 29, 2023-04-30) bumped the minSdk to 29 since it was found to be necessary for publishing the app to Play Store.
    
On further analysis [[ref](https://github.com/commons-app/apps-android-commons/issues/5223#issuecomment-1569554999)], it seems like that might actually not be necessary. The crux is:
    
1. We (rightly) answer "No" to the Play Console question:
    
    > "Does your app access location in the background in APKs or
    >   app bundles targeting Android 9 (Pie) or older (SDK level 28 or lower)?"
    
2. We do not request for the ACCESS_BACKGROUND_LOCATION permission.
    
So, it should be safe for us to have the minSdkVersion as 21 itself. If again we face any rejection of the app update, let us handle it at that point. I clearly am not able to see any valid reason for Play store to reject the app update.\

Fixes #5223 #5228 #5235
