### PR TITLE
Resolved #5411 by rotating button initially

### DIFF
--- a/app/src/main/res/layout/fragment_upload_media_detail_fragment.xml
+++ b/app/src/main/res/layout/fragment_upload_media_detail_fragment.xml
@@ -80,6 +80,7 @@
                   android:clickable="false"
                   android:focusable="false"
                   android:padding="@dimen/medium_height"
+                  android:rotation="180"
                   app:srcCompat="@drawable/ic_expand_less_black_24dp" />
             </RelativeLayout>
 


### PR DESCRIPTION
**Description (required)**

Fixes #5411 

**What changes did you make and why?**
I rotated the image button by 180 degrees in the xml file itself so that initially, the arrow points downward instead of upwards (which is the bug)

**Tests performed (required)**

Tested betaDebug on OnePlus Nord CE 2 Lite with API level 31.

**Screenshots (for UI changes only)**
DARK MODE
Before:

![DarkModeEarlier2](https://github.com/commons-app/apps-android-commons/assets/142137555/27d4b40f-833d-429d-beb7-d4fd48a330a5)

![DarkModeEarlier1](https://github.com/commons-app/apps-android-commons/assets/142137555/5da8fd3c-9a8c-4818-a649-4b5691f731f2)

After:

![DarkModeLater1](https://github.com/commons-app/apps-android-commons/assets/142137555/afd0dbdd-1fec-4bf4-b148-6e2949e7e280)

![DarkModeLater2](https://github.com/commons-app/apps-android-commons/assets/142137555/15f22e10-5ca9-4be9-bb6a-58ed05d0ec01)


LIGHT MODE
Before:

![LightModeEarlier1](https://github.com/commons-app/apps-android-commons/assets/142137555/fc74b3d2-94f8-44ab-ae9a-a7c29f5fd910)

![LightModeEarlier2](https://github.com/commons-app/apps-android-commons/assets/142137555/e1b39f4d-402d-4621-bf4f-bf03c7801efd)

After:

![LightModeLater1](https://github.com/commons-app/apps-android-commons/assets/142137555/517f01a2-2f76-4fcf-a8d6-c3bb9a8a3d5c)

![LightModeLater2](https://github.com/commons-app/apps-android-commons/assets/142137555/2c6a382a-d10b-414d-8bbd-fb47fcf156ca)
