### PR TITLE
Remove occurrence of upload wizard's depictsFragment instead of editDepictsFragment

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.java
@@ -106,7 +106,7 @@ public class DepictsFragment extends UploadBaseFragment implements DepictsContra
             nearbyPlace = bundle.getParcelable(SELECTED_NEARBY_PLACE);
         }
 
-        if(callback!=null){
+        if(callback!=null || media!=null){
             init();
             presenter.getDepictedItems().observe(getViewLifecycleOwner(), this::setDepictsList);
         }


### PR DESCRIPTION
**Description (required)**
Fixes #5485 

What changes did you make and why?
I added a null check for media when calling the `init()` function for `DepictsFragment` because when calling this function from `depictEditButton`, the callback is null. Hence, it was necessary to check callback as well as media when initializing.

**Tests performed (required)**
Manually tested it on my device. However, adding that check didn't affect the motive of PR #5466.

Tested prodDebug on Samsung A14 with API level 34

**Screenshots (for UI changes only)**
Not related to UI.
