### PR TITLE
Toggle photo picker switch behaviour and tweak phrases

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
@@ -79,8 +79,8 @@ public class ContributionController {
      */
     private void initiateGalleryUpload(final Activity activity, final boolean allowMultipleUploads) {
         setPickerConfiguration(activity, allowMultipleUploads);
-        boolean isGetContentPickerPreferred = defaultKvStore.getBoolean("getContentPhotoPickerPref");
-        FilePicker.openGallery(activity, 0, isGetContentPickerPreferred);
+        boolean openDocumentIntentPreferred = defaultKvStore.getBoolean("openDocumentPhotoPickerPref");
+        FilePicker.openGallery(activity, 0, openDocumentIntentPreferred);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.java
@@ -47,10 +47,10 @@ public class FilePicker implements Constants {
     }
 
     private static Intent createGalleryIntent(@NonNull Context context, int type,
-                                              boolean isGetContentPickerPreferred) {
+                                              boolean openDocumentIntentPreferred) {
         // storing picked image type to shared preferences
         storeType(context, type);
-        return plainGalleryPickerIntent(isGetContentPickerPreferred)
+        return plainGalleryPickerIntent(openDocumentIntentPreferred)
                 .putExtra(Intent.EXTRA_ALLOW_MULTIPLE, configuration(context).allowsMultiplePickingInGallery());
     }
 
@@ -106,8 +106,8 @@ public class FilePicker implements Constants {
      *
      * @param type Custom type of your choice, which will be returned with the images
      */
-    public static void openGallery(Activity activity, int type, boolean isGetContentPickerPreferred) {
-        Intent intent = createGalleryIntent(activity, type, isGetContentPickerPreferred);
+    public static void openGallery(Activity activity, int type, boolean openDocumentIntentPreferred) {
+        Intent intent = createGalleryIntent(activity, type, openDocumentIntentPreferred);
         activity.startActivityForResult(intent, RequestCodes.PICK_PICTURE_FROM_GALLERY);
     }
 
@@ -201,8 +201,8 @@ public class FilePicker implements Constants {
         return data == null || (data.getData() == null && data.getClipData() == null);
     }
 
-    private static Intent plainGalleryPickerIntent(boolean isGetContentPickerPreferred) {
-        /**
+    private static Intent plainGalleryPickerIntent(boolean openDocumentIntentPreferred) {
+        /*
          * Asking for ACCESS_MEDIA_LOCATION at runtime solved the location-loss issue
          * in the custom selector in Contributions fragment.
          * Detailed discussion: https://github.com/commons-app/apps-android-commons/issues/5015
@@ -217,8 +217,8 @@ public class FilePicker implements Constants {
          * Reported on the Google Issue Tracker: https://issuetracker.google.com/issues/243294058
          * Status: Won't fix (Intended behaviour)
          *
-         * Switched intent from ACTION_GET_CONTENT to ACTION_OPEN_DOCUMENT
-         * (based on user's preference) as:
+         * Switched intent from ACTION_GET_CONTENT to ACTION_OPEN_DOCUMENT (by default; can
+         * be changed through the Setting page) as:
          *
          * ACTION_GET_CONTENT opens the 'best application' for choosing that kind of data
          * The best application is the new Photo Picker that redacts the location tags
@@ -226,14 +226,15 @@ public class FilePicker implements Constants {
          * ACTION_OPEN_DOCUMENT, however,  displays the various DocumentsProvider instances
          * installed on the device, letting the user interactively navigate through them.
          *
-         * So, this allows us to use the traditional file picker that does not redact location tags from EXIF.
+         * So, this allows us to use the traditional file picker that does not redact location tags
+         * from EXIF.
          *
          */
         Intent intent;
-        if (isGetContentPickerPreferred) {
-            intent = new Intent(Intent.ACTION_GET_CONTENT);
-        } else {
+        if (openDocumentIntentPreferred) {
             intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        } else {
+            intent = new Intent(Intent.ACTION_GET_CONTENT);
         }
         intent.setType("image/*");
         return intent;

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -153,10 +153,10 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             return true;
         });
 
-        Preference getContentPickerPreference = findPreference("getContentPhotoPickerPref");
-        getContentPickerPreference.setOnPreferenceChangeListener(
+        Preference documentBasedPickerPreference = findPreference("openDocumentPhotoPickerPref");
+        documentBasedPickerPreference.setOnPreferenceChangeListener(
             (preference, newValue) -> {
-                boolean isGetContentPickerTurnedOn = (boolean) newValue;
+                boolean isGetContentPickerTurnedOn = !(boolean) newValue;
                 if (isGetContentPickerTurnedOn) {
                     showLocationLossWarning();
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -440,9 +440,9 @@ Upload your first media by tapping on the add button.</string>
   <string name="ends_on">Ends on:</string>
   <string name="display_campaigns">Display campaigns</string>
   <string name="display_campaigns_explanation">See the ongoing campaigns</string>
-  <string name="get_content_photo_picker_title">Use GET_CONTENT photo picker</string>
-  <string name="get_content_photo_picker_explanation">Disable if your pictures get uploaded without location</string>
-  <string name="location_loss_warning">Please make sure that this new Android picker does not strip location from your pictures.</string>
+  <string name="open_document_photo_picker_title">Use document based photo picker</string>
+  <string name="open_document_photo_picker_explanation">The new Android photo picker has the potential to strip location information. Enable if you seem to be using it.</string>
+  <string name="location_loss_warning">Turning this off could trigger the new Android photo picker. It has potential to strip location information.\n\nTap on \'Read more\' for more information.</string>
 
   <string name="nearby_campaign_dismiss_message">You won\'t see the campaigns anymore. However, you can re-enable this notification in Settings if you wish.</string>
   <string name="this_function_needs_network_connection">This function requires network connection, please check your connection settings.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -441,8 +441,8 @@ Upload your first media by tapping on the add button.</string>
   <string name="display_campaigns">Display campaigns</string>
   <string name="display_campaigns_explanation">See the ongoing campaigns</string>
   <string name="open_document_photo_picker_title">Use document based photo picker</string>
-  <string name="open_document_photo_picker_explanation">The new Android photo picker has the potential to strip location information. Enable if you seem to be using it.</string>
-  <string name="location_loss_warning">Turning this off could trigger the new Android photo picker. It has potential to strip location information.\n\nTap on \'Read more\' for more information.</string>
+  <string name="open_document_photo_picker_explanation">The new Android photo picker risks losing location information. Enable if you seem to be using it.</string>
+  <string name="location_loss_warning">Turning this off could trigger the new Android photo picker. It risks losing location information.\n\nTap on \'Read more\' for more information.</string>
 
   <string name="nearby_campaign_dismiss_message">You won\'t see the campaigns anymore. However, you can re-enable this notification in Settings if you wish.</string>
   <string name="this_function_needs_network_connection">This function requires network connection, please check your connection settings.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -72,10 +72,10 @@
           android:title="@string/display_campaigns" />
 
         <SwitchPreference
-            android:defaultValue="false"
-            android:key="getContentPhotoPickerPref"
-            android:summary="@string/get_content_photo_picker_explanation"
-            android:title="@string/get_content_photo_picker_title"/>
+            android:defaultValue="true"
+            android:key="openDocumentPhotoPickerPref"
+            android:summary="@string/open_document_photo_picker_explanation"
+            android:title="@string/open_document_photo_picker_title"/>
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
**Description (required)**

The enable state used to trigger the GET_CONTENT intent. Alter the flow such that the GET_CONTENT intent is triggered when switch is disabled. Adjust default value and other parts of code naming to reflect this.

The existing phrasing had a lot of tech jargon in it which could result in the non-technical users being confused. Tweak the phrasing to avoid such phrases.

The documentation in the website could also use some follow up improvements.

Note: This addresses follow up comments in MR #5227 and _does not_ handle #5242 (that's to be looked into separately).

**Tests performed (required)**

OnePlus Nord running Android 11

**Screenshots (for UI changes only)**

| Preference page | Dialog shown when turning off |
|--------|--------|
| ![Screenshot_2023-06-26-01-08-46-39_d5db3f3edc380047609fe9c266f7c566](https://github.com/commons-app/apps-android-commons/assets/12448084/35c3feaa-6d26-4153-8541-f5aaba7898fe) | ![Screenshot_2023-06-26-01-08-49-62_d5db3f3edc380047609fe9c266f7c566](https://github.com/commons-app/apps-android-commons/assets/12448084/9a088ec9-33ea-4b7e-b207-323a0b0bb4cd) | 

cc @nicolas-raoul @Rishavgupta12345 @kartikaykaushik14 