### PR TITLE
Fixes Issue #5832: Navigation Banner Appears in Media Details Screen

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -445,6 +445,27 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
         }
     }
 
+    /**
+     * Retrieves the ContributionsFragment that is potentially the parent, grandparent, etc
+     * fragment of this fragment.
+     * 
+     * @return The ContributionsFragment instance. If the ContributionsFragment instance could not
+     * be found, null is returned.
+     */
+    private ContributionsFragment getContributionsFragmentParent(){
+        Fragment f = this;
+
+        while(f != null && !(f instanceof ContributionsFragment)){
+            f = f.getParentFragment();
+        }
+
+        if(f != null){
+            return (ContributionsFragment)f;
+        } else {
+            return null;
+        }
+    }
+
     private void displayMediaDetails() {
         setTextFields(media);
         compositeDisposable.addAll(

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -362,15 +362,13 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
     @Override
     public void onResume() {
         super.onResume();
-        if (getParentFragment() != null && getParentFragment().getParentFragment() != null) {
-            //Added a check because, not necessarily, the parent fragment will have a parent fragment, say
-            // in the case when MediaDetailPagerFragment is directly started by the CategoryImagesActivity
-            if (getParentFragment() instanceof ContributionsFragment) {
-                ((ContributionsFragment) (getParentFragment()
-                    .getParentFragment())).binding.cardViewNearby
-                    .setVisibility(View.GONE);
-            }
+
+        //Hide the Nearby card when looking at media details
+        ContributionsFragment cf = this.getContributionsFragmentParent();
+        if(cf != null && cf.binding != null){
+            cf.binding.cardViewNearby.setVisibility(View.GONE);
         }
+
         // detail provider is null when fragment is shown in review activity
         if (detailProvider != null) {
             media = detailProvider.getMediaAtPosition(index);
@@ -448,7 +446,7 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
     /**
      * Retrieves the ContributionsFragment that is potentially the parent, grandparent, etc
      * fragment of this fragment.
-     * 
+     *
      * @return The ContributionsFragment instance. If the ContributionsFragment instance could not
      * be found, null is returned.
      */


### PR DESCRIPTION
**Description (required)**

Fixes #5832 

What changes did you make and why?

There were two changes made.

First, a helper method was created to easily retrieve the ContributionsFragment. Accessing the ContributionsFragment is required to hide the navigation banner.

(One concern I have with this helper method is that it attempts to find the ContributionsFragment by looping through the parent fragments repeatedly in a while loop. The advantage of this strategy is that it can retrieve the ContributionsFragment anywhere in the Fragment parent-child structure if it exists. The primary disadvantage is that if the Fragment parent-child structure is a loop with no ContributionsFragment, then the while loop will never terminate.

I can rewrite this method to retrieve the ContributionsFragment directly (using two calls to getParentFragment()), but this strategy is less flexible. **Should I rewrite this helper method to not use a while loop or is the current implementation okay?**)

Second, old code which attempted to hide the navigation banner (but was unsuccessful) was replaced with a call to the helper method and then checking for null objects. If the objects are not null, then the navigation banner is successfully hidden.



**Tests performed (required)**

Tested betaDebug on Android Studio Emulator with API level 34.

**Screenshots (for UI changes only)**

[issue_5832_compressed.webm](https://github.com/user-attachments/assets/1ad66a66-1684-46a0-8c7c-ac66ca0980da)

In this video, the navigation banner is visible from the contributions menu. When a specific contribution is selected, the navigation banner is hidden. Once the back button is pressed, the contributions menu appears with the navigation banner visible again.
