### PR TITLE
Handle the response shown to the user with correct message

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
@@ -452,8 +452,7 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
                 },
                 throwable -> {
                     Timber.d(throwable);
-                    showErrorMessage(getString(R.string.error_fetching_nearby_places)
-                        + throwable.getLocalizedMessage());
+                    showErrorMessage(getString(R.string.no_pictures_in_this_area));
                     setProgressBarVisibility(false);
                     presenter.lockUnlockNearby(false);
                 }));

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
@@ -448,14 +448,15 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
             .subscribe(explorePlacesInfo -> {
                     mediaList = explorePlacesInfo.mediaList;
                     if(mediaList == null) {
-                        showErrorMessage(getString(R.string.no_pictures_in_this_area));
+                        showResponseMessage(getString(R.string.no_pictures_in_this_area));
                     }
                     updateMapMarkers(explorePlacesInfo);
                     lastMapFocus = new GeoPoint(curLatLng.getLatitude(), curLatLng.getLongitude());
                 },
                 throwable -> {
                     Timber.d(throwable);
-                    showErrorMessage(getString(R.string.no_pictures_in_this_area));
+                    showErrorMessage(getString(R.string.error_fetching_nearby_places)
+                    + throwable.getLocalizedMessage());
                     setProgressBarVisibility(false);
                     presenter.lockUnlockNearby(false);
                 }));
@@ -474,6 +475,10 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
     }
 
     private void showErrorMessage(final String message) {
+        ViewUtil.showLongToast(getActivity(), message);
+    }
+
+    private void showResponseMessage(final String message) {
         ViewUtil.showLongSnackbar(getView(), message);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
@@ -447,6 +447,9 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(explorePlacesInfo -> {
                     mediaList = explorePlacesInfo.mediaList;
+                    if(mediaList == null) {
+                        showErrorMessage(getString(R.string.no_pictures_in_this_area));
+                    }
                     updateMapMarkers(explorePlacesInfo);
                     lastMapFocus = new GeoPoint(curLatLng.getLatitude(), curLatLng.getLongitude());
                 },
@@ -471,7 +474,7 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
     }
 
     private void showErrorMessage(final String message) {
-        ViewUtil.showLongToast(getActivity(), message);
+        ViewUtil.showLongSnackbar(getView(), message);
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapPresenter.java
@@ -167,7 +167,6 @@ public class ExploreMapPresenter
         if (explorePlacesInfo.mediaList != null) {
             prepareNearbyBaseMarkers(explorePlacesInfo, selectedMarker);
         } else {
-            //TODO: SHOW SNACKBAR
             lockUnlockNearby(false); // So that new location updates wont come
             exploreMapFragmentView.setProgressBarVisibility(false);
         }

--- a/app/src/main/java/fr/free/nrw/commons/utils/ViewUtil.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ViewUtil.java
@@ -1,16 +1,22 @@
 package fr.free.nrw.commons.utils;
 
+import static java.security.AccessController.getContext;
+
 import android.app.Activity;
 import android.content.Context;
+import android.graphics.Color;
 import android.view.Display;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.StringRes;
 
+import androidx.core.content.ContextCompat;
 import com.google.android.material.snackbar.Snackbar;
 
+import fr.free.nrw.commons.R;
 import timber.log.Timber;
 
 public class ViewUtil {
@@ -28,6 +34,36 @@ public class ViewUtil {
             try {
                 Snackbar.make(view, messageResourceId, Snackbar.LENGTH_SHORT).show();
             }catch (IllegalStateException e){
+                Timber.e(e.getMessage());
+            }
+        });
+    }
+    public static void showLongSnackbar(View view, String text) {
+        if(view.getContext() == null) {
+            return;
+        }
+
+        ExecutorUtils.uiExecutor().execute(()-> {
+            try {
+                Snackbar snackbar = Snackbar.make(view, text, Snackbar.LENGTH_SHORT);
+
+                View snack_view = snackbar.getView();
+                TextView snack_text = snack_view.findViewById(R.id.snackbar_text);
+
+                snack_view.setBackgroundColor(Color.LTGRAY);
+                snack_text.setTextColor(ContextCompat.getColor(view.getContext(), R.color.primaryColor));
+
+                snackbar.setAction("Dismiss", new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        // Handle the action click
+                        snackbar.dismiss();
+                    }
+                });
+
+                snackbar.show();
+
+            }catch (IllegalStateException e) {
                 Timber.e(e.getMessage());
             }
         });

--- a/app/src/main/java/fr/free/nrw/commons/utils/ViewUtil.java
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ViewUtil.java
@@ -52,6 +52,7 @@ public class ViewUtil {
 
                 snack_view.setBackgroundColor(Color.LTGRAY);
                 snack_text.setTextColor(ContextCompat.getColor(view.getContext(), R.color.primaryColor));
+                snackbar.setActionTextColor(Color.RED);
 
                 snackbar.setAction("Dismiss", new View.OnClickListener() {
                     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -355,6 +355,7 @@
   <string name="rotate">Rotate</string>
 
   <string name="error_fetching_nearby_places">Error fetching nearby places.</string>
+  <string name="no_pictures_in_this_area">No pictures in this area</string>
   <string name="no_nearby_places_around">No nearby places around</string>
   <string name="error_fetching_nearby_monuments">Error fetching nearby monuments.</string>
   <string name="no_recent_searches">No recent searches</string>


### PR DESCRIPTION
**Description (required)**

Fixes #5457

What changes did you make and why?
I added a new method showLongSnackbar in the ViewUtil.java file to show the user a Snackbar.
Also, updated the showErrorMessage() method in ExploreMapFragment() to use Snackbar instead of a Toast.

**Tests performed (required)**

Tested prodDebug on Samsung A14 with API level 34.

**Screenshots (for UI changes only)**
Screenshot that shows the snackbar:
![300532644-5a500990-a801-4ecc-8750-07d666f8cbcf](https://github.com/commons-app/apps-android-commons/assets/101377978/23adaa34-b16d-4f18-91c8-1e6576d16879)

