### PR TITLE
Removed references to the data-client Service interface

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/actions/PageEditInterface.kt
+++ b/app/src/main/java/fr/free/nrw/commons/actions/PageEditInterface.kt
@@ -1,8 +1,8 @@
 package fr.free.nrw.commons.actions
 
+import fr.free.nrw.commons.wikidata.WikidataConstants.MW_API_PREFIX
 import io.reactivex.Observable
 import io.reactivex.Single
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.mwapi.MwQueryResponse
 import org.wikipedia.edit.Edit
 import org.wikipedia.wikidata.Entities
@@ -27,7 +27,7 @@ interface PageEditInterface {
      */
     @FormUrlEncoded
     @Headers("Cache-Control: no-cache")
-    @POST(Service.MW_API_PREFIX + "action=edit")
+    @POST(MW_API_PREFIX + "action=edit")
     fun postEdit(
         @Field("title") title: String,
         @Field("summary") summary: String,
@@ -47,7 +47,7 @@ interface PageEditInterface {
      */
     @FormUrlEncoded
     @Headers("Cache-Control: no-cache")
-    @POST(Service.MW_API_PREFIX + "action=edit")
+    @POST(MW_API_PREFIX + "action=edit")
     fun postAppendEdit(
         @Field("title") title: String,
         @Field("summary") summary: String,
@@ -66,7 +66,7 @@ interface PageEditInterface {
      */
     @FormUrlEncoded
     @Headers("Cache-Control: no-cache")
-    @POST(Service.MW_API_PREFIX + "action=edit")
+    @POST(MW_API_PREFIX + "action=edit")
     fun postPrependEdit(
         @Field("title") title: String,
         @Field("summary") summary: String,
@@ -77,7 +77,7 @@ interface PageEditInterface {
 
     @FormUrlEncoded
     @Headers("Cache-Control: no-cache")
-    @POST(Service.MW_API_PREFIX + "action=wbsetlabel&format=json&site=commonswiki&formatversion=2")
+    @POST(MW_API_PREFIX + "action=wbsetlabel&format=json&site=commonswiki&formatversion=2")
     fun postCaptions(
         @Field("summary") summary: String,
         @Field("title") title: String,
@@ -91,10 +91,7 @@ interface PageEditInterface {
      * @param titles : Name of the file
      * @return Single<MwQueryResult>
      */
-    @GET(
-        Service.MW_API_PREFIX +
-                "action=query&prop=revisions&rvprop=content|timestamp&rvlimit=1&converttitles="
-    )
+    @GET(MW_API_PREFIX + "action=query&prop=revisions&rvprop=content|timestamp&rvlimit=1&converttitles=")
     fun getWikiText(
         @Query("titles") title: String
     ): Single<MwQueryResponse?>

--- a/app/src/main/java/fr/free/nrw/commons/actions/ThanksInterface.kt
+++ b/app/src/main/java/fr/free/nrw/commons/actions/ThanksInterface.kt
@@ -1,7 +1,7 @@
 package fr.free.nrw.commons.actions
 
+import fr.free.nrw.commons.wikidata.WikidataConstants.MW_API_PREFIX
 import io.reactivex.Observable
-import org.wikipedia.dataclient.Service
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.POST
@@ -14,7 +14,7 @@ import retrofit2.http.POST
  */
 interface ThanksInterface {
     @FormUrlEncoded
-    @POST(Service.MW_API_PREFIX + "action=thank")
+    @POST(MW_API_PREFIX + "action=thank")
     fun thank(
         @Field("rev") rev: String?,
         @Field("log") log: String?,

--- a/app/src/main/java/fr/free/nrw/commons/auth/csrf/CsrfTokenInterface.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/csrf/CsrfTokenInterface.kt
@@ -1,6 +1,6 @@
 package fr.free.nrw.commons.auth.csrf
 
-import org.wikipedia.dataclient.Service
+import fr.free.nrw.commons.wikidata.WikidataConstants.MW_API_PREFIX
 import org.wikipedia.dataclient.mwapi.MwQueryResponse
 import retrofit2.Call
 import retrofit2.http.GET
@@ -8,6 +8,6 @@ import retrofit2.http.Headers
 
 interface CsrfTokenInterface {
     @Headers("Cache-Control: no-cache")
-    @GET(Service.MW_API_PREFIX + "action=query&meta=tokens&type=csrf")
+    @GET(MW_API_PREFIX + "action=query&meta=tokens&type=csrf")
     fun getCsrfTokenCall(): Call<MwQueryResponse?>
 }

--- a/app/src/main/java/fr/free/nrw/commons/auth/login/LoginClient.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/login/LoginClient.kt
@@ -3,9 +3,9 @@ package fr.free.nrw.commons.auth.login
 import android.text.TextUtils
 import fr.free.nrw.commons.auth.login.LoginResult.OAuthResult
 import fr.free.nrw.commons.auth.login.LoginResult.ResetPasswordResult
+import fr.free.nrw.commons.wikidata.WikidataConstants.WIKIPEDIA_URL
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryResponse
@@ -57,7 +57,7 @@ class LoginClient {
 
         loginCall = if (twoFactorCode.isNullOrEmpty() && retypedPassword.isNullOrEmpty()) {
             ServiceFactory.get(wiki, LoginInterface::class.java)
-                .postLogIn(userName, password, loginToken, userLanguage, Service.WIKIPEDIA_URL)
+                .postLogIn(userName, password, loginToken, userLanguage, WIKIPEDIA_URL)
         } else {
             ServiceFactory.get(wiki, LoginInterface::class.java).postLogIn(
                 userName, password, retypedPassword, twoFactorCode, loginToken, userLanguage, true
@@ -115,8 +115,7 @@ class LoginClient {
         val loginToken = tokenResponse.body()?.query()?.loginToken()
         val tempLoginCall = if (twoFactorCode.isNullOrEmpty()) {
             ServiceFactory.get(wiki, LoginInterface::class.java).postLogIn(
-                userName, password, loginToken, userLanguage, Service.WIKIPEDIA_URL
-            )
+                userName, password, loginToken, userLanguage, WIKIPEDIA_URL)
         } else {
             ServiceFactory.get(wiki, LoginInterface::class.java).postLogIn(
                 userName, password, null, twoFactorCode, loginToken, userLanguage, true

--- a/app/src/main/java/fr/free/nrw/commons/auth/login/LoginInterface.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/login/LoginInterface.kt
@@ -1,7 +1,7 @@
 package fr.free.nrw.commons.auth.login
 
+import fr.free.nrw.commons.wikidata.WikidataConstants.MW_API_PREFIX
 import io.reactivex.Observable
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.mwapi.MwQueryResponse
 import retrofit2.Call
 import retrofit2.http.Field
@@ -13,12 +13,12 @@ import retrofit2.http.Query
 
 interface LoginInterface {
     @Headers("Cache-Control: no-cache")
-    @GET(Service.MW_API_PREFIX + "action=query&meta=tokens&type=login")
+    @GET(MW_API_PREFIX + "action=query&meta=tokens&type=login")
     fun getLoginToken(): Call<MwQueryResponse?>
 
     @Headers("Cache-Control: no-cache")
     @FormUrlEncoded
-    @POST(Service.MW_API_PREFIX + "action=clientlogin&rememberMe=")
+    @POST(MW_API_PREFIX + "action=clientlogin&rememberMe=")
     fun postLogIn(
         @Field("username") user: String?,
         @Field("password") pass: String?,
@@ -29,7 +29,7 @@ interface LoginInterface {
 
     @Headers("Cache-Control: no-cache")
     @FormUrlEncoded
-    @POST(Service.MW_API_PREFIX + "action=clientlogin&rememberMe=")
+    @POST(MW_API_PREFIX + "action=clientlogin&rememberMe=")
     fun postLogIn(
         @Field("username") user: String?,
         @Field("password") pass: String?,
@@ -40,6 +40,6 @@ interface LoginInterface {
         @Field("logincontinue") loginContinue: Boolean
     ): Call<LoginResponse?>
 
-    @GET(Service.MW_API_PREFIX + "action=query&meta=userinfo&list=users&usprop=groups|cancreate")
+    @GET(MW_API_PREFIX + "action=query&meta=userinfo&list=users&usprop=groups|cancreate")
     fun getUserInfo(@Query("ususers") userName: String): Observable<MwQueryResponse?>
 }

--- a/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
@@ -168,20 +168,6 @@ public class NetworkingModule {
 
     @Provides
     @Singleton
-    @Named("commons-service")
-    public Service provideCommonsService(@Named(NAMED_COMMONS_WIKI_SITE) WikiSite commonsWikiSite) {
-        return ServiceFactory.get(commonsWikiSite);
-    }
-
-    @Provides
-    @Singleton
-    @Named("wikidata-service")
-    public Service provideWikidataService(@Named(NAMED_WIKI_DATA_WIKI_SITE) WikiSite wikidataWikiSite) {
-        return ServiceFactory.get(wikidataWikiSite, BuildConfig.WIKIDATA_URL, Service.class);
-    }
-
-    @Provides
-    @Singleton
     public ReviewInterface provideReviewInterface(@Named(NAMED_COMMONS_WIKI_SITE) WikiSite commonsWikiSite) {
         return ServiceFactory.get(commonsWikiSite, BuildConfig.COMMONS_URL, ReviewInterface.class);
     }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailInterface.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailInterface.java
@@ -1,11 +1,11 @@
 package fr.free.nrw.commons.media;
 
+import static fr.free.nrw.commons.wikidata.WikidataConstants.MW_API_PREFIX;
+
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import org.wikipedia.dataclient.Service;
 import org.wikipedia.dataclient.mwapi.MwQueryResponse;
 import org.wikipedia.wikidata.Entities;
-import retrofit2.Call;
 import retrofit2.http.GET;
 import retrofit2.http.Query;
 
@@ -43,10 +43,7 @@ public interface MediaDetailInterface {
      * @param title file name
      * @return Single<MwQueryResponse>
      */
-    @GET(
-        Service.MW_API_PREFIX +
-            "action=query&prop=revisions&rvprop=content|timestamp&rvlimit=1&converttitles="
-    )
+    @GET(MW_API_PREFIX + "action=query&prop=revisions&rvprop=content|timestamp&rvlimit=1&converttitles=")
     Single<MwQueryResponse> getWikiText(
         @Query("titles") String title
     );

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/UserInterface.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/UserInterface.java
@@ -9,7 +9,7 @@ import retrofit2.http.GET;
 import retrofit2.http.Query;
 import retrofit2.http.QueryMap;
 
-import static org.wikipedia.dataclient.Service.MW_API_PREFIX;
+import static fr.free.nrw.commons.wikidata.WikidataConstants.MW_API_PREFIX;
 
 public interface UserInterface {
 
@@ -20,7 +20,7 @@ public interface UserInterface {
      * @return query response
      */
 
-    @GET(MW_API_PREFIX+"action=query&list=logevents&letype=upload&leprop=title|timestamp|ids&lelimit=500")
+    @GET(MW_API_PREFIX + "action=query&list=logevents&letype=upload&leprop=title|timestamp|ids&lelimit=500")
     Observable<MwQueryResponse> getUserLogEvents(@Query("leuser") String user, @QueryMap Map<String, String> continuation);
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationInterface.kt
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationInterface.kt
@@ -1,7 +1,7 @@
 package fr.free.nrw.commons.notification
 
+import fr.free.nrw.commons.wikidata.WikidataConstants.MW_API_PREFIX
 import io.reactivex.Observable
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.mwapi.MwQueryResponse
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
@@ -13,7 +13,7 @@ import retrofit2.http.Query
 interface NotificationInterface {
 
     @Headers("Cache-Control: no-cache")
-    @GET(Service.MW_API_PREFIX + "action=query&meta=notifications&notformat=model&notlimit=max")
+    @GET(MW_API_PREFIX + "action=query&meta=notifications&notformat=model&notlimit=max")
     fun getAllNotifications(
         @Query("notwikis") wikiList: String?,
         @Query("notfilter") filter: String?,
@@ -22,7 +22,7 @@ interface NotificationInterface {
 
     @FormUrlEncoded
     @Headers("Cache-Control: no-cache")
-    @POST(Service.MW_API_PREFIX + "action=echomarkread")
+    @POST(MW_API_PREFIX + "action=echomarkread")
     fun markRead(
         @Field("token") token: String,
         @Field("list") readList: String?,

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadInterface.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadInterface.java
@@ -1,7 +1,8 @@
 package fr.free.nrw.commons.upload;
 
-import androidx.annotation.NonNull;
+import static fr.free.nrw.commons.wikidata.WikidataConstants.MW_API_PREFIX;
 
+import androidx.annotation.NonNull;
 import com.google.gson.JsonObject;
 import io.reactivex.Observable;
 import okhttp3.MultipartBody;
@@ -12,8 +13,6 @@ import retrofit2.http.Headers;
 import retrofit2.http.Multipart;
 import retrofit2.http.POST;
 import retrofit2.http.Part;
-
-import static org.wikipedia.dataclient.Service.MW_API_PREFIX;
 
 public interface UploadInterface {
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/WikiBaseInterface.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/WikiBaseInterface.java
@@ -1,6 +1,6 @@
 package fr.free.nrw.commons.upload;
 
-import static org.wikipedia.dataclient.Service.MW_API_PREFIX;
+import static fr.free.nrw.commons.wikidata.WikidataConstants.MW_API_PREFIX;
 
 import androidx.annotation.NonNull;
 import io.reactivex.Observable;

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataConstants.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataConstants.java
@@ -5,4 +5,7 @@ public class WikidataConstants {
     public static final String BOOKMARKS_ITEMS = "bookmarks.items";
     public static final String SELECTED_NEARBY_PLACE = "selected.nearby.place";
     public static final String SELECTED_NEARBY_PLACE_CATEGORY = "selected.nearby.place.category";
+
+    public static final String MW_API_PREFIX = "w/api.php?format=json&formatversion=2&errorformat=plaintext&";
+    public static final String WIKIPEDIA_URL = "https://wikipedia.org/";
 }

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataInterface.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataInterface.java
@@ -2,22 +2,17 @@ package fr.free.nrw.commons.wikidata;
 
 import androidx.annotation.NonNull;
 
-import com.google.gson.JsonObject;
 import org.wikipedia.dataclient.mwapi.MwQueryResponse;
 
-import fr.free.nrw.commons.wikidata.model.AddEditTagResponse;
 import fr.free.nrw.commons.wikidata.model.WbCreateClaimResponse;
 import io.reactivex.Observable;
-import okhttp3.RequestBody;
 import retrofit2.http.Field;
 import retrofit2.http.FormUrlEncoded;
 import retrofit2.http.GET;
 import retrofit2.http.Headers;
-import retrofit2.http.Multipart;
 import retrofit2.http.POST;
-import retrofit2.http.Part;
 
-import static org.wikipedia.dataclient.Service.MW_API_PREFIX;
+import static fr.free.nrw.commons.wikidata.WikidataConstants.MW_API_PREFIX;
 
 public interface WikidataInterface {
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/MockWebServerTest.java
+++ b/app/src/test/kotlin/fr/free/nrw/commons/MockWebServerTest.java
@@ -1,5 +1,7 @@
 package fr.free.nrw.commons;
 
+import static fr.free.nrw.commons.wikidata.WikidataConstants.WIKIPEDIA_URL;
+
 import androidx.annotation.NonNull;
 import java.util.List;
 import java.util.concurrent.AbstractExecutorService;
@@ -13,7 +15,6 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.wikipedia.AppAdapter;
-import org.wikipedia.dataclient.Service;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.json.GsonUtil;
 import retrofit2.Retrofit;
@@ -26,7 +27,7 @@ public abstract class MockWebServerTest {
 
     @Before public void setUp() throws Throwable {
         AppAdapter.set(new TestAppAdapter());
-        OkHttpClient.Builder builder = AppAdapter.get().getOkHttpClient(new WikiSite(Service.WIKIPEDIA_URL)).newBuilder();
+        OkHttpClient.Builder builder = AppAdapter.get().getOkHttpClient(new WikiSite(WIKIPEDIA_URL)).newBuilder();
         okHttpClient = builder.dispatcher(new Dispatcher(new ImmediateExecutorService())).build();
         server.setUp();
     }

--- a/app/src/test/kotlin/fr/free/nrw/commons/TestAppAdapter.java
+++ b/app/src/test/kotlin/fr/free/nrw/commons/TestAppAdapter.java
@@ -1,9 +1,9 @@
 package fr.free.nrw.commons;
 
 import androidx.annotation.NonNull;
+import fr.free.nrw.commons.wikidata.WikidataConstants;
 import okhttp3.OkHttpClient;
 import org.wikipedia.AppAdapter;
-import org.wikipedia.dataclient.Service;
 import org.wikipedia.dataclient.SharedPreferenceCookieManager;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.okhttp.TestStubInterceptor;
@@ -13,7 +13,7 @@ public class TestAppAdapter extends AppAdapter {
 
     @Override
     public String getMediaWikiBaseUrl() {
-        return Service.WIKIPEDIA_URL;
+        return WikidataConstants.WIKIPEDIA_URL;
     }
 
     @Override


### PR DESCRIPTION
Now that all of our API calls are self-contained in the main commons code-base, this PR removes references to the big data-client `Service` interface by moving 2 constants, and deleting the Dagger provider methods.

Note: we still need to cleanup Dagger injection of the service interfaces we moved and references to the `ServiceFactory` but those will come in a later PR to keep this one simple.

This PR relates to the discussion in #5165