### PR TITLE
Fixed flickering of nearby banner compass #5483

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.java
@@ -542,7 +542,7 @@ public class ContributionsFragment
             String distance = formatDistanceBetween(curLatLng, closestNearbyPlace.location);
             closestNearbyPlace.setDistance(distance);
             direction = (float) computeBearing(curLatLng, closestNearbyPlace.location);
-            nearbyNotificationCardView.updateContent(closestNearbyPlace, direction);
+            nearbyNotificationCardView.updateContent(closestNearbyPlace);
         } else {
             // Means that no close nearby place is found
             nearbyNotificationCardView.setVisibility(View.GONE);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyNotificationCardView.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyNotificationCardView.java
@@ -113,11 +113,11 @@ public class NearbyNotificationCardView extends SwipableCardView {
     }
 
     /**
-     * Pass place information to views and set compass arrow direction
+     * Pass place information to views
+     *
      * @param place Closes place where we will get information from
-     * @param direction Direction in which compass arrow needs to be set
      */
-    public void updateContent(Place place, float direction) {
+    public void updateContent(Place place) {
         Timber.d("Update nearby card notification content");
         this.setVisibility(VISIBLE);
         cardViewVisibilityState = CardViewVisibilityState.READY;
@@ -132,7 +132,6 @@ public class NearbyNotificationCardView extends SwipableCardView {
         notificationIcon.setVisibility(VISIBLE);
         notificationTitle.setText(place.name);
         notificationDistance.setText(place.distance);
-        notificationCompass.setRotation(direction);
     }
 
     @Override


### PR DESCRIPTION
**Description (required)**
The nearby banner compass was flickering when the user moved. 

Fixes #5483 

**What changes did you make and why?**
Removed setting the initial direction of the nearby banner compass, which was causing the flicker as the direction was being reset every time the location of the user changed.

**Tests performed (required)**

Tested prodDebug on OnePlus Nord CE 2 Lite with API level 31

**Video showing normal behaviour of the compass, even as the user moves**

https://github.com/commons-app/apps-android-commons/assets/142137555/936f66db-f602-4c8c-b940-69809a3afe5b


