### PR TITLE
Resolves #2239 by adding a compass arrow for direction of nearest item

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -809,6 +809,9 @@ public class ContributionsFragment
       }
   };
 
+    /**
+     * When the device rotates, rotate the Nearby banner's compass arrow in tandem.
+     */
     @Override
     public void onSensorChanged(SensorEvent event) {
         float rotateDegree = Math.round(event.values[0]);
@@ -817,9 +820,6 @@ public class ContributionsFragment
 
     @Override
     public void onAccuracyChanged(Sensor sensor, int accuracy) {
-
+        // Nothing to do.
     }
-
-
 }
-

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyNotificationCardView.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyNotificationCardView.java
@@ -27,6 +27,7 @@ public class NearbyNotificationCardView extends SwipableCardView {
     private TextView notificationTitle;
     private TextView notificationDistance;
     private ImageView notificationIcon;
+    private ImageView notificationCompass;
     private ProgressBar progressBar;
 
     public CardViewVisibilityState cardViewVisibilityState;
@@ -64,6 +65,7 @@ public class NearbyNotificationCardView extends SwipableCardView {
         notificationDistance = rootView.findViewById(R.id.nearby_distance);
 
         notificationIcon = rootView.findViewById(R.id.nearby_icon);
+        notificationCompass = rootView.findViewById(R.id.nearby_compass);
 
         progressBar = rootView.findViewById(R.id.progressBar);
 
@@ -111,10 +113,11 @@ public class NearbyNotificationCardView extends SwipableCardView {
     }
 
     /**
-     * Pass place information to views.
+     * Pass place information to views and set compass arrow direction
      * @param place Closes place where we will get information from
+     * @param direction Direction in which compass arrow needs to be set
      */
-    public void updateContent(Place place) {
+    public void updateContent(Place place, float direction) {
         Timber.d("Update nearby card notification content");
         this.setVisibility(VISIBLE);
         cardViewVisibilityState = CardViewVisibilityState.READY;
@@ -129,7 +132,7 @@ public class NearbyNotificationCardView extends SwipableCardView {
         notificationIcon.setVisibility(VISIBLE);
         notificationTitle.setText(place.name);
         notificationDistance.setText(place.distance);
-
+        notificationCompass.setRotation(direction);
     }
 
     @Override
@@ -151,6 +154,7 @@ public class NearbyNotificationCardView extends SwipableCardView {
                     notificationTitle.setVisibility(VISIBLE);
                     notificationDistance.setVisibility(VISIBLE);
                     notificationIcon.setVisibility(VISIBLE);
+                    notificationCompass.setVisibility(VISIBLE);
                     break;
                 case LOADING:
                     permissionRequestButton.setVisibility(GONE);
@@ -160,6 +164,7 @@ public class NearbyNotificationCardView extends SwipableCardView {
                     notificationTitle.setVisibility(GONE);
                     notificationDistance.setVisibility(GONE);
                     notificationIcon.setVisibility(GONE);
+                    notificationCompass.setVisibility(GONE);
                     permissionRequestButton.setVisibility(GONE);
                     break;
                 case ASK_PERMISSION:
@@ -191,5 +196,15 @@ public class NearbyNotificationCardView extends SwipableCardView {
         ENABLE_GPS,
         ENABLE_LOCATION_PERMISSION, // For only after Marshmallow
         NO_PERMISSION_NEEDED
+    }
+
+    /**
+     * Rotates the compass arrow in tandem with the rotation of device
+     *
+     * @param rotateDegree Degree by which device was rotated
+     * @param direction Direction in which arrow has to point
+     */
+    public void rotateCompass(float rotateDegree, float direction){
+        notificationCompass.setRotation(-(rotateDegree-direction));
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/utils/LengthUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/LengthUtils.java
@@ -123,4 +123,24 @@ public class LengthUtils {
         double sinHalf = Math.sin(x * 0.5D);
         return sinHalf * sinHalf;
     }
+
+    /**
+     * Computes bearing between the two given points
+     *
+     * @see <a href="https://www.movable-type.co.uk/scripts/latlong.html">Bearing</a>
+     * @param point1 Coordinates of first point
+     * @param point2 Coordinates of second point
+     * @return Bearing between the two end points in degrees
+     * @throws NullPointerException if one or both the points are null
+     */
+    
+    public static double computeBearing(@NonNull LatLng point1, @NonNull LatLng point2) {
+        double diffLongitute = Math.toRadians(point2.getLongitude() - point1.getLongitude());
+        double lat1 = Math.toRadians(point1.getLatitude());
+        double lat2 = Math.toRadians(point2.getLatitude());
+        double y = Math.sin(diffLongitute) * Math.cos(lat2);
+        double x = Math.cos(lat1) * Math.sin(lat2) - Math.sin(lat1) * Math.cos(lat2) * Math.cos(diffLongitute);
+        double bearing = Math.atan2(y, x);
+        return (Math.toDegrees(bearing) + 360) % 360;
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/utils/LengthUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/LengthUtils.java
@@ -133,7 +133,6 @@ public class LengthUtils {
      * @return Bearing between the two end points in degrees
      * @throws NullPointerException if one or both the points are null
      */
-    
     public static double computeBearing(@NonNull LatLng point1, @NonNull LatLng point2) {
         double diffLongitute = Math.toRadians(point2.getLongitude() - point1.getLongitude());
         double lat1 = Math.toRadians(point1.getLatitude());

--- a/app/src/main/res/drawable/baseline_arrow_upward_24.xml
+++ b/app/src/main/res/drawable/baseline_arrow_upward_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="?attr/tabTextColor"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="?attr/tabTextColor" android:pathData="M4,12l1.41,1.41L11,7.83V20h2V7.83l5.58,5.59L20,12l-8,-8 -8,8z"/>
+</vector>

--- a/app/src/main/res/layout/nearby_card_view.xml
+++ b/app/src/main/res/layout/nearby_card_view.xml
@@ -93,6 +93,13 @@
 
             </TextView>
 
+            <ImageView
+              android:id="@+id/nearby_compass"
+              android:layout_width="40dp"
+              android:layout_height="40dp"
+              android:layout_marginEnd="16dp"
+              app:srcCompat="@drawable/baseline_arrow_upward_24"/>
+
         </LinearLayout>
 
     </LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,4 +1,4 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
 
     <style name="DarkAppTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="contributionsListBackground">@color/contributionListDarkBackground</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="DarkAppTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="contributionsListBackground">@color/contributionListDarkBackground</item>

--- a/app/src/test/kotlin/fr/free/nrw/commons/utils/LengthUtilsTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/utils/LengthUtilsTest.kt
@@ -106,6 +106,29 @@ class LengthUtilsTest {
         assertDistanceBetween(20015115.07, pointA, pointB)
     }
 
+    // Test LengthUtils.formatDistanceBetween()
+
+    @Test
+    fun testBearingPoleToPole() {
+        val pointA = LatLng(90.0, 0.0, 0f)
+        val pointB = LatLng(-90.0, 0.0, 0f)
+        assertBearing(180.00, pointA, pointB)
+    }
+
+    @Test
+    fun testBearingRandomPoints() {
+        val pointA = LatLng(27.17, 78.04, 0f)
+        val pointB = LatLng(-40.69, 04.13, 0f)
+        assertBearing(227.46, pointA, pointB)
+    }
+
+    @Test
+    fun testBearingSamePlace() {
+        val pointA = LatLng(90.0, 0.0, 0f)
+        val pointB = LatLng(90.0, 0.0, 0f)
+        assertBearing(0.0, pointA, pointB)
+    }
+
     // Test assertion helper functions
 
     private fun assertFormattedDistanceBetween(expected: String, pointA: LatLng, pointB: LatLng) =
@@ -117,4 +140,8 @@ class LengthUtilsTest {
     private fun assertDistanceBetween(expected: Double, pointA: LatLng, pointB: LatLng) =
     // Acceptable error: 1cm
             assertEquals(expected, LengthUtils.computeDistanceBetween(pointA, pointB), 0.01)
+
+    private fun assertBearing(expected: Double, pointA: LatLng, pointB: LatLng) =
+        // Acceptable error: 1 degree
+        assertEquals(expected, LengthUtils.computeBearing(pointA,pointB), 1.0)
 }


### PR DESCRIPTION
**Description (required)**
The CTA for the nearest item was missing the direction the user needed to head in. This PR aims to add a compass arrow to aid the user in moving in the direction of the nearest item without knowing where North is.

Fixes #2239 

**What changes did you make and why?**
Computed bearing between the current location and the location of the nearest item and set the initial rotation of the compass arrow to the calculated bearing. Using the onSensorChanged, calculated the degree of rotation of the device and rotated the arrow accordingly, so that if the device is rotated by 30 degrees, the arrow does the same in the opposite direction.

**Tests performed (required)**

Tested prodDebug on OnePlus Nord CE 2 Lite with API level 31.

**Screenshots (for UI changes only)**

Example showing the accuracy of compass arrow:

![Example 1](https://github.com/commons-app/apps-android-commons/assets/142137555/f2c1a3a1-c333-4653-9612-9e622d5d9e89)

![Proof1](https://github.com/commons-app/apps-android-commons/assets/142137555/a1454ebd-5ca1-403c-b88c-738ea957fb7e)


Videos showing the rotation of the compass arrow with the device's rotation.

Dark Mode:
https://github.com/commons-app/apps-android-commons/assets/142137555/db6d20e2-3901-49c9-a661-5c6b58216248

Light Mode:
https://github.com/commons-app/apps-android-commons/assets/142137555/897868f0-3789-4262-916c-75aa1a0eabbd


