### PR TITLE
Fix document picker trigger bug

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
@@ -171,8 +171,8 @@ public class ContributionController {
      */
     private void initiateGalleryUpload(final Activity activity, final boolean allowMultipleUploads) {
         setPickerConfiguration(activity, allowMultipleUploads);
-        boolean isGetContentPickerPreferred = defaultKvStore.getBoolean("getContentPhotoPickerPref");
-        FilePicker.openGallery(activity, 0, isGetContentPickerPreferred);
+        boolean openDocumentIntentPreferred = defaultKvStore.getBoolean("openDocumentPhotoPickerPref");
+        FilePicker.openGallery(activity, 0, openDocumentIntentPreferred);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
@@ -171,7 +171,7 @@ public class ContributionController {
      */
     private void initiateGalleryUpload(final Activity activity, final boolean allowMultipleUploads) {
         setPickerConfiguration(activity, allowMultipleUploads);
-        boolean openDocumentIntentPreferred = defaultKvStore.getBoolean("openDocumentPhotoPickerPref");
+        boolean openDocumentIntentPreferred = defaultKvStore.getBoolean("openDocumentPhotoPickerPref", true);
         FilePicker.openGallery(activity, 0, openDocumentIntentPreferred);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.java
@@ -47,10 +47,10 @@ public class FilePicker implements Constants {
     }
 
     private static Intent createGalleryIntent(@NonNull Context context, int type,
-                                              boolean isGetContentPickerPreferred) {
+                                              boolean openDocumentIntentPreferred) {
         // storing picked image type to shared preferences
         storeType(context, type);
-        return plainGalleryPickerIntent(isGetContentPickerPreferred)
+        return plainGalleryPickerIntent(openDocumentIntentPreferred)
                 .putExtra(Intent.EXTRA_ALLOW_MULTIPLE, configuration(context).allowsMultiplePickingInGallery());
     }
 
@@ -106,8 +106,8 @@ public class FilePicker implements Constants {
      *
      * @param type Custom type of your choice, which will be returned with the images
      */
-    public static void openGallery(Activity activity, int type, boolean isGetContentPickerPreferred) {
-        Intent intent = createGalleryIntent(activity, type, isGetContentPickerPreferred);
+    public static void openGallery(Activity activity, int type, boolean openDocumentIntentPreferred) {
+        Intent intent = createGalleryIntent(activity, type, openDocumentIntentPreferred);
         activity.startActivityForResult(intent, RequestCodes.PICK_PICTURE_FROM_GALLERY);
     }
 
@@ -201,8 +201,8 @@ public class FilePicker implements Constants {
         return data == null || (data.getData() == null && data.getClipData() == null);
     }
 
-    private static Intent plainGalleryPickerIntent(boolean isGetContentPickerPreferred) {
-        /**
+    private static Intent plainGalleryPickerIntent(boolean openDocumentIntentPreferred) {
+        /*
          * Asking for ACCESS_MEDIA_LOCATION at runtime solved the location-loss issue
          * in the custom selector in Contributions fragment.
          * Detailed discussion: https://github.com/commons-app/apps-android-commons/issues/5015
@@ -217,8 +217,8 @@ public class FilePicker implements Constants {
          * Reported on the Google Issue Tracker: https://issuetracker.google.com/issues/243294058
          * Status: Won't fix (Intended behaviour)
          *
-         * Switched intent from ACTION_GET_CONTENT to ACTION_OPEN_DOCUMENT
-         * (based on user's preference) as:
+         * Switched intent from ACTION_GET_CONTENT to ACTION_OPEN_DOCUMENT (by default; can
+         * be changed through the Setting page) as:
          *
          * ACTION_GET_CONTENT opens the 'best application' for choosing that kind of data
          * The best application is the new Photo Picker that redacts the location tags
@@ -226,14 +226,15 @@ public class FilePicker implements Constants {
          * ACTION_OPEN_DOCUMENT, however,  displays the various DocumentsProvider instances
          * installed on the device, letting the user interactively navigate through them.
          *
-         * So, this allows us to use the traditional file picker that does not redact location tags from EXIF.
+         * So, this allows us to use the traditional file picker that does not redact location tags
+         * from EXIF.
          *
          */
         Intent intent;
-        if (isGetContentPickerPreferred) {
-            intent = new Intent(Intent.ACTION_GET_CONTENT);
-        } else {
+        if (openDocumentIntentPreferred) {
             intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        } else {
+            intent = new Intent(Intent.ACTION_GET_CONTENT);
         }
         intent.setType("image/*");
         return intent;

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -171,10 +171,10 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             return true;
         });
 
-        Preference getContentPickerPreference = findPreference("getContentPhotoPickerPref");
-        getContentPickerPreference.setOnPreferenceChangeListener(
+        Preference documentBasedPickerPreference = findPreference("openDocumentPhotoPickerPref");
+        documentBasedPickerPreference.setOnPreferenceChangeListener(
             (preference, newValue) -> {
-                boolean isGetContentPickerTurnedOn = (boolean) newValue;
+                boolean isGetContentPickerTurnedOn = !(boolean) newValue;
                 if (isGetContentPickerTurnedOn) {
                     showLocationLossWarning();
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -451,9 +451,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="in_app_camera_location_unavailable">The app would not record location along with in-shots as the GPS is turned off</string>
   <string name="open_document_photo_picker_title">Use document based photo picker</string>
   <string name="open_document_photo_picker_explanation">The new Android photo picker risks losing location information. Enable if you seem to be using it.</string>
-  <string name="get_content_photo_picker_title">Use GET_CONTENT photo picker</string>
-  <string name="get_content_photo_picker_explanation">Disable if your pictures get uploaded without location</string>
-  <string name="location_loss_warning">Please make sure that this new Android picker does not strip location from your pictures.</string>
+  <string name="location_loss_warning">Turning this off could trigger the new Android photo picker. It risks losing location information.\n\nTap on \'Read more\' for more information.</string>
 
   <string name="nearby_campaign_dismiss_message">You won\'t see the campaigns anymore. However, you can re-enable this notification in Settings if you wish.</string>
   <string name="this_function_needs_network_connection">This function requires network connection, please check your connection settings.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -57,6 +57,7 @@
         android:title="Uploads">
 
         <SwitchPreference
+
           android:defaultValue="true"
           android:key="useExternalStorage"
           app:singleLineTitle="false"
@@ -67,6 +68,12 @@
           android:key="inAppCameraLocationPref"
           android:title="@string/in_app_camera_location_permission_title"
           android:summary="@string/in_app_camera_location_switch_pref_summary"/>
+
+        <SwitchPreference
+          android:defaultValue="true"
+          android:key="openDocumentPhotoPickerPref"
+          android:summary="@string/open_document_photo_picker_explanation"
+          android:title="@string/open_document_photo_picker_title"/>
 
         <SwitchPreference
           android:key="useAuthorName"
@@ -81,11 +88,6 @@
           app:useSimpleSummaryProvider="true"
           android:title="@string/preference_author_name" />
 
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="getContentPhotoPickerPref"
-            android:summary="@string/get_content_photo_picker_explanation"
-            android:title="@string/get_content_photo_picker_title"/>
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
**Description (required)**

Fixes #5274

The initial state of the `openDocumentPhotoPickerPref` seems to be incorrect
during a fresh install on some devices.

Try to ensure we always use the proper initial state by propagating the default
to the preference access code.

**Tests performed (required)**

N/A since I wasn't able to reproduce it.

**Screenshots (for UI changes only)**

N/A

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
