### PR TITLE
fix: thumbnail of rotated image not visible during upload

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionViewHolder.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionViewHolder.java
@@ -103,7 +103,11 @@ public class ContributionViewHolder extends RecyclerView.ViewHolder {
                 imageRequest = ImageRequestBuilder.newBuilderWithSource(Uri.parse(imageSource))
                     .setProgressiveRenderingEnabled(true)
                     .build();
-            } else if(imageSource != null) {
+            }
+            else if (URLUtil.isFileUrl(imageSource)){
+                imageRequest=ImageRequest.fromUri(Uri.parse(imageSource));
+            }
+            else if(imageSource != null) {
                 final File file = new File(imageSource);
                 imageRequest = ImageRequest.fromFile(file);
             }


### PR DESCRIPTION
[The image path of rotated image is not save like nornal image. so imageview cannot load rotated image

check whether the image path is file uri then add imagerequest to load the image]

[fixed: thumbnail not visible when upload rotated image]

**Description (required)**

Fixes #5363 

What changes did you make and why?

**Tests performed (required)**

Tested {build variant, e.g. ProdDebug} on {name of device or emulator} with API level {API level}.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
