### PR TITLE
5346: Ensure that cancelled uploads are really getting cancelled

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -142,6 +142,11 @@ public class CommonsApplication extends MultiDexApplication {
     public static Map<String, Boolean> pauseUploads = new HashMap<>();
 
     /**
+     *  In-memory list of uploads that have been cancelled by the user
+     */
+    public static HashSet<String> cancelledUploads = new HashSet<>();
+
+    /**
      * Used to declare and initialize various components and dependencies
      */
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.java
@@ -36,6 +36,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
@@ -429,6 +430,7 @@ public class ContributionsListFragment extends CommonsDaggerSupportFragment impl
             () -> {
                 ViewUtil.showShortToast(getContext(), R.string.cancelling_upload);
                 contributionsListPresenter.deleteUpload(contribution);
+                CommonsApplication.cancelledUploads.add(contribution.getPageId());
             }, () -> {
                 // Do nothing
             });


### PR DESCRIPTION
**Description (required)**

The `queuedContributions` list does not get updated once the changes have been fetched from the database. So, even the contributions that have been cancelled by the user exist in this list and get uploaded.

Fixes #5346 

What changes did you make and why?
Added an in-memory hashset for cancelled uploads to ensure that they do not get uploaded even after being cancelled. 

**Tests performed (required)**

Tested prodDebug on Redmi 5A with API level 27.
