### PR TITLE
Peer Review Fix

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.java
@@ -27,6 +27,7 @@ import com.facebook.drawee.view.SimpleDraweeView;
 import com.viewpagerindicator.CirclePageIndicator;
 import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
+import fr.free.nrw.commons.auth.AccountUtil;
 import fr.free.nrw.commons.delete.DeleteHelper;
 import fr.free.nrw.commons.media.MediaDetailFragment;
 import fr.free.nrw.commons.theme.BaseActivity;
@@ -214,6 +215,12 @@ public class ReviewActivity extends BaseActivity {
         String fileName = media.getFilename();
         if (fileName.length() == 0) {
             ViewUtil.showShortSnackbar(drawerLayout, R.string.error_review);
+            return;
+        }
+
+        //If The Media User and Current Session Username is same then Skip the Image
+        if (media.getUser() != null && media.getUser().equals(AccountUtil.getUserName(getApplicationContext()))) {
+            runRandomizer();
             return;
         }
 

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
@@ -21,6 +21,7 @@ import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class ReviewImageFragment extends CommonsDaggerSupportFragment {
 
@@ -91,6 +92,15 @@ public class ReviewImageFragment extends CommonsDaggerSupportFragment {
         ButterKnife.bind(this, layoutView);
 
         String question, explanation=null, yesButtonText, noButtonText;
+
+        //Skip Image of it is created by saved user
+        Media media = getReviewActivity().getMedia();
+        if (media != null && Objects.equals(media.getUser(),
+            savedInstanceState.getString(SAVED_USER))) {
+            disableButtons();
+            getReviewActivity().runRandomizer();
+        }
+
         switch (position) {
             case SPAM:
                 question = getString(R.string.review_spam);

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
@@ -93,14 +93,6 @@ public class ReviewImageFragment extends CommonsDaggerSupportFragment {
 
         String question, explanation=null, yesButtonText, noButtonText;
 
-        //Skip Image of it is created by saved user
-        Media media = getReviewActivity().getMedia();
-        if (media != null && Objects.equals(media.getUser(),
-            savedInstanceState.getString(SAVED_USER))) {
-            disableButtons();
-            getReviewActivity().runRandomizer();
-        }
-
         switch (position) {
             case SPAM:
                 question = getString(R.string.review_spam);


### PR DESCRIPTION
**Description (required)**

Fixes #5435 

What changes did you make and why?
Added Logic to skip the Media in Peer Review if the user for the current media is same as the current user reviewing it.

**Tests performed (required)**

Tested {build variant, e.g. ProdDebug} on {name of device or emulator} with API level {API level}.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
