### PR TITLE
Fix Crash in LocationPickerActivity when device configuration is changed

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPicker.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPicker.java
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.LocationPicker;
 import android.app.Activity;
 import android.content.Intent;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
+import fr.free.nrw.commons.Media;
 
 /**
  * Helper class for starting the activity
@@ -51,6 +52,17 @@ public final class LocationPicker {
           intent.putExtra(LocationPickerConstants.ACTIVITY_KEY, activity);
           return this;
         }
+
+        /**
+         * Gets and puts media in intent
+         * @param media Media
+         * @return LocationPicker.IntentBuilder
+         */
+        public LocationPicker.IntentBuilder media(
+                final Media media) {
+              intent.putExtra(LocationPickerConstants.MEDIA, media);
+              return this;
+            }
 
         /**
          * Gets and sets the activity

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -31,8 +31,10 @@ import androidx.core.content.ContextCompat;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import fr.free.nrw.commons.Media;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
+import fr.free.nrw.commons.coordinates.CoordinateEditHelper;
 import fr.free.nrw.commons.filepicker.Constants;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.location.LocationPermissionsHelper;
@@ -41,6 +43,9 @@ import fr.free.nrw.commons.location.LocationPermissionsHelper.LocationPermission
 import fr.free.nrw.commons.location.LocationServiceManager;
 import fr.free.nrw.commons.theme.BaseActivity;
 import fr.free.nrw.commons.utils.SystemThemeUtils;
+import fr.free.nrw.commons.utils.ViewUtilWrapper;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -52,6 +57,7 @@ import org.osmdroid.views.overlay.Marker;
 import org.osmdroid.views.overlay.Overlay;
 import org.osmdroid.views.overlay.ScaleDiskOverlay;
 import org.osmdroid.views.overlay.TilesOverlay;
+import timber.log.Timber;
 
 /**
  * Helps to pick location and return the result with an intent
@@ -59,6 +65,19 @@ import org.osmdroid.views.overlay.TilesOverlay;
 public class LocationPickerActivity extends BaseActivity implements
     LocationPermissionCallback {
 
+
+    @Inject
+    ViewUtilWrapper viewUtil;
+
+    /**
+     * coordinateEditHelper: helps to edit coordinates
+     */
+    @Inject
+    CoordinateEditHelper coordinateEditHelper;
+    /**
+     * media : Media object
+     */
+    private Media media;
     /**
      * cameraPosition : position of picker
      */
@@ -125,6 +144,13 @@ public class LocationPickerActivity extends BaseActivity implements
     @Inject
     LocationServiceManager locationManager;
 
+    /**
+     * Constants
+     */
+    private static final String CAMERA_POS = "cameraPosition";
+    private static final String ACTIVITY = "activity";
+
+
     @SuppressLint("ClickableViewAccessibility")
     @Override
     protected void onCreate(@Nullable final Bundle savedInstanceState) {
@@ -145,8 +171,12 @@ public class LocationPickerActivity extends BaseActivity implements
             cameraPosition = getIntent()
                 .getParcelableExtra(LocationPickerConstants.MAP_CAMERA_POSITION);
             activity = getIntent().getStringExtra(LocationPickerConstants.ACTIVITY_KEY);
+            media = getIntent().getParcelableExtra(LocationPickerConstants.MEDIA);
+        }else{
+            cameraPosition = savedInstanceState.getParcelable(CAMERA_POS);
+            activity = savedInstanceState.getString(ACTIVITY);
+            media = savedInstanceState.getParcelable("sMedia");
         }
-
         bindViews();
         addBackButtonListener();
         addPlaceSelectedButton();
