### PR TITLE
Keeping track of and restart interrupted uploads 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons;
 
 import static fr.free.nrw.commons.data.DBOpenHelper.CONTRIBUTIONS_TABLE;
+import static fr.free.nrw.commons.upload.UploadStatusManager.readUnfinishedUploads;
 import static org.acra.ReportField.ANDROID_VERSION;
 import static org.acra.ReportField.APP_VERSION_CODE;
 import static org.acra.ReportField.APP_VERSION_NAME;
@@ -145,6 +146,10 @@ public class CommonsApplication extends MultiDexApplication {
     public static Map<String, Boolean> pauseUploads = new HashMap<>();
 
     /**
+     *  In-memory list of contributions whose uploads have not been properly fnished
+     */
+    public static Map<String, Boolean> unfinishedUploads = new HashMap<>();
+    /**
      * Used to declare and initialize various components and dependencies
      */
     @Override
@@ -195,6 +200,10 @@ public class CommonsApplication extends MultiDexApplication {
 
         // Fire progress callbacks for every 3% of uploaded content
         System.setProperty("in.yuvi.http.fluent.PROGRESS_TRIGGER_THRESHOLD", "3.0");
+        /**
+         * Loads the map of unfinished uploads from disk when the app starts.
+         */
+        CommonsApplication.unfinishedUploads = UploadStatusManager.readUnfinishedUploads(this);
         checkForUnfinishedUploads();
     }
 
@@ -338,11 +347,9 @@ public class CommonsApplication extends MultiDexApplication {
      * Checks for unfinished uploads and notifies the user if any are found.
      */
     private void checkForUnfinishedUploads() {
-        String uploadStatus = UploadStatusManager.getUploadStatus(this);
-        if ("yes".equals(uploadStatus)) {
+        if (!CommonsApplication.unfinishedUploads.isEmpty()) {
+            // Notify the user about the unfinished uploads
             notifyUser();
-            //set the upload status to no
-            UploadStatusManager.setUploadStatus(this, "no");
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -9,9 +9,11 @@ import static org.acra.ReportField.STACK_TRACE;
 import static org.acra.ReportField.USER_COMMENT;
 
 import android.annotation.SuppressLint;
+import android.app.AlertDialog;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.os.Build;
@@ -41,6 +43,7 @@ import fr.free.nrw.commons.logging.LogUtils;
 import fr.free.nrw.commons.media.CustomOkHttpNetworkFetcher;
 import fr.free.nrw.commons.settings.Prefs;
 import fr.free.nrw.commons.upload.FileUtils;
+import fr.free.nrw.commons.upload.UploadStatusManager;
 import fr.free.nrw.commons.utils.ConfigUtils;
 import io.reactivex.Completable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -192,6 +195,7 @@ public class CommonsApplication extends MultiDexApplication {
 
         // Fire progress callbacks for every 3% of uploaded content
         System.setProperty("in.yuvi.http.fluent.PROGRESS_TRIGGER_THRESHOLD", "3.0");
+        checkForUnfinishedUploads();
     }
 
     /**
@@ -330,6 +334,33 @@ public class CommonsApplication extends MultiDexApplication {
     }
 
 
+    /**
+     * Checks for unfinished uploads and notifies the user if any are found.
+     */
+    private void checkForUnfinishedUploads() {
+        String uploadStatus = UploadStatusManager.getUploadStatus(this);
+        if ("yes".equals(uploadStatus)) {
+            notifyUser();
+            //set the upload status to no
+            UploadStatusManager.setUploadStatus(this, "no");
+        }
+    }
+
+    /**
+     * Notifies the user about unfinished uploads.
+     */
+    private void notifyUser() {
+        AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this);
+        alertDialogBuilder.setTitle("Unfinished Uploads");
+        alertDialogBuilder.setMessage("Your uploads were interrupted."
+            + "Please retry uploading them from Contributions page.");
+        alertDialogBuilder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+                //TODO: restart the upload
+            }
+        });
+    }
     /**
      * Interface used to get log-out events
      */

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadClient.java
@@ -67,6 +67,8 @@ public class UploadClient {
     public Observable<StashUploadResult> uploadFileToStash(
         final Context context, final String filename, final Contribution contribution,
         final NotificationUpdateProgressListener notificationUpdater) throws IOException {
+        // Set the upload status to "yes" at the start of an upload
+        UploadStatusManager.setUploadStatus(context, "yes");
         if (contribution.getChunkInfo() != null
             && contribution.getChunkInfo().getTotalChunks() == contribution.getChunkInfo()
             .getIndexOfNextChunkToUpload()) {
@@ -145,12 +147,15 @@ public class UploadClient {
             return Observable.just(new StashUploadResult(StashUploadState.FAILED, null));
         } else if (chunkInfo.get() != null) {
             Timber.d("Upload stash success %s", contribution.getPageId());
+            // Set the upload status to "no" at the end of an upload
+            UploadStatusManager.setUploadStatus(context, "no");
             return Observable.just(new StashUploadResult(StashUploadState.SUCCESS,
                 chunkInfo.get().getUploadResult().getFilekey()));
         } else {
             Timber.d("Upload stash failed %s", contribution.getPageId());
             return Observable.just(new StashUploadResult(StashUploadState.FAILED, null));
         }
+
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadStatusManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadStatusManager.java
@@ -1,0 +1,57 @@
+package fr.free.nrw.commons.upload;
+import android.content.Context;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+public class UploadStatusManager {
+    private static final String UPLOAD_STATUS_FILE = "upload_status.txt";
+
+    /**
+     * Sets the upload status to the specified value.
+     *
+     * This method writes the provided status to a file named 'upload_status.txt'.
+     * If the file doesn't exist, it will be created.
+     *
+     * @param context The application context, used to access the file system.
+     * @param status  The status to write to the file, should be "yes" or "no".
+     */
+    public static void setUploadStatus(Context context, String status) {
+        File file = new File(context.getFilesDir(), "upload_status.txt");
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(status.getBytes());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+    /**
+     * Retrieves the current upload status from the file.
+     *
+     * This method reads the status from a file named 'upload_status.txt'.
+     * If the file doesn't exist or an error occurs, "no" is returned as a default value.
+     *
+     * @param context The application context, used to access the file system.
+     * @return The current upload status, "yes" or "no".
+     */
+    public static String getUploadStatus(Context context) {
+        File file = new File(context.getFilesDir(), "upload_status.txt");
+        if (!file.exists()) {
+            return "no";
+        }
+        try (FileInputStream fis = new FileInputStream(file);
+            InputStreamReader isr = new InputStreamReader(fis);
+            BufferedReader br = new BufferedReader(isr)) {
+            return br.readLine();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "no";  // default value in case of an error
+        }
+    }
+}
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.1.2'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
         classpath 'org.codehaus.groovy:groovy-all:2.4.15'


### PR DESCRIPTION
**Description (required)**
Add the ability to keep track of and reupload interrupted uploads

Fixes #5282

What changes did you make and why?
Added a Java class to record unfinished uploads on disk, to keep track of the uploads across app closure/device restarts. 
**Tests performed (required)**

Tested {Beta} on {Pixel 7 Pro} with API level {33}.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
