### PR TITLE
nearby: make sure places is initialized

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -259,7 +259,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     /**
      * Saves response of list of places for the first time
      */
-    private List<Place> places;
+    private List<Place> places = new ArrayList<>();
 
     @NonNull
     public static NearbyParentFragment newInstance() {


### PR DESCRIPTION
**Description (required)**

On taking a look at the following stack trace:

```
  java.lang.NullPointerException: Attempt to invoke interface method 'java.util.Iterator java.util.List.iterator()' on a null object reference
  at fr.free.nrw.commons.nearby.fragments.NearbyParentFragment.updatePlaceList(NearbyParentFragment.java:777)
  at fr.free.nrw.commons.nearby.fragments.NearbyParentFragment.lambda$initFilterChips$10$NearbyParentFragment(NearbyParentFragment.java:730)
  at fr.free.nrw.commons.nearby.fragments.-$$Lambda$NearbyParentFragment$AGol6SoJlvIYd45Vbz6tTjDiWU4.onCheckedChanged(Unknown Source:2)
  at android.widget.CompoundButton.setChecked(CompoundButton.java:235)
  at com.google.android.material.chip.Chip.setChecked(Chip.java:665)
  at android.widget.CompoundButton.toggle(CompoundButton.java:150)
  ...
```

... it seems clear the 'places' list is trying to be iterated in the updatePlaceList method when it is empty. This is resulting in an NPE and consequently an app crash.

Avoid the same by ensuring it is always initialized to an empty list.

**Tests performed (required)**

OnePlus Nord running Android 12.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
