### PR TITLE
Fix #5212: removing bug causing progress dialog to load forever

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -505,6 +505,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
                 .subscribe(this::onDepictionsLoaded, Timber::e)
         );
         // compositeDisposable.add(disposable);
+
     }
 
     private void onDiscussionLoaded(String discussion) {

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -505,7 +505,6 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
                 .subscribe(this::onDepictionsLoaded, Timber::e)
         );
         // compositeDisposable.add(disposable);
-
     }
 
     private void onDiscussionLoaded(String discussion) {

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationHelper.java
@@ -5,6 +5,7 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 
+import android.os.Build;
 import androidx.core.app.NotificationCompat;
 
 import javax.inject.Inject;
@@ -49,21 +50,29 @@ public class NotificationHelper {
      * @param intent the intent to be fired when the notification is clicked
      */
     public void showNotification(Context context,
-                                 String notificationTitle,
-                                 String notificationMessage,
-                                 int notificationId,
-                                 Intent intent) {
+        String notificationTitle,
+        String notificationMessage,
+        int notificationId,
+        Intent intent) {
 
         notificationBuilder.setDefaults(DEFAULT_ALL)
-                .setContentTitle(notificationTitle)
-                .setStyle(new NotificationCompat.BigTextStyle()
-                        .bigText(notificationMessage))
-                .setSmallIcon(R.drawable.ic_launcher)
-                .setProgress(0, 0, false)
-                .setOngoing(false)
-                .setPriority(PRIORITY_HIGH);
+            .setContentTitle(notificationTitle)
+            .setStyle(new NotificationCompat.BigTextStyle()
+                .bigText(notificationMessage))
+            .setSmallIcon(R.drawable.ic_launcher)
+            .setProgress(0, 0, false)
+            .setOngoing(false)
+            .setPriority(PRIORITY_HIGH);
 
-        PendingIntent pendingIntent = PendingIntent.getActivity(context, 1, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+
+        // Check if the API level is 31 or higher to modify the flag
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            // For API level 31 or above, PendingIntent requires either FLAG_IMMUTABLE or FLAG_MUTABLE to be set
+            flags |= PendingIntent.FLAG_IMMUTABLE;
+        }
+
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 1, intent, flags);
         notificationBuilder.setContentIntent(pendingIntent);
         notificationManager.notify(notificationId, notificationBuilder.build());
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
@@ -220,13 +220,13 @@ class DepictsPresenter @Inject constructor(
                             view.updateDepicts()
                             view.goBackToPreviousScreen()
                         })
-                        {
-                            Timber.e(
+                        {t: Throwable? ->
+                            Timber.e(t,
                                 "Failed to update depictions"
                             )
+
                         }
                 )
-
             }
         } else {
             repository.cleanup()

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
@@ -220,8 +220,8 @@ class DepictsPresenter @Inject constructor(
                             view.updateDepicts()
                             view.goBackToPreviousScreen()
                         })
-                        {t: Throwable? ->
-                            Timber.e(t,
+                        {
+                            Timber.e(
                                 "Failed to update depictions"
                             )
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
@@ -224,7 +224,6 @@ class DepictsPresenter @Inject constructor(
                             Timber.e(
                                 "Failed to update depictions"
                             )
-
                         }
                 )
             }


### PR DESCRIPTION
Fixes: #5212

Description:
The bug originates from the [updateDepictions](https://github.com/commons-app/apps-android-commons/blob/main/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt#L196) function, which manages depiction updates and observes the result with both success and error handlers. While it does initiate the depiction update in the databases, the subsequent call to the [showNotification](https://github.com/commons-app/apps-android-commons/blob/main/app/src/main/java/fr/free/nrw/commons/notification/NotificationHelper.java#L66) function leads to an error. This issue arises because API levels 31 and above require a more specific flag for pending intents.

Changes:
Introduced an if statement to assess the current API version. If the API version exceeds 31, the flag is set to immutable.

Testing:
Verified on API levels 28 and 33 without any issues.