### PR TITLE
Fix-Peer Review Buttons not get disabled after voting an Image for deletion

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/delete/DeleteHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/delete/DeleteHelper.java
@@ -205,6 +205,8 @@ public class DeleteHelper {
         });
 
         alert.setPositiveButton(context.getString(R.string.ok), (dialogInterface, i) -> {
+            reviewCallback.disableButtons();
+
 
             String reason = getLocalizedResources(context, Locale.ENGLISH).getString(R.string.delete_helper_ask_alert_set_positive_button_reason) + " ";
 

--- a/app/src/main/java/fr/free/nrw/commons/delete/DeleteHelper.java
+++ b/app/src/main/java/fr/free/nrw/commons/delete/DeleteHelper.java
@@ -231,6 +231,7 @@ public class DeleteHelper {
                     } else {
                         reviewCallback.onFailure();
                     }
+                    reviewCallback.enableButtons();
                 });
 
         });

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewController.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewController.java
@@ -191,5 +191,7 @@ public class ReviewController {
         void onSuccess();
 
         void onFailure();
+
+        void disableButtons();
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewController.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewController.java
@@ -193,5 +193,7 @@ public class ReviewController {
         void onFailure();
 
         void disableButtons();
+
+        void enableButtons();
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
@@ -193,6 +193,11 @@ public class ReviewImageFragment extends CommonsDaggerSupportFragment {
             public void onFailure() {
                 //do nothing
             }
+
+            @Override
+            public void disableButtons() {
+                ReviewImageFragment.this.disableButtons();
+            }
         };
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.java
@@ -194,9 +194,22 @@ public class ReviewImageFragment extends CommonsDaggerSupportFragment {
                 //do nothing
             }
 
+            /**
+             * This function is called when an image is being loaded
+             * to disable the review buttons
+             */
             @Override
             public void disableButtons() {
                 ReviewImageFragment.this.disableButtons();
+            }
+
+            /**
+             * This function is called when an image has
+             * been loaded to enable the review buttons.
+             */
+            @Override
+            public void enableButtons() {
+                ReviewImageFragment.this.enableButtons();
             }
         };
     }


### PR DESCRIPTION

**Description (required)**

Fixes #5516 

What changes did you make and why?
Peer Review Buttons ("Yes" and "No") gets disabled to after nominating an Image for deletion to avoid Incorrect Input from user.

**Tests performed (required)**

Tested 4.2.1-debug-main on Xiaomi 11 Lite NE with API level 33

**Screenshots (for UI changes only)**

https://github.com/commons-app/apps-android-commons/assets/126143257/401791e7-accb-4007-a02c-f61ef3967113



