### PR TITLE
Night mode color contrast fix

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <color name="primaryColor">#1e8cab</color>
+  <color name="primaryDarkColor">#1e8cab</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -79,5 +79,6 @@
     <color name="card_light_grey">#EDEDED</color>
 
     <color name="wikimedia_green">#339966</color>
+    <color name="primary_color_night">#1e8cab</color>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,11 +10,11 @@
         <item name="achievementBackground">@color/achievement_background_dark</item>
         <item name="drawerHeaderBackground">@color/drawerHeader_background_dark</item>
         <item name="tutorialBackground">@color/tutorial_background_dark</item>
-        <item name="icon">@color/primaryTextColor</item>
-        <item name="colorPrimary">@color/primaryColor</item>
-        <item name="colorPrimaryDark">@color/primaryDarkColor</item>
-        <item name="colorAccent">@color/primaryColor</item>
-        <item name="colorButtonNormal">@color/primaryColor</item>
+        <item name="icon">@color/primary_color_night</item>
+        <item name="colorPrimary">@color/primary_color_night</item>
+        <item name="colorPrimaryDark">@color/primary_color_night</item>
+        <item name="colorAccent">@color/primary_color_night</item>
+        <item name="colorButtonNormal">@color/primary_color_night</item>
         <item name="bookmarkButtonColor">@color/button_blue_dark</item>
         <item name="rowButtonColor">@color/button_blue_dark</item>
         <item name="reviewHeading">@color/white</item>


### PR DESCRIPTION
**Description (required)**

Fixes #5301 

What changes did you make and why?

**Tests performed (required)**
Fixes app level dark mode text color contrast.

Tested {prodDebug} on {Pixel 5 emulator} with API level {api 30}.

**Screenshots (for UI changes only)**
![light_dark](https://github.com/commons-app/apps-android-commons/assets/53987325/2b2f1577-f564-492d-b681-c2ba994cf8d2)
![light_dark2](https://github.com/commons-app/apps-android-commons/assets/53987325/db6f9e45-3edb-45bc-8d80-c667ed359f21)


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