@@ -220,7 +250,12 @@ public class LocationPickerActivity extends BaseActivity implements
      */
     private void addBackButtonListener() {
         final ImageView backButton = findViewById(R.id.maplibre_place_picker_toolbar_back_button);
-        backButton.setOnClickListener(view -> finish());
+        backButton.setOnClickListener(v -> {
+            viewUtil.showShortToast(getApplicationContext(),
+                getString(R.string.coordinates_picking_unsuccessful));
+            finish();
+        });
+
     }
 
     /**
@@ -315,8 +350,21 @@ public class LocationPickerActivity extends BaseActivity implements
         returningIntent.putExtra(LocationPickerConstants.MAP_CAMERA_POSITION,
             new CameraPosition(new LatLng(mapView.getMapCenter().getLatitude(),
                 mapView.getMapCenter().getLongitude()), 14f, 0, 0));
-        setResult(AppCompatActivity.RESULT_OK, returningIntent);
+        updateCoordinates(String.valueOf(mapView.getMapCenter().getLatitude()),
+            String.valueOf(mapView.getMapCenter().getLongitude()),
+            String.valueOf(0.0f));
         finish();
+    }
+
+    public void updateCoordinates(final String Latitude, final String Longitude,
+        final String Accuracy) {
+        compositeDisposable.add(coordinateEditHelper.makeCoordinatesEdit(getApplicationContext(),media,
+                Latitude, Longitude, Accuracy)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(s -> {
+                Timber.d("Coordinates are added.");
+            }));
     }
 
     /**
@@ -458,4 +506,22 @@ public class LocationPickerActivity extends BaseActivity implements
         mapView.getOverlays().add(startMarker);
     }
 
+    /**
+     * Saves the state of the activity
+     * @param outState Bundle
+     */
+    @Override
+    public void onSaveInstanceState(@NonNull final Bundle outState) {
+        super.onSaveInstanceState(outState);
+        if(cameraPosition!=null){
+            outState.putParcelable(CAMERA_POS, cameraPosition);
+        }
+        if(activity!=null){
+            outState.putString(ACTIVITY, activity);
+        }
+
+        if(media!=null){
+            outState.putParcelable("sMedia", media);
+        }
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -356,6 +356,12 @@ public class LocationPickerActivity extends BaseActivity implements
         finish();
     }
 
+    /**
+     * Fetched coordinates are replaced with existing coordinates by a POST API call.
+     * @param Latitude to be added
+     * @param Longitude to be added
+     * @param Accuracy to be added
+     */
     public void updateCoordinates(final String Latitude, final String Longitude,
         final String Accuracy) {
         compositeDisposable.add(coordinateEditHelper.makeCoordinatesEdit(getApplicationContext(),media,

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -339,10 +339,6 @@ public class LocationPickerActivity extends BaseActivity implements
                     + mapView.getMapCenter().getLongitude());
             applicationKvStore.putString(LAST_ZOOM, mapView.getZoomLevel() + "");
         }
-        final Intent returningIntent = new Intent();
-        returningIntent.putExtra(LocationPickerConstants.MAP_CAMERA_POSITION,
-            new CameraPosition(new LatLng(mapView.getMapCenter().getLatitude(),
-                mapView.getMapCenter().getLongitude()), 14f, 0, 0));
         updateCoordinates(String.valueOf(mapView.getMapCenter().getLatitude()),
             String.valueOf(mapView.getMapCenter().getLongitude()),
             String.valueOf(0.0f));

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -64,11 +64,6 @@ import timber.log.Timber;
  */
 public class LocationPickerActivity extends BaseActivity implements
     LocationPermissionCallback {
-
-
-    @Inject
-    ViewUtilWrapper viewUtil;
-
     /**
      * coordinateEditHelper: helps to edit coordinates
      */
@@ -251,8 +246,6 @@ public class LocationPickerActivity extends BaseActivity implements
     private void addBackButtonListener() {
         final ImageView backButton = findViewById(R.id.maplibre_place_picker_toolbar_back_button);
         backButton.setOnClickListener(v -> {
-            viewUtil.showShortToast(getApplicationContext(),
-                getString(R.string.coordinates_picking_unsuccessful));
             finish();
         });
 

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -339,9 +339,19 @@ public class LocationPickerActivity extends BaseActivity implements
                     + mapView.getMapCenter().getLongitude());
             applicationKvStore.putString(LAST_ZOOM, mapView.getZoomLevel() + "");
         }
-        updateCoordinates(String.valueOf(mapView.getMapCenter().getLatitude()),
-            String.valueOf(mapView.getMapCenter().getLongitude()),
-            String.valueOf(0.0f));
+
+        if (media == null) {
+            final Intent returningIntent = new Intent();
+            returningIntent.putExtra(LocationPickerConstants.MAP_CAMERA_POSITION,
+                new CameraPosition(new LatLng(mapView.getMapCenter().getLatitude(),
+                    mapView.getMapCenter().getLongitude()), 14f, 0, 0));
+            setResult(AppCompatActivity.RESULT_OK, returningIntent);
+        } else {
+            updateCoordinates(String.valueOf(mapView.getMapCenter().getLatitude()),
+                String.valueOf(mapView.getMapCenter().getLongitude()),
+                String.valueOf(0.0f));
+        }
+
         finish();
     }
 
