### PR TITLE
fixes copy paste option not appearing for multi asset upload

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
@@ -88,6 +88,21 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
                 .inflate(R.layout.row_item_description, parent, false));
     }
 
+    /**
+     * This is a workaround for a known bug by android here https://issuetracker.google.com/issues/37095917
+     * makes the edit text on second and subsequent fragments inside an adapter receptive to long click
+     * for copy/paste options
+     * @param holder the view holder
+     */
+    @Override
+    public void onViewAttachedToWindow(@NonNull final ViewHolder holder) {
+        super.onViewAttachedToWindow(holder);
+        holder.captionItemEditText.setEnabled(false);
+        holder.captionItemEditText.setEnabled(true);
+        holder.descItemEditText.setEnabled(false);
+        holder.descItemEditText.setEnabled(true);
+    }
+
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         holder.bind(position);


### PR DESCRIPTION
**Description (required)**

Fixes #5312 

What changes did you make and why?
Added fix for copy paste option not appearing when uploading multiple images.

**Tests performed (required)**

Tested {prodDebug} on {Pixel 5 emulator} with API level {34}.

**Screenshots (for UI changes only)**
![copy](https://github.com/commons-app/apps-android-commons/assets/53987325/2bad5b6c-097f-4e02-aaad-47efef9995ed)


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
