### PR TITLE
NearbyParentFragment : added referer

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -400,12 +400,16 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         org.osmdroid.config.Configuration.getInstance().load(this.getContext(),
             PreferenceManager.getDefaultSharedPreferences(this.getContext()));
 
-        mapView.setTileSource(TileSourceFactory.WIKIMEDIA); // Added tileSource - WIKIMEDIA
+        // Use the Wikimedia tile server, rather than OpenStreetMap (Mapnik) which has various
+        // restrictions that we do not satisfy.
+        mapView.setTileSource(TileSourceFactory.WIKIMEDIA);
         mapView.setTilesScaledToDpi(true);
 
+        // Add referer HTTP header because the Wikimedia tile server requires it.
+        // This was suggested by Dmitry Brant within an email thread between us and WMF.
         org.osmdroid.config.Configuration.getInstance().getAdditionalHttpRequestProperties().put(
             "Referer", "http://maps.wikimedia.org/"
-        ); // Added referer in the header
+        );
 
         if (applicationKvStore.getString("LastLocation")
             != null) { // Checking for last searched location

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -125,6 +125,7 @@ import org.osmdroid.events.MapEventsReceiver;
 import org.osmdroid.events.MapListener;
 import org.osmdroid.events.ScrollEvent;
 import org.osmdroid.events.ZoomEvent;
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.util.constants.GeoConstants;
 import org.osmdroid.views.CustomZoomButtonsController;
@@ -398,7 +399,14 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         presenter.setActionListeners(applicationKvStore);
         org.osmdroid.config.Configuration.getInstance().load(this.getContext(),
             PreferenceManager.getDefaultSharedPreferences(this.getContext()));
+
+        mapView.setTileSource(TileSourceFactory.WIKIMEDIA); // Added tileSource - WIKIMEDIA
         mapView.setTilesScaledToDpi(true);
+
+        org.osmdroid.config.Configuration.getInstance().getAdditionalHttpRequestProperties().put(
+            "Referer", "http://maps.wikimedia.org/"
+        ); // Added referer in the header
+
         if (applicationKvStore.getString("LastLocation")
             != null) { // Checking for last searched location
             String[] locationLatLng = applicationKvStore.getString("LastLocation").split(",");


### PR DESCRIPTION
**Description (required)**
In the file NearbyParentFragment.java, I added a header property, i.e., the referer - http://maps.wikimedia.org/, and set the tile source to Wikimedia.

Fixes #5374

What changes did you make and why?
I added a `Referer` - http://maps.wikimedia.org/ in the header requests sent when fetching map images in the Nearby section.
This change was needed to prevent us from being banned from the map tiles server.

Also, setTileSource to WIKIMEDIA

**Tests performed (required)**

Tested betaDebug on Samsung A14 with API level 34.

**Screenshots (for UI changes only)**
Did not perform any UI changes.