@@ -353,6 +363,9 @@ public class LocationPickerActivity extends BaseActivity implements
      */
     public void updateCoordinates(final String Latitude, final String Longitude,
         final String Accuracy) {
+        if (media == null) {
+            return;
+        }
         compositeDisposable.add(coordinateEditHelper.makeCoordinatesEdit(getApplicationContext(),media,
                 Latitude, Longitude, Accuracy)
             .subscribeOn(Schedulers.io())

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerConstants.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerConstants.java
@@ -13,6 +13,9 @@ public final class LocationPickerConstants {
     public static final String MAP_CAMERA_POSITION
         = "location.picker.cameraPosition";
 
+    public static final String MEDIA
+        = "location.picker.media";
+
 
     private LocationPickerConstants() {
     }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -942,12 +942,14 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             }
         }
 
-        startActivityForResult(new LocationPicker.IntentBuilder()
+
+        startActivity(new LocationPicker.IntentBuilder()
             .defaultLocation(new CameraPosition.Builder()
                 .target(new LatLng(defaultLatitude, defaultLongitude))
                 .zoom(16).build())
             .activityKey("MediaActivity")
-            .build(getActivity()), REQUEST_CODE);
+            .media(media)
+            .build(getActivity()));
     }
 
     @OnClick(R.id.description_edit)
