### PR TITLE
Fixes in-app camera behaviour

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.java
@@ -41,7 +41,7 @@ public class UploadableFile implements Parcelable {
 
     public UploadableFile(File file) {
         this.file = file;
-        this.contentUri = Uri.parse(file.getAbsolutePath());
+        this.contentUri = Uri.fromFile(new File(file.getPath()));
     }
 
     public UploadableFile(Parcel in) {


### PR DESCRIPTION
**Description (required)**

Fixes #5300 


What changes did you make and why?
The toast for `file not found, try another file` does not appear now. The camera picture seems to upload for me but sometimes due to an API error as below it (any picture from this app) never completely uploads for me.
The API error is here, maybe indicates some limit on API usage:
```
{"errors":[{"code":"lockmanager-fail-svr-acquire","text":"Could not acquire locks on server rdb1.","data":{"filekey":"1adhazkfc1ow.3n4e5j.22648.jpg","sessionkey":"1adhazkfc1ow.3n4e5j.22648.jpg"},"module":"upload"},{"code":"lockmanager-fail-svr-acquire","text":"Could not acquire locks on server rdb2.","data":{"filekey":"1adhazkfc1ow.3n4e5j.22648.jpg","sessionkey":"1adhazkfc1ow.3n4e5j.22648.jpg"},"module":"upload"}],"docref":"See https://commons.wikimedia.beta.wmflabs.org/w/api.php for API usage. Subscribe to the mediawiki-api-announce mailing list at &lt;https://lists.wikimedia.org/postorius/lists/mediawiki-api-announce.lists.wikimedia.org/&gt; for notice of API deprecations and breaking changes.","servedby":"deployment-mediawiki11"}
```
Maybe someone else should try on their device.

**Tests performed (required)**

Tested {Debug} on {samsung galaxy M31} with API level {12}.

**Screenshots (for UI changes only)**

https://github.com/commons-app/apps-android-commons/assets/53987325/077964ff-caea-4d40-8397-f735007c14ac



Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
