### PR TITLE
Resolved Problems in UploadMediaDetails flow and UX #5511

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -48,6 +48,7 @@ import fr.free.nrw.commons.contributions.ContributionController;
 import fr.free.nrw.commons.contributions.MainActivity;
 import fr.free.nrw.commons.filepicker.Constants.RequestCodes;
 import fr.free.nrw.commons.filepicker.UploadableFile;
+import fr.free.nrw.commons.kvstore.BasicKvStore;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.location.LatLng;
 import fr.free.nrw.commons.location.LocationPermissionsHelper;
@@ -329,6 +330,8 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
 
     @Override
     protected void onStop() {
+        // Resetting setImageCancelled to false
+        setImageCancelled(false);
         super.onStop();
     }
 
@@ -717,6 +720,12 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
             vpUpload.setCurrentItem(index + 1, false);
             vpUpload.setCurrentItem(index, false);
         }
+    }
+
+    @Override
+    public void setImageCancelled(boolean isCancelled) {
+        BasicKvStore basicKvStore = new BasicKvStore(this,"IsAnyImageCancelled");
+        basicKvStore.putBoolean("IsAnyImageCancelled", isCancelled);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -711,6 +711,14 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
         return true;
     }
 
+    @Override
+    public void highlightNextImageOnCancelledImage(int index, int maxSize) {
+        if (vpUpload != null && index < (maxSize)) {
+            vpUpload.setCurrentItem(index + 1, false);
+            vpUpload.setCurrentItem(index, false);
+        }
+    }
+
     /**
      * Calculate the difference between current location and
      * location recorded before capturing the image

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -714,6 +714,13 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
         return true;
     }
 
+    /**
+     * Changes current image when one image upload is cancelled, to highlight next image in the top thumbnail.
+     * Fixes: <a href="https://github.com/commons-app/apps-android-commons/issues/5511">Issue</a>
+     *
+     * @param index Index of image to be removed
+     * @param maxSize Max size of the {@code uploadableFiles}
+     */
     @Override
     public void highlightNextImageOnCancelledImage(int index, int maxSize) {
         if (vpUpload != null && index < (maxSize)) {
@@ -722,6 +729,13 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
         }
     }
 
