### PR TITLE
Prevent deletion of other structured data when editing depicts

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/WikiBaseInterface.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/WikiBaseInterface.kt
@@ -34,7 +34,7 @@ interface WikiBaseInterface {
     </MwPostResponse> */
     @Headers("Cache-Control: no-cache")
     @FormUrlEncoded
-    @POST(WikidataConstants.MW_API_PREFIX + "action=wbeditentity&site=commonswiki&clear=1")
+    @POST(WikidataConstants.MW_API_PREFIX + "action=wbeditentity&site=commonswiki")
     fun postEditEntityByFilename(
         @Field("title") filename: String,
         @Field("token") editToken: String,

--- a/app/src/main/java/fr/free/nrw/commons/upload/WikiBaseInterface.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/WikiBaseInterface.kt
@@ -1,5 +1,6 @@
 package fr.free.nrw.commons.upload
 
+import fr.free.nrw.commons.upload.depicts.Claims
 import fr.free.nrw.commons.wikidata.WikidataConstants
 import fr.free.nrw.commons.wikidata.mwapi.MwPostResponse
 import fr.free.nrw.commons.wikidata.mwapi.MwQueryResponse
@@ -58,5 +59,20 @@ interface WikiBaseInterface {
         @Field("token") editToken: String?,
         @Field("language") language: String?,
         @Field("value") captionValue: String?
+    ): Observable<MwPostResponse>
+
+    @GET(WikidataConstants.MW_API_PREFIX + "action=wbgetclaims")
+    fun getClaimsByProperty(
+        @Query("entity") entityId: String,
+        @Query("property") property: String
+    ) : Observable<Claims>
+
+    @Headers("Cache-Control: no-cache")
+    @FormUrlEncoded
+    @POST(WikidataConstants.MW_API_PREFIX + "action=wbeditentity")
+    fun postDeleteClaims(
+        @Field("token") editToken: String,
+        @Field("id") entityId: String,
+        @Field("data") data: String
     ): Observable<MwPostResponse>
 }

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/Claims.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/Claims.kt
@@ -1,0 +1,9 @@
+package fr.free.nrw.commons.upload.depicts
+
+import com.google.gson.annotations.SerializedName
+import fr.free.nrw.commons.wikidata.model.Statement_partial
+
+data class Claims(
+    @SerializedName(value = "claims")
+    val claims: Map<String, List<Statement_partial>> = emptyMap()
+)

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictEditHelper.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictEditHelper.kt
@@ -69,7 +69,7 @@ class DepictEditHelper @Inject constructor (notificationHelper: NotificationHelp
      */
      private fun addDepiction(media: Media, depictions: List<String>): Observable<Boolean> {
         Timber.d("thread is adding depiction %s", Thread.currentThread().name)
-        return wikidataEditService.updateDepictsProperty(media.filename, depictions)
+        return wikidataEditService.updateDepictsProperty(media.pageId, depictions)
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
@@ -223,9 +223,8 @@ class DepictsPresenter @Inject constructor(
                             if (error is InvalidLoginTokenException) {
                                 view.navigateToLoginScreen();
                             } else {
-                                Timber.e(
-                                    "Failed to update depictions"
-                                )
+                                view.dismissProgressDialog()
+                                Timber.e("Failed to update depictions")
                             }
                         })
                 )

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsPresenter.kt
@@ -16,6 +16,9 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.processors.PublishProcessor
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.lang.reflect.Proxy
 import java.util.*
@@ -267,10 +270,13 @@ class DepictsPresenter @Inject constructor(
      */
     fun getRecentDepictedItems(): MutableList<DepictedItem> {
         val depictedItemList: MutableList<DepictedItem> = ArrayList()
-        val depictsList = depictsDao.depictsList()
-        for (i in depictsList.indices) {
-            val depictedItem = depictsList[i].item
-            depictedItemList.add(depictedItem)
+        CoroutineScope(Dispatchers.IO).launch {
+            val depictsList = depictsDao.depictsList().await()
+
+            for (i in depictsList.indices) {
+                val depictedItem = depictsList[i].item
+                depictedItemList.add(depictedItem)
+            }
         }
         return depictedItemList
     }

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikiBaseClient.kt
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikiBaseClient.kt
@@ -8,7 +8,6 @@ import fr.free.nrw.commons.upload.WikiBaseInterface
 import fr.free.nrw.commons.wikidata.mwapi.MwPostResponse
 import fr.free.nrw.commons.wikidata.mwapi.MwQueryResponse
 import io.reactivex.Observable
-import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -42,12 +41,29 @@ class WikiBaseClient @Inject constructor(
         }
     }
 
+    fun getClaimIdsByProperty(fileEntityId: String, property: String ): Observable<List<String>> {
+        return wikiBaseInterface.getClaimsByProperty(fileEntityId, property).map { claimsResponse ->
+            claimsResponse.claims[property]?.mapNotNull { claim -> claim.id } ?: emptyList()
+        }
+    }
+
+    fun postDeleteClaims(entityId: String, data: String): Observable<Boolean> {
+        return csrfToken().switchMap { editToken ->
+            wikiBaseInterface.postDeleteClaims(editToken, entityId, data)
+                .map { response: MwPostResponse -> response.successVal == 1 }
+        }
+    }
+
     fun getFileEntityId(uploadResult: UploadResult): Observable<Long> {
         return wikiBaseInterface.getFileEntityId(uploadResult.createCanonicalFileName())
             .map { response: MwQueryResponse -> response.query()!!.pages()!![0].pageId().toLong() }
     }
 
-    fun addLabelstoWikidata(fileEntityId: Long, languageCode: String?, captionValue: String?): Observable<MwPostResponse> {
+    fun addLabelsToWikidata(
+        fileEntityId: Long,
+        languageCode: String?,
+        captionValue: String?
+    ): Observable<MwPostResponse> {
         return csrfToken().switchMap { editToken ->
             wikiBaseInterface.addLabelstoWikidata(
                 PAGE_ID_PREFIX + fileEntityId,

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikidataEditService.java
@@ -8,7 +8,6 @@ import android.content.Context;
 import androidx.annotation.Nullable;
 import com.google.gson.Gson;
 import fr.free.nrw.commons.R;
-import fr.free.nrw.commons.auth.csrf.InvalidLoginTokenException;
 import fr.free.nrw.commons.contributions.Contribution;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
 import fr.free.nrw.commons.upload.UploadResult;
@@ -19,9 +18,11 @@ import fr.free.nrw.commons.utils.ViewUtil;
 import fr.free.nrw.commons.wikidata.model.DataValue;
 import fr.free.nrw.commons.wikidata.model.DataValue.ValueString;
 import fr.free.nrw.commons.wikidata.model.EditClaim;
+import fr.free.nrw.commons.wikidata.model.RemoveClaim;
 import fr.free.nrw.commons.wikidata.model.Snak_partial;
 import fr.free.nrw.commons.wikidata.model.Statement_partial;
 import fr.free.nrw.commons.wikidata.model.WikiBaseMonolingualTextValue;
+import fr.free.nrw.commons.wikidata.mwapi.MwPostResponse;
 import io.reactivex.Observable;
 import io.reactivex.schedulers.Schedulers;
 import java.util.ArrayList;
@@ -34,7 +35,6 @@ import java.util.UUID;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import fr.free.nrw.commons.wikidata.mwapi.MwPostResponse;
 import timber.log.Timber;
 
 /**
@@ -72,9 +72,10 @@ public class WikidataEditService {
      * to the wikibase API to set tag against the entity.
      */
     @SuppressLint("CheckResult")
-    private Observable<Boolean> addDepictsProperty(final String fileEntityId,
-        final List<String> depictedItems) {
-
+    private Observable<Boolean> addDepictsProperty(
+        final String fileEntityId,
+        final List<String> depictedItems
+    ) {
         final EditClaim data = editClaim(
             ConfigUtils.isBetaFlavour() ? Collections.singletonList("Q10")
                 // Wikipedia:Sandbox (Q10)
@@ -165,11 +166,10 @@ public class WikidataEditService {
      * @param fileEntityId
      * @return
      */
-
     @SuppressLint("CheckResult")
     private Observable<Boolean> addCaption(final long fileEntityId, final String languageCode,
         final String captionValue) {
-        return wikiBaseClient.addLabelstoWikidata(fileEntityId, languageCode, captionValue)
+        return wikiBaseClient.addLabelsToWikidata(fileEntityId, languageCode, captionValue)
             .doOnNext(mwPostResponse -> onAddCaptionResponse(fileEntityId, mwPostResponse))
             .doOnError(throwable -> {
                 Timber.e(throwable, "Error occurred while setting Captions");
@@ -229,8 +229,10 @@ public class WikidataEditService {
         }
     }
 
-    public Observable addDepictionsAndCaptions(final UploadResult uploadResult,
-        final Contribution contribution) {
+    public Observable<Boolean> addDepictionsAndCaptions(
+        final UploadResult uploadResult,
+        final Contribution contribution
+    ) {
         return wikiBaseClient.getFileEntityId(uploadResult)
             .doOnError(throwable -> {
                 Timber

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/model/EditClaim.kt
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/model/EditClaim.kt
@@ -11,19 +11,19 @@ data class EditClaim(val claims: List<Statement_partial>) {
             entityIds.forEach {
                 list.add(
                     Statement_partial(
-                        Snak_partial(
-                            "value",
-                            propertyName,
-                            DataValue.EntityId(
+                        mainSnak = Snak_partial(
+                            snakType = "value",
+                            property = propertyName,
+                            dataValue = DataValue.EntityId(
                                 WikiBaseEntityValue(
-                                    "item",
-                                    it,
-                                    it.removePrefix("Q").toLong()
+                                    entityType = "item",
+                                    id = it,
+                                    numericId = it.removePrefix("Q").toLong()
                                 )
                             )
                         ),
-                        "statement",
-                        "preferred"
+                        type = "statement",
+                        rank = "preferred"
                     )
                 )
             }

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/model/RemoveClaim.kt
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/model/RemoveClaim.kt
@@ -1,0 +1,20 @@
+package fr.free.nrw.commons.wikidata.model
+
+data class RemoveClaim(val claims: List<ClaimRemoveRequest>) {
+    companion object {
+        @JvmStatic
+        fun from(claimIds: List<String>): RemoveClaim {
+            val claimsToRemove = mutableListOf<ClaimRemoveRequest>()
+
+            claimIds.forEach {
+                claimsToRemove.add(
+                    ClaimRemoveRequest(id = it, remove = "")
+                )
+            }
+
+            return RemoveClaim(claimsToRemove)
+        }
+    }
+}
+
+data class ClaimRemoveRequest(val id: String, val remove: String)

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/model/Snak_partial.kt
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/model/Snak_partial.kt
@@ -5,15 +5,15 @@ import com.google.gson.annotations.SerializedName
 /*"mainsnak": {
     "snaktype": "value",
     "property": "P17",
-    "datatype": "wikibase-item",
     "datavalue": {
         "value": {
-        "entity-type": "item",
-        "id": "Q30",
-        "numeric-id": 30
-    },
+            "entity-type": "item",
+            "numeric-id": 30,
+            "id": "Q30"
+        },
         "type": "wikibase-entityid"
-    }
+    },
+    "datatype": "wikibase-item",
 }*/
 data class Snak_partial(
     @SerializedName("snaktype") val snakType: String,

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/model/Statement_partial.kt
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/model/Statement_partial.kt
@@ -3,9 +3,9 @@ package fr.free.nrw.commons.wikidata.model
 import com.google.gson.annotations.SerializedName
 
 /*{
-    "id": "q60$5083E43C-228B-4E3E-B82A-4CB20A22A3FB",
     "mainsnak": {},
     "type": "statement",
+    "id": "q60$5083E43C-228B-4E3E-B82A-4CB20A22A3FB",
     "rank": "normal",
     "qualifiers": {
     "P580": [],

--- a/app/src/test/kotlin/fr/free/nrw/commons/wikidata/WikiBaseClientUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/wikidata/WikiBaseClientUnitTest.kt
@@ -77,7 +77,7 @@ class WikiBaseClientUnitTest {
             "M123", "test", "en", "caption"
         )).thenReturn(Observable.just(mwPostResponse))
 
-        val result = wikiBaseClient.addLabelstoWikidata(123L, "en", "caption").blockingFirst()
+        val result = wikiBaseClient.addLabelsToWikidata(123L, "en", "caption").blockingFirst()
 
         assertSame(mwPostResponse, result)
     }


### PR DESCRIPTION
**Description (required)**

**Before**: Previously, the API was deleting whole entity data and updating with new depictions.
**Now**: Two APIs are used to delete older depictions only and update with the new ones.

> **Note**:- Please provide your valuable insights about the changes as I am not familiar with using Multi-threading in Java but familiar with Coroutines in Kotlin :)

Fixes #5728

What changes did you make and why?
**Major Changes**
**`WikiBaseInterface.kt`**: Added new methods to use two new APIs to get the work done.
**`WikidataEditService`**: Updated method to update depictions that performs deletion and creation of depiction. Although, added some utility functions for convenience.

**Some Additional Changes**
File `DepictsDao.kt`, was using runBlocking to perform database operations, resulting in the blocking of the current  **Thread** in which the runBlocking was used. So, I replaced them with the `Coroutines`.

Some minor changes to related files for better readability

**Tests performed (required)**

Tested ProdDebug on Samsung A14 with API level 34.

**Screenshots (for UI changes only)**
None
