### PR TITLE
5338 bug fix

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
@@ -25,7 +25,14 @@ class LanguagesAdapter constructor(
     context: Context,
     private val selectedLanguages: HashMap<*, String>
 ) : ArrayAdapter<String?>(context, R.layout.row_item_languages_spinner) {
+
     companion object {
+        /**
+         * Represents the default index for the language list. By default, this index corresponds to the
+         * English language. This serves as a fallback when the user's system language is not present in
+         * the language_list.xml. Though this default can be changed by the user, it does not affect other
+         * functionalities of the application. Fix bug issue 5338
+         */
         const val DEFAULT_INDEX = 0
     }
 
@@ -88,6 +95,18 @@ class LanguagesAdapter constructor(
         return languageNamesList[position]
     }
 
+    /**
+     * Retrieves the index of the user's default locale from the list of available languages.
+     *
+     * This function checks the user's system language and finds its index within the application's
+     * list of supported languages. If the system language is not supported, or any error occurs,
+     * it falls back to the default language index, typically representing English.
+     * Fix bug issue 5338
+     *
+     * @param context The context used to get the user's system locale.
+     * @return The index of the user's default language in the supported language list,
+     *         or the default index if the language is not found.
+     */
     fun getIndexOfUserDefaultLocale(context: Context): Int {
 
         val userLanguageCode = context.locale?.language ?: return DEFAULT_INDEX
@@ -95,6 +114,7 @@ class LanguagesAdapter constructor(
     }
 
     fun getIndexOfLanguageCode(languageCode: String): Int {
+
         return languageCodesList.indexOf(languageCode)
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
@@ -25,7 +25,9 @@ class LanguagesAdapter constructor(
     context: Context,
     private val selectedLanguages: HashMap<*, String>
 ) : ArrayAdapter<String?>(context, R.layout.row_item_languages_spinner) {
-
+    companion object {
+        const val DEFAULT_INDEX = 0
+    }
 
     private var languageNamesList: List<String>
     private var languageCodesList: List<String>
@@ -87,8 +89,11 @@ class LanguagesAdapter constructor(
     }
 
     fun getIndexOfUserDefaultLocale(context: Context): Int {
-        return language.codes.indexOf(context.locale!!.language)
+
+        val userLanguageCode = context.locale?.language ?: return DEFAULT_INDEX
+        return language.codes.indexOf(userLanguageCode).takeIf { it >= 0 } ?: DEFAULT_INDEX
     }
+
     fun getIndexOfLanguageCode(languageCode: String): Int {
         return languageCodesList.indexOf(languageCode)
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
@@ -25,6 +25,9 @@ class LanguagesAdapter constructor(
     context: Context,
     private val selectedLanguages: HashMap<*, String>
 ) : ArrayAdapter<String?>(context, R.layout.row_item_languages_spinner) {
+    companion object {
+        const val DEFAULT_INDEX = 0
+    }
 
     private var languageNamesList: List<String>
     private var languageCodesList: List<String>
@@ -86,7 +89,8 @@ class LanguagesAdapter constructor(
     }
 
     fun getIndexOfUserDefaultLocale(context: Context): Int {
-        return language.codes.indexOf(context.locale!!.language)
+        val userLanguageCode = context.locale?.language ?: return DEFAULT_INDEX
+        return language.codes.indexOf(userLanguageCode).takeIf { it >= 0 } ?: DEFAULT_INDEX
     }
 
     fun getIndexOfLanguageCode(languageCode: String): Int {

--- a/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
@@ -101,11 +101,18 @@ class LanguagesAdapter constructor(
      * This function checks the user's system language and finds its index within the application's
      * list of supported languages. If the system language is not supported, or any error occurs,
      * it falls back to the default language index, typically representing English.
-     * Fix bug issue 5338
+     *
      *
      * @param context The context used to get the user's system locale.
      * @return The index of the user's default language in the supported language list,
      *         or the default index if the language is not found.
+     * Note: This function was implemented to address a bug where unsupported system languages
+     * resulted in an incorrect language selection. Directly returning the result of `indexOf`
+     * without checking its validity could result in returning an index of -1, leading to ArrayIndex
+     * OutOfBoundsException.
+     * [See bug  issue 5338]
+     * It's essential to ensure that the returned index is valid or fall back to a default index.
+     * Future contributors are advised not to simplify this function without addressing this concern.
      */
     fun getIndexOfUserDefaultLocale(context: Context): Int {
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
@@ -31,7 +31,7 @@ class LanguagesAdapter constructor(
          * Represents the default index for the language list. By default, this index corresponds to the
          * English language. This serves as a fallback when the user's system language is not present in
          * the language_list.xml. Though this default can be changed by the user, it does not affect other
-         * functionalities of the application. Fixs bug issue 5338
+         * functionalities of the application. Fixes bug issue 5338
          */
         const val DEFAULT_INDEX = 0
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
@@ -31,7 +31,7 @@ class LanguagesAdapter constructor(
          * Represents the default index for the language list. By default, this index corresponds to the
          * English language. This serves as a fallback when the user's system language is not present in
          * the language_list.xml. Though this default can be changed by the user, it does not affect other
-         * functionalities of the application. Fix bug issue 5338
+         * functionalities of the application. Fixs bug issue 5338
          */
         const val DEFAULT_INDEX = 0
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
@@ -89,6 +89,7 @@ class LanguagesAdapter constructor(
     }
 
     fun getIndexOfUserDefaultLocale(context: Context): Int {
+
         val userLanguageCode = context.locale?.language ?: return DEFAULT_INDEX
         return language.codes.indexOf(userLanguageCode).takeIf { it >= 0 } ?: DEFAULT_INDEX
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
@@ -25,9 +25,7 @@ class LanguagesAdapter constructor(
     context: Context,
     private val selectedLanguages: HashMap<*, String>
 ) : ArrayAdapter<String?>(context, R.layout.row_item_languages_spinner) {
-    companion object {
-        const val DEFAULT_INDEX = 0
-    }
+
 
     private var languageNamesList: List<String>
     private var languageCodesList: List<String>
@@ -89,11 +87,8 @@ class LanguagesAdapter constructor(
     }
 
     fun getIndexOfUserDefaultLocale(context: Context): Int {
-
-        val userLanguageCode = context.locale?.language ?: return DEFAULT_INDEX
-        return language.codes.indexOf(userLanguageCode).takeIf { it >= 0 } ?: DEFAULT_INDEX
+        return language.codes.indexOf(context.locale!!.language)
     }
-
     fun getIndexOfLanguageCode(languageCode: String): Int {
         return languageCodesList.indexOf(languageCode)
     }


### PR DESCRIPTION
Description (required)

Fixes #5338  (you should insert the actual issue number if one exists)

What changes did you make and why?

Fixed a potential ArrayIndexOutOfBoundsException in LanguagesAdapter. The bug was due to the method getIndexOfUserDefaultLocale possibly returning -1 when the user's default locale wasn't found in the language. codes list. The returned value is now properly checked and, if -1, defaults to DEFAULT_INDEX which is set to 0.

Tests performed (required)

Tested ProdDebug on Pixel 3 with API level 30. (replace with actual device and API details)
After multiple rounds of testing, in the case of Chinese and other languages, the program will not directly crash during the process of selecting and uploading images.
![image](https://github.com/commons-app/apps-android-commons/assets/59361311/88be5f6a-45b9-4c88-b34e-bfceb8244f32)
Before, the app would crash instantly before reaching this page.
Screenshots (for UI changes only)

N/A (since this is a bug fix and doesn't involve any UI changes)

Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request.

Remember, it's important to actually test the changes on a real device or emulator before submitting a pull request to ensure that the bug is genuinely fixed and no new issues are introduced.
