### PR TITLE
Fix - Unable to Access Privacy Policy

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -8,6 +8,7 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.text.SpannableString;
 import android.text.style.UnderlineSpan;
+import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -137,12 +138,6 @@ public class Utils {
      */
     public static void handleWebUrl(Context context, Uri url) {
         Timber.d("Launching web url %s", url.toString());
-        Intent browserIntent = new Intent(Intent.ACTION_VIEW, url);
-        if (browserIntent.resolveActivity(context.getPackageManager()) == null) {
-            Toast toast = Toast.makeText(context, context.getString(R.string.no_web_browser), LENGTH_SHORT);
-            toast.show();
-            return;
-        }
 
         final CustomTabColorSchemeParams color = new CustomTabColorSchemeParams.Builder()
             .setToolbarColor(ContextCompat.getColor(context, R.color.primaryColor))

--- a/app/src/main/java/fr/free/nrw/commons/Utils.java
+++ b/app/src/main/java/fr/free/nrw/commons/Utils.java
@@ -8,10 +8,8 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.text.SpannableString;
 import android.text.style.UnderlineSpan;
-import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.browser.customtabs.CustomTabColorSchemeParams;


### PR DESCRIPTION
**Description (required)**

Fixes #5532 

What changes did you make and why?
Removed a misleading check that was stopping the GitHub App to Open the Url for Privacy Policy.

**Tests performed (required)**

Tested 4.2.1-debug-main  on {Xiaomi 11 Lite NE with API level 33

**Screenshots (for UI changes only)**

IF GITHUB IS NOT INSTALLED:

https://github.com/commons-app/apps-android-commons/assets/126143257/6de10335-fd74-4a0c-b981-4d3c58a1c91a

IF GITHUB APP IS INSTALLED:

https://github.com/commons-app/apps-android-commons/assets/126143257/658f8990-5ce6-40ce-a908-9b8e5040ee31



