### PR TITLE
Fix #5711 Incorrect rotation in Edit Image while uploading. 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/edit/TransformImageImpl.kt
+++ b/app/src/main/java/fr/free/nrw/commons/edit/TransformImageImpl.kt
@@ -49,10 +49,10 @@ class TransformImageImpl() : TransformImage {
                          180 -> LLJTran.ROT_180
                          270 -> LLJTran.ROT_270
                     else -> {
-                      LLJTran.ROT_90
+                      // no rotation if degree = 0 or 360 
+                      LLJTran.OPT_DEFAULTS
                     }
                 },
-                LLJTran.OPT_DEFAULTS or LLJTran.OPT_XFORM_ORIENTATION
             )
             BufferedOutputStream(FileOutputStream(output)).use { writer ->
                 lljTran.save(writer, LLJTran.OPT_WRITE_ALL )


### PR DESCRIPTION
**Description (required)**

Fixes #5711. While uploading, when click "Edit Image" and  then perform no rotation (click Save, or click Rotate 4 times to get back to the original position and Save), the image will be automatically rotated 90 degrees. 

What changes did you make and why?
Change rotateImage() function implementation in `edit/TransformImageImpl.kt`. When the given degree is not expected (e.g 0), the transformation of the image should be default instead of rotating 90 degree (`LLJTran.ROT_90`). 

**Tests performed (required)**

Tested on Pixel 8  with API level 35.

**Reproduce:**
1. Open app. 
2. Upload image. 
3. Click "Edit Image". 
4. Click "Save" or "Rotate" 4 times so that the image will be in the original position then "Save". 

**Error Behavior:**

https://github.com/commons-app/apps-android-commons/assets/69811879/59b17b02-3612-48fc-b791-f2cc3ee73b0e



**Expected Behavior:**
The image will be shown as original instead of being rotated 90 degree after clicking "Save". 

**Screenshots (for UI changes only)**

https://github.com/commons-app/apps-android-commons/assets/69811879/0a28ac6b-9219-4a35-ae9a-19e9e7a6b32d




---

