### PR TITLE
5279: Target the latest Android version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -178,7 +178,7 @@ android {
         setProperty("archivesBaseName", "app-commons-v$versionName-" + getBranchName())
 
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
 

--- a/data-client/build.gradle
+++ b/data-client/build.gradle
@@ -32,11 +32,11 @@ version = "${VERSION_NAME}"
 group = "${GROUP_ID}"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "${VERSION_NAME}"
 


### PR DESCRIPTION
**Description (required)**

Fixes #5279 

What changes did you make and why?
Changed `targetSdkVersion` and `compileSdkVersion`.

**Tests performed (required)**

Tested prodDebug on Redmi 5A with API level 27.
