### PR TITLE
fixed the bug by reducing margin_end between edit button and previous button

### DIFF
--- a/app/src/main/res/layout/fragment_upload_media_detail_fragment.xml
+++ b/app/src/main/res/layout/fragment_upload_media_detail_fragment.xml
@@ -147,7 +147,7 @@
                       style="@style/Widget.AppCompat.Button.Borderless"
                       android:layout_width="wrap_content"
                       android:layout_height="wrap_content"
-                      android:layout_marginEnd="@dimen/standard_gap"
+                      android:layout_marginEnd="@dimen/tiny_gap"
                       android:layout_marginBottom="24dp"
                       android:layout_toStartOf="@id/btn_previous"
                       android:contentDescription="Edit Image"


### PR DESCRIPTION
**Description (required)**

Fixes #5388

What changes did you make and why?
reduced the marin so that the + sign will not overlap 

**Tests performed (required)**

Tested {build variant, e.g. ProdDebug} on {name of device or emulator} with API level {API level}.

**Screenshots (for UI changes only)**
From This
<img width="183" alt="from" src="https://github.com/commons-app/apps-android-commons/assets/44166843/52de7090-bbb6-4e4d-8a09-5bb745530e2c">
To This
<img width="181" alt="to" src="https://github.com/commons-app/apps-android-commons/assets/44166843/e8a7ebd5-a3a0-4230-a315-b116d29cf18e">

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
