### PR TITLE
Switch to using the commons toolforge instance fully

### DIFF
--- a/app/src/androidTest/java/fr/free/nrw/commons/UploadTest.kt
+++ b/app/src/androidTest/java/fr/free/nrw/commons/UploadTest.kt
@@ -234,7 +234,7 @@ class UploadTest {
                         .actionOnItemAtPosition<UploadMediaDetailAdapter.ViewHolder>(0,
                                 MyViewAction.typeTextInChildViewWithId(R.id.description_item_edit_text, "Test description")))
 
-        onView(withId(R.id.btn_add_description))
+        onView(withId(R.id.btn_add))
                 .perform(click())
 
         onView(withId(R.id.rv_descriptions)).perform(

--- a/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
@@ -48,9 +48,7 @@ import timber.log.Timber;
 @SuppressWarnings({"WeakerAccess", "unused"})
 public class NetworkingModule {
     private static final String WIKIDATA_SPARQL_QUERY_URL = "https://query.wikidata.org/sparql";
-    private static final String TOOLS_FORGE_URL = "https://tools.wmflabs.org/urbanecmbot/commonsmisc";
-
-    private static final String TEST_TOOLS_FORGE_URL = "https://tools.wmflabs.org/commons-android-app/tool-commons-android-app";
+    private static final String TOOLS_FORGE_URL = "https://tools.wmflabs.org/commons-android-app/tool-commons-android-app";
 
     public static final long OK_HTTP_CACHE_SIZE = 10 * 1024 * 1024;
 
@@ -91,13 +89,11 @@ public class NetworkingModule {
     public OkHttpJsonApiClient provideOkHttpJsonApiClient(OkHttpClient okHttpClient,
                                                           DepictsClient depictsClient,
                                                           @Named("tools_forge") HttpUrl toolsForgeUrl,
-                                                          @Named("test_tools_forge") HttpUrl testToolsForgeUrl,
                                                           @Named("default_preferences") JsonKvStore defaultKvStore,
                                                           Gson gson) {
         return new OkHttpJsonApiClient(okHttpClient,
                 depictsClient,
                 toolsForgeUrl,
-                testToolsForgeUrl,
                 WIKIDATA_SPARQL_QUERY_URL,
                 BuildConfig.WIKIMEDIA_CAMPAIGNS_URL,
             gson);
@@ -131,14 +127,6 @@ public class NetworkingModule {
     @SuppressWarnings("ConstantConditions")
     public HttpUrl provideToolsForgeUrl() {
         return HttpUrl.parse(TOOLS_FORGE_URL);
-    }
-
-    @Provides
-    @Named("test_tools_forge")
-    @NonNull
-    @SuppressWarnings("ConstantConditions")
-    public HttpUrl provideTestToolsForgeUrl() {
-        return HttpUrl.parse(TEST_TOOLS_FORGE_URL);
     }
 
     @Provides

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
@@ -47,7 +47,6 @@ public class OkHttpJsonApiClient {
     private final OkHttpClient okHttpClient;
     private final DepictsClient depictsClient;
     private final HttpUrl wikiMediaToolforgeUrl;
-    private final HttpUrl wikiMediaTestToolforgeUrl;
     private final String sparqlQueryUrl;
     private final String campaignsUrl;
     private final Gson gson;
@@ -57,14 +56,12 @@ public class OkHttpJsonApiClient {
     public OkHttpJsonApiClient(OkHttpClient okHttpClient,
         DepictsClient depictsClient,
         HttpUrl wikiMediaToolforgeUrl,
-        HttpUrl wikiMediaTestToolforgeUrl,
         String sparqlQueryUrl,
         String campaignsUrl,
         Gson gson) {
         this.okHttpClient = okHttpClient;
         this.depictsClient = depictsClient;
         this.wikiMediaToolforgeUrl = wikiMediaToolforgeUrl;
-        this.wikiMediaTestToolforgeUrl = wikiMediaTestToolforgeUrl;
         this.sparqlQueryUrl = sparqlQueryUrl;
         this.campaignsUrl = campaignsUrl;
         this.gson = gson;
@@ -83,7 +80,7 @@ public class OkHttpJsonApiClient {
     @NonNull
     public Observable<LeaderboardResponse> getLeaderboard(String userName, String duration,
         String category, String limit, String offset) {
-        final String fetchLeaderboardUrlTemplate = wikiMediaTestToolforgeUrl
+        final String fetchLeaderboardUrlTemplate = wikiMediaToolforgeUrl
             + LEADERBOARD_END_POINT;
         String url = String.format(Locale.ENGLISH,
             fetchLeaderboardUrlTemplate,
@@ -129,7 +126,7 @@ public class OkHttpJsonApiClient {
      */
     @NonNull
     public Single<UpdateAvatarResponse> setAvatar(String username, String avatar) {
-        final String urlTemplate = wikiMediaTestToolforgeUrl
+        final String urlTemplate = wikiMediaToolforgeUrl
             + UPDATE_AVATAR_END_POINT;
         return Single.fromCallable(() -> {
             String url = String.format(Locale.ENGLISH,

--- a/app/src/test/kotlin/fr/free/nrw/commons/OkHttpJsonApiClientTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/OkHttpJsonApiClientTests.kt
@@ -27,8 +27,6 @@ class OkHttpJsonApiClientTests {
     @Mock
     lateinit var wikiMediaToolforgeUrl: HttpUrl
 
-    @Mock
-    lateinit var wikiMediaTestToolforgeUrl: HttpUrl
     var sparqlQueryUrl: String = "https://www.testqparql.com"
     var campaignsUrl: String = "https://www.testcampaignsurl.com"
 
@@ -52,7 +50,6 @@ class OkHttpJsonApiClientTests {
             okhttpClient,
             depictsClient,
             wikiMediaToolforgeUrl,
-            wikiMediaTestToolforgeUrl,
             sparqlQueryUrl,
             campaignsUrl,
             gson


### PR DESCRIPTION
**Description (required)**

So far we used both the urbanecmbot instances and also the commons-android-app toolforge instance for the functioning of the app.

The reality is that the commons-android-app instance itself had the ability to return all the data necessary for the app. Use the same to get all the data necessary for the app.

Fixes #5462

**Tests performed (required)**

Tested prodDebug on OnePlus Nord with API level 32.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
