### PR TITLE
Makes depicted place and category items unselectable for nearby place

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -136,7 +136,11 @@ class CategoriesModel @Inject constructor(
         return Observable.fromIterable(categoryNames)
             .map { categoryName ->
                 buildCategories(categoryName)
-            }.toList().toObservable()
+            }
+            .filter { categoryItem ->
+                categoryItem.name != "Hidden"
+            }
+            .toList().toObservable()
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
+++ b/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
@@ -299,7 +299,7 @@ public class UploadRepository {
      *
      * @return a single that provides the categories
      */
-    public Single<List<CategoryItem>> getCategoryDepictions() {
+    public Single<List<CategoryItem>> getPlaceCategories() {
         final Set<String> qids = new HashSet<>();
         for (final UploadItem item : getUploads()) {
             final Place place = item.getPlace();

--- a/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
+++ b/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
@@ -294,6 +294,23 @@ public class UploadRepository {
     }
 
     /**
+     * Gets the category for each unique {@link Place} associated with an {@link UploadItem}
+     * from {@link #getUploads()}
+     *
+     * @return a single that provides the categories
+     */
+    public Single<List<CategoryItem>> getCategoryDepictions() {
+        final Set<String> qids = new HashSet<>();
+        for (final UploadItem item : getUploads()) {
+            final Place place = item.getPlace();
+            if (place != null) {
+                qids.add(place.getCategory());
+            }
+        }
+        return Single.fromObservable(categoriesModel.getCategoriesByName(new ArrayList<>(qids)));
+    }
+
+    /**
      * Takes depict IDs as a parameter, converts into a slash separated String and Gets DepictItem
      * from the server
      *

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -3,6 +3,8 @@ package fr.free.nrw.commons.upload;
 import static fr.free.nrw.commons.contributions.ContributionController.ACTION_INTERNAL_UPLOADS;
 import static fr.free.nrw.commons.utils.PermissionUtils.PERMISSIONS_STORAGE;
 import static fr.free.nrw.commons.wikidata.WikidataConstants.PLACE_OBJECT;
+import static fr.free.nrw.commons.wikidata.WikidataConstants.SELECTED_NEARBY_PLACE;
+import static fr.free.nrw.commons.wikidata.WikidataConstants.SELECTED_NEARBY_PLACE_CATEGORY;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
@@ -483,9 +485,17 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
             }
 
             uploadCategoriesFragment = new UploadCategoriesFragment();
+            if (place != null) {
+                Bundle categoryBundle = new Bundle();
+                categoryBundle.putString(SELECTED_NEARBY_PLACE_CATEGORY, place.getCategory());
+                uploadCategoriesFragment.setArguments(categoryBundle);
+            }
             uploadCategoriesFragment.setCallback(this);
 
             depictsFragment = new DepictsFragment();
+            Bundle placeBundle = new Bundle();
+            placeBundle.putParcelable(SELECTED_NEARBY_PLACE, place);
+            depictsFragment.setArguments(placeBundle);
             depictsFragment.setCallback(this);
 
             mediaLicenseFragment = new MediaLicenseFragment();

--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/CategoriesContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/CategoriesContract.java
@@ -83,7 +83,7 @@ public interface CategoriesContract {
 
         LiveData<List<CategoryItem>> getCategories();
 
-        void selectCategoryDepictions();
+        void selectCategories();
 
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/CategoriesContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/CategoriesContract.java
@@ -2,6 +2,7 @@ package fr.free.nrw.commons.upload.categories;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
+import androidx.lifecycle.LiveData;
 import fr.free.nrw.commons.BasePresenter;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.category.CategoryItem;
@@ -80,6 +81,9 @@ public interface CategoriesContract {
          */
         void updateCategories(Media media, String wikiText);
 
+        LiveData<List<CategoryItem>> getCategories();
+
+        void selectCategoryDepictions();
 
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/CategoriesPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/CategoriesPresenter.kt
@@ -242,7 +242,7 @@ class CategoriesPresenter @Inject constructor(
                 repository.onCategoryClicked(it, media)
             }
 
-        // Add the new selections to the list of depicted items so that the selections appear
+        // Add the new selections to the list of category items so that the selections appear
         // immediately (i.e. without any search term queries)
         categoryList.value?.toMutableList()
             ?.filterNot { it.thumbnail == "hidden" }

--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.java
@@ -193,10 +193,9 @@ public class UploadCategoriesFragment extends UploadBaseFragment implements Cate
 
     @Override
     public void setCategories(List<CategoryItem> categories) {
-        if(categories == null) {
+        if (categories == null) {
             adapter.clear();
-        }
-        else{
+        } else {
             adapter.setItems(categories);
         }
     }
@@ -303,7 +302,7 @@ public class UploadCategoriesFragment extends UploadBaseFragment implements Cate
     @Override
     protected void onBecameVisible() {
         super.onBecameVisible();
-        presenter.selectCategoryDepictions();
+        presenter.selectCategories();
         final Editable text = etSearch.getText();
         if (text != null) {
             presenter.searchForCategories(text.toString());

--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.java
@@ -1,5 +1,7 @@
 package fr.free.nrw.commons.upload.categories;
 
+import static fr.free.nrw.commons.wikidata.WikidataConstants.SELECTED_NEARBY_PLACE_CATEGORY;
+
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
@@ -81,6 +83,7 @@ public class UploadCategoriesFragment extends UploadBaseFragment implements Cate
      * WikiText from the server
      */
     private String wikiText;
+    private String nearbyPlaceCategory;
 
     @Nullable
     @Override
@@ -97,9 +100,10 @@ public class UploadCategoriesFragment extends UploadBaseFragment implements Cate
         if (bundle != null) {
             media = bundle.getParcelable("Existing_Categories");
             wikiText = bundle.getString("WikiText");
+            nearbyPlaceCategory = bundle.getString(SELECTED_NEARBY_PLACE_CATEGORY);
         }
-
         init();
+        presenter.getCategories().observe(getViewLifecycleOwner(), this::setCategories);
     }
 
     private void init() {
@@ -160,7 +164,7 @@ public class UploadCategoriesFragment extends UploadBaseFragment implements Cate
         adapter = new UploadCategoryAdapter(categoryItem -> {
             presenter.onCategoryItemClicked(categoryItem);
             return Unit.INSTANCE;
-        });
+        }, nearbyPlaceCategory);
         rvCategories.setLayoutManager(new LinearLayoutManager(getContext()));
         rvCategories.setAdapter(adapter);
     }
@@ -189,7 +193,7 @@ public class UploadCategoriesFragment extends UploadBaseFragment implements Cate
 
     @Override
     public void setCategories(List<CategoryItem> categories) {
-        if(categories==null) {
+        if(categories == null) {
             adapter.clear();
         }
         else{
@@ -299,6 +303,7 @@ public class UploadCategoriesFragment extends UploadBaseFragment implements Cate
     @Override
     protected void onBecameVisible() {
         super.onBecameVisible();
+        presenter.selectCategoryDepictions();
         final Editable text = etSearch.getText();
         if (text != null) {
             presenter.searchForCategories(text.toString());

--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoryAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoryAdapter.kt
@@ -4,9 +4,9 @@ import fr.free.nrw.commons.category.CategoryItem
 import org.jetbrains.annotations.NotNull
 
 class UploadCategoryAdapter(
-    onCategoryClicked: @NotNull() (CategoryItem) -> Unit) :
+    onCategoryClicked: @NotNull() (CategoryItem) -> Unit, nearbyPlaceCategory: String?) :
     BaseDelegateAdapter<CategoryItem>(
-        uploadCategoryDelegate(onCategoryClicked),
+        uploadCategoryDelegate(onCategoryClicked, nearbyPlaceCategory),
         areItemsTheSame = { oldItem, newItem -> oldItem.name == newItem.name },
         areContentsTheSame = { oldItem, newItem ->
             oldItem.name == newItem.name && oldItem.isSelected == newItem.isSelected

--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoryAdapterDelegates.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoryAdapterDelegates.kt
@@ -6,30 +6,39 @@ import fr.free.nrw.commons.R
 import fr.free.nrw.commons.category.CategoryItem
 import fr.free.nrw.commons.databinding.LayoutUploadCategoriesItemBinding
 
-fun uploadCategoryDelegate(onCategoryClicked: (CategoryItem) -> Unit) =
+fun uploadCategoryDelegate(onCategoryClicked: (CategoryItem) -> Unit, nearbyPlaceCategory: String?) =
     adapterDelegateViewBinding<CategoryItem, CategoryItem,
             LayoutUploadCategoriesItemBinding>({ layoutInflater, root ->
         LayoutUploadCategoriesItemBinding.inflate(layoutInflater, root, false)
     }) {
         val onClickListener = { _: View? ->
-            item.isSelected = !item.isSelected
-            binding.uploadCategoryCheckbox.isChecked = item.isSelected
-            onCategoryClicked(item)
+            if (item.name != nearbyPlaceCategory) {
+                item.isSelected = !item.isSelected
+                binding.uploadCategoryCheckbox.isChecked = item.isSelected
+                onCategoryClicked(item)
+            }
         }
 
         binding.root.setOnClickListener(onClickListener)
         binding.uploadCategoryCheckbox.setOnClickListener(onClickListener)
 
         bind {
-            binding.uploadCategoryCheckbox.isChecked = item.isSelected
+            if (item.name == nearbyPlaceCategory) {
+                item.isSelected = true
+                binding.uploadCategoryCheckbox.isChecked = true
+                binding.uploadCategoryCheckbox.isEnabled = false
+            } else {
+                binding.uploadCategoryCheckbox.isEnabled = true
+                binding.uploadCategoryCheckbox.isChecked = item.isSelected
+            }
             binding.categoryLabel.text = item.name
-            if(item.thumbnail != "null") {
+            if (item.thumbnail != "null") {
                 binding.categoryImage.setImageURI(item.thumbnail)
             } else {
                 binding.categoryImage.setActualImageResource(R.drawable.commons)
             }
 
-            if(item.description != "null") {
+            if (item.description != "null") {
                 binding.categoryDescription.text = item.description
             } else {
                 binding.categoryDescription.text = ""

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
@@ -1,5 +1,7 @@
 package fr.free.nrw.commons.upload.depicts;
 
+import static fr.free.nrw.commons.wikidata.WikidataConstants.SELECTED_NEARBY_PLACE;
+
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
@@ -29,6 +31,7 @@ import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.contributions.ContributionsFragment;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.media.MediaDetailFragment;
+import fr.free.nrw.commons.nearby.Place;
 import fr.free.nrw.commons.ui.PasteSensitiveTextInputEditText;
 import fr.free.nrw.commons.upload.UploadActivity;
 import fr.free.nrw.commons.upload.UploadBaseFragment;
@@ -83,6 +86,7 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
      * Determines each encounter of edit depicts
      */
     private int count;
+    private Place nearbyPlace;
 
     @Nullable
     @Override
@@ -99,6 +103,7 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
         Bundle bundle = getArguments();
         if (bundle != null) {
             media = bundle.getParcelable("Existing_Depicts");
+            nearbyPlace = bundle.getParcelable(SELECTED_NEARBY_PLACE);
         }
 
         init();
@@ -111,8 +116,7 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
     private void init() {
 
         if (media == null) {
-            depictsTitle
-                .setText(getString(R.string.step_count, callback.getIndexInViewFlipper(this) + 1,
+            depictsTitle.setText(String.format(getString(R.string.step_count), callback.getIndexInViewFlipper(this) + 1,
                     callback.getTotalNumberOfSteps(), getString(R.string.depicts_step_title)));
         } else {
             depictsTitle.setText(R.string.edit_depictions);
@@ -156,12 +160,12 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
             adapter = new UploadDepictsAdapter(categoryItem -> {
                 presenter.onDepictItemClicked(categoryItem);
                 return Unit.INSTANCE;
-            });
+            }, nearbyPlace);
         } else {
             adapter = new UploadDepictsAdapter(item -> {
                 presenter.onDepictItemClicked(item);
                 return Unit.INSTANCE;
-            });
+            }, nearbyPlace);
         }
         depictsRecyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
         depictsRecyclerView.setAdapter(adapter);

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
@@ -101,11 +101,10 @@ class DepictsPresenter @Inject constructor(
                         it.commonsCategories, true, it.id)
                 }
             },
-                repository.searchAllEntities(querystring),
-                { it1, it2 ->
-                    it1 + it2
-                }
-            )
+                repository.searchAllEntities(querystring)
+            ) { it1, it2 ->
+                it1 + it2
+            }
                 .subscribeOn(ioScheduler)
                 .map { repository.selectedDepictions + it + recentDepictedItemList + controller.loadFavoritesItems() }
                 .map { it.filterNot { item -> WikidataDisambiguationItems.isDisambiguationItem(item.instanceOfs) } }

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/UploadDepictsAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/UploadDepictsAdapter.kt
@@ -1,11 +1,12 @@
 package fr.free.nrw.commons.upload.depicts
 
+import fr.free.nrw.commons.nearby.Place
 import fr.free.nrw.commons.upload.categories.BaseDelegateAdapter
 import fr.free.nrw.commons.upload.structure.depictions.DepictedItem
 
-class UploadDepictsAdapter(onDepictsClicked: (DepictedItem) -> Unit) :
+class UploadDepictsAdapter(onDepictsClicked: (DepictedItem) -> Unit, nearbyPlace: Place?) :
     BaseDelegateAdapter<DepictedItem>(
-        uploadDepictsDelegate(onDepictsClicked),
+        uploadDepictsDelegate(onDepictsClicked, nearbyPlace),
         areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id },
         areContentsTheSame = { itemA, itemB -> itemA.isSelected == itemB.isSelected}
     )

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/UploadDepictsAdapterDelegates.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/UploadDepictsAdapterDelegates.kt
@@ -6,29 +6,39 @@ import android.view.View
 import com.hannesdorfmann.adapterdelegates4.dsl.adapterDelegateViewBinding
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.databinding.LayoutUploadDepictsItemBinding
+import fr.free.nrw.commons.nearby.Place
 import fr.free.nrw.commons.upload.structure.depictions.DepictedItem
 
 
-fun uploadDepictsDelegate(onDepictClicked: (DepictedItem) -> Unit) =
+fun uploadDepictsDelegate(onDepictClicked: (DepictedItem) -> Unit, nearbyPlace: Place?) =
     adapterDelegateViewBinding<DepictedItem, DepictedItem, LayoutUploadDepictsItemBinding>({ layoutInflater, parent ->
         LayoutUploadDepictsItemBinding.inflate(layoutInflater, parent, false)
     }) {
         val onClickListener = { _: View? ->
-            item.isSelected = !item.isSelected
-            binding.depictCheckbox.isChecked = item.isSelected
-            onDepictClicked(item)
+            if (item.name != nearbyPlace?.name) {
+                item.isSelected = !item.isSelected
+                binding.depictCheckbox.isChecked = item.isSelected
+                onDepictClicked(item)
+            }
         }
         binding.root.setOnClickListener(onClickListener)
         binding.depictCheckbox.setOnClickListener(onClickListener)
         bind {
-            binding.depictCheckbox.isChecked = item.isSelected
-            binding.depictsLabel.text = item.name
-            binding.description.text = item.description
-            val imageUrl = item.imageUrl
-            if (TextUtils.isEmpty(imageUrl)) {
-                binding.depictedImage.setActualImageResource(R.drawable.ic_wikidata_logo_24dp)
+            if (item.name == nearbyPlace?.name) {
+                item.isSelected = true
+                binding.depictCheckbox.isChecked = true
+                binding.depictCheckbox.isEnabled = false
             } else {
-                binding.depictedImage.setImageURI(Uri.parse(imageUrl))
+                binding.depictCheckbox.isEnabled = true
+                binding.depictCheckbox.isChecked = item.isSelected
             }
+                binding.depictsLabel.text = item.name
+                binding.description.text = item.description
+                val imageUrl = item.imageUrl
+                if (TextUtils.isEmpty(imageUrl)) {
+                    binding.depictedImage.setActualImageResource(R.drawable.ic_wikidata_logo_24dp)
+                } else {
+                    binding.depictedImage.setImageURI(Uri.parse(imageUrl))
+                }
         }
     }

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataConstants.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataConstants.java
@@ -3,4 +3,6 @@ package fr.free.nrw.commons.wikidata;
 public class WikidataConstants {
     public static final String PLACE_OBJECT = "place";
     public static final String BOOKMARKS_ITEMS = "bookmarks.items";
+    public static final String SELECTED_NEARBY_PLACE = "selected.nearby.place";
+    public static final String SELECTED_NEARBY_PLACE_CATEGORY = "selected.nearby.place.category";
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/categories/UploadCategoriesFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/categories/UploadCategoriesFragmentUnitTests.kt
@@ -145,9 +145,34 @@ class UploadCategoriesFragmentUnitTests {
 
     @Test
     @Throws(Exception::class)
-    fun testOnViewCreated() {
+    fun testInitMethod() {
+        val method: Method = UploadCategoriesFragment::class.java.getDeclaredMethod(
+            "init"
+        )
         Shadows.shadowOf(Looper.getMainLooper()).idle()
-        fragment.onViewCreated(view, null)
+        method.isAccessible = true
+        method.invoke(fragment)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun `Test init when media is non null`() {
+        Whitebox.setInternalState(fragment, "media", media)
+        val method: Method = UploadCategoriesFragment::class.java.getDeclaredMethod(
+            "init"
+        )
+        method.isAccessible = true
+        method.invoke(fragment)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testFragmentOnBecameVisible() {
+        val method: Method = UploadCategoriesFragment::class.java.getDeclaredMethod(
+            "onBecameVisible"
+        )
+        method.isAccessible = true
+        method.invoke(fragment)
     }
 
     @Test


### PR DESCRIPTION
**Description (required)**

Fixes #5317 

What changes did you make and why?
Makes the place and category unselectable

**Tests performed (required)**

Tested {prodDebug} on {pixel 5 emulator} with API level {34, 30}.

**Screenshots (for UI changes only)**
![greyed_check](https://github.com/commons-app/apps-android-commons/assets/53987325/77c99a93-13c4-4f89-897d-ff70cabf8c00)


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
