### PR TITLE
Fix #5276: improve the media location access dialog strings

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -268,30 +268,13 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private ActivityResultLauncher<String[]> locationPermissionLauncher = registerForActivityResult(new ActivityResultContracts.RequestMultiplePermissions(), new ActivityResultCallback<Map<String, Boolean>>() {
         @Override
         public void onActivityResult(Map<String, Boolean> result) {
-            boolean areAllGranted = true;
-            for (final boolean b : result.values()) {
-                areAllGranted = areAllGranted && b;
-            }
 
-            if (areAllGranted) {
-                locationPermissionGranted();
-            } else {
-                if (shouldShowRequestPermissionRationale(permission.ACCESS_FINE_LOCATION)) {
-                    DialogUtil.showAlertDialog(getActivity(), getActivity().getString(R.string.location_permission_title),
-                        getActivity().getString(R.string.location_permission_rationale_nearby),
-                        getActivity().getString(android.R.string.ok),
-                        getActivity().getString(android.R.string.cancel),
-                        () -> {
-                            if (!(locationManager.isNetworkProviderEnabled() || locationManager.isGPSProviderEnabled())) {
-                                showLocationOffDialog();
-                            }
-                        },
-                        () -> isPermissionDenied = true,
-                        null,
-                        false);
-                } else {
-                    isPermissionDenied = true;
+            if (shouldShowRequestPermissionRationale(permission.ACCESS_FINE_LOCATION)) {
+                if (!(locationManager.isNetworkProviderEnabled() || locationManager.isGPSProviderEnabled())) {
+                    showLocationOffDialog();
                 }
+            } else {
+                isPermissionDenied = true;
             }
         }
     });
@@ -1268,7 +1251,16 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     @Override
     public void checkPermissionsAndPerformAction() {
         Timber.d("Checking permission and perfoming action");
-        locationPermissionLauncher.launch(new String[]{permission.ACCESS_FINE_LOCATION});
+        DialogUtil.showAlertDialog(getActivity(), getActivity().getString(R.string.location_permission_title),
+            getActivity().getString(R.string.location_permission_rationale_nearby),
+            getActivity().getString(android.R.string.ok),
+            getActivity().getString(android.R.string.cancel),
+            () -> {
+                locationPermissionLauncher.launch(new String[]{permission.ACCESS_FINE_LOCATION});
+            },
+            () -> isPermissionDenied = true,
+            null,
+            false);
     }
 
     /**


### PR DESCRIPTION
Modify the sequence of displaying dialogues

**Description (required)**

Fixes #5276 

I modified some codes in NearbyParentFragment.java, including two functions: checkPermissionsAndPerformAction and locationPermissionLauncher.  By this modification, the app can show the developers' defined dialog block before the Android pre-defined location access dialog block. 

**Tests performed (required)**

Tested ProdDebug on Oppo Reno 8 with API level 13.

**Screenshots (for UI changes only)**
![first jpg 1](https://github.com/commons-app/apps-android-commons/assets/142494954/b7d0689e-4bad-47e1-8768-a1ce53724404)


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
![second_dialog_block 1](https://github.com/commons-app/apps-android-commons/assets/142494954/a23591da-a1e0-4048-b94a-871d58b4d552)
