### PR TITLE
fixes crash in sign up activity in api 21 and 22

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/SignupActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/SignupActivity.java
@@ -1,5 +1,7 @@
 package fr.free.nrw.commons.auth;
 
+import android.content.res.Configuration;
+import android.os.Build;
 import android.os.Bundle;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -60,5 +62,14 @@ public class SignupActivity extends BaseActivity {
         } else {
             super.onBackPressed();
         }
+    }
+
+    @Override
+    public void applyOverrideConfiguration(final Configuration overrideConfiguration) {
+        if (Build.VERSION.SDK_INT == 21 || Build.VERSION.SDK_INT == 25 && (
+            getResources().getConfiguration().uiMode == getApplicationContext().getResources().getConfiguration().uiMode)) {
+            return;
+        }
+        super.applyOverrideConfiguration(overrideConfiguration);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/auth/SignupActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/SignupActivity.java
@@ -64,10 +64,17 @@ public class SignupActivity extends BaseActivity {
         }
     }
 
+    /**
+     * Known bug in androidx.appcompat library version 1.1.0 being tracked here
+     * https://issuetracker.google.com/issues/141132133
+     * App tries to put light/dark theme to webview and crashes in the process
+     * This code tries to prevent applying the theme when sdk is between api 21 to 25
+     * @param overrideConfiguration
+     */
     @Override
     public void applyOverrideConfiguration(final Configuration overrideConfiguration) {
-        if (Build.VERSION.SDK_INT == 21 || Build.VERSION.SDK_INT == 25 && (
-            getResources().getConfiguration().uiMode == getApplicationContext().getResources().getConfiguration().uiMode)) {
+        if (Build.VERSION.SDK_INT <= 25 &&
+            (getResources().getConfiguration().uiMode == getApplicationContext().getResources().getConfiguration().uiMode)) {
             return;
         }
         super.applyOverrideConfiguration(overrideConfiguration);


### PR DESCRIPTION
**Description (required)**

Fixes #5303 

What changes did you make and why?
Fixes crash fix observed on API 21 when trying to sign up.

**Tests performed (required)**

Tested {prodDebug} on {pixel 5 emulator} with API level {21}.

**Screenshots (for UI changes only)**
![signup](https://github.com/commons-app/apps-android-commons/assets/53987325/111516e7-d57f-4434-8767-65e84efc35af)


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
