### PR TITLE
Rename "View user page" menu as "View user profile"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -738,7 +738,7 @@ Upload your first media by tapping on the add button.</string>
 
   <string name="contributions_of_user">Contributions of User: %s</string>
   <string name="achievements_of_user">Achievements of User: %s</string>
-  <string name="menu_view_user_page">View user page</string>
+  <string name="menu_view_user_page">View user profile</string>
   <string name="edit_depictions">Edit depictions</string>
   <string name="edit_categories">Edit categories</string>
   <string name="advanced_options">Advanced Options</string>


### PR DESCRIPTION

**Description (required)**

As suggested by @whym on #5754, the name "User page" is ambiguous with the on-wiki uers page. We actually show the leaderboard when the menu is clicked on. So, rename the menu as "User profile" instead.

Ref: https://github.com/commons-app/apps-android-commons/issues/5754#issuecomment-2196796213

**Tests performed (required)**

Tested on OnePlus Nord with API 32.

**Screenshots (for UI changes only)**

![Screenshot_2024-07-14-15-48-05-15_d5db3f3edc380047609fe9c266f7c566](https://github.com/user-attachments/assets/ce573e99-d7f7-4cbd-bb63-429b3bd5eb95)
