### PR TITLE
Resolves #5444 & #5455 updating nearest item distance and direction as user moves 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -118,7 +118,6 @@ public class ContributionsFragment
 
     private LatLng curLatLng;
 
-    private boolean firstLocationUpdate = true;
     private boolean isFragmentAttachedBefore = false;
     private View checkBoxView;
     private CheckBox checkBox;
@@ -453,7 +452,6 @@ public class ContributionsFragment
     public void onResume() {
         super.onResume();
         contributionsPresenter.onAttachView(this);
-        firstLocationUpdate = true;
         locationManager.addLocationListener(this);
         nearbyNotificationCardView.permissionRequestButton.setOnClickListener(v -> {
             showNearbyCardPermissionRationale();
@@ -572,22 +570,17 @@ public class ContributionsFragment
     @Override
     public void onLocationChangedSignificantly(LatLng latLng) {
         // Will be called if location changed more than 1000 meter
-        // Do nothing on slight changes for using network efficiently
-        firstLocationUpdate = false;
         updateClosestNearbyCardViewInfo();
     }
 
     @Override
     public void onLocationChangedSlightly(LatLng latLng) {
         /* Update closest nearby notification card onLocationChangedSlightly
-        If first time to update location after onResume, then no need to wait for significant
-        location change. Any closest location is better than no location
         */
-        if (firstLocationUpdate) {
+        try {
             updateClosestNearbyCardViewInfo();
-            // Turn it to false, since it is not first location update anymore. To change closest location
-            // notification, we need to wait for a significant location change.
-            firstLocationUpdate = false;
+        } catch (Exception e) {
+            Timber.e(e);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LocationServiceManager.java
@@ -21,8 +21,8 @@ import timber.log.Timber;
 public class LocationServiceManager implements LocationListener {
 
     // Maybe these values can be improved for efficiency
-    private static final long MIN_LOCATION_UPDATE_REQUEST_TIME_IN_MILLIS = 2 * 60 * 100;
-    private static final long MIN_LOCATION_UPDATE_REQUEST_DISTANCE_IN_METERS = 10;
+    private static final long MIN_LOCATION_UPDATE_REQUEST_TIME_IN_MILLIS = 10 * 100;
+    private static final long MIN_LOCATION_UPDATE_REQUEST_DISTANCE_IN_METERS = 1;
 
     private LocationManager locationManager;
     private Location lastLocation;


### PR DESCRIPTION
**Description (required)**
This PR aims to add the feature of updating the distance from the nearest item as the user moves, which would aid the users while travelling towards it. Also, the bug of the compass not updating directions after walking past the place will be solved.

Fixes #5444 and #5455

**What changes did you make and why?**
Updated nearby banner whenever the location is changed slightly and fine-tuned the minimum distance and minimum time parameters to request for location updates. This will not only update the distance from the nearest item, but also update the direction of it, even after walking past the place.

**Tests performed (required)**

Tested prodDebug on OnePlusNord CE 2 Lite with API level 31.

**Screenshots (for UI changes only)**

Screencast showing updation of distance from nearest item as user moves:
https://drive.google.com/file/d/1_8RayBnvMDGLfYpSiwWTXui2PkgjO3iT/view?usp=share_link
