### PR TITLE
fixes image retention when no network is available

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -604,11 +604,12 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         image.getHierarchy().setFailureImage(R.drawable.image_placeholder);
 
         DraweeController controller = Fresco.newDraweeControllerBuilder()
-                .setLowResImageRequest(ImageRequest.fromUri(media != null ? media.getThumbUrl() : null))
-                .setImageRequest(ImageRequest.fromUri(media != null ? media.getImageUrl() : null))
-                .setControllerListener(aspectRatioListener)
-                .setOldController(image.getController())
-                .build();
+            .setLowResImageRequest(ImageRequest.fromUri(media != null ? media.getThumbUrl() : null))
+            .setRetainImageOnFailure(true)
+            .setImageRequest(ImageRequest.fromUri(media != null ? media.getImageUrl() : null))
+            .setControllerListener(aspectRatioListener)
+            .setOldController(image.getController())
+            .build();
         image.setController(controller);
     }
 


### PR DESCRIPTION
**Description (required)**

Fixes #5234 

What changes did you make and why?
Tried reproducing the reported issue by turning off wifi and trying to open the uploaded image file. Fresco will now retain image when possible.

**Tests performed (required)**

Tested prodDebug on Samsung galaxy m31 with API level 30.

**Screenshots (for UI changes only)**
![Screenshot_20231010-163344_Commons](https://github.com/commons-app/apps-android-commons/assets/53987325/57870281-fc8d-451f-9ff4-a9aefc6ff561)
android/answer/9075928

Need help? See https://support.google.com/


---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
