### PR TITLE
Resolves Issue #5413 Crash when opening Nearby when location permission hasn't been granted yet

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -305,12 +305,10 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         });
 
     private ActivityResultLauncher<String> locationPermissionLauncher = registerForActivityResult(
-        new ActivityResultContracts.RequestPermission(), isGranted ->{
-            if(isGranted)
-            {
+        new ActivityResultContracts.RequestPermission(), isGranted -> {
+            if (isGranted) {
                 locationPermissionGranted();
-            }
-            else {
+            } else {
                 if (shouldShowRequestPermissionRationale(permission.ACCESS_FINE_LOCATION)) {
                     DialogUtil.showAlertDialog(getActivity(),
                         getActivity().getString(R.string.location_permission_title),
@@ -1030,6 +1028,11 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         return latLng;
     }
 
+    /**
+     * Computes location where map should be centered
+     *
+     * @return returns the last location, if available, else returns default location
+     */
     @Override
     public fr.free.nrw.commons.location.LatLng getMapCenter() {
         if (applicationKvStore.getString("LastLocation") != null) {
@@ -1043,8 +1046,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
                 -0.07520, 1f);
         }
         fr.free.nrw.commons.location.LatLng latLnge = lastKnownLocation;
-        if(mapCenter!=null)
-        {
+        if (mapCenter != null) {
             latLnge = new fr.free.nrw.commons.location.LatLng(
                 mapCenter.getLatitude(), mapCenter.getLongitude(), 100);
         }


### PR DESCRIPTION
*Description (required)*

Fixes #5413 

*What changes did you make and why?*
I saw that the app crashed because a function inside ActivityResultCallback, was being called even without the user giving/denying permission. Also, the code was using RequestMultiplePermissions when, in reality, we were requesting only one permission, so I updated the code to RequestPermission, which also solved the above problem. Moreover, when location permission was not given, in the getMapCenter, mapCenter was null when trying to extract latitude from it, so I assigned mapCenter to lastKnownLocation (after retrieving it) to prevent the exception, if null. 

This can also happen with getMapFocus and getLastMapFocus, as even mapView and lastMapFocus are not being checked for a null value, but I did not change that, as I felt it was out of the scope of this exception.

*Tests performed (required)*

Tested betaDebug on OnePlus Nord CE 2 Lite with API level 31 and Emulator Pixel 7 Pro with API level 34.