### PR TITLE
Create CsrfTokenClient and LoginClient by injection

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.java
@@ -65,10 +65,6 @@ public class LoginActivity extends AccountAuthenticatorActivity {
     SessionManager sessionManager;
 
     @Inject
-    @Named(NAMED_COMMONS_WIKI_SITE)
-    WikiSite commonsWikiSite;
-
-    @Inject
     @Named("default_preferences")
     JsonKvStore applicationKvStore;
 
@@ -231,13 +227,13 @@ public class LoginActivity extends AccountAuthenticatorActivity {
 
     private void doLogin(String username, String password, String twoFactorCode) {
         progressDialog.show();
-        loginToken = ServiceFactory.get(commonsWikiSite, LoginInterface.class).getLoginToken();
+        loginToken = loginClient.getLoginToken();
         loginToken.enqueue(
                 new Callback<MwQueryResponse>() {
                     @Override
                     public void onResponse(Call<MwQueryResponse> call,
                                            Response<MwQueryResponse> response) {
-                        loginClient.login(commonsWikiSite, username, password, null, twoFactorCode,
+                        loginClient.login(username, password, null, twoFactorCode,
                                 response.body().query().loginToken(), Locale.getDefault().getLanguage(), new LoginCallback() {
                                     @Override
                                     public void success(@NonNull LoginResult result) {

--- a/app/src/main/java/fr/free/nrw/commons/auth/login/LoginResponse.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/login/LoginResponse.kt
@@ -4,7 +4,6 @@ import com.google.gson.annotations.SerializedName
 import fr.free.nrw.commons.auth.login.LoginResult.OAuthResult
 import fr.free.nrw.commons.auth.login.LoginResult.ResetPasswordResult
 import fr.free.nrw.commons.auth.login.LoginResult.Result
-import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwServiceError
 
 class LoginResponse {
@@ -14,8 +13,8 @@ class LoginResponse {
     @SerializedName("clientlogin")
     private val clientLogin: ClientLogin? = null
 
-    fun toLoginResult(site: WikiSite, password: String): LoginResult? {
-        return clientLogin?.toLoginResult(site, password)
+    fun toLoginResult(password: String): LoginResult? {
+        return clientLogin?.toLoginResult(password)
     }
 }
 
@@ -27,15 +26,15 @@ internal class ClientLogin {
     @SerializedName("username")
     private val userName: String? = null
 
-    fun toLoginResult(site: WikiSite, password: String): LoginResult {
+    fun toLoginResult(password: String): LoginResult {
         var userMessage = message
         if ("UI" == status) {
             if (requests != null) {
                 for (req in requests) {
                     if ("MediaWiki\\Extension\\OATHAuth\\Auth\\TOTPAuthenticationRequest" == req.id()) {
-                        return OAuthResult(site, status, userName, password, message)
+                        return OAuthResult(status, userName, password, message)
                     } else if ("MediaWiki\\Auth\\PasswordAuthenticationRequest" == req.id()) {
-                        return ResetPasswordResult(site, status, userName, password, message)
+                        return ResetPasswordResult(status, userName, password, message)
                     }
                 }
             }
@@ -43,7 +42,7 @@ internal class ClientLogin {
             //TODO: String resource -- Looks like needed for others in this class too
             userMessage = "An unknown error occurred."
         }
-        return Result(site, status ?: "", userName, password, userMessage)
+        return Result(status ?: "", userName, password, userMessage)
     }
 }
 

--- a/app/src/main/java/fr/free/nrw/commons/auth/login/LoginResult.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/login/LoginResult.kt
@@ -1,9 +1,6 @@
 package fr.free.nrw.commons.auth.login
 
-import org.wikipedia.dataclient.WikiSite
-
 sealed class LoginResult(
-    val site: WikiSite,
     val status: String,
     val userName: String?,
     val password: String?,
@@ -14,26 +11,23 @@ sealed class LoginResult(
     val pass: Boolean get() = "PASS" == status
 
     class Result(
-        site: WikiSite,
         status: String,
         userName: String?,
         password: String?,
         message: String?
-    ): LoginResult(site, status, userName, password, message)
+    ): LoginResult(status, userName, password, message)
 
     class OAuthResult(
-        site: WikiSite,
         status: String,
         userName: String?,
         password: String?,
         message: String?
-    ) : LoginResult(site, status, userName, password, message)
+    ) : LoginResult(status, userName, password, message)
 
     class ResetPasswordResult(
-        site: WikiSite,
         status: String,
         userName: String?,
         password: String?,
         message: String?
-    ) : LoginResult(site, status, userName, password, message)
+    ) : LoginResult(status, userName, password, message)
 }

--- a/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
+++ b/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.java
@@ -11,6 +11,8 @@ import fr.free.nrw.commons.actions.PageEditClient;
 import fr.free.nrw.commons.actions.PageEditInterface;
 import fr.free.nrw.commons.actions.ThanksInterface;
 import fr.free.nrw.commons.auth.SessionManager;
+import fr.free.nrw.commons.auth.csrf.CsrfTokenInterface;
+import fr.free.nrw.commons.auth.login.LoginInterface;
 import fr.free.nrw.commons.category.CategoryInterface;
 import fr.free.nrw.commons.explore.depictions.DepictsClient;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
@@ -37,7 +39,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
 import okhttp3.logging.HttpLoggingInterceptor.Level;
 import fr.free.nrw.commons.auth.csrf.CsrfTokenClient;
-import org.wikipedia.dataclient.Service;
 import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.json.GsonUtil;
@@ -106,15 +107,27 @@ public class NetworkingModule {
     @Named(NAMED_COMMONS_CSRF)
     @Provides
     @Singleton
-    public CsrfTokenClient provideCommonsCsrfTokenClient(
-        @Named(NAMED_COMMONS_WIKI_SITE) WikiSite commonsWikiSite, SessionManager sessionManager) {
-        return new CsrfTokenClient(commonsWikiSite, sessionManager);
+    public CsrfTokenClient provideCommonsCsrfTokenClient(SessionManager sessionManager,
+        CsrfTokenInterface tokenInterface, LoginClient loginClient) {
+        return new CsrfTokenClient(sessionManager, tokenInterface, loginClient);
     }
 
     @Provides
     @Singleton
-    public LoginClient provideLoginClient() {
-        return new LoginClient();
+    public CsrfTokenInterface provideCsrfTokenInterface(@Named(NAMED_COMMONS_WIKI_SITE) WikiSite commonsWikiSite) {
+        return ServiceFactory.get(commonsWikiSite, BuildConfig.COMMONS_URL, CsrfTokenInterface.class);
+    }
+
+    @Provides
+    @Singleton
+    public LoginInterface provideLoginInterface(@Named(NAMED_COMMONS_WIKI_SITE) WikiSite commonsWikiSite) {
+        return ServiceFactory.get(commonsWikiSite, BuildConfig.COMMONS_URL, LoginInterface.class);
+    }
+
+    @Provides
+    @Singleton
+    public LoginClient provideLoginClient(LoginInterface loginInterface) {
+        return new LoginClient(loginInterface);
     }
 
     @Provides

--- a/app/src/test/kotlin/fr/free/nrw/commons/auth/csrf/CsrfTokenClientTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/auth/csrf/CsrfTokenClientTest.kt
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.auth.csrf
 import com.google.gson.stream.MalformedJsonException
 import fr.free.nrw.commons.MockWebServerTest
 import fr.free.nrw.commons.auth.SessionManager
+import fr.free.nrw.commons.auth.login.LoginClient
 import org.junit.Test
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.eq
@@ -10,16 +11,15 @@ import org.mockito.ArgumentMatchers.isA
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
-import org.wikipedia.dataclient.Service
-import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwException
 import org.wikipedia.dataclient.okhttp.HttpStatusException
 
 class CsrfTokenClientTest : MockWebServerTest() {
-    private val wikiSite = WikiSite("test.wikipedia.org")
     private val cb = mock(CsrfTokenClient.Callback::class.java)
     private val sessionManager = mock(SessionManager::class.java)
-    private val subject = CsrfTokenClient(wikiSite, sessionManager)
+    private val tokenInterface = mock(CsrfTokenInterface::class.java)
+    private val loginClient = mock(LoginClient::class.java)
+    private val subject = CsrfTokenClient(sessionManager, tokenInterface, loginClient)
 
     @Test
     @Throws(Throwable::class)


### PR DESCRIPTION
This PR relates to the discussion in #5165

Previous PRs moved the Csrf Token Client / Interface out of the data-client module along with the Login Client / Interface.  This PR brings them into alignment with the rest of the app in terms of being created through dependency injection.

In the process, it was clear that the "wiki" parameter was being passed around but ultimately unused (except for a single _verbose_ level log statement) so in the spirit of deleting _dead code_ I removed that parameter.