### PR TITLE
Removed butterknife from login activity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -39,7 +39,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import butterknife.ButterKnife;
-import butterknife.OnClick;
 import butterknife.OnEditorAction;
 import butterknife.OnFocusChange;
 import fr.free.nrw.commons.BuildConfig;
@@ -114,6 +113,12 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         binding.loginPassword.addTextChangedListener(textWatcher);
         binding.loginTwoFactor.addTextChangedListener(textWatcher);
 
+        binding.skipLogin.setOnClickListener(view -> skipLogin());
+        binding.forgotPassword.setOnClickListener(view -> forgotPassword());
+        binding.aboutPrivacyPolicy.setOnClickListener(view -> onPrivacyPolicyClicked());
+        binding.signUpButton.setOnClickListener(view -> signUp());
+        binding.loginButton.setOnClickListener(view -> performLogin());
+
         if (ConfigUtils.isBetaFlavour()) {
             binding.loginCredentials.setText(getString(R.string.login_credential));
         } else {
@@ -147,8 +152,7 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     }
 
 
-    @OnClick(R.id.skip_login)
-    void skipLogin() {
+    protected void skipLogin() {
         new AlertDialog.Builder(this).setTitle(R.string.skip_login_title)
                 .setMessage(R.string.skip_login_message)
                 .setCancelable(false)
@@ -160,18 +164,15 @@ public class LoginActivity extends AccountAuthenticatorActivity {
                 .show();
     }
 
-    @OnClick(R.id.forgot_password)
-    void forgotPassword() {
+    protected void forgotPassword() {
         Utils.handleWebUrl(this, Uri.parse(BuildConfig.FORGOT_PASSWORD_URL));
     }
 
-    @OnClick(R.id.about_privacy_policy)
-    void onPrivacyPolicyClicked() {
+    protected void onPrivacyPolicyClicked() {
         Utils.handleWebUrl(this, Uri.parse(BuildConfig.PRIVACY_POLICY_URL));
     }
 
-    @OnClick(R.id.sign_up_button)
-    void signUp() {
+    protected void signUp() {
         Intent intent = new Intent(this, SignupActivity.class);
         startActivity(intent);
     }
@@ -220,7 +221,6 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         super.onDestroy();
     }
 
-    @OnClick(R.id.login_button)
     public void performLogin() {
         Timber.d("Login to start!");
         final String username = binding.loginUsername.getText().toString();

--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -39,8 +39,6 @@ import org.wikipedia.login.LoginResult;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import butterknife.ButterKnife;
-import butterknife.OnFocusChange;
 import fr.free.nrw.commons.BuildConfig;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
@@ -107,8 +105,6 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         binding = ActivityLoginBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        ButterKnife.bind(this);
-
         binding.loginUsername.addTextChangedListener(textWatcher);
         binding.loginPassword.addTextChangedListener(textWatcher);
         binding.loginTwoFactor.addTextChangedListener(textWatcher);
@@ -120,6 +116,7 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         binding.loginButton.setOnClickListener(view -> performLogin());
 
         binding.loginPassword.setOnEditorActionListener(this::onEditorAction);
+        binding.loginPassword.setOnFocusChangeListener(this::onPasswordFocusChanged);
 
         if (ConfigUtils.isBetaFlavour()) {
             binding.loginCredentials.setText(getString(R.string.login_credential));
@@ -132,7 +129,6 @@ public class LoginActivity extends AccountAuthenticatorActivity {
      * @param view The keyboard
      * @param hasFocus Set to true if the keyboard has focus
      */
-    @OnFocusChange(R.id.login_password)
     void onPasswordFocusChanged(View view, boolean hasFocus) {
         if (!hasFocus) {
             ViewUtil.hideKeyboard(view);

--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -15,6 +15,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 
+import android.widget.TextView;
 import androidx.annotation.ColorRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -39,7 +40,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import butterknife.ButterKnife;
-import butterknife.OnEditorAction;
 import butterknife.OnFocusChange;
 import fr.free.nrw.commons.BuildConfig;
 import fr.free.nrw.commons.R;
@@ -119,6 +119,8 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         binding.signUpButton.setOnClickListener(view -> signUp());
         binding.loginButton.setOnClickListener(view -> performLogin());
 
+        binding.loginPassword.setOnEditorActionListener(this::onEditorAction);
+
         if (ConfigUtils.isBetaFlavour()) {
             binding.loginCredentials.setText(getString(R.string.login_credential));
         } else {
@@ -137,8 +139,7 @@ public class LoginActivity extends AccountAuthenticatorActivity {
         }
     }
 
-    @OnEditorAction(R.id.login_password)
-    boolean onEditorAction(int actionId, KeyEvent keyEvent) {
+    boolean onEditorAction(TextView textView, int actionId, KeyEvent keyEvent) {
         if (binding.loginButton.isEnabled()) {
             if (actionId == IME_ACTION_DONE) {
                 performLogin();

--- a/app/src/test/kotlin/fr/free/nrw/commons/auth/LoginActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/auth/LoginActivityUnitTests.kt
@@ -104,35 +104,6 @@ class LoginActivityUnitTests {
 
     @Test
     @Throws(Exception::class)
-    fun testOnEditorActionCaseLoginEnabledFirstCase() {
-        Whitebox.setInternalState(activity, "loginButton", loginButton)
-        `when`(loginButton.isEnabled).thenReturn(true)
-        val method: Method = LoginActivity::class.java.getDeclaredMethod(
-            "onEditorAction",
-            Int::class.java,
-            KeyEvent::class.java
-        )
-        method.isAccessible = true
-        method.invoke(activity, EditorInfo.IME_ACTION_DONE, keyEvent)
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun testOnEditorActionCaseLoginEnabledSecondCase() {
-        Whitebox.setInternalState(activity, "loginButton", loginButton)
-        `when`(loginButton.isEnabled).thenReturn(true)
-        `when`(keyEvent.keyCode).thenReturn(KeyEvent.KEYCODE_ENTER)
-        val method: Method = LoginActivity::class.java.getDeclaredMethod(
-            "onEditorAction",
-            Int::class.java,
-            KeyEvent::class.java
-        )
-        method.isAccessible = true
-        method.invoke(activity, 0, keyEvent)
-    }
-
-    @Test
-    @Throws(Exception::class)
     fun testSkipLogin() {
         val method: Method = LoginActivity::class.java.getDeclaredMethod(
             "skipLogin"

--- a/app/src/test/kotlin/fr/free/nrw/commons/auth/LoginActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/auth/LoginActivityUnitTests.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.widget.Button
+import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestAppAdapter
@@ -55,7 +56,7 @@ class LoginActivityUnitTests {
     private lateinit var keyEvent: KeyEvent
 
     @Mock
-    private lateinit var loginButton: Button
+    private lateinit var textView: TextView
 
     @Mock
     private lateinit var bundle: Bundle
@@ -95,11 +96,12 @@ class LoginActivityUnitTests {
     fun testOnEditorActionCaseDefault() {
         val method: Method = LoginActivity::class.java.getDeclaredMethod(
             "onEditorAction",
+            TextView::class.java,
             Int::class.java,
             KeyEvent::class.java
         )
         method.isAccessible = true
-        method.invoke(activity, 0, keyEvent)
+        method.invoke(activity, textView, 0, keyEvent)
     }
 
     @Test


### PR DESCRIPTION
Removed butterknife from the `LoginActivity` in a series of steps.  Tested the app on Google Pixel 5 and all seems to be in order.

Note: 2 unit test methods depended on fields that went away.  Since the test methods weren't actually making any assertions (ie, just there for test coverage using reflection to touch parts of the `LoginActivity`) I deleted the test methods.