### PR TITLE
app: avoid R8 from obfuscating our model classes

### DIFF
--- a/app/proguard-rules.txt
+++ b/app/proguard-rules.txt
@@ -31,8 +31,15 @@
 -keepattributes Signature
 # Retain declared checked exceptions for use by a Proxy instance.
 -keepattributes Exceptions
-# Classes used by retrofit to fetch API repsonse
+
+# Application classes that will be serialized/deserialized over Gson
 -keepclasseswithmembers class org.wikipedia.** { *; }
+# Note: The model package right now seems to include some other classes that
+# are not used for serialization / deserialization over Gson. Hopefully
+# that's not a problem since it only prevents R8 from avoiding trimming
+# of few more classes.
+-keepclasseswithmembers class fr.free.nrw.commons.*.model.** { *; }
+
 # --- /Retrofit ---
 
 # --- OkHttp + Okio ---


### PR DESCRIPTION
**Description (required)**

R8 shouldn't obfuscate the classes that we use for serialization / de-serialization over Gson. This causes issues with app functioning.

Fixes #5358

**Tests performed (required)**

Tested prodDebug (with minifaction) on OnePlus Nord with Android 12.

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
