### PR TITLE
Resolved Issue #5388 + button

### DIFF
--- a/app/src/main/res/layout/fragment_upload_media_detail_fragment.xml
+++ b/app/src/main/res/layout/fragment_upload_media_detail_fragment.xml
@@ -121,6 +121,7 @@
                       android:layout_width="wrap_content"
                       android:layout_height="wrap_content"
                       android:minWidth="@dimen/fragment_height"
+                      android:translationZ="@dimen/dimen_5"
                       android:text="+" />
 
                     <androidx.appcompat.widget.AppCompatButton
@@ -138,8 +139,7 @@
                       style="@style/Widget.AppCompat.Button.Borderless"
                       android:layout_width="wrap_content"
                       android:layout_height="wrap_content"
-                      android:layout_marginEnd="@dimen/standard_gap"
-                      android:layout_marginRight="@dimen/standard_gap"
+                      android:layout_marginEnd="@dimen/tiny_gap"
                       android:layout_toLeftOf="@+id/btn_next"
                       android:text="@string/previous" />
                     <Button
@@ -147,7 +147,7 @@
                       style="@style/Widget.AppCompat.Button.Borderless"
                       android:layout_width="wrap_content"
                       android:layout_height="wrap_content"
-                      android:layout_marginEnd="@dimen/standard_gap"
+                      android:layout_marginEnd="@dimen/tiny_gap"
                       android:layout_marginBottom="24dp"
                       android:layout_toStartOf="@id/btn_previous"
                       android:contentDescription="Edit Image"


### PR DESCRIPTION
**Description (required)**
The + button near the Edit Image button was not fully visible and thus could not be used properly.

Fixes #5388 

**What changes did you make and why?**
I reduced the marginEnd property of two buttons and also added a translationZ property to the + button so that it always stays above the Edit Image button. I also removed the marginRight property from the PREVIOUS button, as it was redundant due to the presence of marginEnd property.

**Tests performed (required)**

Tested betaDebug on OnePlus Nord CE 2 Lite with API level 31.

**Screenshots (for UI changes only)**

Before :
![b4](https://github.com/commons-app/apps-android-commons/assets/142137555/29f52fd9-574f-4ef1-b2f3-1e3b4a50c4c5)

After:
![after](https://github.com/commons-app/apps-android-commons/assets/142137555/35d0684c-4334-4565-980a-0bcb605ad6f3)

Recording showing the functionality of the + button after the changes:
https://github.com/commons-app/apps-android-commons/assets/142137555/094e41aa-e1bc-44b0-96a5-f6fcb4ff5b02

