### PR TITLE
Fixes dark mode color contrast fix

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <color name="primaryColor">#1e8cab</color>
+  <color name="primaryDarkColor">#1e8cab</color>
+</resources>


### PR DESCRIPTION
**Description (required)**

Fixes #5301 

What changes did you make and why?
Light blue color in place of dark blue when device is in dark mode.
Changes dark mode appearance. Light mode remains unaffected.

**Tests performed (required)**

Tested {prodDebug} on {pixel 5 emulator} with API level {34}.

**Screenshots (for UI changes only)**
![light](https://github.com/commons-app/apps-android-commons/assets/53987325/4051f34c-784e-43ae-9d89-9efdbe524e83)
![light2](https://github.com/commons-app/apps-android-commons/assets/53987325/5dc6509a-56ab-45b1-9a36-d9964f3f8aa1)
![ligh3](https://github.com/commons-app/apps-android-commons/assets/53987325/33fba174-06c6-4243-9030-8f8604f20283)
![light4](https://github.com/commons-app/apps-android-commons/assets/53987325/671683a6-2856-425e-ad4f-52810b539a24)



Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
