### PR TITLE
Enhancement-Show Icon Labels When Long Pressed

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceAdapterDelegate.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceAdapterDelegate.kt
@@ -17,10 +17,15 @@ fun placeAdapterDelegate(
     bookmarkLocationDao: BookmarkLocationsDao,
     onItemClick: ((Place) -> Unit)? = null,
     onCameraClicked: (Place, ActivityResultLauncher<Array<String>>) -> Unit,
+    onCameraLongPressed: () -> Boolean,
     onGalleryClicked: (Place) -> Unit,
+    onGalleryLongPressed: () -> Boolean,
     onBookmarkClicked: (Place, Boolean) -> Unit,
+    onBookmarkLongPressed: () -> Boolean,
     onOverflowIconClicked: (Place, View) -> Unit,
+    onOverFlowLongPressed: () -> Boolean,
     onDirectionsClicked: (Place) -> Unit,
+    onDirectionsLongPressed: () -> Boolean,
     inAppCameraLocationPermissionLauncher: ActivityResultLauncher<Array<String>>
 ) = adapterDelegateViewBinding<Place, Place, ItemPlaceBinding>({ layoutInflater, parent ->
     ItemPlaceBinding.inflate(layoutInflater, parent, false)
@@ -39,7 +44,10 @@ fun placeAdapterDelegate(
             }
         }
         nearbyButtonLayout.cameraButton.setOnClickListener { onCameraClicked(item, inAppCameraLocationPermissionLauncher) }
+        nearbyButtonLayout.cameraButton.setOnLongClickListener { onCameraLongPressed() }
+
         nearbyButtonLayout.galleryButton.setOnClickListener { onGalleryClicked(item) }
+        nearbyButtonLayout.galleryButton.setOnLongClickListener{onGalleryLongPressed()}
         bookmarkButtonImage.setOnClickListener {
             val isBookmarked = bookmarkLocationDao.updateBookmarkLocation(item)
             bookmarkButtonImage.setImageResource(
@@ -47,7 +55,9 @@ fun placeAdapterDelegate(
             )
             onBookmarkClicked(item, isBookmarked)
         }
+        bookmarkButtonImage.setOnLongClickListener{onBookmarkLongPressed()}
         nearbyButtonLayout.iconOverflow.setOnClickListener { onOverflowIconClicked(item, it) }
+        nearbyButtonLayout.iconOverflow.setOnLongClickListener{onOverFlowLongPressed()}
         nearbyButtonLayout.directionsButton.setOnClickListener { onDirectionsClicked(item) }
         bind {
             tvName.text = item.name
@@ -74,6 +84,7 @@ fun placeAdapterDelegate(
                     R.drawable.ic_round_star_border_24px
             )
         }
+        nearbyButtonLayout.directionsButton.setOnLongClickListener{onDirectionsLongPressed()}
     }
 }
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/CommonPlaceClickActions.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/CommonPlaceClickActions.kt
@@ -38,6 +38,9 @@ class CommonPlaceClickActions @Inject constructor(
         }
     }
 
+    /**
+    * Shows the Label for the Icon when it's long pressed
+     **/
     fun onCameraLongPressed(): () -> Boolean = {
         Toast.makeText(activity, R.string.menu_from_camera, Toast.LENGTH_SHORT).show()
         true

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/CommonPlaceClickActions.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/CommonPlaceClickActions.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.view.MenuItem
 import android.view.View
+import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.PopupMenu
@@ -35,6 +36,27 @@ class CommonPlaceClickActions @Inject constructor(
             storeSharedPrefs(place)
             contributionController.initiateCameraPick(activity, launcher)
         }
+    }
+
+    fun onCameraLongPressed(): () -> Boolean = {
+        Toast.makeText(activity, R.string.menu_from_camera, Toast.LENGTH_SHORT).show()
+        true
+    }
+    fun onGalleryLongPressed(): () -> Boolean = {
+        Toast.makeText(activity, R.string.menu_from_gallery, Toast.LENGTH_SHORT).show()
+        true
+    }
+    fun onBookmarkLongPressed(): () -> Boolean = {
+        Toast.makeText(activity, R.string.menu_bookmark, Toast.LENGTH_SHORT).show()
+        true
+    }
+    fun onDirectionsLongPressed(): () -> Boolean = {
+        Toast.makeText(activity, R.string.nearby_directions, Toast.LENGTH_SHORT).show()
+        true
+    }
+    fun onOverflowLongPressed(): () -> Boolean = {
+        Toast.makeText(activity, R.string.more, Toast.LENGTH_SHORT).show()
+        true
     }
 
     fun onGalleryClicked(): (Place) -> Unit = {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1905,21 +1905,41 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             updateMarker(isBookmarked, selectedPlace, locationManager.getLastLocation());
             mapView.invalidate();
         });
