### PR TITLE
UploadMediaDetailInputFilter: added a pattern to identify colon.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailInputFilter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailInputFilter.java
@@ -20,6 +20,7 @@ public class UploadMediaDetailInputFilter implements InputFilter {
             Pattern.compile("[\\x{00A0}\\x{1680}\\x{180E}\\x{2000}-\\x{200B}\\x{2028}\\x{2029}\\x{202F}\\x{205F}]"),
             Pattern.compile("[\\x{202A}-\\x{202E}]"),
             Pattern.compile("\\p{Cc}"),
+            Pattern.compile("\\x{3A}"), // Added for colon(:)
             Pattern.compile("\\x{FEFF}"),
             Pattern.compile("\\x{00AD}"),
             Pattern.compile("[\\x{E000}-\\x{F8FF}\\x{FFF0}-\\x{FFFF}]"),

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailInputFilterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailInputFilterTest.kt
@@ -61,7 +61,7 @@ class UploadMediaDetailInputFilterTest {
         builder.filters = arrayOf(UploadMediaDetailInputFilter())
 
         //Sample of control characters
-        val tests = intArrayOf(0x00, 0x08, 0x10, 0x18, 0x1F, 0x7F)
+        val tests = intArrayOf(0x00, 0x08, 0x10, 0x18, 0x1F, 0x7F, 0x3A)
         for (test: Int in tests) {
             builder.insert(0, String(Character.toChars(test)))
             Assert.assertEquals(builder.toString(), "")


### PR DESCRIPTION
**Description (required)**
Added hex code of colon for MediaDetailInputFilter and updated test for it.

Fixes #5416 

What changes did you make and why?
In the file UploadMediaDetailInputFilter.java, I added a pattern that identifies colon that needs to be filtered from the caption.
Also updated test - `testFilterControlCharacters()` in file `MediaDetailInputFilterTest.kt`.

**Tests performed (required)**
1 Test - `testFilterControlCharacters()` passed.
Also, manually tested it on my device.

Tested betaDebug on Samsung A14 with API level 34.

**Screenshots (for UI changes only)**
No UI changes.