@@ -1125,32 +1127,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         @Nullable final Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
-        if (requestCode == REQUEST_CODE && resultCode == RESULT_OK) {
-
-            assert data != null;
-            final CameraPosition cameraPosition = LocationPicker.getCameraPosition(data);
-
-            if (cameraPosition != null) {
-
-                final String latitude = String.valueOf(cameraPosition.target.getLatitude());
-                final String longitude = String.valueOf(cameraPosition.target.getLongitude());
-                final String accuracy = String.valueOf(cameraPosition.target.getAltitude());
-                String currentLatitude = null;
-                String currentLongitude = null;
-
-                if (media.getCoordinates() != null) {
-                    currentLatitude = String.valueOf(media.getCoordinates().getLatitude());
-                    currentLongitude = String.valueOf(media.getCoordinates().getLongitude());
-                }
-
-                if (!latitude.equals(currentLatitude) || !longitude.equals(currentLongitude)) {
-                    updateCoordinates(latitude, longitude, accuracy);
-                } else if (media.getCoordinates() == null) {
-                    updateCoordinates(latitude, longitude, accuracy);
-                }
-            }
-
-        } else if (requestCode == REQUEST_CODE_EDIT_DESCRIPTION && resultCode == RESULT_OK) {
+        if (requestCode == REQUEST_CODE_EDIT_DESCRIPTION && resultCode == RESULT_OK) {
             final String updatedWikiText = data.getStringExtra(UPDATED_WIKITEXT);
             compositeDisposable.add(descriptionEditHelper.addDescription(getContext(), media,
                 updatedWikiText)
@@ -1177,11 +1154,6 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             }
             progressBarEditDescription.setVisibility(GONE);
             editDescription.setVisibility(VISIBLE);
-
-        } else if (requestCode == REQUEST_CODE && resultCode == RESULT_CANCELED) {
-            viewUtil.showShortToast(getContext(),
-                requireContext()
-                    .getString(R.string.coordinates_picking_unsuccessful));
 
         } else if (requestCode == REQUEST_CODE_EDIT_DESCRIPTION && resultCode == RESULT_CANCELED) {
             progressBarEditDescription.setVisibility(GONE);
@@ -1602,4 +1574,38 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         SharedPreferences imageBackgroundColorPref = this.getImageBackgroundColorPref();
         return imageBackgroundColorPref.getInt(IMAGE_BACKGROUND_COLOR, DEFAULT_IMAGE_BACKGROUND_COLOR);
     }
+
+
+//    private void initResultLauncher(){
+//        mStartForResult = registerForActivityResult(new StartActivityForResult(),
+//            result -> {
+//                Log.d("IssueS", "onActivityResult: " + result.getResultCode() + " " + result.getData());
+//                if (result.getResultCode() == RESULT_OK) {
+//                    Intent data = result.getData();
+//                    final CameraPosition cameraPosition = LocationPicker.getCameraPosition(data);
+//                    if (cameraPosition != null) {
+//                        final String latitude = String.valueOf(cameraPosition.target.getLatitude());
+//                        final String longitude = String.valueOf(cameraPosition.target.getLongitude());
+//                        final String accuracy = String.valueOf(cameraPosition.target.getAltitude());
+//                        String currentLatitude = null;
+//                        String currentLongitude = null;
+//
+//                        if (media.getCoordinates() != null) {
+//                            currentLatitude = String.valueOf(media.getCoordinates().getLatitude());
+//                            currentLongitude = String.valueOf(media.getCoordinates().getLongitude());
+//                        }
+//
+//                        if (!latitude.equals(currentLatitude) || !longitude.equals(currentLongitude)) {
+//                            updateCoordinates(latitude, longitude, accuracy);
+//                        } else if (media.getCoordinates() == null) {
+//                            updateCoordinates(latitude, longitude, accuracy);
+//                        }
+//                    }
+//                } else if (result.getResultCode() == RESULT_CANCELED) {
+//                    viewUtil.showShortToast(getContext(),
+//                        requireContext()
+//                            .getString(R.string.coordinates_picking_unsuccessful));
+//                }
+//            });
+//    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -1172,24 +1172,6 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         media.setCaptions(updatedCaptions);
     }
 
-    /**
-     * Fetched coordinates are replaced with existing coordinates by a POST API call.
-     * @param Latitude to be added
-     * @param Longitude to be added
-     * @param Accuracy to be added
-     */
-    public void updateCoordinates(final String Latitude, final String Longitude,
-        final String Accuracy) {
-        compositeDisposable.add(coordinateEditHelper.makeCoordinatesEdit(getContext(), media,
-            Latitude, Longitude, Accuracy)
-            .subscribeOn(Schedulers.io())
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribe(s -> {
-                Timber.d("Coordinates are added.");
-                coordinates.setText(prettyCoordinates(media));
-            }));
-    }
-
     @SuppressLint("StringFormatInvalid")
     @OnClick(R.id.nominateDeletion)
     public void onDeleteButtonClicked(){
@@ -1575,37 +1557,4 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         return imageBackgroundColorPref.getInt(IMAGE_BACKGROUND_COLOR, DEFAULT_IMAGE_BACKGROUND_COLOR);
     }
 
