### PR TITLE
Fixes Issue #5713: "Edit location" is hard to use (and confusing)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -331,7 +331,7 @@ public class LocationPickerActivity extends BaseActivity implements
         moveMapToMediaLocation();
         modifyLocationButton.setOnClickListener(v -> onClickModifyLocation());
         removeLocationButton.setOnClickListener(v -> onClickRemoveLocation());
-        showInMapButton.setOnClickListener(v -> showInMap());
+        showInMapButton.setOnClickListener(v -> showInMapApp());
         darkThemeSetup();
     }
 
@@ -388,8 +388,9 @@ public class LocationPickerActivity extends BaseActivity implements
 
     /**
      * Show the location in map app. Map will center on EXIF location, if available.
+     * If there is no EXIF data, the map will center on the commons app map center.
      */
-    public void showInMap() {
+    private void showInMapApp() {
         //Check to see if EXIF location data is available
         if(cameraPosition != null){
             Utils.handleGeoCoordinates(this,

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -267,7 +267,9 @@ public class LocationPickerActivity extends BaseActivity implements
      * @param point The GeoPoint object which contains the coordinates to move to
      */
     private void moveMapTo(GeoPoint point){
-        moveMapTo(point.getLatitude(), point.getLongitude());
+        if(point != null){
+            moveMapTo(point.getLatitude(), point.getLongitude());
+        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -273,19 +273,6 @@ public class LocationPickerActivity extends BaseActivity implements
     }
 
     /**
-     * Moves the center of the map to the media's location (likely EXIF data), if that data
-     * is available.
-     */
-    private void moveMapToMediaLocation(){
-        if(cameraPosition != null){
-            double latitude = cameraPosition.getLatitude();
-            double longitude = cameraPosition.getLongitude();
-
-            moveMapTo(latitude, longitude);
-        }
-    }
-
-    /**
      * For showing credits
      */
     private void addCredits() {
@@ -340,7 +327,7 @@ public class LocationPickerActivity extends BaseActivity implements
     }
 
     private void setupMapView() {
-        adjustCameraBasedOnOptions();
+        moveMapToMediaLocation();
         modifyLocationButton.setOnClickListener(v -> onClickModifyLocation());
         removeLocationButton.setOnClickListener(v -> onClickRemoveLocation());
         showInMapButton.setOnClickListener(v -> showInMap());
@@ -416,12 +403,16 @@ public class LocationPickerActivity extends BaseActivity implements
     }
 
     /**
-     * move the location to the current media coordinates
+     * Moves the center of the map to the media's location (likely EXIF data), if that data
+     * is available.
      */
-    private void adjustCameraBasedOnOptions() {
+    private void moveMapToMediaLocation() {
         if (cameraPosition != null) {
-            mapView.getController().setCenter(new GeoPoint(cameraPosition.getLatitude(),
-                cameraPosition.getLongitude()));
+
+            GeoPoint point = new GeoPoint(cameraPosition.getLatitude(),
+                cameraPosition.getLongitude());
+
+            moveMapTo(point);
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -45,6 +45,7 @@ import fr.free.nrw.commons.coordinates.CoordinateEditHelper;
 import fr.free.nrw.commons.filepicker.Constants;
 import fr.free.nrw.commons.kvstore.BasicKvStore;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
+import fr.free.nrw.commons.location.LatLng;
 import fr.free.nrw.commons.location.LocationPermissionsHelper;
 import fr.free.nrw.commons.location.LocationPermissionsHelper.LocationPermissionCallback;
 import fr.free.nrw.commons.location.LocationServiceManager;
@@ -328,7 +329,6 @@ public class LocationPickerActivity extends BaseActivity implements
 
     private void setupMapView() {
         requestLocationPermissions();
-        moveMapToMediaLocation();
         modifyLocationButton.setOnClickListener(v -> onClickModifyLocation());
         removeLocationButton.setOnClickListener(v -> onClickRemoveLocation());
         showInMapButton.setOnClickListener(v -> showInMapApp());
@@ -414,6 +414,21 @@ public class LocationPickerActivity extends BaseActivity implements
                 cameraPosition.getLongitude());
 
             moveMapTo(point);
+        }
+    }
+
+    /**
+     * Moves the center of the map to the device's GPS location, if that data is available.
+     */
+    private void moveMapToGPSLocation(){
+        if(locationManager != null){
+            fr.free.nrw.commons.location.LatLng location = locationManager.getLastLocation();
+
+            if(location != null){
+                GeoPoint point = new GeoPoint(location.getLatitude(), location.getLongitude());
+
+                moveMapTo(point);
+            }
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -318,11 +318,11 @@ public class LocationPickerActivity extends BaseActivity implements
     private void setupMapView() {
         requestLocationPermissions();
 
-        //If EXIF data is available, move map to EXIF location.
+        //If location metadata is available, move map to that location.
         if(activity.equals("UploadActivity") || activity.equals("MediaActivity")){
             moveMapToMediaLocation();
         } else {
-            //EXIF data is not available. Move map to device GPS location.
+            //If location metadata is not available, move map to device GPS location.
             moveMapToGPSLocation();
         }
 
@@ -379,18 +379,18 @@ public class LocationPickerActivity extends BaseActivity implements
     }
 
     /**
-     * Show the location in map app. Map will center on EXIF location, if available.
-     * If there is no EXIF data, the map will center on the commons app map center.
+     * Show the location in map app. Map will center on the location metadata, if available.
+     * If there is no location metadata, the map will center on the commons app map center.
      */
     private void showInMapApp() {
         fr.free.nrw.commons.location.LatLng position = null;
 
         if(activity.equals("UploadActivity") && cameraPosition != null){
-            //EXIF location data is available
+            //location metadata is available
             position = new fr.free.nrw.commons.location.LatLng(cameraPosition.getLatitude(),
                 cameraPosition.getLongitude(), 0.0f);
         } else if(mapView != null){
-            //EXIF location data is not available
+            //location metadata is not available
             position = new fr.free.nrw.commons.location.LatLng(mapView.getMapCenter().getLatitude(),
                 mapView.getMapCenter().getLongitude(), 0.0f);
         }
@@ -401,7 +401,7 @@ public class LocationPickerActivity extends BaseActivity implements
     }
 
     /**
-     * Moves the center of the map to the media's location (likely EXIF data), if that data
+     * Moves the center of the map to the media's location, if that data
      * is available.
      */
     private void moveMapToMediaLocation() {

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -329,6 +329,15 @@ public class LocationPickerActivity extends BaseActivity implements
 
     private void setupMapView() {
         requestLocationPermissions();
+
+        //If EXIF data is available, move map to EXIF location.
+        if(activity.equals("UploadActivity")){
+            moveMapToMediaLocation();
+        } else {
+            //EXIF data is not available. Move map to device GPS location.
+            moveMapToGPSLocation();
+        }
+
         modifyLocationButton.setOnClickListener(v -> onClickModifyLocation());
         removeLocationButton.setOnClickListener(v -> onClickRemoveLocation());
         showInMapButton.setOnClickListener(v -> showInMapApp());

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -238,16 +238,6 @@ public class LocationPickerActivity extends BaseActivity implements
                 cameraPosition.getLongitude()));
         }
         setupMapView();
-        
-        if("UploadActivity".equals(activity)){
-            if(mapView != null && mapView.getController() != null && cameraPosition != null){
-                GeoPoint cameraGeoPoint = new GeoPoint(cameraPosition.getLatitude(),
-                    cameraPosition.getLongitude());
-
-                mapView.getController().setCenter(cameraGeoPoint);
-                mapView.getController().animateTo(cameraGeoPoint);
-            }
-        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -400,18 +400,20 @@ public class LocationPickerActivity extends BaseActivity implements
      * If there is no EXIF data, the map will center on the commons app map center.
      */
     private void showInMapApp() {
-
         fr.free.nrw.commons.location.LatLng position = null;
+        
         //Check to see if EXIF location data is available
-        if(activity.equals("UploadActivity")){
+        if(activity.equals("UploadActivity") && cameraPosition != null){
             position = new fr.free.nrw.commons.location.LatLng(cameraPosition.getLatitude(),
                 cameraPosition.getLongitude(), 0.0f);
-        } else {
+        } else if(mapView != null){
             position = new fr.free.nrw.commons.location.LatLng(mapView.getMapCenter().getLatitude(),
                 mapView.getMapCenter().getLongitude(), 0.0f);
         }
 
-        Utils.handleGeoCoordinates(this, position);
+        if(position != null){
+            Utils.handleGeoCoordinates(this, position);
+        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -364,12 +364,19 @@ public class LocationPickerActivity extends BaseActivity implements
     }
 
     /**
-     * Show the location in map app
+     * Show the location in map app. Map will center on EXIF location, if available.
      */
     public void showInMap() {
-        Utils.handleGeoCoordinates(this,
-            new fr.free.nrw.commons.location.LatLng(mapView.getMapCenter().getLatitude(),
-                mapView.getMapCenter().getLongitude(), 0.0f));
+        //Check to see if EXIF location data is available
+        if(cameraPosition != null){
+            Utils.handleGeoCoordinates(this,
+                new fr.free.nrw.commons.location.LatLng(cameraPosition.getLatitude(),
+                    cameraPosition.getLongitude(), 0.0f));
+        } else {
+            Utils.handleGeoCoordinates(this,
+                new fr.free.nrw.commons.location.LatLng(mapView.getMapCenter().getLatitude(),
+                    mapView.getMapCenter().getLongitude(), 0.0f));
+        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -319,7 +319,7 @@ public class LocationPickerActivity extends BaseActivity implements
         requestLocationPermissions();
 
         //If EXIF data is available, move map to EXIF location.
-        if(activity.equals("UploadActivity")){
+        if(activity.equals("UploadActivity") || activity.equals("MediaActivity")){
             moveMapToMediaLocation();
         } else {
             //EXIF data is not available. Move map to device GPS location.

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -400,16 +400,18 @@ public class LocationPickerActivity extends BaseActivity implements
      * If there is no EXIF data, the map will center on the commons app map center.
      */
     private void showInMapApp() {
+
+        fr.free.nrw.commons.location.LatLng position = null;
         //Check to see if EXIF location data is available
-        if(cameraPosition != null){
-            Utils.handleGeoCoordinates(this,
-                new fr.free.nrw.commons.location.LatLng(cameraPosition.getLatitude(),
-                    cameraPosition.getLongitude(), 0.0f));
+        if(activity.equals("UploadActivity")){
+            position = new fr.free.nrw.commons.location.LatLng(cameraPosition.getLatitude(),
+                cameraPosition.getLongitude(), 0.0f);
         } else {
-            Utils.handleGeoCoordinates(this,
-                new fr.free.nrw.commons.location.LatLng(mapView.getMapCenter().getLatitude(),
-                    mapView.getMapCenter().getLongitude(), 0.0f));
+            position = new fr.free.nrw.commons.location.LatLng(mapView.getMapCenter().getLatitude(),
+                mapView.getMapCenter().getLongitude(), 0.0f);
         }
+
+        Utils.handleGeoCoordinates(this, position);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -250,6 +250,40 @@ public class LocationPickerActivity extends BaseActivity implements
     }
 
     /**
+     * Moves the center of the map to the specified coordinates
+     *
+     */
+    private void moveMapTo(double latitude, double longitude){
+        if(mapView != null && mapView.getController() != null){
+            GeoPoint point = new GeoPoint(latitude, longitude);
+
+            mapView.getController().setCenter(point);
+            mapView.getController().animateTo(point);
+        }
+    }
+
+    /**
+     * Moves the center of the map to the specified coordinates
+     * @param point The GeoPoint object which contains the coordinates to move to
+     */
+    private void moveMapTo(GeoPoint point){
+        moveMapTo(point.getLatitude(), point.getLongitude());
+    }
+
+    /**
+     * Moves the center of the map to the media's location (likely EXIF data), if that data
+     * is available.
+     */
+    private void moveMapToMediaLocation(){
+        if(cameraPosition != null){
+            double latitude = cameraPosition.getLatitude();
+            double longitude = cameraPosition.getLongitude();
+
+            moveMapTo(latitude, longitude);
+        }
+    }
+
+    /**
      * For showing credits
      */
     private void addCredits() {

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -40,12 +40,10 @@ import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.Utils;
 import fr.free.nrw.commons.auth.SessionManager;
 import fr.free.nrw.commons.auth.csrf.CsrfTokenClient;
-import fr.free.nrw.commons.auth.csrf.InvalidLoginTokenException;
 import fr.free.nrw.commons.coordinates.CoordinateEditHelper;
 import fr.free.nrw.commons.filepicker.Constants;
 import fr.free.nrw.commons.kvstore.BasicKvStore;
 import fr.free.nrw.commons.kvstore.JsonKvStore;
-import fr.free.nrw.commons.location.LatLng;
 import fr.free.nrw.commons.location.LocationPermissionsHelper;
 import fr.free.nrw.commons.location.LocationPermissionsHelper.LocationPermissionCallback;
 import fr.free.nrw.commons.location.LocationServiceManager;
@@ -606,9 +604,9 @@ public class LocationPickerActivity extends BaseActivity implements
                 locationManager.requestLocationUpdatesFromProvider(
                     LocationManager.NETWORK_PROVIDER);
                 locationManager.requestLocationUpdatesFromProvider(LocationManager.GPS_PROVIDER);
-                getLocation();
+                addMarkerAtGPSLocation();
             } else {
-                getLocation();
+                addMarkerAtGPSLocation();
                 locationPermissionsHelper.showLocationOffDialog(this,
                     R.string.ask_to_turn_location_on_text);
             }
@@ -616,16 +614,15 @@ public class LocationPickerActivity extends BaseActivity implements
     }
 
     /**
-     * Gets new location if locations services are on, else gets last location
+     * Adds a marker to the map at the most recent GPS location
+     * (which may be the current GPS location).
      */
-    private void getLocation() {
+    private void addMarkerAtGPSLocation() {
         fr.free.nrw.commons.location.LatLng currLocation = locationManager.getLastLocation();
         if (currLocation != null) {
             GeoPoint currLocationGeopoint = new GeoPoint(currLocation.getLatitude(),
                 currLocation.getLongitude());
             addLocationMarker(currLocationGeopoint);
-            mapView.getController().setCenter(currLocationGeopoint);
-            mapView.getController().animateTo(currLocationGeopoint);
             markerImage.setTranslationY(0);
         }
     }

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -402,11 +402,12 @@ public class LocationPickerActivity extends BaseActivity implements
     private void showInMapApp() {
         fr.free.nrw.commons.location.LatLng position = null;
         
-        //Check to see if EXIF location data is available
         if(activity.equals("UploadActivity") && cameraPosition != null){
+            //EXIF location data is available
             position = new fr.free.nrw.commons.location.LatLng(cameraPosition.getLatitude(),
                 cameraPosition.getLongitude(), 0.0f);
         } else if(mapView != null){
+            //EXIF location data is not available
             position = new fr.free.nrw.commons.location.LatLng(mapView.getMapCenter().getLatitude(),
                 mapView.getMapCenter().getLongitude(), 0.0f);
         }

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -327,12 +327,12 @@ public class LocationPickerActivity extends BaseActivity implements
     }
 
     private void setupMapView() {
+        requestLocationPermissions();
         moveMapToMediaLocation();
         modifyLocationButton.setOnClickListener(v -> onClickModifyLocation());
         removeLocationButton.setOnClickListener(v -> onClickRemoveLocation());
         showInMapButton.setOnClickListener(v -> showInMap());
         darkThemeSetup();
-        requestLocationPermissions();
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.java
@@ -358,12 +358,7 @@ public class LocationPickerActivity extends BaseActivity implements
         smallToolbarText.setText(getResources().getString(R.string.pan_and_zoom_to_adjust));
         fabCenterOnLocation.setVisibility(View.VISIBLE);
         removeSelectedLocationMarker();
-        if (cameraPosition != null && mapView != null) {
-            if (mapView.getController() != null) {
-                mapView.getController().animateTo(new GeoPoint(cameraPosition.getLatitude(),
-                    cameraPosition.getLongitude()));
-            }
-        }
+        moveMapToMediaLocation();
     }
 
     /**
@@ -401,7 +396,7 @@ public class LocationPickerActivity extends BaseActivity implements
      */
     private void showInMapApp() {
         fr.free.nrw.commons.location.LatLng position = null;
-        
+
         if(activity.equals("UploadActivity") && cameraPosition != null){
             //EXIF location data is available
             position = new fr.free.nrw.commons.location.LatLng(cameraPosition.getLatitude(),

--- a/app/src/main/res/layout/content_location_picker.xml
+++ b/app/src/main/res/layout/content_location_picker.xml
@@ -16,6 +16,7 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"
     app:srcCompat="@drawable/map_default_map_marker"
+    android:layout_marginBottom="45dp"
     android:contentDescription="@string/location_picker_image_view" />
 
   <ImageView
@@ -24,10 +25,10 @@
     android:layout_height="wrap_content"
     android:contentDescription="@string/location_picker_image_view_shadow"
     android:elevation="1dp"
+    app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintRight_toRightOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="@+id/location_picker_image_view_marker"
+    app:layout_constraintTop_toTopOf="parent"
     app:srcCompat="@drawable/map_default_map_marker_shadow" />
 
   <org.osmdroid.views.MapView


### PR DESCRIPTION
**Description (required)**

Fixes #5713

What changes did you make and why?

Changes were made for both functionality and clarity.

Functionality:

Changes for functionality were made to solve the first 2 subissues that were described in issue #5713. The third subissue was discussed further in the comments and does not seem to be a bug at this point.

To fix subissue 1, an if check was added to see if the selected image had EXIF location data. If it did, the map center would move to the EXIF location. If the image did not have EXIF location data, the map center would move to the device's GPS location (if available).

To fix subissue 2, the correct location variable was used in the (renamed) showInMapApp() method so that the map app would center on the location EXIF data.


Clarity:

Changes for clarity included moving around, rewriting, or adding code (such as helper methods). Also, redundant code was removed. These changes make the code easier to understand and should help with long term maintenance.

**Tests performed (required)**

Tested betaDebug on Android Studio Emulator with API level 34.

**Screenshots (for UI changes only)**

In this first video, the device's GPS location is set to NYC. The first image selected for upload contains EXIF location data of Seattle. When the "Edit Location" button is pressed, the map will center on the EXIF location. The second image selected for upload does not contain EXIF location data. When the "Edit Location" button is pressed, the map will center on the device's GPS location in NYC.

[issue5713_part1_compressed.webm](https://github.com/commons-app/apps-android-commons/assets/30037173/1e7bb1e1-ed54-4b0e-8765-9c7ca1e1c6ac)

In this second video, the image with EXIF data is selected for upload. In the "Edit Location" menu, the map center is moved out into the water and then the "Show in Map App" button is pressed. The external map app correctly centers on the image's EXIF location, rather than centering on the water.

[issue5713_part2_compressed.webm](https://github.com/commons-app/apps-android-commons/assets/30037173/eec8a319-ae89-47fc-bfac-e2749bfb881a)


---
