### PR TITLE
Make sure to clear cookies on logout

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.java
@@ -294,6 +294,7 @@ public class CommonsApplication extends MultiDexApplication {
         }
 
         sessionManager.logout()
+            .andThen(Completable.fromAction(() -> cookieJar.clear()))
             .andThen(Completable.fromAction(() -> {
                     Timber.d("All accounts have been removed");
                     clearImageCache();

--- a/app/src/main/java/fr/free/nrw/commons/auth/SessionManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/SessionManager.java
@@ -125,13 +125,15 @@ public class SessionManager {
      * Returns a Completable that clears existing accounts from account manager
      */
     public Completable logout() {
-        AccountManager accountManager = AccountManager.get(context);
-        Account[] allAccounts = accountManager.getAccountsByType(BuildConfig.ACCOUNT_TYPE);
-        return Completable.fromObservable(Observable.fromArray(allAccounts)
-                .map(a -> accountManager.removeAccount(a, null, null).getResult()))
-                .doOnComplete(() -> {
-                    currentAccount = null;
-                });
+        return Completable.fromObservable(
+            Observable.empty()
+                      .doOnComplete(
+                          () -> {
+                              removeAccount();
+                              currentAccount = null;
+                          }
+                      )
+        );
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/auth/SessionManager.java
+++ b/app/src/main/java/fr/free/nrw/commons/auth/SessionManager.java
@@ -122,9 +122,7 @@ public class SessionManager {
     }
 
     /**
-     * 1. Clears existing accounts from account manager
-     * 2. Calls MediaWikiApi's logout function to clear cookies
-     * @return
+     * Returns a Completable that clears existing accounts from account manager
      */
     public Completable logout() {
         AccountManager accountManager = AccountManager.get(context);

--- a/app/src/main/java/fr/free/nrw/commons/auth/csrf/CsrfTokenClient.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/csrf/CsrfTokenClient.kt
@@ -10,7 +10,6 @@ import fr.free.nrw.commons.auth.login.LoginResult
 import retrofit2.Call
 import retrofit2.Response
 import timber.log.Timber
-import java.io.IOException
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors.newSingleThreadExecutor
 

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/cookies/CommonsCookieJar.kt
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/cookies/CommonsCookieJar.kt
@@ -95,4 +95,9 @@ class CommonsCookieJar(private val cookieStorage: CommonsCookieStorage) : Cookie
 
     private fun Cookie.domainSpec(url: HttpUrl): String =
         domain.ifEmpty { url.toUri().getAuthority() }
+
+    fun clear() {
+        cookieStorage.clear()
+    }
+
 }


### PR DESCRIPTION
**Description (required)**

It turns out that we failed to clear the cookies from the cookie JAR when logging the user out. As a consequence, the cookie were retained and it was possible to edit depictions as the previous user even without logging in to the app (using the retained cookies).

Make sure we properly clear the cookies when we log the user out.
    
As an aside, the fact that the edit button shouldn't have been shown is a different issue being tracked in #5726

**Tests performed (required)**

OnePlus Nord running Android 12

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