-
-//    private void initResultLauncher(){
-//        mStartForResult = registerForActivityResult(new StartActivityForResult(),
-//            result -> {
-//                Log.d("IssueS", "onActivityResult: " + result.getResultCode() + " " + result.getData());
-//                if (result.getResultCode() == RESULT_OK) {
-//                    Intent data = result.getData();
-//                    final CameraPosition cameraPosition = LocationPicker.getCameraPosition(data);
-//                    if (cameraPosition != null) {
-//                        final String latitude = String.valueOf(cameraPosition.target.getLatitude());
-//                        final String longitude = String.valueOf(cameraPosition.target.getLongitude());
-//                        final String accuracy = String.valueOf(cameraPosition.target.getAltitude());
-//                        String currentLatitude = null;
-//                        String currentLongitude = null;
-//
-//                        if (media.getCoordinates() != null) {
-//                            currentLatitude = String.valueOf(media.getCoordinates().getLatitude());
-//                            currentLongitude = String.valueOf(media.getCoordinates().getLongitude());
-//                        }
-//
-//                        if (!latitude.equals(currentLatitude) || !longitude.equals(currentLongitude)) {
-//                            updateCoordinates(latitude, longitude, accuracy);
-//                        } else if (media.getCoordinates() == null) {
-//                            updateCoordinates(latitude, longitude, accuracy);
-//                        }
-//                    }
-//                } else if (result.getResultCode() == RESULT_CANCELED) {
-//                    viewUtil.showShortToast(getContext(),
-//                        requireContext()
-//                            .getString(R.string.coordinates_picking_unsuccessful));
-//                }
-//            });
-//    }
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
@@ -58,13 +58,7 @@ class LocationPickerActivityUnitTests {
     private lateinit var context: Context
 
     @Mock
-    private lateinit var media: Media
-
-    @Mock
     private lateinit var applicationKvStore: JsonKvStore
-
-    @Mock
-    private lateinit var coordinateEditHelper: CoordinateEditHelper
 
     @Mock
     private lateinit var mapView: org.osmdroid.views.MapView

--- a/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
@@ -2,6 +2,7 @@ package fr.free.nrw.commons.locationpicker
 
 import android.content.Context
 import android.os.Looper
+import android.util.Log
 import android.view.View
 import android.widget.Button
 import android.widget.ImageView
@@ -26,6 +27,8 @@ import fr.free.nrw.commons.coordinates.CoordinateEditHelper
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.LAST_LOCATION
 import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.LAST_ZOOM
+import io.reactivex.android.plugins.RxAndroidPlugins
+import io.reactivex.schedulers.Schedulers
 import org.junit.Assert
 import org.junit.Assert.*
 import org.junit.Before
@@ -101,12 +104,11 @@ class LocationPickerActivityUnitTests {
         MockitoAnnotations.initMocks(this)
         context = RuntimeEnvironment.getApplication().applicationContext
         activity = Robolectric.buildActivity(LocationPickerActivity::class.java).get()
+        RxAndroidPlugins.setInitMainThreadSchedulerHandler { Schedulers.trampoline() }
 
         Whitebox.setInternalState(activity, "mapView", mapView)
         Whitebox.setInternalState(activity, "applicationKvStore", applicationKvStore)
         Whitebox.setInternalState(activity, "cameraPosition", cameraPosition)
-        Whitebox.setInternalState(activity, "media", media)
-        Whitebox.setInternalState(activity, "coordinateEditHelper", coordinateEditHelper)
         Whitebox.setInternalState(activity, "modifyLocationButton", modifyLocationButton)
         Whitebox.setInternalState(activity, "placeSelectedButton", placeSelectedButton)
         Whitebox.setInternalState(activity, "showInMapButton", showInMapButton)
@@ -154,25 +156,6 @@ class LocationPickerActivityUnitTests {
         verify(fabCenterOnLocation, times(1)).visibility = View.VISIBLE
     }
 
-    @Test
-    @Throws(Exception::class)
-    fun testPlaceSelected() {
-        Shadows.shadowOf(Looper.getMainLooper()).idle()
-        Whitebox.setInternalState(activity,"activity", "NoLocationUploadActivity")
-        val position = GeoPoint(51.50550, -0.07520)
-        val method: Method = LocationPickerActivity::class.java.getDeclaredMethod(
-            "placeSelected"
-        )
-        `when`(mapView.mapCenter).thenReturn(position)
-        `when`(mapView.zoomLevel).thenReturn(15)
-        method.isAccessible = true
-        method.invoke(activity)
-        verify(applicationKvStore, times(1)).putString(
-            LAST_LOCATION,
-            position.latitude.toString() + "," + position.longitude.toString()
-        )
-        verify(applicationKvStore, times(1)).putString(LAST_ZOOM, mapView.zoomLevel.toString())
-    }
 
 
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
@@ -20,7 +20,9 @@ import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import fr.free.nrw.commons.LocationPicker.LocationPickerActivity
+import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.TestCommonsApplication
+import fr.free.nrw.commons.coordinates.CoordinateEditHelper
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.LAST_LOCATION
 import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.LAST_ZOOM
@@ -51,9 +53,14 @@ class LocationPickerActivityUnitTests {
 
     private lateinit var activity: LocationPickerActivity
     private lateinit var context: Context
+    private lateinit var media: Media
+
 
     @Mock
     private lateinit var applicationKvStore: JsonKvStore
+
+    @Mock
+    private lateinit var coordinateEditHelper: CoordinateEditHelper
 
     @Mock
     private lateinit var mapView: org.osmdroid.views.MapView
@@ -97,6 +104,8 @@ class LocationPickerActivityUnitTests {
         Whitebox.setInternalState(activity, "mapView", mapView)
         Whitebox.setInternalState(activity, "applicationKvStore", applicationKvStore)
         Whitebox.setInternalState(activity, "cameraPosition", cameraPosition)
+        Whitebox.setInternalState(activity, "media", media)
+        Whitebox.setInternalState(activity, "coordinateEditHelper", coordinateEditHelper)
         Whitebox.setInternalState(activity, "modifyLocationButton", modifyLocationButton)
         Whitebox.setInternalState(activity, "placeSelectedButton", placeSelectedButton)
         Whitebox.setInternalState(activity, "showInMapButton", showInMapButton)

--- a/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
@@ -53,8 +53,9 @@ class LocationPickerActivityUnitTests {
 
     private lateinit var activity: LocationPickerActivity
     private lateinit var context: Context
-    private lateinit var media: Media
 
+    @Mock
+    private lateinit var media: Media
 
     @Mock
     private lateinit var applicationKvStore: JsonKvStore

--- a/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
@@ -150,6 +150,26 @@ class LocationPickerActivityUnitTests {
         verify(fabCenterOnLocation, times(1)).visibility = View.VISIBLE
     }
 
+    @Test
+    @Throws(Exception::class)
+    fun testPlaceSelected() {
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        Whitebox.setInternalState(activity,"activity", "NoLocationUploadActivity")
+        val position = GeoPoint(51.50550, -0.07520)
+        val method: Method = LocationPickerActivity::class.java.getDeclaredMethod(
+            "placeSelected"
+        )
+        `when`(mapView.mapCenter).thenReturn(position)
+        `when`(mapView.zoomLevel).thenReturn(15)
+        method.isAccessible = true
+        method.invoke(activity)
+        verify(applicationKvStore, times(1)).putString(
+            LAST_LOCATION,
+            position.latitude.toString() + "," + position.longitude.toString()
+        )
+        verify(applicationKvStore, times(1)).putString(LAST_ZOOM, mapView.zoomLevel.toString())
+    }
+
 
 
 }


### PR DESCRIPTION

**Description (required)**

Fixes #5474 

What changes did you make and why?
Identified and fixed a critical issue in the open-source project related to the ```LocationPickerActivity```.
The crash occurred when the device configuration changed, specifically during UI mode switches (dark to light or light to dark mode)

Investigated the crash root cause, which was tied to how the activity handled UI mode changes.


**Tests performed (required)**

Tested 4.2.1-debug on Xiaomi 11 Lite NE with API level 33

**Screenshots (for UI changes only)**


https://github.com/commons-app/apps-android-commons/assets/126143257/e44b401f-3fed-4982-b468-be3401fd0803

