### PR TITLE
[WIP] Fix 5263: Custom picker displays pictures in non-historical order

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/ImageFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/ImageFragment.kt
@@ -238,7 +238,11 @@ class ImageFragment: CommonsDaggerSupportFragment(), RefreshUIListener, PassData
      */
     private fun handleResult(result:Result){
         if(result.status is CallbackStatus.SUCCESS){
-            val images = result.images
+            // Sort images by name, rather than the default ID number which is almost random (see issue #5263).
+            var images = ArrayList<Image>(
+                result.images.sortedWith(compareBy({ it.name }))
+            )
+
             if(images.isNotEmpty()) {
                 filteredImages = ImageHelper.filterImages(images, bucketId)
                 allImages = ArrayList(filteredImages)


### PR DESCRIPTION
Fixes #5263 Custom picker displays pictures in non-historical order

TODO:
- Reverse the order: Sort from latest to earliest
- Full-screen mode shows wrong picture
- Bonus: Let user choose the order (alphabetical or last modified date), and implement the same for albums

**Tests performed**

Tested prodDebug on Pixel 6 and unit tests.