### PR TITLE
Add ability to suppress logging of known unsuccessful API calls

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.kt
+++ b/app/src/main/java/fr/free/nrw/commons/MediaDataExtractor.kt
@@ -43,7 +43,7 @@ class MediaDataExtractor @Inject constructor(private val mediaClient: MediaClien
         return Single.ambArray(
             mediaClient.getMediaById(PAGE_ID_PREFIX + media.pageId)
                 .onErrorResumeNext { Single.never() },
-            mediaClient.getMedia(media.filename)
+            mediaClient.getMediaSuppressingErrors(media.filename)
                 .onErrorResumeNext { Single.never() }
         )
 

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaClient.kt
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaClient.kt
@@ -131,6 +131,17 @@ class MediaClient @Inject constructor(
     }
 
     /**
+     * Fetches Media object from the imageInfo API but suppress (known) errors
+     *
+     * @param titles the tiles to be searched for. Can be filename or template name
+     * @return
+     */
+    fun getMediaSuppressingErrors(titles: String?): Single<Media> {
+        return responseMapper(mediaInterface.getMediaSuppressingErrors(titles))
+            .map { it.first() }
+    }
+
+    /**
      * The method returns the picture of the day
      *
      * @return Media object corresponding to the picture of the day

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaInterface.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaInterface.java
@@ -1,9 +1,12 @@
 package fr.free.nrw.commons.media;
 
+import static fr.free.nrw.commons.OkHttpConnectionFactory.UnsuccessfulResponseInterceptor.SUPPRESS_ERROR_LOG_HEADER;
+
 import io.reactivex.Single;
 import java.util.Map;
 import fr.free.nrw.commons.wikidata.mwapi.MwQueryResponse;
 import retrofit2.http.GET;
+import retrofit2.http.Headers;
 import retrofit2.http.Query;
 import retrofit2.http.QueryMap;
 
@@ -104,6 +107,17 @@ public interface MediaInterface {
     Single<MwQueryResponse> getMedia(@Query("titles") String title);
 
     /**
+     * Fetches Media object from the imageInfo API but suppress (known) errors
+     *
+     * @param title       the tiles to be searched for. Can be filename or template name
+     * @return
+     */
+    @GET("w/api.php?action=query&format=json&formatversion=2" +
+        MEDIA_PARAMS_WITH_CATEGORY_DETAILS)
+    @Headers(SUPPRESS_ERROR_LOG_HEADER)
+    Single<MwQueryResponse> getMediaSuppressingErrors(@Query("titles") String title);
+
+    /**
      * Fetches Media object from the imageInfo API
      *
      * @param pageIds       the ids to be searched for
@@ -111,6 +125,7 @@ public interface MediaInterface {
      */
     @GET("w/api.php?action=query&format=json&formatversion=2" +
             MEDIA_PARAMS)
+    @Headers(SUPPRESS_ERROR_LOG_HEADER)
     Single<MwQueryResponse> getMediaById(@Query("pageids") String pageIds);
 
     /**
@@ -125,6 +140,7 @@ public interface MediaInterface {
     Single<MwQueryResponse> getMediaWithGenerator(@Query("titles") String title);
 
     @GET("w/api.php?format=json&action=parse&prop=text")
+    @Headers(SUPPRESS_ERROR_LOG_HEADER)
     Single<MwParseResponse> getPageHtml(@Query("page") String title);
 
     /**


### PR DESCRIPTION
Added the ability to mark Retrofit interface methods we want to have error logs suppressed.  The error will be logged at `debug` instead of `error`.

This fixes #5244
