### PR TITLE
wikidata-feedback: avoid sentence lego

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/WikidataFeedback.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/WikidataFeedback.kt
@@ -45,7 +45,7 @@ class WikidataFeedback : BaseActivity() {
         pageTitle = getString(R.string.talk) + ":" + wikidataQId
         binding.toolbarBinding.toolbar.title = pageTitle
         binding.textHeader.text =
-            getString(R.string.write_something_about_the) + "'$place'" + getString(R.string.item_it_will_be_publicly_visible)
+            getString(R.string.write_something_about_the_item, place)
         binding.radioButton1.setText(
             getString(
                 R.string.does_not_exist_anymore_no_picture_can_ever_be_taken_of_it,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -821,8 +821,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="nearby_wikitalk">Report a problem about this item to Wikidata</string>
   <string name="please_enter_some_comments">Please enter some comments</string>
   <string name="talk">Talk</string>
-  <string name="write_something_about_the">"Write something about the "</string>
-  <string name="item_it_will_be_publicly_visible">" item. It will be publicly visible."</string>
+  <string name="write_something_about_the_item">"Write something about the \'%1$s\' item. It will be publicly visible."</string>
   <string name="does_not_exist_anymore_no_picture_can_ever_be_taken_of_it">\'%1$s\' does not exist anymore, no picture can ever be taken of it.</string>
   <string name="is_at_a_different_place_please_specify_the_correct_place_below_if_possible_tell_us_the_correct_latitude_longitude">\'%1$s\' is at a different place. Please specify the correct place below, and if possible, write the correct latitude and longitude.</string>
   <string name="other_problem_or_information_please_explain_below">Other problem or information (please explain below).</string>


### PR DESCRIPTION
**Description (required)**

Fixes #5763 by avoiding sentence lego in the string

**Tests performed (required)**

OnePlus Nord running Android 12

**Screenshots (for UI changes only)**

![Screenshot_2024-07-17-10-39-25-25_d5db3f3edc380047609fe9c266f7c566](https://github.com/user-attachments/assets/d45816b3-59f2-43ba-96c4-5848be4d8255)

