### PR TITLE
Replaced campaignPreference with CAMPAIGNS_DEFAULT_PREFERENCE

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/campaigns/CampaignView.java
+++ b/app/src/main/java/fr/free/nrw/commons/campaigns/CampaignView.java
@@ -69,7 +69,7 @@ public class CampaignView extends SwipableCardView {
     @Override public boolean onSwipe(final View view) {
         view.setVisibility(View.GONE);
         ((BaseActivity) getContext()).defaultKvStore
-            .putBoolean(CAMPAIGNS_DEFAULT_PREFERENCE, false); // Issue 5288: Replaced campaignPreference with CAMPAIGNS_DEFAULT_PREFERENCE
+            .putBoolean(CAMPAIGNS_DEFAULT_PREFERENCE, false);
         ViewUtil.showLongToast(getContext(),
             getResources().getString(R.string.nearby_campaign_dismiss_message));
         return true;

--- a/app/src/main/java/fr/free/nrw/commons/campaigns/CampaignView.java
+++ b/app/src/main/java/fr/free/nrw/commons/campaigns/CampaignView.java
@@ -69,7 +69,7 @@ public class CampaignView extends SwipableCardView {
     @Override public boolean onSwipe(final View view) {
         view.setVisibility(View.GONE);
         ((BaseActivity) getContext()).defaultKvStore
-            .putBoolean(campaignPreference, false);
+            .putBoolean(CAMPAIGNS_DEFAULT_PREFERENCE, false); // Issue 5288: Replaced campaignPreference with CAMPAIGNS_DEFAULT_PREFERENCE
         ViewUtil.showLongToast(getContext(),
             getResources().getString(R.string.nearby_campaign_dismiss_message));
         return true;


### PR DESCRIPTION
Fixed the bug "Swiping campaign notification shows 'You won't see campaigns anymore', but actually same notification comes back after a few days."

Fixes #5288

What changes did you make and why?

I replaced the variable _campaignPreference_ with _CAMPAIGNS_DEFAULT_PREFERENCE_. 

In the _**ContributionsFragment**_ class, the function _fetchCampaigns_() checks the _CAMPAIGNS_DEFAULT_PREFERENCE_ if it is True. However, in the **_CampaignView_** class, it switches  _campaignPreference_ to False without updating the default preference after swiping.

https://github.com/commons-app/apps-android-commons/blob/1490710a514e58ea5052868637da60dd3ccec1b3/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java#L591

https://github.com/commons-app/apps-android-commons/blob/1490710a514e58ea5052868637da60dd3ccec1b3/app/src/main/java/fr/free/nrw/commons/campaigns/CampaignView.java#L72

Tested {} on {emulator 32.1.12-9751036} with API level {API Tiramisu}.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
