### PR TITLE
feedback: add info about where the feedback gets posted

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/feedback/FeedbackDialog.java
+++ b/app/src/main/java/fr/free/nrw/commons/feedback/FeedbackDialog.java
@@ -3,6 +3,9 @@ package fr.free.nrw.commons.feedback;
 import android.app.Dialog;
 import android.content.Context;
 import android.os.Bundle;
+import android.text.Html;
+import android.text.Spanned;
+import android.text.method.LinkMovementMethod;
 import android.view.View;
 import android.view.WindowManager.LayoutParams;
 import fr.free.nrw.commons.R;
@@ -21,15 +24,20 @@ public class FeedbackDialog extends Dialog {
 
     private OnFeedbackSubmitCallback onFeedbackSubmitCallback;
 
+    private Spanned feedbackDestinationHtml;
+
     public FeedbackDialog(Context context, OnFeedbackSubmitCallback onFeedbackSubmitCallback) {
         super(context);
         this.onFeedbackSubmitCallback = onFeedbackSubmitCallback;
+        feedbackDestinationHtml = Html.fromHtml(context.getString(R.string.feedback_destination_note));
     }
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         dialogFeedbackBinding = DialogFeedbackBinding.inflate(getLayoutInflater());
+        dialogFeedbackBinding.feedbackDestination.setText(feedbackDestinationHtml);
+        dialogFeedbackBinding.feedbackDestination.setMovementMethod(LinkMovementMethod.getInstance());
         Objects.requireNonNull(getWindow()).setSoftInputMode(LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
         final View view = dialogFeedbackBinding.getRoot();
         setContentView(view);

--- a/app/src/main/res/layout/dialog_feedback.xml
+++ b/app/src/main/res/layout/dialog_feedback.xml
@@ -122,6 +122,16 @@
       android:layout_margin="@dimen/dimen_6"
       />
 
+    <TextView
+      android:id="@+id/feedback_destination"
+      android:layout_margin="@dimen/dimen_6"
+      android:padding="4dp"
+      android:textSize="14sp"
+      android:textColor="?android:attr/textColorPrimary"
+      android:text="@string/feedback_destination_note"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content" />
+
     <Button
       android:id="@+id/btn_submit_feedback"
       android:textColor="@color/white"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -818,5 +818,5 @@ Upload your first media by tapping on the add button.</string>
   </plurals>
   <string name="multiple_files_depiction">Please remember that all images in a multi-upload get the same categories and depictions. If the images do not share depictions and categories, please perform several separate uploads.</string>
   <string name="multiple_files_depiction_header">Note about multi-uploads</string>
-  <string name="feedback_destination_note">Your feedback gets posted on the following wiki page: <![CDATA[ <a href="https://commons.wikimedia.org/wiki/Commons:Mobile_app/Feedback">Commons:Mobile_app/Feedback</a> ]]></string>
+  <string name="feedback_destination_note">Your feedback gets posted on the following wiki page: <![CDATA[ <a href="https://commons.wikimedia.org/wiki/Commons:Mobile_app/Feedback">Commons:Mobile app/Feedback</a> ]]></string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -818,4 +818,5 @@ Upload your first media by tapping on the add button.</string>
   </plurals>
   <string name="multiple_files_depiction">Please remember that all images in a multi-upload get the same categories and depictions. If the images do not share depictions and categories, please perform several separate uploads.</string>
   <string name="multiple_files_depiction_header">Note about multi-uploads</string>
+  <string name="feedback_destination_note">Your feedback gets posted on the following wiki page: <![CDATA[ <a href="https://commons.wikimedia.org/wiki/Commons:Mobile_app/Feedback">Commons:Mobile_app/Feedback</a> ]]></string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -818,5 +818,5 @@ Upload your first media by tapping on the add button.</string>
   </plurals>
   <string name="multiple_files_depiction">Please remember that all images in a multi-upload get the same categories and depictions. If the images do not share depictions and categories, please perform several separate uploads.</string>
   <string name="multiple_files_depiction_header">Note about multi-uploads</string>
-  <string name="feedback_destination_note">Your feedback gets posted on the following wiki page: <![CDATA[ <a href="https://commons.wikimedia.org/wiki/Commons:Mobile_app/Feedback">Commons:Mobile app/Feedback</a> ]]></string>
+  <string name="feedback_destination_note">Your feedback gets posted to the following wiki page: <![CDATA[ <a href="https://commons.wikimedia.org/wiki/Commons:Mobile_app/Feedback">Commons:Mobile app/Feedback</a> ]]></string>
 </resources>


### PR DESCRIPTION
**Description (required)**

Fixes #5747

This helps users get an idea on where their feedback is getting posted so that it would be helpful for checking existing feedback and also checking in on the feedback that they've posted.

**Tests performed (required)**

Tested on a OnePlus Nord running API level 32.

**Screenshots (for UI changes only)**
![Screenshot_2024-06-02-23-35-48-82_d5db3f3edc380047609fe9c266f7c566](https://github.com/commons-app/apps-android-commons/assets/12448084/86a2606b-278b-47d4-82ca-4f327f70548e)

