### PR TITLE
Fix failing tests for updateDepictsProperty method

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'com.github.deano2390:MaterialShowcaseView:1.2.0'
-    implementation 'com.dinuscxj:circleprogressbar:1.1.1'
+    implementation "com.google.android.material:material:1.9.0"
     implementation 'com.karumi:dexter:5.0.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 

--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -306,6 +306,7 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
         if (uploadCount==0){
             setZeroAchievements();
         }else {
+
             binding.imagesUploadedProgressbar.setVisibility(View.VISIBLE);
             binding.imagesUploadedProgressbar.setProgress
                     (100*uploadCount/levelInfo.getMaxUploadCount());
@@ -342,8 +343,8 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
     private void setImageRevertPercentage(int notRevertPercentage){
         binding.imageRevertsProgressbar.setVisibility(View.VISIBLE);
         binding.imageRevertsProgressbar.setProgress(notRevertPercentage);
-        String revertPercentage = Integer.toString(notRevertPercentage);
-        binding.imageRevertsProgressbar.setProgressTextFormatPattern(revertPercentage + "%%");
+        final String revertPercentage = Integer.toString(notRevertPercentage);
+        binding.tvRevertedImages.setText(revertPercentage + "%");
         binding.imagesRevertLimitText.setText(getResources().getString(R.string.achievements_revert_limit_message)+ levelInfo.getMinNonRevertPercentage() + "%");
     }
 
@@ -357,10 +358,8 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
         binding.thanksReceived.setText(String.valueOf(achievements.getThanksReceived()));
         binding.imagesUsedByWikiProgressBar.setProgress
                 (100 * achievements.getUniqueUsedImages() / levelInfo.getMaxUniqueImages());
-        if(binding.tvWikiPb != null) {
-            binding.tvWikiPb.setText
-                (achievements.getUniqueUsedImages() + "/" + levelInfo.getMaxUniqueImages());
-        }
+        binding.tvWikiPb.setText(achievements.getUniqueUsedImages() + "/"
+            + levelInfo.getMaxUniqueImages());
         binding.imageFeatured.setText(String.valueOf(achievements.getFeaturedImages()));
         binding.qualityImages.setText(String.valueOf(achievements.getQualityImages()));
         String levelUpInfoString = getString(R.string.level).toUpperCase();

--- a/app/src/main/java/fr/free/nrw/commons/quiz/QuizResultActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/quiz/QuizResultActivity.java
@@ -65,10 +65,10 @@ public class QuizResultActivity extends AppCompatActivity {
      * @param score
      */
     public void setScore(int score) {
-        int per = score * MULTIPLIER_TO_GET_PERCENTAGE;
-        binding.resultProgressBar.setProgress(per);
-        binding.resultProgressBar.setProgressTextFormatPattern(score +" / " + NUMBER_OF_QUESTIONS);
-        String message = getResources().getString(R.string.congratulatory_message_quiz,per + "%");
+        final int scorePercent = score * MULTIPLIER_TO_GET_PERCENTAGE;
+        binding.resultProgressBar.setProgress(scorePercent);
+        binding.tvResultProgress.setText(score +" / " + NUMBER_OF_QUESTIONS);
+        final String message = getResources().getString(R.string.congratulatory_message_quiz,scorePercent + "%");
         binding.congratulatoryMessage.setText(message);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsActivity.java
@@ -15,7 +15,7 @@ import fr.free.nrw.commons.theme.BaseActivity;
 public class SettingsActivity extends BaseActivity {
 
     private ActivitySettingsBinding binding;
-    private AppCompatDelegate settingsDelegate;
+//    private AppCompatDelegate settingsDelegate;
     /**
      * to be called when the activity starts
      * @param savedInstanceState the previously saved state
@@ -39,10 +39,10 @@ public class SettingsActivity extends BaseActivity {
     @Override
     protected void onPostCreate(Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
-        if (settingsDelegate == null) {
-            settingsDelegate = AppCompatDelegate.create(this, null);
-        }
-        settingsDelegate.onPostCreate(savedInstanceState);
+//        if (settingsDelegate == null) {
+//            settingsDelegate = AppCompatDelegate.create(this, null);
+//        }
+//        settingsDelegate.onPostCreate(savedInstanceState);
     }
 
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/wikidata/WikiBaseClient.kt
+++ b/app/src/main/java/fr/free/nrw/commons/wikidata/WikiBaseClient.kt
@@ -47,9 +47,9 @@ class WikiBaseClient @Inject constructor(
         }
     }
 
-    fun postDeleteClaims(entityId: String, data: String): Observable<Boolean> {
+    fun postDeleteClaims(entityId: String, data: String?): Observable<Boolean> {
         return csrfToken().switchMap { editToken ->
-            wikiBaseInterface.postDeleteClaims(editToken, entityId, data)
+            wikiBaseInterface.postDeleteClaims(editToken, entityId, data!!)
                 .map { response: MwPostResponse -> response.successVal == 1 }
         }
     }

--- a/app/src/main/res/layout/activity_quiz_result.xml
+++ b/app/src/main/res/layout/activity_quiz_result.xml
@@ -41,20 +41,37 @@
                         android:textSize="32sp"
                         android:layout_marginTop="@dimen/activity_margin_vertical" />
 
-                    <com.dinuscxj.progressbar.CircleProgressBar
-                        android:layout_width="match_parent"
-                        android:layout_height="@dimen/dimen_250"
-                        android:layout_marginRight="@dimen/activity_margin_horizontal"
-                        android:layout_marginLeft="@dimen/activity_margin_horizontal"
-                        android:layout_marginTop="@dimen/activity_margin_vertical"
-                        android:progress="50"
-                        app:progress_end_color="#8C8B98"
-                        app:progress_start_color="#3A3381"
-                        app:progress_stroke_width="@dimen/first_fab"
-                        app:progress_text_size="@dimen/large_gap"
-                        app:progress_text_format_pattern="4/5"
-                        app:style="solid_line"
-                        android:id="@+id/result_progress_bar"/>
+                    <FrameLayout
+                      android:layout_width="match_parent"
+                      android:layout_height="@dimen/dimen_250"
+                      android:layout_marginRight="@dimen/activity_margin_horizontal"
+                      android:layout_marginLeft="@dimen/activity_margin_horizontal"
+                      android:layout_marginTop="@dimen/activity_margin_vertical">
+
+                        <com.google.android.material.progressindicator.CircularProgressIndicator
+                          android:id="@+id/result_progress_bar"
+                          android:layout_width="match_parent"
+                          android:layout_height="@dimen/dimen_250"
+                          android:layout_gravity="center"
+                          android:indeterminate="false"
+                          app:showAnimationBehavior="outward"
+                          app:indicatorColor="#3A3381"
+                          app:indicatorSize="128dp"
+                          app:trackThickness="@dimen/first_fab"
+                          app:trackColor="#B7B6B6" />
+
+                        <androidx.appcompat.widget.AppCompatTextView
+                          android:id="@+id/tv_result_progress"
+                          android:layout_width="match_parent"
+                          android:layout_height="match_parent"
+                          android:padding="@dimen/progressbar_padding"
+                          android:gravity="center"
+                          android:maxLines="1"
+                          android:textColor="@color/secondaryColor"
+                          app:autoSizeMaxTextSize="@dimen/large_gap"
+                          app:autoSizeStepGranularity="1sp"
+                          app:autoSizeTextType="uniform" />
+                    </FrameLayout>
 
                     <TextView
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_achievements.xml
+++ b/app/src/main/res/layout/fragment_achievements.xml
@@ -133,27 +133,20 @@
               android:layout_width="@dimen/dimen_40"
               android:layout_height="@dimen/dimen_40"
               android:layout_alignParentEnd="true"
-              android:layout_alignParentRight="true"
-              android:layout_marginEnd="32dp"
-              android:layout_marginRight="32dp">
+              android:layout_marginEnd="32dp">
 
-              <com.dinuscxj.progressbar.CircleProgressBar
+              <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/images_uploaded_progressbar"
                 android:layout_width="@dimen/dimen_40"
                 android:layout_height="@dimen/dimen_40"
-                android:layout_alignParentRight="true"
-                android:layout_alignParentEnd="true"
+                android:indeterminate="false"
                 android:layout_marginEnd="@dimen/large_gap"
-                android:layout_marginRight="@dimen/large_gap"
-                android:id="@+id/images_uploaded_progressbar"
-                android:progress="50"
-                app:progress_text_size="@dimen/progressbar_text"
-                app:progress_end_color="#8C8B98"
-                app:progress_start_color="#3A3381"
-                app:progress_stroke_width="@dimen/progressbar_stroke"
-                app:progress_text_format_pattern=""
-                android:visibility="gone"
-                app:progress_text_color="@color/secondaryColor"
-                app:style="solid_line" />
+                app:showAnimationBehavior="outward"
+                app:indicatorColor="@color/primaryColor"
+                app:indicatorSize="32dp"
+                app:trackThickness="@dimen/progressbar_stroke"
+                app:trackColor="#B7B6B6"
+                android:visibility="gone"/>
 
               <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/tv_uploaded_images"
@@ -228,24 +221,38 @@
               android:layout_marginStart="@dimen/activity_margin_horizontal"
               android:layout_below="@id/images_reverted_info"/>
 
-            <com.dinuscxj.progressbar.CircleProgressBar
+            <FrameLayout
               android:layout_width="@dimen/dimen_40"
               android:layout_height="@dimen/dimen_40"
-              android:layout_alignParentRight="true"
               android:layout_alignParentEnd="true"
-              android:layout_marginRight="@dimen/large_gap"
-              android:layout_marginEnd="@dimen/large_gap"
-              android:progress="50"
-              android:visibility="gone"
-              android:id="@+id/image_reverts_progressbar"
-              app:progress_end_color="#8C8B98"
-              app:progress_start_color="#3A3381"
-              app:progress_text_size="@dimen/progressbar_text"
-              app:progress_stroke_width="@dimen/progressbar_stroke"
-              app:progress_text_format_pattern="92%%"
-              app:progress_text_color="@color/secondaryColor"
-              app:style="solid_line" />
+              android:layout_marginEnd="32dp">
 
+              <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/image_reverts_progressbar"
+                android:layout_width="@dimen/dimen_40"
+                android:layout_height="@dimen/dimen_40"
+                android:indeterminate="false"
+                android:layout_marginEnd="@dimen/large_gap"
+                app:showAnimationBehavior="outward"
+                app:indicatorColor="@color/primaryColor"
+                app:indicatorSize="32dp"
+                app:trackThickness="@dimen/progressbar_stroke"
+                app:trackColor="#B7B6B6"
+                android:visibility="gone"/>
+
+              <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tv_reverted_images"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="@dimen/progressbar_padding"
+                android:gravity="center"
+                android:maxLines="1"
+                android:textColor="@color/secondaryColor"
+                app:autoSizeMaxTextSize="@dimen/progressbar_text"
+                app:autoSizeMinTextSize="2sp"
+                app:autoSizeStepGranularity="1sp"
+                app:autoSizeTextType="uniform" />
+            </FrameLayout>
           </RelativeLayout>
 
           <RelativeLayout
@@ -295,27 +302,20 @@
               android:layout_width="@dimen/dimen_40"
               android:layout_height="@dimen/dimen_40"
               android:layout_alignParentEnd="true"
-              android:layout_alignParentRight="true"
-              android:layout_marginEnd="32dp"
-              android:layout_marginRight="32dp">
+              android:layout_marginEnd="32dp">
 
-              <com.dinuscxj.progressbar.CircleProgressBar
+              <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/images_used_by_wiki_progress_bar"
                 android:layout_width="@dimen/dimen_40"
                 android:layout_height="@dimen/dimen_40"
-                android:layout_alignParentRight="true"
-                android:layout_alignParentEnd="true"
-                android:layout_marginRight="@dimen/large_gap"
+                android:indeterminate="false"
                 android:layout_marginEnd="@dimen/large_gap"
-                android:progress="50"
-                app:progress_text_size="@dimen/progressbar_text"
-                android:id="@+id/images_used_by_wiki_progress_bar"
-                app:progress_end_color="#8C8B98"
-                app:progress_start_color="#3A3381"
-                app:progress_stroke_width="2.5dp"
-                android:visibility="gone"
-                app:progress_text_color="@color/secondaryColor"
-                app:progress_text_format_pattern=""
-                app:style="solid_line" />
+                app:showAnimationBehavior="outward"
+                app:indicatorColor="@color/primaryColor"
+                app:indicatorSize="32dp"
+                app:trackThickness="@dimen/progressbar_stroke"
+                app:trackColor="#B7B6B6"
+                android:visibility="gone"/>
 
               <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/tv_wiki_pb"

--- a/app/src/test/kotlin/fr/free/nrw/commons/wikidata/WikidataEditServiceTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/wikidata/WikidataEditServiceTest.kt
@@ -8,6 +8,7 @@ import com.nhaarman.mockitokotlin2.whenever
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import fr.free.nrw.commons.upload.UploadResult
 import fr.free.nrw.commons.upload.WikidataPlace
+import fr.free.nrw.commons.wikidata.model.RemoveClaim
 import io.reactivex.Observable
 import org.junit.Before
 import org.junit.Test
@@ -18,8 +19,6 @@ import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.MockitoAnnotations
-import fr.free.nrw.commons.wikidata.model.EditClaim
-import fr.free.nrw.commons.wikidata.model.RemoveClaim
 
 class WikidataEditServiceTest {
     @Mock
@@ -56,7 +55,8 @@ class WikidataEditServiceTest {
     fun testUpdateDepictsProperty() {
         val fileEntityId = "12345"
 
-        whenever(wikibaseClient.getClaimIdsByProperty("M" + fileEntityId, "P180"))
+        whenever(wikibaseClient.getClaimIdsByProperty("M" + fileEntityId,
+            WikidataProperties.DEPICTS.propertyName))
             .thenReturn(Observable.just(emptyList()))
         whenever(wikibaseClient.postDeleteClaims("M" + fileEntityId,
             gson.toJson(Mockito.mock(RemoveClaim::class.java)))

--- a/app/src/test/kotlin/fr/free/nrw/commons/wikidata/WikidataEditServiceTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/wikidata/WikidataEditServiceTest.kt
@@ -19,6 +19,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.MockitoAnnotations
 import fr.free.nrw.commons.wikidata.model.EditClaim
+import fr.free.nrw.commons.wikidata.model.RemoveClaim
 
 class WikidataEditServiceTest {
     @Mock
@@ -53,9 +54,15 @@ class WikidataEditServiceTest {
 
     @Test
     fun testUpdateDepictsProperty() {
-        whenever(wikibaseClient.postEditEntityByFilename("Test.jpg",
-            gson.toJson(Mockito.mock(EditClaim::class.java)))).thenReturn(Observable.just(true))
-        wikidataEditService.updateDepictsProperty("Test.jpg", listOf())
+        val fileEntityId = "12345"
+
+        whenever(wikibaseClient.getClaimIdsByProperty("M" + fileEntityId, "P180"))
+            .thenReturn(Observable.just(emptyList()))
+        whenever(wikibaseClient.postDeleteClaims("M" + fileEntityId,
+            gson.toJson(Mockito.mock(RemoveClaim::class.java)))
+        ).thenReturn(Observable.just(true))
+
+        wikidataEditService.updateDepictsProperty(fileEntityId, listOf())
     }
 
     @Test


### PR DESCRIPTION
**Description (required)**

Fixes #5793 and #5787 

What changes did you make and why?
- **1. testUpdateDepictsProperty**:- Update the test to adapt to the updateDepictsProperty() method.
- **2. Material Circular Progress Bar**:- Replace the deprecated progress bar with the material one.
- **3. SettingsActivity**:- Remove to logic to manually initialize `AppCompatDelegate` because it was causing SettingsActivity to crash. The reason is adding a new dependency for `Material Components`, it uses the latest version of appCompat library.


**Tests performed (required)**

Tested ProdDebug on Samsung A14 with API level 34.

**Screenshots (for UI changes only)**

None