### PR TITLE
rename method setImageTobeUploaded to setImageToBeUploaded

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -535,7 +535,7 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
                         currLocation = null;
                     }
                 }
-                uploadMediaDetailFragment.setImageTobeUploaded(uploadableFile, place, currLocation);
+                uploadMediaDetailFragment.setImageToBeUploaded(uploadableFile, place, currLocation);
                 locationManager.unregisterLocationManager();
 
                 UploadMediaDetailFragmentCallback uploadMediaDetailFragmentCallback = new UploadMediaDetailFragmentCallback() {

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -154,7 +154,7 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
 
 
 
-    public void setImageTobeUploaded(UploadableFile uploadableFile, Place place,
+    public void setImageToBeUploaded(UploadableFile uploadableFile, Place place,
         LatLng inAppPictureLocation) {
         this.uploadableFile = uploadableFile;
         this.place = place;

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
@@ -166,9 +166,9 @@ class UploadMediaDetailFragmentUnitTest {
 
     @Test
     @Throws(Exception::class)
-    fun testSetImageTobeUploaded() {
+    fun testSetImageToBeUploaded() {
         Shadows.shadowOf(Looper.getMainLooper()).idle()
-        fragment.setImageTobeUploaded(null, null, location)
+        fragment.setImageToBeUploaded(null, null, location)
     }
 
     @Test


### PR DESCRIPTION
**Description (required)**
Renamed method `setImageTobeUploaded` to `setImageToBeUploaded`

Fixes #5705

What changes did you make and why?

**Tests performed (required)**

Tested {build variant, e.g. ProdDebug} on {name of device or emulator} with API level {API level}.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
