### PR TITLE
Add Adaptive Icon

### DIFF
--- a/app/src/main/res/drawable/commons_logo_monochrome.xml
+++ b/app/src/main/res/drawable/commons_logo_monochrome.xml
@@ -1,0 +1,75 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <path
+      android:pathData="M54,60.31m-7.08,0a7.08,7.08 0,1 1,14.15 0a7.08,7.08 0,1 1,-14.15 0"
+      android:strokeAlpha="0.85"
+      android:fillColor="#fff"
+      android:fillAlpha="0.85"/>
+  <group>
+    <clip-path
+        android:pathData="M54,60.31m-21.09,0a21.09,21.09 0,1 1,42.17 0a21.09,21.09 0,1 1,-42.17 0"/>
+    <path
+        android:pathData="m53.22,73.05l0,8.35l1.56,0l0,-8.35"
+        android:fillColor="#fff"/>
+    <path
+        android:pathData="m50.96,73.4 l3.04,-5.31 3.04,5.31"
+        android:fillColor="#fff"/>
+  </group>
+  <path
+      android:pathData="m44.44,68.77l-5.9,5.9l1.1,1.1l5.9,-5.9"
+      android:fillColor="#fff"/>
+  <path
+      android:pathData="m42.59,67.42l5.9,-1.6 -1.6,5.9"
+      android:fillColor="#fff"/>
+  <path
+      android:pathData="m41.26,59.54l-8.35,0l-0,1.56l8.35,0"
+      android:fillColor="#fff"/>
+  <path
+      android:pathData="m40.91,57.27l5.31,3.04 -5.31,3.04"
+      android:fillColor="#fff"/>
+  <path
+      android:pathData="m45.54,50.76l-5.9,-5.9l-1.1,1.1l5.9,5.9"
+      android:fillColor="#fff"/>
+  <path
+      android:pathData="m46.89,48.91l1.6,5.9 -5.9,-1.6"
+      android:fillColor="#fff"/>
+  <group>
+    <clip-path
+        android:pathData="M54,60.31m14.91,-14.91a21.09,21.09 0,1 0,-29.82 29.82a21.09,21.09 0,1 0,29.82 -29.82"/>
+    <path
+        android:pathData="m63.56,68.77l5.9,5.9l-1.1,1.1l-5.9,-5.9"
+        android:fillColor="#fff"/>
+    <path
+        android:pathData="m65.41,67.42 l-5.9,-1.6 1.6,5.9"
+        android:fillColor="#fff"/>
+  </group>
+  <group>
+    <clip-path
+        android:pathData="M54,60.31m0,-21.09a21.09,21.09 0,1 0,0 42.17a21.09,21.09 0,1 0,0 -42.17"/>
+    <path
+        android:pathData="m66.74,59.54l8.35,0l0,1.56l-8.35,0"
+        android:fillColor="#fff"/>
+    <path
+        android:pathData="m67.09,57.27 l-5.31,3.04 5.31,3.04"
+        android:fillColor="#fff"/>
+  </group>
+  <group>
+    <clip-path
+        android:pathData="M54,60.31m-14.91,-14.91a21.09,21.09 0,1 0,29.82 29.82a21.09,21.09 0,1 0,-29.82 -29.82"/>
+    <path
+        android:pathData="m62.46,50.76l5.9,-5.9l1.1,1.1l-5.9,5.9"
+        android:fillColor="#fff"/>
+    <path
+        android:pathData="m61.11,48.91 l-1.6,5.9 5.9,-1.6"
+        android:fillColor="#fff"/>
+  </group>
+  <path
+      android:pathData="m49.8,34.45c0.84,6.2 4.11,9.61 7.32,11.23 3.21,1.62 5.79,2.13 7.58,3.93 4.34,4.34 5.63,10.84 3.28,16.5 -2.35,5.67 -7.86,9.35 -13.99,9.35 -6.13,-0 -11.64,-3.68 -13.99,-9.35 -2.35,-5.67 -1.05,-12.17 3.28,-16.5l-4.2,-4.2c-6.02,6.02 -7.83,15.11 -4.57,22.98 3.26,7.87 10.96,13.02 19.48,13.02s16.22,-5.15 19.48,-13.02c3.26,-7.87 1.45,-16.96 -4.57,-22.98 -3.21,-3.21 -6.91,-3.92 -9.11,-5.03 -2.2,-1.11 -3.45,-1.92 -4.11,-6.73z"
+      android:fillColor="#fff"/>
+  <path
+      android:pathData="m52.37,23.87s-2.55,9.55 -5.66,13.09 8.21,-4.39 12.03,-0.35 -6.37,-12.74 -6.37,-12.74z"
+      android:fillColor="#fff"/>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <monochrome android:drawable="@drawable/commons_logo_monochrome" />
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/values-yue-hant/error.xml
+++ b/app/src/main/res/values-yue-hant/error.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Authors:
-* Winston Sung
--->
-<resources>
-  <string name="crash_dialog_title">同享壞咗</string>
-  <string name="crash_dialog_text">哎呀。出咗錯！</string>
-  <string name="crash_dialog_ok_toast">多謝你！</string>
-</resources>


### PR DESCRIPTION

**Description**

add monochrome icon variant, allows for Adaptive Icon theming on android 13 and above.
(see https://developer.android.com/develop/ui/views/launch/icon_design_adaptive)
(doesn't overwrite existing icon, only applies when themed icons are enabled)

**Tests performed**

Tested betaRelease on Oneplus 9 Pro with API level 34.

**Screenshot**
before/after
![Screenshot_20240411-175002_Trebuchet](https://github.com/commons-app/apps-android-commons/assets/26939824/60fb3561-eb93-49f8-bbed-d69d72f01889)

