### PR TITLE
use standard geo: URI format

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LatLng.java
@@ -168,7 +168,7 @@ public class LatLng implements Parcelable {
     }
 
     public Uri getGmmIntentUri() {
-        return Uri.parse("geo:0,0?q=" + latitude + "," + longitude);
+        return Uri.parse("geo:" + latitude + "," + longitude + "?z=16");
     }
 
     @Override


### PR DESCRIPTION
(like OsmAnd, StreetComplete etc do), which works with all apps, and not only some.

**Description (required)**
Clicking on coordinates in app sends the intent to open user-defined geo-enabled app. However, the specific intent format used only works for some apps, but fails on many others (it opens `0,0` coordinates instead).
 
This PR implements strict [RFC 5870](https://datatracker.ietf.org/doc/html/rfc5870) `geo:` format, which should be supported by all apps.

Fixes #5264

**Tests performed (required)**

Tested ProdDebug on Huawei P30 Pro with API level {API level}.

**Screenshots (for UI changes only)**

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
