### PR TITLE
#5611 removed MapBox from CREDIS because it has already been replaced

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -53,7 +53,6 @@ their contribution to the product.
 * Butterknife
 * GSON
 * Timber
-* MapBox
 
 3rd party open source apps from which significant code has been reused:
 * Android Wikipedia app https://github.com/wikimedia/apps-android-wikipedia


### PR DESCRIPTION
Since MapBox is no longer used, removed it from CRDITS file

Fixes #5611