+    /**
+     * Used to check if user has cancelled upload of any image in current upload
+     * so that location compare doesn't show up again in same upload.
+     * Fixes: <a href="https://github.com/commons-app/apps-android-commons/issues/5511">Issue</a>
+     *
+     * @param isCancelled Is true when user has cancelled upload of any image in current upload
+     */
     @Override
     public void setImageCancelled(boolean isCancelled) {
         BasicKvStore basicKvStore = new BasicKvStore(this,"IsAnyImageCancelled");

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadContract.java
@@ -20,6 +20,14 @@ public interface UploadContract {
 
         void askUserToLogIn();
 
+        /**
+         * Changes current image when one image upload is cancelled, to highlight next image
+         *
+         * @param index Index of image to be removed
+         * @param maxSize Max size of the {@code uploadableFiles}
+         */
+        void highlightNextImageOnCancelledImage(int index, int maxSize);
+
         void showProgress(boolean shouldShow);
 
         void showMessage(int messageResourceId);

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadContract.java
@@ -21,12 +21,22 @@ public interface UploadContract {
         void askUserToLogIn();
 
         /**
-         * Changes current image when one image upload is cancelled, to highlight next image
+         * Changes current image when one image upload is cancelled, to highlight next image in the top thumbnail.
+         * Fixes: <a href="https://github.com/commons-app/apps-android-commons/issues/5511">Issue</a>
          *
          * @param index Index of image to be removed
          * @param maxSize Max size of the {@code uploadableFiles}
          */
         void highlightNextImageOnCancelledImage(int index, int maxSize);
+
+        /**
+         * Used to check if user has cancelled upload of any image in current upload
+         * so that location compare doesn't show up again in same upload.
+         * Fixes: <a href="https://github.com/commons-app/apps-android-commons/issues/5511">Issue</a>
+         *
+         * @param isCancelled Is true when user has cancelled upload of any image in current upload
+         */
+        void setImageCancelled(boolean isCancelled);
 
         void showProgress(boolean shouldShow);
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
@@ -155,6 +155,7 @@ public class UploadPresenter implements UploadContract.UserActionListener {
 
         //In case lets update the number of uploadable media
         view.updateTopCardTitle();
+        view.highlightNextImageOnCancelledImage(index, uploadableFiles.size());
 
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
@@ -141,6 +141,7 @@ public class UploadPresenter implements UploadContract.UserActionListener {
         if (index == uploadableFiles.size() - 1) {//If the next fragment to be shown is not one of the MediaDetailsFragment, lets hide the top card
             view.showHideTopCard(false);
         }
+        view.setImageCancelled(true);
         repository.deletePicture(uploadableFiles.get(index).getFilePath());
         if (uploadableFiles.size() == 1) {
             view.showMessage(R.string.upload_cancelled);

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -458,7 +458,7 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
                 false);
         } else {
             uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
-            onNextButtonClicked();
+            onImageValidationSuccess();
         }
     }
 
@@ -481,9 +481,15 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
 
                     // validate image only when same file name error does not occur
                     // show the same file name error if exists.
-                    if ((errorCode & FILE_NAME_EXISTS) == 0) {
-                        uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
-                        onImageValidationSuccess();
+                    // If image with same file name exists check the bit in errorCode is set or not
+                    if ((errorCode & FILE_NAME_EXISTS) != 0) {
+                        Timber.d("Trying to show duplicate picture popup");
+                        showDuplicatePicturePopup(uploadItem);
+                    } else {
+                        if ((errorCode & FILE_NAME_EXISTS) == 0) {
+                            uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
+                            onImageValidationSuccess();
+                        }
                     }
                 },
                 () -> deleteThisPicture()

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -36,6 +36,7 @@ import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.edit.EditActivity;
 import fr.free.nrw.commons.contributions.MainActivity;
 import fr.free.nrw.commons.filepicker.UploadableFile;
+import fr.free.nrw.commons.kvstore.BasicKvStore;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.location.LatLng;
 import fr.free.nrw.commons.nearby.Place;
@@ -309,31 +310,35 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
     @Override
     public void showSimilarImageFragment(String originalFilePath, String possibleFilePath,
         ImageCoordinates similarImageCoordinates) {
-        SimilarImageDialogFragment newFragment = new SimilarImageDialogFragment();
-        newFragment.setCallback(new SimilarImageDialogFragment.Callback() {
-            @Override
-            public void onPositiveResponse() {
-                Timber.d("positive response from similar image fragment");
-                presenter.useSimilarPictureCoordinates(similarImageCoordinates, callback.getIndexInViewFlipper(UploadMediaDetailFragment.this));
+        BasicKvStore basicKvStore = new BasicKvStore(getActivity(), "IsAnyImageCancelled");
+        if (!basicKvStore.getBoolean("IsAnyImageCancelled", false)) {
+            SimilarImageDialogFragment newFragment = new SimilarImageDialogFragment();
+            newFragment.setCallback(new SimilarImageDialogFragment.Callback() {
+                @Override
+                public void onPositiveResponse() {
+                    Timber.d("positive response from similar image fragment");
+                    presenter.useSimilarPictureCoordinates(similarImageCoordinates,
+                        callback.getIndexInViewFlipper(UploadMediaDetailFragment.this));
 
-                // set the description text when user selects to use coordinate from the other image
-                // which was taken within 20s
-                // fixing: https://github.com/commons-app/apps-android-commons/issues/4700
-                uploadMediaDetailAdapter.getItems().get(0).setDescriptionText(
-                    getString(R.string.similar_coordinate_description_auto_set));
-                updateMediaDetails(uploadMediaDetailAdapter.getItems());
-            }
+                    // set the description text when user selects to use coordinate from the other image
+                    // which was taken within 120s
+                    // fixing: https://github.com/commons-app/apps-android-commons/issues/4700
+                    uploadMediaDetailAdapter.getItems().get(0).setDescriptionText(
+                        getString(R.string.similar_coordinate_description_auto_set));
+                    updateMediaDetails(uploadMediaDetailAdapter.getItems());
+                }
 
-            @Override
-            public void onNegativeResponse() {
-                Timber.d("negative response from similar image fragment");
-            }
-        });
-        Bundle args = new Bundle();
-        args.putString("originalImagePath", originalFilePath);
-        args.putString("possibleImagePath", possibleFilePath);
-        newFragment.setArguments(args);
-        newFragment.show(getChildFragmentManager(), "dialog");
+                @Override
+                public void onNegativeResponse() {
+                    Timber.d("negative response from similar image fragment");
+                }
+            });
+            Bundle args = new Bundle();
+            args.putString("originalImagePath", originalFilePath);
+            args.putString("possibleImagePath", possibleFilePath);
+            newFragment.setArguments(args);
+            newFragment.show(getChildFragmentManager(), "dialog");
+        }
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -463,6 +463,7 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
                 false);
         } else {
             uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
+            // Calling below, instead of onNextButtonClicked() to not show locationDialog twice
             onImageValidationSuccess();
         }
     }
@@ -491,10 +492,8 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
                         Timber.d("Trying to show duplicate picture popup");
                         showDuplicatePicturePopup(uploadItem);
                     } else {
-                        if ((errorCode & FILE_NAME_EXISTS) == 0) {
-                            uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
-                            onImageValidationSuccess();
-                        }
+                        uploadItem.setImageQuality(ImageUtils.IMAGE_KEEP);
+                        onImageValidationSuccess();
                     }
                 },
                 () -> deleteThisPicture()

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -251,7 +251,10 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
         photoViewBackgroundImage.setOnScaleChangeListener(
             (scaleFactor, focusX, focusY) -> {
                 //Whenever the uses plays with the image, lets collapse the media detail container
-                expandCollapseLlMediaDetail(false);
+                //only if it is not already collapsed, which resolves flickering of arrow
+                if (isExpanded) {
+                    expandCollapseLlMediaDetail(false);
+                }
             });
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -345,15 +345,14 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
             view.showMessage(R.string.add_caption_toast, R.color.color_error);
         }
 
