### PR TITLE
Fix multi-upload bugs

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -187,6 +187,7 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
         }
         locationManager.requestLocationUpdatesFromProvider(LocationManager.GPS_PROVIDER);
         locationManager.requestLocationUpdatesFromProvider(LocationManager.NETWORK_PROVIDER);
+        checkStoragePermissions();
     }
 
     private void init() {
@@ -245,12 +246,6 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        checkStoragePermissions();
-    }
-
-    @Override
     protected void onResume() {
         super.onResume();
         presenter.onAttachView(this);
@@ -258,7 +253,6 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
             askUserToLogIn();
         }
         checkBlockStatus();
-        checkStoragePermissions();
     }
 
     /**


### PR DESCRIPTION
**Description (required)**

Fixes #5377 

What changes did you make and why?

Removed redundant calls to `checkStoragePermissions()` from multiple activity lifecycle components so that it receives shared items only once.

**Tests performed (required)**

Tested prodDebug on Redmi 5A with API level 27.