### PR TITLE
fixes popup message title and description on cancelling uploading image

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -419,11 +419,11 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment impl
     @Override
     public void deleteUpload(final Contribution contribution) {
         DialogUtil.showAlertDialog(getActivity(),
-            String.format(Locale.getDefault().getDisplayLanguage(),
+            String.format(Locale.getDefault(),
                 getString(R.string.cancelling_upload)),
-            String.format(Locale.getDefault().getDisplayLanguage(),
+            String.format(Locale.getDefault(),
                 getString(R.string.cancel_upload_dialog)),
-            "YES", "NO",
+            String.format(Locale.getDefault(), getString(R.string.yes)), String.format(Locale.getDefault(), getString(R.string.no)),
             () -> {
                 ViewUtil.showShortToast(getContext(), R.string.cancelling_upload);
                 contributionsListPresenter.deleteUpload(contribution);


### PR DESCRIPTION
**Description (required)**

Fixes #5321 

What changes did you make and why?
Fixes popup messages error. Makes the popup work when default language of the device is something else other than english.

**Tests performed (required)**

Tested prodDebug on samsung galaxy M31 with API level 30.

**Screenshots (for UI changes only)**
![Screenshot_20231010-150009_Commons](https://github.com/commons-app/apps-android-commons/assets/53987325/df9f4cb3-398d-4e01-8a4d-89a943fb7a60)
![Screenshot_20231010-151336_Commons (1)](https://github.com/commons-app/apps-android-commons/assets/53987325/fee940f2-67da-40dd-87c0-f4801a882f52)


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
