### PR TITLE
Remove unnecessary double quotes from a message

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -821,7 +821,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="nearby_wikitalk">Report a problem about this item to Wikidata</string>
   <string name="please_enter_some_comments">Please enter some comments</string>
   <string name="talk">Talk</string>
-  <string name="write_something_about_the_item">"Write something about the \'%1$s\' item. It will be publicly visible."</string>
+  <string name="write_something_about_the_item">Write something about the \'%1$s\' item. It will be publicly visible.</string>
   <string name="does_not_exist_anymore_no_picture_can_ever_be_taken_of_it">\'%1$s\' does not exist anymore, no picture can ever be taken of it.</string>
   <string name="is_at_a_different_place_please_specify_the_correct_place_below_if_possible_tell_us_the_correct_latitude_longitude">\'%1$s\' is at a different place. Please specify the correct place below, and if possible, write the correct latitude and longitude.</string>
   <string name="other_problem_or_information_please_explain_below">Other problem or information (please explain below).</string>


### PR DESCRIPTION
I am removing those double quotes because they seem unnecessary.

Perhaps I misunderstand something and they are needed :)

In that case, close this pull request, but please add documentation that explains why they are needed to qq.

Thanks :)