### PR TITLE
(fixes #5855) fetch item label in nearby based on user configured lan…

### DIFF
--- a/app/src/main/resources/queries/query_for_item.rq
+++ b/app/src/main/resources/queries/query_for_item.rq
@@ -18,7 +18,7 @@ WHERE {
   }
 
   # Get the label in the preferred language of the user, or any other language if no label is available in that language.
-  OPTIONAL {?item rdfs:label ?itemLabelPreferredLanguage. FILTER (lang(?itemLabelPreferredLanguage) = "en")}
+  OPTIONAL {?item rdfs:label ?itemLabelPreferredLanguage. FILTER (lang(?itemLabelPreferredLanguage) = "${LANG}")}
   OPTIONAL {?item rdfs:label ?itemLabelAnyLanguage}
   BIND(COALESCE(?itemLabelPreferredLanguage, ?itemLabelAnyLanguage, "?") as ?label)
 


### PR DESCRIPTION
Fix the Nearby functionality to fetch Item tag based on user's preferred language

Currently, the nearby feature, fetches all the labels to be in English. However, the expected behaviour would be to fetch based on user's preferred language.

Fixes #5855 

### What changes did you make and why?
The only change made was to the query [file](app/src/main/resources/queries/query_for_item.rq). It was updated to fetch labels based on `{LANG}` variable. 

## Tests performed (required)
Tested `ProdDebug` on Pixel 7 with API level 34 to ensure that Wiki Items were presented with labels in user language if available. Tested for the Wiki Item [Bust of Gustave Eiffel](https://www.wikidata.org/wiki/Q2928782).  The languages tested were, French, Armenian, Arabic & Turkish. Before each screenshot was taken, language preference was updated and then the item was located in Nearby.

<img src="https://github.com/user-attachments/assets/9814caee-c1b4-437f-a8d7-6b08f410717b"  width=200 />
<img src="https://github.com/user-attachments/assets/495c1a8c-2590-4134-b67f-35a8cf25123d"  width=200 />
<img src="https://github.com/user-attachments/assets/3609814b-e0ce-499e-b020-91b6f2fd4cad"  width=200 />
<img src="https://github.com/user-attachments/assets/3497e917-3e0d-4aba-964f-3484a7aa5651"  width=200 />
