### PR TITLE
Resolved issue of dark icons not visible in bottom NavBar and Achievement Fragments, in dark mode

### DIFF
--- a/app/src/main/res/color/color_state_nav_tab_dark.xml
+++ b/app/src/main/res/color/color_state_nav_tab_dark.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_checked="true" android:color="@color/white" />
-  <item android:color="@color/black" />
+  <item android:color="@color/primaryLightColor" />
 </selector>

--- a/app/src/main/res/layout/fragment_achievements.xml
+++ b/app/src/main/res/layout/fragment_achievements.xml
@@ -123,7 +123,7 @@
                 android:layout_toRightOf="@+id/images_upload_text_param"
                 android:layout_toEndOf="@+id/images_upload_text_param"
                 app:srcCompat="@drawable/ic_info_outline_24dp"
-                android:tint="@color/primaryDarkColor"
+                android:tint="@color/primaryLightColor"
                 android:layout_marginLeft="@dimen/activity_margin_horizontal"
                 android:layout_marginStart="@dimen/activity_margin_horizontal"/>
 
@@ -210,7 +210,7 @@
                 android:layout_toRightOf="@+id/images_reverted_text"
                 android:layout_toEndOf="@+id/images_reverted_text"
                 app:srcCompat="@drawable/ic_info_outline_24dp"
-                android:tint="@color/primaryDarkColor"
+                android:tint="@color/primaryLightColor"
                 android:layout_marginLeft="@dimen/activity_margin_horizontal"
                 android:layout_marginStart="@dimen/activity_margin_horizontal"/>
 
@@ -285,7 +285,7 @@
                 android:layout_toRightOf="@+id/images_used_by_wiki_text"
                 android:layout_toEndOf="@+id/images_used_by_wiki_text"
                 app:srcCompat="@drawable/ic_info_outline_24dp"
-                android:tint="@color/primaryDarkColor"
+                android:tint="@color/primaryLightColor"
                 android:layout_marginLeft="@dimen/activity_margin_horizontal"
                 android:layout_marginStart="@dimen/activity_margin_horizontal"/>
 
@@ -414,7 +414,7 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintRight_toRightOf="parent"
                 app:srcCompat="@drawable/ic_info_outline_24dp"
-                android:tint="@color/primaryDarkColor" />
+                android:tint="@color/primaryLightColor" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -493,7 +493,7 @@
                 app:layout_constraintRight_toRightOf="parent"
                 android:layout_gravity="top"
                 app:srcCompat="@drawable/ic_info_outline_24dp"
-                android:tint="@color/primaryDarkColor" />
+                android:tint="@color/primaryLightColor" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -571,7 +571,7 @@
                 app:layout_constraintRight_toRightOf="parent"
                 android:layout_gravity="top"
                 app:srcCompat="@drawable/ic_info_outline_24dp"
-                android:tint="@color/primaryDarkColor" />
+                android:tint="@color/primaryLightColor" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -650,7 +650,7 @@
                 app:layout_constraintRight_toRightOf="parent"
                 android:layout_gravity="top"
                 app:srcCompat="@drawable/ic_info_outline_24dp"
-                android:tint="@color/primaryDarkColor" />
+                android:tint="@color/primaryLightColor" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_contributions_list.xml
+++ b/app/src/main/res/layout/fragment_contributions_list.xml
@@ -113,6 +113,7 @@
           app:backgroundTint="@color/status_bar_blue"
           app:elevation="@dimen/tiny_margin"
           app:srcCompat="@drawable/ic_add_white_24dp"
+          android:tint="?attr/floatingActionButtonStyle"
           app:useCompatPadding="true" />
 
     </LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,6 +20,7 @@
         <item name="reviewHeading">@color/white</item>
         <item name="aboutIconsColor">@color/white</item>
         <item name="caption_description_text_color">@color/white</item>
+        <item name="floatingActionButtonStyle">@color/black</item>
 
         <item name="semitransparentText">@color/commons_app_blue_dark</item>
         <item name="subBackground">@color/sub_background_dark</item>
@@ -80,6 +81,7 @@
         <item name="reviewHeading">@color/black</item>
         <item name="aboutIconsColor">@color/black</item>
         <item name="caption_description_text_color">@color/black</item>
+        <item name="floatingActionButtonStyle">@color/white</item>
 
         <item name="semitransparentText">@color/commons_app_blue_light</item>
         <item name="subBackground">@color/sub_background_light</item>


### PR DESCRIPTION


**Description (required)**

This PR resolves the issue of visibility of black/dark blue coloured icons in the bottom navigation bar and in the achievements fragment.
 

Fixes #5194 


**What changes did you make and why?**

1. For the info icon in the Achievements fragment, I changed the colour-tint of icons to primaryLightColour
2. For the BottomNavbar icons, I changed the 'color_state_nav_tab_dark' to primaryLightColour
3. Additionally, I noticed that the floating button's plus sign was not aligned with the UI guidelines for dark mode, so I added a tint colour to it 

**Tests performed (required)**

Tested betaDebug on OnePlus Nord CE 2 Lite with API level 31.

**Screenshots (for UI changes only)**

![Issue ss1](https://github.com/commons-app/apps-android-commons/assets/142137555/04378031-83f2-4424-8bdc-7a86ae8f2c5d)



![Issue ss 2](https://github.com/commons-app/apps-android-commons/assets/142137555/d8ca23d4-78b8-44da-b864-205d91e3b550)


