### PR TITLE
Issue 5835 nearby

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1380,7 +1380,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
 
         // Instead of loading all pins in a single SPARQL query, we query in batches.
         // This variable controls the number of pins queried per batch.
-        int batchSize = 50;
+        int batchSize = 3;
 
         updatedLatLng = curLatLng;
         updatedPlacesList = new ArrayList<>(placeList);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -212,7 +212,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     private boolean isSearchInProgress = false;
     private final Handler searchHandler = new Handler();
     private Runnable searchRunnable;
-    private static final long SCROLL_DELAY = 800; // Delay for debounce of onscroll
+    private static final long SCROLL_DELAY = 800; // Delay for debounce of onscroll, in milliseconds.
 
     private List<Place> updatedPlacesList;
     private LatLng updatedLatLng;


### PR DESCRIPTION
Fixes #5835 

Fix for reported bug: Nearby map does not show new pins when moving map a little, especially noticeable when zoomed in

What changes did you make and why?

Modified NearbyParentFragment.java:

- Onscroll - removed distance threshold that was requiring the user to scroll a distance of at least 2000m before a search was initiated.  Added logic to delay search by 800ms when OnScroll is fired, mulitple scrolls within 800ms are debounced and only most recent is actioned.

- OnDestroy - destroy any queued OnScroll initiated searches that could be waiting to run when the OnDestroy event is fired.


**Tests performed (required)**

- Tested main app on virtual device API Level 35

- Ran all automatic tests, same results as unmodified code base.

- Tested Nearby screen on virtual device:
-- multiple scrolls within 800ms threshold
-- scroll and wait 800ms for search initiation
--make successive scrolls within 10 seconds

Test notes:
- Experienced occassional HTTP 500 error but it is coming from the unchanged UpdateMarkers()  


**Screenshots (for UI changes only)**
- no UI changes included
