### PR TITLE
Mark a string as not for formatting

### DIFF
--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -617,7 +617,7 @@
   <string name="wikipedia_instructions_step_3">3. V članku poiščite ustrezen razdelek za svojo sliko.</string>
   <string name="wikipedia_instructions_step_4">4. Kliknite ikono Uredi (svinčnik) tega razdelka.</string>
   <string name="wikipedia_instructions_step_5">5. Prilepite vikibesedilo na ustrezno mesto.</string>
-  <string name="wikipedia_instructions_step_6">6. Po potrebi vikibesedilo uredite, da popravite položaj slike. Za več informacij glejte &lt;a href=\"https://sl.wikipedia.org/wiki/Wikipedija:Raz%C5%A1irjena_skladnja_za_slike\"&gt;tukaj&lt;/a&gt;.</string>
+  <string name="wikipedia_instructions_step_6" formatted="false">6. Po potrebi vikibesedilo uredite, da popravite položaj slike. Za več informacij glejte &lt;a href=\"https://sl.wikipedia.org/wiki/Wikipedija:Raz%C5%A1irjena_skladnja_za_slike\"&gt;tukaj&lt;/a&gt;.</string>
   <string name="wikipedia_instructions_step_7">7. Objavite članek.</string>
   <string name="copy_wikicode_to_clipboard">Kopiraj vikibesedilo v odložišče</string>
   <string name="pause">premor</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -625,7 +625,7 @@
   <string name="wikipedia_instructions_step_3">3. 尋找適合插入您的圖片的章節。</string>
   <string name="wikipedia_instructions_step_4">4. 點擊章節裡的編輯按鈕（為筆狀模樣的圖案）。</string>
   <string name="wikipedia_instructions_step_5">5. 將wikitext貼到適當的位置。</string>
-  <string name="wikipedia_instructions_step_6">6. 若有需要，可編輯wikitext來調整到適當的定位。更多相關資訊請查看&lt;a href=\"https://zh.wikipedia.org/wiki/Help:%E5%9B%BE%E5%83%8F\"&gt;此頁面&lt;/a&gt;。</string>
+  <string name="wikipedia_instructions_step_6" formatted="false">6. 若有需要，可編輯wikitext來調整到適當的定位。更多相關資訊請查看&lt;a href=\"https://zh.wikipedia.org/wiki/Help:%E5%9B%BE%E5%83%8F\"&gt;此頁面&lt;/a&gt;。</string>
   <string name="wikipedia_instructions_step_7">7. 發布條目</string>
   <string name="copy_wikicode_to_clipboard">複製維基代碼到剪貼簿</string>
   <string name="pause">暫停</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -647,7 +647,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="wikipedia_instructions_step_3">3. Find an appropriate section in the article for your image</string>
   <string name="wikipedia_instructions_step_4">4. Click on the Edit icon (the one like a pencil) for that section.</string>
   <string name="wikipedia_instructions_step_5">5. Paste the wikitext in the appropriate place.</string>
-  <string name="wikipedia_instructions_step_6">6. Edit the wikitext for appropriate positioning, if necessary. For more information, see &lt;a href="https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Images#How_to_place_an_image"&gt;here&lt;/a&gt;.</string>
+  <string name="wikipedia_instructions_step_6" formatted="false">6. Edit the wikitext for appropriate positioning, if necessary. For more information, see &lt;a href="https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Images#How_to_place_an_image"&gt;here&lt;/a&gt;.</string>
   <string name="wikipedia_instructions_step_7">7. Publish the article</string>
   <string name="copy_wikicode_to_clipboard">Copy wikicode to clipboard</string>
   <string name="pause">pause</string>


### PR DESCRIPTION
**Description (required)**

Fixes #5774

The wikipedia instruction step 6 has a link in it. When translated, the translators replace the english version of the link with the local version. The links sometimes includes percent encoded characters which is being interpreted as a format string.

To avoid the same, mark it as not formatted.

**Tests performed (required)**

I'm not sure what the reliable way to trigger the wikipedia step and hence could not yet verify the changes visually. But I suppose the warnings are now gone while building, though.

Let me know if there's a way to test the same visually.

**Screenshots (for UI changes only)**

N/A. See reason above
