### PR TITLE
Replaced the 'Add location' button with 'Edit location' button when user clicks yes in similar image dialog

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -333,6 +333,13 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
                     uploadMediaDetailAdapter.getItems().get(0).setDescriptionText(
                         getString(R.string.similar_coordinate_description_auto_set));
                     updateMediaDetails(uploadMediaDetailAdapter.getItems());
+
+                    // Replace the 'Add location' button with 'Edit location' button when user clicks
+                    // yes in similar image dialog
+                    // fixing: https://github.com/commons-app/apps-android-commons/issues/5669
+                    Drawable mapTick = getResources().getDrawable(R.drawable.ic_map_available_20dp);
+                    binding.locationImageView.setImageDrawable(mapTick);
+                    binding.locationTextView.setText(R.string.edit_location);
                 }
 
                 @Override


### PR DESCRIPTION
**Description**
There was an Issue to change the name of the 'add location' button's text to 'edit location' if the user was copying the location of a recently uploaded image.

**Fixes:** #5669

**What changes did you make and why?**
We were able to do this by editing "UploadMediaDetailFragment.java". We wrote code that replaced the button if the user clicks yes for the similar image dialog, which fixed the issue.

**Tests performed**
We followed the guide given in the issue to reproduce the results and when we performed them with the newly written code, it produced the expected behavior.

Tested betaDebug on Pixel 8 with API level 34.

**Screenshot**
![Issue_5669](https://github.com/commons-app/apps-android-commons/assets/64763007/9f2a9d25-f157-4300-9b8b-5c2ed029b05c)