-        // If image with same file name exists check the bit in errorCode is set or not
-        if ((errorCode & FILE_NAME_EXISTS) != 0) {
-            Timber.d("Trying to show duplicate picture popup");
-            view.showDuplicatePicturePopup(uploadItem);
-        }
-
         // If image has some other problems, show popup accordingly
         if (errorCode != EMPTY_CAPTION && errorCode != FILE_NAME_EXISTS) {
             view.showBadImagePopup(errorCode, uploadItem);
+        } else { // If no other problem but duplicate fileName
+            if ((errorCode & FILE_NAME_EXISTS) != 0) {
+                Timber.d("Trying to show duplicate picture popup");
+                view.showDuplicatePicturePopup(uploadItem);
+            }
         }
 
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -345,16 +345,14 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
             view.showMessage(R.string.add_caption_toast, R.color.color_error);
         }
 
-        // If image has some other problems, show popup accordingly
+        // If image has some problems, show popup accordingly
         if (errorCode != EMPTY_CAPTION && errorCode != FILE_NAME_EXISTS) {
             view.showBadImagePopup(errorCode, uploadItem);
-        } else { // If no other problem but duplicate fileName
-            if ((errorCode & FILE_NAME_EXISTS) != 0) {
-                Timber.d("Trying to show duplicate picture popup");
-                view.showDuplicatePicturePopup(uploadItem);
-            }
+        } else if ((errorCode & FILE_NAME_EXISTS) != 0) {
+            // When image has duplicate caption problem
+            Timber.d("Trying to show duplicate picture popup");
+            view.showDuplicatePicturePopup(uploadItem);
         }
-
     }
 
     /**


### PR DESCRIPTION
**Description (required)**
The uploadMediaDetailFragment flow had some flaws, as discussed in #5511. This PR aims to remove those flaws and improve the UX of uploadMediaDetailFragment.

Fixes #5511

**What changes did you make and why?**
Changed the flow of dialogs in uploadMediaDetailFragment, resolved the flickering of arrow on zooming the image and added logic to keep the location comparer from popping up several times.

**Tests performed (required)**

Tested prodDebug on OnePlus Nord CE 2 Lite with API level 31.

**Screencasts**

Resolved issue part 1 (2 dialogs popping up and no highlight in thumbnail): 
https://drive.google.com/file/d/1mXXfMk_XP-jzOBqzPNaTDILO8H5p-Ey5/view?usp=sharing

Resolved issue part 2 (location comparison several times):
https://drive.google.com/file/d/1m7e1RXvqBiMcp-VkPdF6N-0fkkRwfOSR/view?usp=sharing

Resolved issue part 3 (no location dialog pops up twice):
https://drive.google.com/file/d/1lujbBtPPUEzd8ag1uYfZpmKlz65OMzfR/view?usp=sharing

Resolved issue part 4 (arrow flickers on zooming image):
https://drive.google.com/file/d/1lrGmZnJy6Zhmi2PVirw5WRPdk8ZOi5ms/view?usp=sharing

