### PR TITLE
Fixes Issue #5704: Upload Wizard: "Edit location" shows my location instead of picture's location

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -237,6 +237,16 @@ public class LocationPickerActivity extends BaseActivity implements
                 cameraPosition.getLongitude()));
         }
         setupMapView();
+        
+        if("UploadActivity".equals(activity)){
+            if(mapView != null && mapView.getController() != null && cameraPosition != null){
+                GeoPoint cameraGeoPoint = new GeoPoint(cameraPosition.getLatitude(),
+                    cameraPosition.getLongitude());
+
+                mapView.getController().setCenter(cameraGeoPoint);
+                mapView.getController().animateTo(cameraGeoPoint);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
**Description (required)**

Fixes #5704. When editing a location on the upload wizard, the map will now center on the picture's location which is retrieved from the picture's metadata. If this location metadata does not exist, the map will center on the device's GPS location.

What changes did you make and why?:
I added a simple check which primarily sees if the cameraPosition object (which contains image location metadata) is not null. If it is not null, the map is centered at the cameraPosition's coordinates.

Prior to this change, code called within setupMapView() (LocationPickerActivity.java:239, right above the new code) would center the map on the image location (if available), then center the map on the device's current or last known GPS location. This change simply attempts centering the map to the image location again.

This change is a simple solution. Code within LocationPickerActivity.java could be refactored to have a more elegant solution, but I don't know if that should be done for this issue or as a new issue.

**Tests performed (required)**

Tested betaDebug on the Android Studio emulator with API level 34.

**Screenshots (for UI changes only)**
In the following demonstration, I have set the emulator device location to NYC. I have two pictures on the device to upload. Both pictures are taken in Seattle, WA. The first picture has location metadata, the second does not.

When editing the location on the first picture, the map is correctly centered on the picture's location. When adding the location on the second picture, the map is centered on the device's current location in NYC.

[location_bugfix_compressed.webm](https://github.com/commons-app/apps-android-commons/assets/30037173/d4c28b5f-59c7-4d32-8b4a-57ef904b1464)

