### PR TITLE
fixes blank screen decrepancy when sharing items from external apps

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/filepicker/Constants.java
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/Constants.java
@@ -8,6 +8,7 @@ public interface Constants {
      */
     interface RequestCodes {
         int LOCATION = 1;
+        int STORAGE = 2;
         int FILE_PICKER_IMAGE_IDENTIFICATOR = 0b1101101100; //876
         int SOURCE_CHOOSER = 1 << 15;
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -154,6 +154,8 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
         compositeDisposable = new CompositeDisposable();
         init();
         nearbyPopupAnswers = new HashMap<>();
+        //getting the current dpi of the device and if it is less than 320dp i.e. overlapping
+        //threshold, thumbnails automatically minimizes
         DisplayMetrics metrics = getResources().getDisplayMetrics();
         float dpi = (metrics.widthPixels)/(metrics.density);
         if (dpi<=321) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -775,6 +775,8 @@ Upload your first media by tapping on the add button.</string>
   <string name="full_screen_mode_features_info">Swipe fast and long to perform these actions: \n- Left/Right: Go to previous/next \n- Up: Select\n- Down: Mark as not for upload.</string>
   <string name="set_up_avatar_toast_string">To set up your leaderboard avatar, tap \"Set as avatar\" in the three-dots menu of any image.</string>
   <string name="similar_coordinate_description_auto_set">The coordinates are not the exact coordinates, but the person who uploaded this picture thinks they are close enough.</string>
+  <string name="storage_permissions_denied">Storage Permissions Denied</string>
+  <string name="unable_to_share_upload_item">Unable to share this item</string>
   <plurals name="custom_picker_images_selected_title_appendix">
     <item quantity="one">%d image selected</item>
     <item quantity="other">%d images selected</item>


### PR DESCRIPTION
**Description (required)**

Fixes #5342 

What changes did you make and why?
Dexter was not correctly asking for storage permission when upload activity was resumed.

**Tests performed (required)**

Tested {prodDebug} on {samsung galaxy M31} with API level {30}.

**Screenshots (for UI changes only)**

https://github.com/commons-app/apps-android-commons/assets/53987325/b2ac633f-0d79-4951-98b7-866ac9f676df



Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
