### PR TITLE
Show progress dialog on mark/unmark photos not for upload

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/CustomSelectorActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/CustomSelectorActivity.kt
@@ -95,6 +95,8 @@ class CustomSelectorActivity : BaseActivity(), FolderClickListener, ImageSelectL
      */
     var imageFragment: ImageFragment? = null
 
+    private var progressDialogText:String=""
+
     /**
      * onCreate Activity, sets theme, initialises the view model, setup view.
      */
@@ -221,6 +223,10 @@ class CustomSelectorActivity : BaseActivity(), FolderClickListener, ImageSelectL
      */
     private fun insertIntoNotForUpload(images: ArrayList<Image>) {
         scope.launch {
+            imageFragment!!.showMarkUnmarkProgressDialog(
+                text= progressDialogText
+            )
+
             var allImagesAlreadyNotForUpload = true
             images.forEach {
                 val imageSHA1 = CustomSelectorUtils.getImageSHA1(
@@ -269,6 +275,8 @@ class CustomSelectorActivity : BaseActivity(), FolderClickListener, ImageSelectL
             }
 
             imageFragment!!.refresh()
+            imageFragment!!.dismissMarkUnmarkProgressDialog()
+
             val bottomLayout: ConstraintLayout = findViewById(R.id.bottom_layout)
             bottomLayout.visibility = View.GONE
         }
@@ -334,8 +342,14 @@ class CustomSelectorActivity : BaseActivity(), FolderClickListener, ImageSelectL
 
         bottomSheetBinding.notForUpload.text =
             when (selectedImages.size == selectedNotForUploadImages) {
-                true -> getString(R.string.unmark_as_not_for_upload)
-                else -> getString(R.string.mark_as_not_for_upload)
+                true -> {
+                    progressDialogText=getString(R.string.unmarking_as_not_for_upload)
+                    getString(R.string.unmark_as_not_for_upload)
+                }
+                else -> {
+                    progressDialogText=getString(R.string.marking_as_not_for_upload)
+                    getString(R.string.mark_as_not_for_upload)
+                }
             }
 
         val bottomLayout: ConstraintLayout = findViewById(R.id.bottom_layout)

--- a/app/src/main/res/layout/progress_dialog.xml
+++ b/app/src/main/res/layout/progress_dialog.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:orientation="horizontal"
+  android:id="@+id/progressDialog"
   android:layout_width="match_parent"
+  android:layout_height="wrap_content"
   android:layout_marginHorizontal="10dp"
-  android:paddingVertical="20dp"
   android:layout_weight="2"
-  android:layout_height="wrap_content">
+  android:orientation="horizontal"
+  android:paddingVertical="20dp">
 
   <ProgressBar
     android:layout_width="0dp"
@@ -13,11 +14,12 @@
     android:layout_weight="0.6" />
 
   <TextView
+    android:id="@+id/progressDialogText"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
-    android:text="@string/pausing_upload"
-    android:layout_weight="1.5"
     android:layout_gravity="center"
+    android:layout_weight="1.5"
+    android:text="@string/pausing_upload"
     android:textSize="14sp" />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -756,6 +756,8 @@ Upload your first media by tapping on the add button.</string>
   <string name="your_feedback">Your feedback</string>
   <string name="mark_as_not_for_upload">Mark as not for upload</string>
   <string name="unmark_as_not_for_upload">Unmark as not for upload</string>
+  <string name="marking_as_not_for_upload">Marking as not for upload</string>
+  <string name="unmarking_as_not_for_upload">Unmarking as not for upload</string>
   <string name="show_already_actioned_pictures">Show already actioned pictures</string>
   <string name="hiding_already_actioned_pictures">Hiding already actioned pictures</string>
   <string name="no_more_images_found">No more images found</string>


### PR DESCRIPTION
**Description (required)**

Fixes #5289

Added a progress dialog when processing marking/unmarking images not for upload.

**Screenshots (for UI changes only)**

![Sol_Scrshot](https://github.com/commons-app/apps-android-commons/assets/23309033/be84b389-1e97-4b01-9615-ed77fb917990)


