### PR TITLE
5355: Fix uploadCancelled AfterLocationPickedTest

### DIFF
--- a/app/src/androidTest/java/fr/free/nrw/commons/UploadCancelledTest.kt
+++ b/app/src/androidTest/java/fr/free/nrw/commons/UploadCancelledTest.kt
@@ -134,8 +134,8 @@ class UploadCancelledTest {
         )
         linearLayout3.perform(click())
 
-        // Dismiss the one-time "Record location for in-app shots" dialog
-        onView(withText(R.string.option_dismiss)).check { view, _ ->
+        // Tap "Allow" on the one-time "Record location for in-app shots" dialog
+        onView(withText(R.string.option_allow)).check { view, _ ->
             view?.performClick()
         }
 
@@ -198,5 +198,9 @@ class UploadCancelledTest {
         )
         UITestHelper.sleep(2000)
         floatingActionButton3.perform(click())
+
+        // Cancel Upload
+        UITestHelper.sleep(2000)
+        onView(withText(R.string.cancel)).perform(click())
     }
 }

--- a/app/src/androidTest/java/fr/free/nrw/commons/UploadCancelledTest.kt
+++ b/app/src/androidTest/java/fr/free/nrw/commons/UploadCancelledTest.kt
@@ -10,6 +10,7 @@ import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
@@ -37,7 +38,8 @@ class UploadCancelledTest {
     @JvmField
     var mGrantPermissionRule: GrantPermissionRule =
         GrantPermissionRule.grant(
-            "android.permission.WRITE_EXTERNAL_STORAGE"
+            "android.permission.WRITE_EXTERNAL_STORAGE",
+            "android.permission.ACCESS_FINE_LOCATION"
         )
 
     private val device: UiDevice =
@@ -102,6 +104,8 @@ class UploadCancelledTest {
         )
         actionMenuItemView.perform(click())
 
+        UITestHelper.sleep(2000)
+
         val recyclerView = onView(
             allOf(
                 withId(R.id.rv_nearby_list),
@@ -113,6 +117,8 @@ class UploadCancelledTest {
                 click()
             )
         )
+
+        UITestHelper.sleep(2000)
 
         val linearLayout3 = onView(
             allOf(
@@ -127,6 +133,11 @@ class UploadCancelledTest {
             )
         )
         linearLayout3.perform(click())
+
+        // Dismiss the one-time "Record location for in-app shots" dialog
+        onView(withText(R.string.option_dismiss)).check { view, _ ->
+            view?.performClick()
+        }
 
         val pasteSensitiveTextInputEditText = onView(
             allOf(
@@ -158,16 +169,11 @@ class UploadCancelledTest {
         )
         pasteSensitiveTextInputEditText2.perform(replaceText("test"), closeSoftKeyboard())
 
+        UITestHelper.sleep(2000)
+
         val appCompatButton2 = onView(
             allOf(
                 withId(R.id.btn_next),
-                childAtPosition(
-                    childAtPosition(
-                        withId(R.id.ll_container_media_detail),
-                        2
-                    ),
-                    1
-                ),
                 isDisplayed()
             )
         )
@@ -181,6 +187,8 @@ class UploadCancelledTest {
         appCompatButton3.perform(scrollTo(), click())
 
         Intents.intended(IntentMatchers.hasComponent(LocationPickerActivity::class.java.name))
+
+        UITestHelper.sleep(2000)
 
         val floatingActionButton3 = onView(
             allOf(

--- a/app/src/androidTest/java/fr/free/nrw/commons/UploadTest.kt
+++ b/app/src/androidTest/java/fr/free/nrw/commons/UploadTest.kt
@@ -234,9 +234,6 @@ class UploadTest {
                         .actionOnItemAtPosition<UploadMediaDetailAdapter.ViewHolder>(0,
                                 MyViewAction.typeTextInChildViewWithId(R.id.description_item_edit_text, "Test description")))
 
-        onView(withId(R.id.btn_add_description))
-                .perform(click())
-
         onView(withId(R.id.rv_descriptions)).perform(
                 RecyclerViewActions
                         .actionOnItemAtPosition<UploadMediaDetailAdapter.ViewHolder>(1,

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -21,6 +21,7 @@ import android.view.animation.OvershootInterpolator;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
@@ -389,7 +390,7 @@ public class LocationPickerActivity extends BaseActivity implements
             && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
             onLocationPermissionGranted();
         } else {
-            onLocationPermissionDenied("");
+            onLocationPermissionDenied(getString(R.string.upload_map_location_access));
         }
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
@@ -409,6 +410,7 @@ public class LocationPickerActivity extends BaseActivity implements
     @Override
     public void onLocationPermissionDenied(String toastMessage) {
         //do nothing
+        Toast.makeText(getBaseContext(),toastMessage,Toast.LENGTH_LONG).show();
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -40,7 +40,6 @@ import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.filepicker.Constants;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.location.LocationPermissionsHelper;
-import fr.free.nrw.commons.location.LocationPermissionsHelper.Dialog;
 import fr.free.nrw.commons.location.LocationPermissionsHelper.LocationPermissionCallback;
 import fr.free.nrw.commons.location.LocationServiceManager;
 import fr.free.nrw.commons.theme.BaseActivity;
@@ -371,19 +370,10 @@ public class LocationPickerActivity extends BaseActivity implements
      * Center the map at user's current location
      */
     private void requestLocationPermissions() {
-        LocationPermissionsHelper.Dialog locationAccessDialog = new Dialog(
-            R.string.location_permission_title,
-            R.string.upload_map_location_access
-        );
-
-        LocationPermissionsHelper.Dialog locationOffDialog = new Dialog(
-            R.string.ask_to_turn_location_on,
-            R.string.upload_map_location_access
-        );
         locationPermissionsHelper = new LocationPermissionsHelper(
             this, locationManager, this);
-        locationPermissionsHelper.handleLocationPermissions(locationAccessDialog,
-            locationOffDialog);
+        locationPermissionsHelper.requestForLocationAccess(R.string.location_permission_title,
+            R.string.upload_map_location_access);
     }
 
     @Override
@@ -413,12 +403,13 @@ public class LocationPickerActivity extends BaseActivity implements
 
     @Override
     public void onLocationPermissionDenied(String toastMessage) {
-        Toast.makeText(getBaseContext(),toastMessage,Toast.LENGTH_LONG).show();
         if (!ActivityCompat.shouldShowRequestPermissionRationale(this, permission.ACCESS_FINE_LOCATION)) {
             if(!locationPermissionsHelper.checkLocationPermission(this)) {
             // means user has denied location permission twice or checked the "Don't show again"
-            locationPermissionsHelper.showAppSettingsDialog(this);
+            locationPermissionsHelper.showAppSettingsDialog(this, R.string.upload_map_location_access);
             }
+        } else {
+        Toast.makeText(getBaseContext(),toastMessage,Toast.LENGTH_LONG).show();
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
@@ -130,7 +130,7 @@ public class ContributionController {
             activity.getString(android.R.string.cancel),
             () -> {
                 if (!locationPermissionsHelper.isLocationAccessToAppsTurnedOn()) {
-                    locationPermissionsHelper.showLocationOffDialog(activity);
+                    locationPermissionsHelper.showLocationOffDialog(activity, R.string.in_app_camera_needs_location);
                 }
             },
             () -> locationPermissionCallback.onLocationPermissionDenied(

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.java
@@ -18,7 +18,6 @@ import fr.free.nrw.commons.filepicker.UploadableFile;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.location.LatLng;
 import fr.free.nrw.commons.location.LocationPermissionsHelper;
-import fr.free.nrw.commons.location.LocationPermissionsHelper.Dialog;
 import fr.free.nrw.commons.location.LocationPermissionsHelper.LocationPermissionCallback;
 import fr.free.nrw.commons.location.LocationServiceManager;
 import fr.free.nrw.commons.nearby.Place;
@@ -85,15 +84,6 @@ public class ContributionController {
      */
     private void createDialogsAndHandleLocationPermissions(Activity activity,
         ActivityResultLauncher<String[]> inAppCameraLocationPermissionLauncher) {
-        LocationPermissionsHelper.Dialog locationAccessDialog = new Dialog(
-            R.string.location_permission_title,
-            R.string.in_app_camera_location_permission_rationale
-        );
-
-        LocationPermissionsHelper.Dialog locationOffDialog = new Dialog(
-            R.string.ask_to_turn_location_on,
-            R.string.in_app_camera_needs_location
-        );
         locationPermissionCallback = new LocationPermissionCallback() {
             @Override
             public void onLocationPermissionDenied(String toastMessage) {
@@ -117,8 +107,8 @@ public class ContributionController {
             inAppCameraLocationPermissionLauncher.launch(
                 new String[]{permission.ACCESS_FINE_LOCATION});
         } else {
-            locationPermissionsHelper.handleLocationPermissions(locationAccessDialog,
-                locationOffDialog);
+            locationPermissionsHelper.requestForLocationAccess(R.string.location_permission_title,
+                R.string.in_app_camera_location_permission_rationale);
         }
 
     }

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapContract.java
@@ -15,7 +15,7 @@ public class ExploreMapContract {
     interface View {
         boolean isNetworkConnectionEstablished();
         void populatePlaces(LatLng curlatLng);
-        void checkPermissionsAndPerformAction();
+        void askForLocationPermission();
         void recenterMap(LatLng curLatLng);
         void showLocationOffDialog();
         void openLocationSettings();

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapContract.java
@@ -19,6 +19,8 @@ public class ExploreMapContract {
         void recenterMap(LatLng curLatLng);
         void showLocationOffDialog();
         void openLocationSettings();
+        void showAppSettingsDialog();
+        void openAppSettings();
         void hideBottomDetailsSheet();
         void displayBottomSheetWithInfo(Marker marker);
         LatLng getMapCenter();

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapContract.java
@@ -17,10 +17,6 @@ public class ExploreMapContract {
         void populatePlaces(LatLng curlatLng);
         void askForLocationPermission();
         void recenterMap(LatLng curLatLng);
-        void showLocationOffDialog();
-        void openLocationSettings();
-        void showAppSettingsDialog();
-        void openAppSettings();
         void hideBottomDetailsSheet();
         void displayBottomSheetWithInfo(Marker marker);
         LatLng getMapCenter();

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
@@ -491,7 +491,7 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
             setProgressBarVisibility(true);
         }
         else {
-            locationPermissionsHelper.showLocationOffDialog(getActivity(), R.string.explore_map_needs_location);
+            locationPermissionsHelper.showLocationOffDialog(getActivity(), R.string.ask_to_turn_location_on_text);
         }
         presenter.onMapReady(exploreMapController);
         registerUnregisterLocationListener(false);

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
@@ -506,11 +506,6 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
 
     @Override
     public void recenterMap(LatLng curLatLng) {
-        if (!locationPermissionsHelper.checkLocationPermission(getActivity())) {
-            askForLocationPermission();
-        } else {
-            locationPermissionGranted();
-        }
         // if user has denied permission twice, then show dialog
         if (isPermissionDenied) {
             if (locationPermissionsHelper.checkLocationPermission(getActivity())) {
@@ -520,6 +515,12 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
             } else {
                 locationPermissionsHelper.showAppSettingsDialog(getActivity(),
                     R.string.explore_map_needs_location);
+            }
+        } else {
+            if (!locationPermissionsHelper.checkLocationPermission(getActivity())) {
+                askForLocationPermission();
+            } else {
+                locationPermissionGranted();
             }
         }
         if (curLatLng == null) {

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
@@ -156,41 +156,30 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
     @BindView(R.id.category)
     TextView distance;
 
-    private ActivityResultLauncher<String[]> activityResultLauncher = registerForActivityResult(
-        new ActivityResultContracts.RequestMultiplePermissions(),
-        new ActivityResultCallback<Map<String, Boolean>>() {
-            @Override
-            public void onActivityResult(Map<String, Boolean> result) {
-                boolean areAllGranted = true;
-                for (final boolean b : result.values()) {
-                    areAllGranted = areAllGranted && b;
-                }
-
-                if (areAllGranted) {
-                    locationPermissionGranted();
+    private ActivityResultLauncher<String> activityResultLauncher = registerForActivityResult(
+        new ActivityResultContracts.RequestPermission(), isGranted -> {
+            if (isGranted) {
+                locationPermissionGranted();
+            } else {
+                if (shouldShowRequestPermissionRationale(permission.ACCESS_FINE_LOCATION)) {
+                    DialogUtil.showAlertDialog(getActivity(), getActivity().getString(R.string.location_permission_title),
+                        getActivity().getString(R.string.location_permission_rationale_nearby),
+                        getActivity().getString(android.R.string.ok),
+                        getActivity().getString(android.R.string.cancel),
+                        () -> {
+                            checkPermissionsAndPerformAction();
+                        },
+                        () -> {
+                            isPermissionDenied = true;
+                        },
+                        null,
+                        false);
                 } else {
-                    if (shouldShowRequestPermissionRationale(permission.ACCESS_FINE_LOCATION)) {
-                        DialogUtil.showAlertDialog(getActivity(),
-                            getActivity().getString(R.string.location_permission_title),
-                            getActivity().getString(R.string.location_permission_rationale_nearby),
-                            getActivity().getString(android.R.string.ok),
-                            getActivity().getString(android.R.string.cancel),
-                            () -> {
-                                if (!(locationManager.isNetworkProviderEnabled()
-                                    || locationManager.isGPSProviderEnabled())) {
-                                    showLocationOffDialog();
-                                }
-                            },
-                            () -> isPermissionDenied = true,
-                            null,
-                            false);
-                    } else {
-                        isPermissionDenied = true;
-                    }
-
+                    isPermissionDenied = true;
                 }
             }
-        });
+
+});
 
 
     @NonNull
@@ -452,8 +441,8 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
                 },
                 throwable -> {
                     Timber.d(throwable);
-                    showErrorMessage(getString(R.string.error_fetching_nearby_places)
-                        + throwable.getLocalizedMessage());
+                    // Not showing the user, throwable localizedErrorMessage
+                    showErrorMessage(getString(R.string.error_fetching_nearby_places));
                     setProgressBarVisibility(false);
                     presenter.lockUnlockNearby(false);
                 }));
@@ -478,7 +467,7 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
     @Override
     public void checkPermissionsAndPerformAction() {
         Timber.d("Checking permission and perfoming action");
-        activityResultLauncher.launch(new String[]{permission.ACCESS_FINE_LOCATION});
+            activityResultLauncher.launch(permission.ACCESS_FINE_LOCATION);
     }
 
     private void locationPermissionGranted() {

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
@@ -519,7 +519,7 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
                 isPermissionDenied = false;
                 recenterMap(curLatLng);
             } else {
-                locationPermissionsHelper.showAppSettingsDialog(getActivity());
+                locationPermissionsHelper.showAppSettingsDialog(getActivity(), R.string.explore_map_needs_location);
             }
             return;
         }

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapPresenter.java
@@ -136,7 +136,6 @@ public class ExploreMapPresenter
 
     public void onMapReady(ExploreMapController exploreMapController) {
         this.exploreMapController = exploreMapController;
-        exploreMapFragmentView.addSearchThisAreaButtonAction();
         if (null != exploreMapFragmentView) {
             exploreMapFragmentView.addSearchThisAreaButtonAction();
             initializeMapOperations();
@@ -146,7 +145,6 @@ public class ExploreMapPresenter
     public void initializeMapOperations() {
         lockUnlockNearby(false);
         updateMap(LOCATION_SIGNIFICANTLY_CHANGED);
-        exploreMapFragmentView.addSearchThisAreaButtonAction();
     }
 
     public Observable<ExplorePlacesInfo> loadAttractionsFromLocation(LatLng curLatLng,

--- a/app/src/main/java/fr/free/nrw/commons/location/LocationPermissionsHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/location/LocationPermissionsHelper.java
@@ -98,7 +98,7 @@ public class LocationPermissionsHelper {
                 activity.getString(R.string.cancel),
                 () -> openLocationSettings(activity),
                 () -> callback.onLocationPermissionDenied(activity.getString(
-                    R.string.in_app_camera_location_unavailable)));
+                    R.string.ask_to_turn_location_on)));
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
@@ -25,7 +25,7 @@ public interface NearbyParentFragmentContract {
 
         boolean isListBottomSheetExpanded();
 
-        void checkPermissionsAndPerformAction();
+        void askForLocationPermission();
 
         void displayLoginSkippedWarning();
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.java
@@ -94,7 +94,6 @@ public class NearbyParentFragmentPresenter
     public void initializeMapOperations() {
         lockUnlockNearby(false);
         updateMapAndList(LOCATION_SIGNIFICANTLY_CHANGED);
-        this.nearbyParentFragmentView.addSearchThisAreaButtonAction();
         nearbyParentFragmentView.setCheckBoxAction();
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -354,7 +354,7 @@
   <string name="share_app_title">Share App</string>
   <string name="rotate">Rotate</string>
 
-  <string name="error_fetching_nearby_places">No nearby places found due to lack of location permission</string>
+  <string name="error_fetching_nearby_places">Could not load nearby places</string>
   <string name="no_nearby_places_around">No nearby places around</string>
   <string name="error_fetching_nearby_monuments">Error fetching nearby monuments.</string>
   <string name="no_recent_searches">No recent searches</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -354,7 +354,7 @@
   <string name="share_app_title">Share App</string>
   <string name="rotate">Rotate</string>
 
-  <string name="error_fetching_nearby_places">Error fetching nearby places.</string>
+  <string name="error_fetching_nearby_places">No nearby places found due to lack of location permission</string>
   <string name="no_nearby_places_around">No nearby places around</string>
   <string name="error_fetching_nearby_monuments">Error fetching nearby monuments.</string>
   <string name="no_recent_searches">No recent searches</string>
@@ -622,6 +622,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="recommend_high_accuracy_mode">For best results, choose the High Accuracy mode.</string>
   <string name="ask_to_turn_location_on">Turn on location?</string>
   <string name="nearby_needs_location">Nearby needs location enabled to work properly</string>
+  <string name="explore_map_needs_location">Explore map needs location permission to display nearby images</string>
   <string name="upload_map_location_access">You need to give access to your current location to set location automatically.</string>
   <string name="use_location_from_similar_image">Did you shoot these two pictures at the same place? Do you want to use the latitude/longitude of the picture on the right?</string>
   <string name="load_more">Load More</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -621,6 +621,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="cannot_open_location_settings">Failed to open location settings. Please turn on location manually</string>
   <string name="recommend_high_accuracy_mode">For best results, choose the High Accuracy mode.</string>
   <string name="ask_to_turn_location_on">Turn on location?</string>
+  <string name="ask_to_turn_location_on_text">Kindly turn on location services for the app show your current location</string>
   <string name="nearby_needs_location">Nearby needs location enabled to work properly</string>
   <string name="explore_map_needs_location">Explore map needs location permission to display nearby images</string>
   <string name="upload_map_location_access">You need to give access to your current location to set location automatically.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -584,7 +584,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="coordinates_edit_helper_edit_message_else">Could not add coordinates.</string>
   <string name="description_edit_helper_edit_message_else">Could not add descriptions.</string>
   <string name="caption_edit_helper_edit_message_else">Could not add caption.</string>
-  <string name="coordinates_picking_unsuccessful">Unable to get coordinates.</string>
+  <string name="coordinates_picking_unsuccessful">Image\'s coordinates not updated</string>
   <string name="descriptions_picking_unsuccessful">Unable to get descriptions.</string>
   <string name="description_activity_title">Edit descriptions and captions</string>
 
@@ -624,7 +624,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="ask_to_turn_location_on_text">Kindly turn on location services for the app show your current location</string>
   <string name="nearby_needs_location">Nearby needs location enabled to work properly</string>
   <string name="explore_map_needs_location">Explore map needs location permission to display nearby images</string>
-  <string name="upload_map_location_access">You need to give access to your current location to set location automatically.</string>
+  <string name="upload_map_location_access">You need to give location permission to set location automatically.</string>
   <string name="use_location_from_similar_image">Did you shoot these two pictures at the same place? Do you want to use the latitude/longitude of the picture on the right?</string>
   <string name="load_more">Load More</string>
   <string name="nearby_no_results">No places found, try changing your search criteria.</string>


### PR DESCRIPTION
**Description (required)**

Fixes #5355 

What changes did you make and why?
Added additional `sleep()` calls due to the delay caused by animations and a few other changes to comply with the latest UI changes in the app. 

One of the requirements for this test to run was the list icon at the top-right corner of Nearby, so the additional changes are from PR #5494 

**Tests performed (required)**

Tested `uploadCancelledAfterLocationPickedTest` on Redmi 5A with API level 27.