+        bookmarkButton.setOnLongClickListener(view -> {
+            Toast.makeText(getContext(), R.string.menu_bookmark, Toast.LENGTH_SHORT).show();
+            return true;
+        });
 
         wikipediaButton.setVisibility(place.hasWikipediaLink() ? View.VISIBLE : View.GONE);
         wikipediaButton.setOnClickListener(
             view -> Utils.handleWebUrl(getContext(), selectedPlace.siteLinks.getWikipediaLink()));
+        wikipediaButton.setOnLongClickListener(view -> {
+            Toast.makeText(getContext(), R.string.nearby_wikipedia, Toast.LENGTH_SHORT).show();
+            return true;
+        });
 
         wikidataButton.setVisibility(place.hasWikidataLink() ? View.VISIBLE : View.GONE);
         wikidataButton.setOnClickListener(
             view -> Utils.handleWebUrl(getContext(), selectedPlace.siteLinks.getWikidataLink()));
+        wikidataButton.setOnLongClickListener(view -> {
+            Toast.makeText(getContext(), R.string.nearby_wikidata, Toast.LENGTH_SHORT).show();
+            return true;
+        });
 
         directionsButton.setOnClickListener(view -> Utils.handleGeoCoordinates(getActivity(),
             selectedPlace.getLocation()));
+        directionsButton.setOnLongClickListener(view -> {
+            Toast.makeText(getContext(), R.string.nearby_directions, Toast.LENGTH_SHORT).show();
+            return true;
+        });
 
         commonsButton.setVisibility(selectedPlace.hasCommonsLink() ? View.VISIBLE : View.GONE);
         commonsButton.setOnClickListener(
             view -> Utils.handleWebUrl(getContext(), selectedPlace.siteLinks.getCommonsLink()));
+        commonsButton.setOnLongClickListener(view -> {
+            Toast.makeText(getContext(), R.string.nearby_commons, Toast.LENGTH_SHORT).show();
+            return true;
+        });
 
         icon.setImageResource(selectedPlace.getLabel().getIcon());
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/PlaceAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/PlaceAdapter.kt
@@ -18,10 +18,15 @@ class PlaceAdapter(
             bookmarkLocationsDao,
             onPlaceClicked,
             commonPlaceClickActions.onCameraClicked(),
+            commonPlaceClickActions.onCameraLongPressed(),
             commonPlaceClickActions.onGalleryClicked(),
+            commonPlaceClickActions.onGalleryLongPressed(),
             onBookmarkClicked,
+            commonPlaceClickActions.onBookmarkLongPressed(),
             commonPlaceClickActions.onOverflowClicked(),
+            commonPlaceClickActions.onOverflowLongPressed(),
             commonPlaceClickActions.onDirectionsClicked(),
+            commonPlaceClickActions.onDirectionsLongPressed(),
             inAppCameraLocationPermissionLauncher
         ),
         areItemsTheSame = {oldItem, newItem -> oldItem.wikiDataEntityId == newItem.wikiDataEntityId }

--- a/app/src/test/kotlin/fr/free/nrw/commons/nearby/CommonPlaceClickActionsUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/nearby/CommonPlaceClickActionsUnitTest.kt
@@ -55,6 +55,11 @@ class CommonPlaceClickActionsUnitTest {
         Assert.assertNotNull(commonPlaceClickActions.onGalleryClicked())
         Assert.assertNotNull(commonPlaceClickActions.onOverflowClicked())
         Assert.assertNotNull(commonPlaceClickActions.onDirectionsClicked())
+        Assert.assertNotNull(commonPlaceClickActions.onCameraLongPressed())
+        Assert.assertNotNull(commonPlaceClickActions.onGalleryLongPressed())
+        Assert.assertNotNull(commonPlaceClickActions.onBookmarkLongPressed())
+        Assert.assertNotNull(commonPlaceClickActions.onDirectionsLongPressed())
+        Assert.assertNotNull(commonPlaceClickActions.onOverflowLongPressed())
     }
 
     @Test


### PR DESCRIPTION
**Description (required)**

Fixes #5470 

What changes did you make and why?
Added ```onLongClickListeners``` to Icons that do not have Visible Labels to show Toast with the Labels of corresponding Icons to make it more user-friendly.

**Tests performed (required)**

Tested 4.2.1-debug on Xiaomi 11 lite NE with API level 33.

**Screenshots (for UI changes only)**
![WhatsApp Image 2024-01-29 at 12 43 11 PM](https://github.com/commons-app/apps-android-commons/assets/126143257/1ae02f27-2a92-427c-88d7-2eb10970c1ef)
![WhatsApp Image 2024-01-29 at 12 43 12 PM](https://github.com/commons-app/apps-android-commons/assets/126143257/35161a66-4caf-41fb-9a98-bf23fb884592)
![WhatsApp Image 2024-01-29 at 12 43 14 PM](https://github.com/commons-app/apps-android-commons/assets/126143257/fc4354e0-fb51-46e0-a47c-9bc20812e39b)
