### PR TITLE
Fix Custom picker: "uploading" overlay icon disappears when marking another pic as "not for upload"

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/adapter/ImageAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/adapter/ImageAdapter.kt
@@ -390,7 +390,7 @@ class ImageAdapter(
             sharedPreferences.getBoolean(SHOW_ALREADY_ACTIONED_IMAGES_PREFERENCE_KEY, true)
 
         if(showAlreadyActionedImages) {
-            refresh(allImages, allImages)
+            refresh(allImages, allImages, uploadingContributionList)
         } else {
             val iterator = actionableImagesMap.entries.iterator()
             var index = 0


### PR DESCRIPTION
**Description (required)**

Fixes #5644 

What changes did you make and why?

**Tests performed (required)**

Tested {build variant, e.g. ProdDebug} on {name of device or emulator} with API level {API level}.


