### PR TITLE
Resolves #2307 make achievements activity more visible 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetFragment.java
@@ -92,7 +92,7 @@ public class MoreBottomSheetFragment extends BottomSheetDialogFragment {
     }
 
     /**
-     * Set the username and user level (if available) in navigationHeader.
+     * Set the username and user achievements level (if available) in navigationHeader.
      */
     private void setUserName() {
         BasicKvStore store = new BasicKvStore(this.getContext(), getUserName());

--- a/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetFragment.java
@@ -96,13 +96,12 @@ public class MoreBottomSheetFragment extends BottomSheetDialogFragment {
      */
     private void setUserName() {
         BasicKvStore store = new BasicKvStore(this.getContext(), getUserName());
-        String level = store.getString("userLevel","0");
-        if(level.equals("0"))
-        {
-            moreProfile.setText(getUserName() + " ("+getString(R.string.see_your_achievements)+")");
+        String level = store.getString("userAchievementsLevel","0");
+        if (level.equals("0")) {
+            moreProfile.setText(getUserName() + " (" + getString(R.string.see_your_achievements) + ")");
         }
         else {
-            moreProfile.setText(getUserName() + " ("+getString(R.string.level)+" "+level+")");
+            moreProfile.setText(getUserName() + " (" + getString(R.string.level) + " " + level + ")");
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetFragment.java
@@ -28,6 +28,7 @@ import fr.free.nrw.commons.di.ApplicationlessInjection;
 import fr.free.nrw.commons.feedback.FeedbackContentCreator;
 import fr.free.nrw.commons.feedback.model.Feedback;
 import fr.free.nrw.commons.feedback.FeedbackDialog;
+import fr.free.nrw.commons.kvstore.BasicKvStore;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.logging.CommonsLogSender;
 import fr.free.nrw.commons.profile.ProfileActivity;
@@ -91,17 +92,24 @@ public class MoreBottomSheetFragment extends BottomSheetDialogFragment {
     }
 
     /**
-     * Set the username in navigationHeader.
+     * Set the username and user level (if available) in navigationHeader.
      */
     private void setUserName() {
-        moreProfile.setText(getUserName());
+        BasicKvStore store = new BasicKvStore(this.getContext(), getUserName());
+        String level = store.getString("userLevel","0");
+        if(level.equals("0"))
+        {
+            moreProfile.setText(getUserName() + " ("+getString(R.string.see_your_achievements)+")");
+        }
+        else {
+            moreProfile.setText(getUserName() + " ("+getString(R.string.level)+" "+level+")");
+        }
     }
 
     private String getUserName(){
         final AccountManager accountManager = AccountManager.get(getActivity());
         final Account[] allAccounts = accountManager.getAccountsByType(BuildConfig.ACCOUNT_TYPE);
         if (allAccounts.length != 0) {
-            moreProfile.setText(allAccounts[0].name);
             return allAccounts[0].name;
         }
         return "";

--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -379,7 +379,7 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
                 new ContextThemeWrapper(getActivity(), levelInfo.getLevelStyle()).getTheme()));
         binding.achievementBadgeText.setText(Integer.toString(levelInfo.getLevelNumber()));
         BasicKvStore store = new BasicKvStore(this.getContext(), userName);
-        store.putString("userLevel", Integer.toString(levelInfo.getLevelNumber()));
+        store.putString("userAchievementsLevel", Integer.toString(levelInfo.getLevelNumber()));
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -358,7 +358,7 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
 
     /**
      * Used the inflate the fetched statistics of the images uploaded by user
-     * and assign badge and level. Also stores the level of user in BasicKvStore to display in menu
+     * and assign badge and level. Also stores the achivements level of the user in BasicKvStore to display in menu
      * @param achievements
      */
     private void inflateAchievements(Achievements achievements) {

--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -27,6 +27,7 @@ import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.auth.SessionManager;
 import fr.free.nrw.commons.databinding.FragmentAchievementsBinding;
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment;
+import fr.free.nrw.commons.kvstore.BasicKvStore;
 import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient;
 import fr.free.nrw.commons.utils.ConfigUtils;
 import fr.free.nrw.commons.utils.DialogUtil;
@@ -357,7 +358,7 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
 
     /**
      * Used the inflate the fetched statistics of the images uploaded by user
-     * and assign badge and level
+     * and assign badge and level. Also stores the level of user in BasicKvStore to display in menu
      * @param achievements
      */
     private void inflateAchievements(Achievements achievements) {
@@ -377,6 +378,8 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
         binding.achievementBadgeImage.setImageDrawable(VectorDrawableCompat.create(getResources(), R.drawable.badge,
                 new ContextThemeWrapper(getActivity(), levelInfo.getLevelStyle()).getTheme()));
         binding.achievementBadgeText.setText(Integer.toString(levelInfo.getLevelNumber()));
+        BasicKvStore store = new BasicKvStore(this.getContext(), userName);
+        store.putString("userLevel", Integer.toString(levelInfo.getLevelNumber()));
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -358,7 +358,7 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
 
     /**
      * Used the inflate the fetched statistics of the images uploaded by user
-     * and assign badge and level. Also stores the achivements level of the user in BasicKvStore to display in menu
+     * and assign badge and level. Also stores the achievements level of the user in BasicKvStore to display in menu
      * @param achievements
      */
     private void inflateAchievements(Achievements achievements) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -786,6 +786,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="permissions_are_required_for_functionality">Permissions are required for functionality</string>
   <string name="learn_how_to_write_a_useful_description">Learn how to write a useful description</string>
   <string name="learn_how_to_write_a_useful_caption">Learn how to write a useful caption</string>
+  <string name="see_your_achievements">see your achievements</string>
   <plurals name="custom_picker_images_selected_title_appendix">
     <item quantity="one">%d image selected</item>
     <item quantity="other">%d images selected</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -786,7 +786,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="permissions_are_required_for_functionality">Permissions are required for functionality</string>
   <string name="learn_how_to_write_a_useful_description">Learn how to write a useful description</string>
   <string name="learn_how_to_write_a_useful_caption">Learn how to write a useful caption</string>
-  <string name="see_your_achievements">see your achievementS</string>
+  <string name="see_your_achievements">See your achievements</string>
   <plurals name="custom_picker_images_selected_title_appendix">
     <item quantity="one">%d image selected</item>
     <item quantity="other">%d images selected</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -786,7 +786,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="permissions_are_required_for_functionality">Permissions are required for functionality</string>
   <string name="learn_how_to_write_a_useful_description">Learn how to write a useful description</string>
   <string name="learn_how_to_write_a_useful_caption">Learn how to write a useful caption</string>
-  <string name="see_your_achievements">see your achievements</string>
+  <string name="see_your_achievements">see your achievementS</string>
   <plurals name="custom_picker_images_selected_title_appendix">
     <item quantity="one">%d image selected</item>
     <item quantity="other">%d images selected</item>


### PR DESCRIPTION
**Description (required)**
The achievements activity needed to be made more discoverable to the users, so this PR aims to add their user level next to their username.

Fixes #2307 

**What changes did you make and why?**
Stored the level of the user using BasicKvStore and displayed the user level next to their username in the menu. If the user level is unknown, then a (see your achievements) CTA is added.

**Tests performed (required)**

Tested prodDebug on OnePlus Nord CE 2 Lite with API level 31 and emulator Pixel 7 Pro with API Level 31.

**Screenshots (for UI changes only)**

Dark Mode:

When user level is unkown 
![Dark 1](https://github.com/commons-app/apps-android-commons/assets/142137555/594fa5a1-a919-457d-b778-a4fa378db245)

When user level is known:
![Dark 2](https://github.com/commons-app/apps-android-commons/assets/142137555/3e4337a0-5409-43e4-8f93-f5458ebb73b7)


Light Mode:

When user level is unknown:
![Light 1](https://github.com/commons-app/apps-android-commons/assets/142137555/bdf1153d-0a00-498d-bc50-448b27440895)

When user level is known:
![light 2](https://github.com/commons-app/apps-android-commons/assets/142137555/85997a51-d82f-4256-ac2b-c0b9f96a2b5b)

