### PR TITLE
achievements: make sure thanks count is displayed properly

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -354,7 +354,7 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
      */
     private void inflateAchievements(Achievements achievements) {
         binding.imagesUsedByWikiProgressBar.setVisibility(View.VISIBLE);
-        binding.achievementLevel.setText(String.valueOf(achievements.getThanksReceived()));
+        binding.thanksReceived.setText(String.valueOf(achievements.getThanksReceived()));
         binding.imagesUsedByWikiProgressBar.setProgress
                 (100 * achievements.getUniqueUsedImages() / levelInfo.getMaxUniqueImages());
         if(binding.tvWikiPb != null) {


### PR DESCRIPTION
**Description (required)**

We seem to be incorrectly setting the the thanks count in the achievement level text. This was then being over-written by the actual achievement level value in the code flow. In the end, the thanks count seems not to have been displayed at all.

Correct this by properly updating the thanks count.

Fixes #5641

**Tests performed (required)**

Tested prodDebug on OnePlus Nord with API level 32.

**Screenshots (for UI changes only)**
![signal-2024-03-25-115435_002](https://github.com/commons-app/apps-android-commons/assets/12448084/291ad070-5cfc-45a7-830c-4c2deaffbfab)
