### PR TITLE
Update the SoLoader SDK version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,7 +94,7 @@ dependencies {
     testImplementation "androidx.arch.core:core-testing:2.2.0"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.0"
-    testImplementation 'com.facebook.soloader:soloader:0.10.1'
+    testImplementation 'com.facebook.soloader:soloader:0.10.5'
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3"
 
     // Android testing


### PR DESCRIPTION
**Description (required)**

Fixes #5347

What changes did you make and why?

I update the SoLoader SDK `testImplementation 'com.facebook.soloader:soloader:0.10.1'` in build.gradle to
`testImplementation 'com.facebook.soloader:soloader:0.10.5'`.
Because the 0.10.1 version SoLoader SDK is causing crashes on 64-bit-only devices as the issue said.

**Tests performed (required)**

Tested {ProdDebug} on {samsung SM-F946B} with API level {33}.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
