### PR TITLE
Issue Fixed  #5758: Category related functionality such as explore search, viewing parent and sub categories of a category don't work

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/media/PageableMediaFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/media/PageableMediaFragment.kt
@@ -2,23 +2,14 @@ package fr.free.nrw.commons.explore.media
 
 import android.content.Context
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.category.CategoryImagesCallback
-import fr.free.nrw.commons.databinding.FragmentSearchPaginatedBinding
 import fr.free.nrw.commons.explore.paging.BasePagingFragment
 import fr.free.nrw.commons.media.MediaDetailPagerFragment.MediaDetailProvider
 
 abstract class PageableMediaFragment : BasePagingFragment<Media>(), MediaDetailProvider {
-
-    /**
-     * ViewBinding
-     */
-    private var _binding: FragmentSearchPaginatedBinding? = null
-    private val binding get() = _binding!!
 
     override val pagedListAdapter by lazy {
         PagedMediaAdapter(categoryImagesCallback::onMediaClicked)
@@ -39,15 +30,6 @@ abstract class PageableMediaFragment : BasePagingFragment<Media>(), MediaDetailP
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentSearchPaginatedBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
     private val simpleDataObserver =
         SimpleDataObserver { categoryImagesCallback.viewPagerNotifyDataSetChanged() }
 
@@ -57,7 +39,6 @@ abstract class PageableMediaFragment : BasePagingFragment<Media>(), MediaDetailP
     }
 
     override fun onDestroyView() {
-        _binding = null
         super.onDestroyView()
         pagedListAdapter.unregisterAdapterDataObserver(simpleDataObserver)
     }

--- a/app/src/main/java/fr/free/nrw/commons/explore/paging/BasePagingFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/paging/BasePagingFragment.kt
@@ -29,12 +29,19 @@ abstract class BasePagingFragment<T> : CommonsDaggerSupportFragment(),
     private val mergeAdapter by lazy { MergeAdapter(pagedListAdapter, loadingAdapter) }
     private var searchResults: LiveData<PagedList<T>>? = null
 
-    private var binding : FragmentSearchPaginatedBinding? = null
+    protected lateinit var binding : FragmentSearchPaginatedBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentSearchPaginatedBinding.inflate(inflater, container, false)
+        return binding.root
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val binding = FragmentSearchPaginatedBinding.bind(view)
-        this.binding = binding
 
         binding.paginatedSearchResultsList.apply {
             layoutManager = GridLayoutManager(context, if (isPortrait) 1 else 2)
@@ -51,7 +58,7 @@ abstract class BasePagingFragment<T> : CommonsDaggerSupportFragment(),
      */
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        binding!!.paginatedSearchResultsList.apply {
+        binding.paginatedSearchResultsList.apply {
             layoutManager = GridLayoutManager(context, if (isPortrait) 1 else 2)
         }
     }
@@ -75,15 +82,15 @@ abstract class BasePagingFragment<T> : CommonsDaggerSupportFragment(),
     }
 
     override fun hideInitialLoadProgress() {
-        binding!!.paginatedSearchInitialLoadProgress.visibility = GONE
+        binding.paginatedSearchInitialLoadProgress.visibility = GONE
     }
 
     override fun showInitialLoadInProgress() {
-        binding!!.paginatedSearchInitialLoadProgress.visibility = VISIBLE
+        binding.paginatedSearchInitialLoadProgress.visibility = VISIBLE
     }
 
     override fun showSnackbar() {
-        ViewUtil.showShortSnackbar(binding!!.paginatedSearchResultsList, errorTextId)
+        ViewUtil.showShortSnackbar(binding.paginatedSearchResultsList, errorTextId)
     }
 
     fun onQueryUpdated(query: String) {
@@ -91,14 +98,14 @@ abstract class BasePagingFragment<T> : CommonsDaggerSupportFragment(),
     }
 
     override fun showEmptyText(query: String) {
-        binding!!.contentNotFound.text = getEmptyText(query)
-        binding!!.contentNotFound.visibility = VISIBLE
+        binding.contentNotFound.text = getEmptyText(query)
+        binding.contentNotFound.visibility = VISIBLE
     }
 
     abstract fun getEmptyText(query: String): String
 
     override fun hideEmptyText() {
-        binding!!.contentNotFound.visibility = GONE
+        binding.contentNotFound.visibility = GONE
     }
 }
 


### PR DESCRIPTION
**Description (required)**

Fixes #5758

What changes did you make and why?
Changes were made to fix the UI Issue as described in #5758. When user navigate from Home Screen > Explore > Featured > Choose Any Media Post > Scroll to 'Categories' Section and Choose Any Category > Category Details Screen: On this screen when user navigate to 'SUBCATEGORIES' or 'PARENT CATEGORIES' tab, both screens show blank. It was due to optimisation was request for viewbinding handling in their parent fragments to fix this problem.

**Tests performed (required)**
Tested betaDebug on Android Studio Emulator with API level 34.

**Screenshots (for UI changes only)**
Due to the issue, the screens were showing as totally blank:

![Screenshot_20240917_012612](https://github.com/user-attachments/assets/8b2f1b7b-5e2e-4e80-b213-b229e03e507f)
![Screenshot_20240917_012619](https://github.com/user-attachments/assets/c0c02ed2-53f0-4435-806e-fc07ab1251bc)


After ViewBinding Optimisation:
![Screenshot_20240917_012941](https://github.com/user-attachments/assets/da896892-f806-49ea-a40c-130b459c595e)
![Screenshot_20240917_012947](https://github.com/user-attachments/assets/b6ed089a-0ac1-4245-a771-cba9b560985c)
