### PR TITLE
Removed butterknife from contributions list fragment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ app/src/main/jniLibs
 #https://docs.opencv.org/3.3.0/
 /libraries/opencv/javadoc/
 captures/*
+
+# Test and other output
+app/jacoco.exec
+app/CommonsContributions

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,14 +81,17 @@ dependencies {
     //Mocking
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     testImplementation 'org.mockito:mockito-inline:5.2.0'
-    testImplementation 'org.mockito:mockito-core:5.5.0'
+    testImplementation 'org.mockito:mockito-core:5.6.0'
     testImplementation "org.powermock:powermock-module-junit4:2.0.9"
     testImplementation "org.powermock:powermock-api-mockito2:2.0.9"
 
     // Unit testing
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.robolectric:robolectric:4.10.3'
+    testImplementation 'org.robolectric:robolectric:4.11.1'
     testImplementation 'androidx.test:core:1.5.0'
+    testImplementation "androidx.test:runner:1.5.2"
+    testImplementation 'androidx.test.ext:junit:1.1.5'
+    testImplementation "androidx.test:rules:1.5.0"
     testImplementation "com.squareup.okhttp3:mockwebserver:$OKHTTP_VERSION"
     testImplementation "com.jraska.livedata:testing-ktx:1.1.2"
     testImplementation "androidx.arch.core:core-testing:2.2.0"
@@ -96,6 +99,7 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.0"
     testImplementation 'com.facebook.soloader:soloader:0.10.5'
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3"
+    debugImplementation("androidx.fragment:fragment-testing:1.6.2")
 
     // Android testing
     androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
@@ -206,8 +210,10 @@ android {
     testOptions {
         animationsDisabled true
 
-        unitTests.returnDefaultValues = true
-        unitTests.includeAndroidResources = true
+        unitTests {
+            returnDefaultValues = true
+            includeAndroidResources = true
+        }
 
         unitTests.all {
             jvmArgs '-noverify'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,7 +75,6 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:$DAGGER_VERSION"
     annotationProcessor "com.google.dagger:dagger-android-processor:$DAGGER_VERSION"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$KOTLIN_VERSION"
 
     //Mocking
@@ -102,7 +101,6 @@ dependencies {
     debugImplementation("androidx.fragment:fragment-testing:1.6.2")
 
     // Android testing
-    androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0-alpha04'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.5.0-alpha04'
@@ -162,6 +160,15 @@ dependencies {
     kaptAndroidTest "androidx.databinding:databinding-compiler:8.0.2"
 
     implementation("io.github.coordinates2country:coordinates2country-android:1.3") {  exclude group: 'com.google.android', module: 'android' }
+
+    constraints {
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0") {
+            because("kotlin-stdlib-jdk7 is now a part of kotlin-stdlib")
+        }
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0") {
+            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
+        }
+    }
 }
 
 task disableAnimations(type: Exec) {

--- a/data-client/build.gradle
+++ b/data-client/build.gradle
@@ -78,7 +78,6 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxjava:2.2.3"
     implementation "io.reactivex.rxjava2:rxandroid:2.1.0"
     implementation 'org.apache.commons:commons-lang3:3.8.1'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
 
@@ -88,6 +87,15 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-junit:2.0.0.0'
     testImplementation "com.squareup.okhttp3:mockwebserver:4.10.0"
     testImplementation "commons-io:commons-io:2.6"
+
+    constraints {
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0") {
+            because("kotlin-stdlib-jdk7 is now a part of kotlin-stdlib")
+        }
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0") {
+            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
+        }
+    }
 }
 
 repositories {


### PR DESCRIPTION
This PR removes Butterknife from the `ContributionsListFragment`.

A large barrier to removing Butterknife from other places in the code is the plethora of _mock_ UI elements that rely on Butterknife bound member variables.  The PR introduces Google's `FragmentScenario` - designed for unit testing Fragments - along with a slight bump to some library versions.  

`FragmentScenario` gives you complete control of the Fragment lifecycle and coupled with Robolectric allows you to _safely_ run through the `onCreateView()` method to create real components removing the need for all the mock objects. As you can see from the PR, this **greatly** simplifies the test!

The pattern for other tests will be fairly similar to - 
```kotlin
private lateinit var scenario: FragmentScenario<ContributionsListFragment>
private lateinit var fragment: ContributionsListFragment
```

and in the setup method
```kotlin
scenario = launchFragmentInContainer(
    initialState = Lifecycle.State.RESUMED,
    themeResId = R.style.LightAppTheme
) {
    ContributionsListFragment().apply {
        // ... setup mock objects on the target class, if needed
    }.also {
        fragment = it
    }
}
```

if you dont want to keep a fragment reference, then use `FragmentScenario` - 
```kotlin
scenario.onFragment {
    // "it" is the fragment we're testing
    it.adapter = adapter
}
```