### PR TITLE
Fixes #5285: Do not filter out category that exactly matches the search

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/CategoriesPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/CategoriesPresenter.kt
@@ -83,7 +83,8 @@ class CategoriesPresenter @Inject constructor(
         if (media == null) {
             return repository.searchAll(term, getImageTitleList(), repository.selectedDepictions)
                 .subscribeOn(ioScheduler)
-                .map { it.filterNot { categoryItem -> repository.containsYear(categoryItem.name) } }
+                .map { it.filter { categoryItem -> !repository.containsYear(categoryItem.name)
+                        || categoryItem.name==term } }
         } else {
             return Observable.zip(
                 repository.getCategories(repository.selectedExistingCategories)
@@ -97,7 +98,8 @@ class CategoriesPresenter @Inject constructor(
                 }
             )
                 .subscribeOn(ioScheduler)
-                .map { it.filterNot { categoryItem -> repository.containsYear(categoryItem.name) } }
+                .map { it.filter { categoryItem -> !repository.containsYear(categoryItem.name)
+                        || categoryItem.name==term } }
                 .map { it.filterNot { categoryItem -> categoryItem.thumbnail == "hidden" } }
         }
     }


### PR DESCRIPTION
**Description**

Fixes #5285

**What changes did you make and why?**

added check for exact match on categories upload search function filter.

**Tests performed**

Tested ProdDebug on Pixel a3 with API level 34.
