### PR TITLE
Fixes bug #5721 (Crash when adding and then removing media details)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
@@ -197,14 +197,7 @@ public class UploadMediaDetailAdapter extends
      */
     public void removeDescription(final UploadMediaDetail uploadMediaDetail, final int position) {
         selectedLanguages.remove(position);
-        int listPosition = 0;
-        List<Integer> keysList = new ArrayList<>(selectedLanguages.keySet());
-        for (Integer key : keysList) {
-            if (key < position) {
-                listPosition++;
-            }
-        }
-        this.uploadMediaDetails.remove(uploadMediaDetails.get(listPosition));
+        this.uploadMediaDetails.remove(uploadMediaDetail);
         int i = position + 1;
         while (selectedLanguages.containsKey(i)) {
             selectedLanguages.remove(i);
@@ -311,12 +304,10 @@ public class UploadMediaDetailAdapter extends
 
             removeButton.setOnClickListener(v -> removeDescription(uploadMediaDetail, position));
             captionListener = new AbstractTextWatcher(
-                captionText -> uploadMediaDetails.get(position)
-                    .setCaptionText(convertIdeographicSpaceToLatinSpace(
+                captionText -> uploadMediaDetail.setCaptionText(convertIdeographicSpaceToLatinSpace(
                         removeLeadingAndTrailingWhitespace(captionText))));
             descriptionListener = new AbstractTextWatcher(
-                descriptionText -> uploadMediaDetails.get(position)
-                    .setDescriptionText(descriptionText));
+                descriptionText -> uploadMediaDetail.setDescriptionText(descriptionText));
             captionItemEditText.addTextChangedListener(captionListener);
             initLanguage(position, uploadMediaDetail);
 


### PR DESCRIPTION
**Description (required)**

Fixes #5721

I replaced uploadMediaDetail.get(position) with a direct reference to uploadMediaDetail in 3 locations to avoid out of bounds errors.

The usage of RecyclerView in this code is still a bit buggy, and maybe a RecyclerView is not necessary here since the number of items is limited. The fix also revealed problems in the logic of adding the "addButton" only to the last item, which couldn't be reproduced before because the app crashed first. I can submit a new bug for that if this fix goes live.

I did not feel very comfortable with the code so I restricted my commit to fixing the first reported crash.

**Tests performed (required)**

Tested with same steps described in #5721 on emulated Pixel 3 in AndroidStudio.