### PR TITLE
Update allowed recent years to include 2020s

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -51,10 +51,11 @@ class CategoriesModel @Inject constructor(
         }
 
         if (mentionsDecade) {
-            //Check if the year in the form of XX(X)0s is recent/relevant, i.e. in the 2000s or 2010s/2020s as stated in Issue #1029
+            // Check if the year in the form of XX(X)0s is recent/relevant, i.e. in the 2000s or 2010s/2020s as stated in Issue #1029
+            // Example: "2020s" is OK, but "1920s" is not (and should be skipped)
             return !recentDecade
         } else {
-            // If it is not an year in 20xxs form, then check if item contains a 4-digit word
+            // If it is not an year in decade form (e.g. 19xxs/20xxs), then check if item contains a 4-digit year
             // anywhere within the string (.* is wildcard) (Issue #47)
             // And that item does not equal the current year or previous year
             return item.matches(".*(19|20)\\d{2}.*".toRegex())

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -46,19 +46,21 @@ class CategoriesModel @Inject constructor(
         val spammyCategory = item.matches("(.*)needing(.*)".toRegex())
                           || item.matches("(.*)taken on(.*)".toRegex())
 
+        // always skip irrelevant categories such as Media_needing_categories_as_of_16_June_2017(Issue #750)
+        if (spammyCategory) {
+            return true
+        }
+
         if (mentionsDecade) {
             //Check if the year in the form of XX(X)0s is recent/relevant, i.e. in the 2000s or 2010s/2020s as stated in Issue #1029
-            // If not, check if it is an irrelevant category such as Media_needing_categories_as_of_16_June_2017(Issue #750)
-            return oldDecade || spammyCategory
+            return oldDecade
         } else {
             // If it is not an year in 20xxs form, then check if item contains a 4-digit word
             // anywhere within the string (.* is wildcard) (Issue #47)
             // And that item does not equal the current year or previous year
-            // And if it is an irrelevant category such as Media_needing_categories_as_of_16_June_2017(Issue #750)
             return item.matches(".*(19|20)\\d{2}.*".toRegex())
                     && !item.contains(yearInString)
                     && !item.contains(prevYearInString)
-                    || spammyCategory
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -40,10 +40,10 @@ class CategoriesModel @Inject constructor(
         val prevYearInString = prevYear.toString()
         Timber.d("Previous year: %s", prevYearInString)
 
-        val is20xxsYear = item.matches(".*0s.*".toRegex())
+        val mentionsDecade = item.matches(".*0s.*".toRegex())
 
-        if (is20xxsYear) {
-            //Check if the year in the form of XX(X)0s is relevant, i.e. in the 2000s or 2010s as stated in Issue #1029
+        if (mentionsDecade) {
+            //Check if the year in the form of XX(X)0s is relevant, i.e. in the 2000s or 2010s (or 2020s) as stated in Issue #1029
             // If not, check if it is an irrelevant category such as Media_needing_categories_as_of_16_June_2017(Issue #750)
             return !item.matches(".*20[0-2]0s.*".toRegex())
                     || item.matches("(.*)needing(.*)".toRegex())

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -27,7 +27,7 @@ class CategoriesModel @Inject constructor(
     private var selectedExistingCategories: MutableList<String> = mutableListOf()
 
     /**
-     * Returns if the item contains an year
+     * Returns if the item contains an year which should be ignored
      * @param item
      * @return
      */

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -40,7 +40,7 @@ class CategoriesModel @Inject constructor(
         val prevYearInString = prevYear.toString()
         Timber.d("Previous year: %s", prevYearInString)
 
-        //Check if item contains a 4-digit word anywhere within the string (.* is wildcard)
+        //Check if item contains a 4-digit word anywhere within the string (.* is wildcard) (Issue #47)
         //And that item does not equal the current year or previous year
         //And if it is an irrelevant category such as Media_needing_categories_as_of_16_June_2017(Issue #750)
         //Check if the year in the form of XX(X)0s is relevant, i.e. in the 2000s or 2010s as stated in Issue #1029

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -40,17 +40,26 @@ class CategoriesModel @Inject constructor(
         val prevYearInString = prevYear.toString()
         Timber.d("Previous year: %s", prevYearInString)
 
-        //Check if item contains a 4-digit word anywhere within the string (.* is wildcard) (Issue #47)
-        //And that item does not equal the current year or previous year
-        //And if it is an irrelevant category such as Media_needing_categories_as_of_16_June_2017(Issue #750)
-        //Check if the year in the form of XX(X)0s is relevant, i.e. in the 2000s or 2010s as stated in Issue #1029
-        return item.matches(".*(19|20)\\d{2}.*".toRegex())
-                && !item.contains(curYearInString)
-                && !item.contains(prevYearInString)
-                || item.matches("(.*)needing(.*)".toRegex())
-                || item.matches("(.*)taken on(.*)".toRegex())
-                || item.matches(".*0s.*".toRegex())
-                && !item.matches(".*20[0-2]0s.*".toRegex())
+        val is20xxsYear = item.matches(".*0s.*".toRegex())
+
+        if (is20xxsYear) {
+            //Check if the year in the form of XX(X)0s is relevant, i.e. in the 2000s or 2010s as stated in Issue #1029
+            // If not, check if it is an irrelevant category such as Media_needing_categories_as_of_16_June_2017(Issue #750)
+            return !item.matches(".*20[0-2]0s.*".toRegex())
+                    || item.matches("(.*)needing(.*)".toRegex())
+                    || item.matches("(.*)taken on(.*)".toRegex())
+        }
+        else {
+            // If it is not an year in 20xxs form, then check if item contains a 4-digit word
+            // anywhere within the string (.* is wildcard) (Issue #47)
+            // And that item does not equal the current year or previous year
+            // And if it is an irrelevant category such as Media_needing_categories_as_of_16_June_2017(Issue #750)
+            return item.matches(".*(19|20)\\d{2}.*".toRegex())
+                    && !item.contains(yearInString)
+                    && !item.contains(prevYearInString)
+                    || item.matches("(.*)needing(.*)".toRegex())
+                    || item.matches("(.*)taken on(.*)".toRegex())
+        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -50,7 +50,7 @@ class CategoriesModel @Inject constructor(
                 || item.matches("(.*)needing(.*)".toRegex())
                 || item.matches("(.*)taken on(.*)".toRegex())
                 || item.matches(".*0s.*".toRegex())
-                && !item.matches(".*(200|201)0s.*".toRegex())
+                && !item.matches(".*20[0-2]0s.*".toRegex())
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -41,13 +41,14 @@ class CategoriesModel @Inject constructor(
         Timber.d("Previous year: %s", prevYearInString)
 
         val mentionsDecade = item.matches(".*0s.*".toRegex())
+        val spammyCategory = item.matches("(.*)needing(.*)".toRegex())
+                          || item.matches("(.*)taken on(.*)".toRegex())
 
         if (mentionsDecade) {
-            //Check if the year in the form of XX(X)0s is relevant, i.e. in the 2000s or 2010s (or 2020s) as stated in Issue #1029
+            //Check if the year in the form of XX(X)0s is recent/relevant, i.e. in the 2000s or 2010s/2020s as stated in Issue #1029
             // If not, check if it is an irrelevant category such as Media_needing_categories_as_of_16_June_2017(Issue #750)
             return !item.matches(".*20[0-2]0s.*".toRegex())
-                    || item.matches("(.*)needing(.*)".toRegex())
-                    || item.matches("(.*)taken on(.*)".toRegex())
+                    || spammyCategory
         }
         else {
             // If it is not an year in 20xxs form, then check if item contains a 4-digit word
@@ -57,8 +58,7 @@ class CategoriesModel @Inject constructor(
             return item.matches(".*(19|20)\\d{2}.*".toRegex())
                     && !item.contains(yearInString)
                     && !item.contains(prevYearInString)
-                    || item.matches("(.*)needing(.*)".toRegex())
-                    || item.matches("(.*)taken on(.*)".toRegex())
+                    || spammyCategory
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -42,7 +42,6 @@ class CategoriesModel @Inject constructor(
 
         val mentionsDecade = item.matches(".*0s.*".toRegex())
         val recentDecade = item.matches(".*20[0-2]0s.*".toRegex())
-        val oldDecade = !recentDecade
         val spammyCategory = item.matches("(.*)needing(.*)".toRegex())
                           || item.matches("(.*)taken on(.*)".toRegex())
 
@@ -53,7 +52,7 @@ class CategoriesModel @Inject constructor(
 
         if (mentionsDecade) {
             //Check if the year in the form of XX(X)0s is recent/relevant, i.e. in the 2000s or 2010s/2020s as stated in Issue #1029
-            return oldDecade
+            return !recentDecade
         } else {
             // If it is not an year in 20xxs form, then check if item contains a 4-digit word
             // anywhere within the string (.* is wildcard) (Issue #47)

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -27,11 +27,12 @@ class CategoriesModel @Inject constructor(
     private var selectedExistingCategories: MutableList<String> = mutableListOf()
 
     /**
-     * Returns true if the item contains an year which should be ignored
-     * @param item
+     * Returns true if an item is considered to be a spammy category which should be ignored
+     *
+     * @param item a category item that needs to be validated to know if it is spammy or not
      * @return
      */
-    fun containsYear(item: String): Boolean {
+    fun isSpammyCategory(item: String): Boolean {
         //Check for current and previous year to exclude these categories from removal
         val now = Calendar.getInstance()
         val curYear = now[Calendar.YEAR]

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -58,7 +58,7 @@ class CategoriesModel @Inject constructor(
             // anywhere within the string (.* is wildcard) (Issue #47)
             // And that item does not equal the current year or previous year
             return item.matches(".*(19|20)\\d{2}.*".toRegex())
-                    && !item.contains(yearInString)
+                    && !item.contains(curYearInString)
                     && !item.contains(prevYearInString)
         }
     }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -27,7 +27,7 @@ class CategoriesModel @Inject constructor(
     private var selectedExistingCategories: MutableList<String> = mutableListOf()
 
     /**
-     * Returns if the item contains an year which should be ignored
+     * Returns true if the item contains an year which should be ignored
      * @param item
      * @return
      */
@@ -41,16 +41,16 @@ class CategoriesModel @Inject constructor(
         Timber.d("Previous year: %s", prevYearInString)
 
         val mentionsDecade = item.matches(".*0s.*".toRegex())
+        val recentDecade = item.matches(".*20[0-2]0s.*".toRegex())
+        val oldDecade = !recentDecade
         val spammyCategory = item.matches("(.*)needing(.*)".toRegex())
                           || item.matches("(.*)taken on(.*)".toRegex())
 
         if (mentionsDecade) {
             //Check if the year in the form of XX(X)0s is recent/relevant, i.e. in the 2000s or 2010s/2020s as stated in Issue #1029
             // If not, check if it is an irrelevant category such as Media_needing_categories_as_of_16_June_2017(Issue #750)
-            return !item.matches(".*20[0-2]0s.*".toRegex())
-                    || spammyCategory
-        }
-        else {
+            return oldDecade || spammyCategory
+        } else {
             // If it is not an year in 20xxs form, then check if item contains a 4-digit word
             // anywhere within the string (.* is wildcard) (Issue #47)
             // And that item does not equal the current year or previous year

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -34,9 +34,9 @@ class CategoriesModel @Inject constructor(
     fun containsYear(item: String): Boolean {
         //Check for current and previous year to exclude these categories from removal
         val now = Calendar.getInstance()
-        val year = now[Calendar.YEAR]
-        val yearInString = year.toString()
-        val prevYear = year - 1
+        val curYear = now[Calendar.YEAR]
+        val curYearInString = curYear.toString()
+        val prevYear = curYear - 1
         val prevYearInString = prevYear.toString()
         Timber.d("Previous year: %s", prevYearInString)
 
@@ -45,7 +45,7 @@ class CategoriesModel @Inject constructor(
         //And if it is an irrelevant category such as Media_needing_categories_as_of_16_June_2017(Issue #750)
         //Check if the year in the form of XX(X)0s is relevant, i.e. in the 2000s or 2010s as stated in Issue #1029
         return item.matches(".*(19|20)\\d{2}.*".toRegex())
-                && !item.contains(yearInString)
+                && !item.contains(curYearInString)
                 && !item.contains(prevYearInString)
                 || item.matches("(.*)needing(.*)".toRegex())
                 || item.matches("(.*)taken on(.*)".toRegex())

--- a/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
+++ b/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
@@ -148,7 +148,7 @@ public class UploadRepository {
      * @param name
      * @return
      */
-    public boolean containsYear(String name) {
+    public boolean isSpammyCategory(String name) {
         return categoriesModel.isSpammyCategory(name);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
+++ b/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.java
@@ -149,7 +149,7 @@ public class UploadRepository {
      * @return
      */
     public boolean containsYear(String name) {
-        return categoriesModel.containsYear(name);
+        return categoriesModel.isSpammyCategory(name);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/CategoriesPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/CategoriesPresenter.kt
@@ -89,7 +89,7 @@ class CategoriesPresenter @Inject constructor(
         if (media == null) {
             return repository.searchAll(term, getImageTitleList(), repository.selectedDepictions)
                 .subscribeOn(ioScheduler)
-                .map { it.filter { categoryItem -> !repository.containsYear(categoryItem.name)
+                .map { it.filter { categoryItem -> !repository.isSpammyCategory(categoryItem.name)
                         || categoryItem.name==term } }
         } else {
             return Observable.zip(
@@ -103,7 +103,7 @@ class CategoriesPresenter @Inject constructor(
                 it1 + it2
             }
                 .subscribeOn(ioScheduler)
-                .map { it.filter { categoryItem -> !repository.containsYear(categoryItem.name)
+                .map { it.filter { categoryItem -> !repository.isSpammyCategory(categoryItem.name)
                         || categoryItem.name==term } }
                 .map { it.filterNot { categoryItem -> categoryItem.thumbnail == "hidden" } }
         }

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/CategoriesPresenterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/CategoriesPresenterTest.kt
@@ -14,7 +14,6 @@ import media
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.MockitoAnnotations
 import java.lang.reflect.Method
 
@@ -97,8 +96,8 @@ class CategoriesPresenterTest {
                     )
                 )
             )
-        whenever(repository.containsYear("selected")).thenReturn(false)
-        whenever(repository.containsYear("doesContainYear")).thenReturn(true)
+        whenever(repository.isSpammyCategory("selected")).thenReturn(false)
+        whenever(repository.isSpammyCategory("doesContainYear")).thenReturn(true)
         whenever(repository.selectedCategories).thenReturn(listOf(
             categoryItem("selected", "", "",true)))
         categoriesPresenter.searchForCategories("test")

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadRepositoryUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadRepositoryUnitTest.kt
@@ -156,7 +156,7 @@ class UploadRepositoryUnitTest {
     @Test
     fun testContainsYear() {
         assertEquals(
-            repository.containsYear(""), categoriesModel.isSpammyCategory("")
+            repository.isSpammyCategory(""), categoriesModel.isSpammyCategory("")
         )
     }
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadRepositoryUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadRepositoryUnitTest.kt
@@ -156,7 +156,7 @@ class UploadRepositoryUnitTest {
     @Test
     fun testContainsYear() {
         assertEquals(
-            repository.containsYear(""), categoriesModel.containsYear("")
+            repository.containsYear(""), categoriesModel.isSpammyCategory("")
         )
     }
 


### PR DESCRIPTION
**Description (required)**

As suggested in https://github.com/commons-app/apps-android-commons/issues/5749#issuecomment-2156382032, this updates "non-archaic years" filter to include `2020s` too (in addition to existing `2000s` and `2010s`)

Also adds a comment to identify source of some of the regexes.

**Tests performed (required)**

Not in position to build/test currently; would appreciate if someone else could check. The change is rather trivial regex change, though.
