### PR TITLE
Fix #5571 - Removed values-yue-hant file

### DIFF
--- a/app/src/main/res/values-yue-hant/error.xml
+++ b/app/src/main/res/values-yue-hant/error.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Authors:
-* Winston Sung
--->
-<resources>
-  <string name="crash_dialog_title">同享壞咗</string>
-  <string name="crash_dialog_text">哎呀。出咗錯！</string>
-  <string name="crash_dialog_ok_toast">多謝你！</string>
-</resources>


### PR DESCRIPTION
**Description (required)**

Fixes #5571 

What changes did you make and why?

Removed values-yue-hant, the error happened because Android expects a specific format for resource directory names, and values-yue-hant does not conform to these expectations, also there is exist values-yue with the same translate

**Tests performed (required)**

I used `gradle :app:testBetaDebugUnitTest` Tested on Google pixel 6A with API level 31 
