### PR TITLE
Add ProgressBar to MediaDetailPagerFragment for Image Loading Indicator

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -506,12 +506,13 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
      * @param position current item that to be shown
      */
     private void setViewPagerCurrentItem(int position) {
-        // Show the ProgressBar while waiting for the item to load
-        imageProgressBar.setVisibility(View.VISIBLE);
+
         final Handler handler = new Handler(Looper.getMainLooper());
         final Runnable runnable = new Runnable() {
             @Override
             public void run() {
+                // Show the ProgressBar while waiting for the item to load
+                imageProgressBar.setVisibility(View.VISIBLE);
                 // Check if the adapter has enough items loaded
                 if(adapter.getCount() > position){
                     // Set the current item in the ViewPager

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -79,6 +79,9 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
     private boolean isFromFeaturedRootFragment;
     private int position;
 
+    /**
+     * ProgressBar used to indicate the loading status of media items.
+     */
     private ProgressBar imageProgressBar;
 
     private ArrayList<Integer> removedItems=new ArrayList<Integer>();
@@ -121,6 +124,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                              Bundle savedInstanceState) {
         binding = FragmentMediaDetailPagerBinding.inflate(inflater, container, false);
         binding.mediaDetailsPager.addOnPageChangeListener(this);
+        // Initialize the ProgressBar by finding it in the layout
         imageProgressBar = binding.getRoot().findViewById(R.id.itemProgressBar);
         adapter = new MediaDetailAdapter(getChildFragmentManager());
 
@@ -502,13 +506,17 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
      * @param position current item that to be shown
      */
     private void setViewPagerCurrentItem(int position) {
+        // Show the ProgressBar while waiting for the item to load
         imageProgressBar.setVisibility(View.VISIBLE);
         final Handler handler = new Handler(Looper.getMainLooper());
         final Runnable runnable = new Runnable() {
             @Override
             public void run() {
+                // Check if the adapter has enough items loaded
                 if(adapter.getCount() > position){
+                    // Set the current item in the ViewPager
                     binding.mediaDetailsPager.setCurrentItem(position, false);
+                    // Hide the ProgressBar once the item is loaded
                     imageProgressBar.setVisibility(View.GONE);
                 } else {
                     // If the item is not ready yet, post the Runnable again
@@ -516,6 +524,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                 }
             }
         };
+        // Start the Runnable
         handler.post(runnable);
     }
 

--- a/app/src/main/res/layout/fragment_media_detail_pager.xml
+++ b/app/src/main/res/layout/fragment_media_detail_pager.xml
@@ -1,14 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    >
-    <androidx.viewpager.widget.ViewPager
-        android:id="@+id/mediaDetailsPager"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fadingEdge="none"
-        />
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              xmlns:app="http://schemas.android.com/apk/res-auto">
+    <ProgressBar
+        android:id="@+id/itemProgressBar"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:progressBackgroundTint="@android:color/white"/>
 
-</LinearLayout>
+    <androidx.viewpager.widget.ViewPager
+      android:id="@+id/mediaDetailsPager"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:fadingEdge="none" />
+  </LinearLayout>


### PR DESCRIPTION
**Description**

This pull request introduces a ProgressBar to the MediaDetailPagerFragment to enhance the user experience by indicating when an image is loading. The ProgressBar is displayed while the image is being loaded and hidden once the loading is complete.

Fixes #5714

Changes Made:

1. Updated Layout File (fragment_media_detail_pager.xml):
-Added a ProgressBar element to the XML layout file.
-Positioned the ProgressBar appropriately within the layout to ensure it appears prominently when an image is loading.

2. Updated MediaDetailPagerFragment.java:
-Integrated the ProgressBar into the fragment by finding the view and managing its visibility.
-Implemented logic to display the ProgressBar while waiting for images to load and hide it once loading is complete.

**Tests performed**

Tested ProdDebug on Pixel 3 with API level 34

**Screenshots**
![Screenshot_20240520_115938](https://github.com/commons-app/apps-android-commons/assets/115378448/fe5ba19b-0aab-4efd-b387-cf1d45fa7c65)
![Screenshot_20240520_115802](https://github.com/commons-app/apps-android-commons/assets/115378448/29f1ba6c-7e13-4c4a-a0f8-33a05676ec2b)