### PR TITLE
Fix : Dialog Scroll Issue for devices below Android 10

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/feedback/FeedbackDialog.java
+++ b/app/src/main/java/fr/free/nrw/commons/feedback/FeedbackDialog.java
@@ -4,11 +4,13 @@ import android.app.Dialog;
 import android.content.Context;
 import android.os.Bundle;
 import android.view.View;
+import android.view.WindowManager.LayoutParams;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.databinding.DialogFeedbackBinding;
 import fr.free.nrw.commons.feedback.model.Feedback;
 import fr.free.nrw.commons.utils.ConfigUtils;
 import fr.free.nrw.commons.utils.DeviceInfoUtil;
+import java.util.Objects;
 
 /**
  * Feedback dialog that asks user for message and
@@ -28,6 +30,7 @@ public class FeedbackDialog extends Dialog {
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         dialogFeedbackBinding = DialogFeedbackBinding.inflate(getLayoutInflater());
+        Objects.requireNonNull(getWindow()).setSoftInputMode(LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
         final View view = dialogFeedbackBinding.getRoot();
         setContentView(view);
         dialogFeedbackBinding.btnSubmitFeedback.setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
## Fix Related Issue

* Fixes #5581

## Issue

This issue arises on devices having below API level 25. The layout doesn't get adjusted when the keyboard is shown. Thus doesn't allows the user's to submit the feedback as the user cannot tap the submit button.

## VIdeo

**Before**

https://github.com/commons-app/apps-android-commons/assets/60827173/57480466-d4cf-4205-b64b-416ee5ef6fc7

**After**

https://github.com/commons-app/apps-android-commons/assets/60827173/ae0c6542-29d2-4059-9275-b018d6ebba8f



