### PR TITLE
(fixes #5803) Modify image author name to licensing name. (#5803)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/media/MediaConverter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/media/MediaConverter.kt
@@ -40,7 +40,7 @@ class MediaConverter
                 metadata.licenseShortName(),
                 metadata.prefixedLicenseUrl,
                 getAuthor(metadata),
-                imageInfo.user,
+                getAuthor(metadata),
                 MediaDataExtractorUtil.extractCategoriesFromList(metadata.categories),
                 metadata.latLng,
                 entity.labels().mapValues { it.value.value() },


### PR DESCRIPTION
**Description (required)**

Fixes #5803

What changes did you make and why?

Replaced imageInfo.user with getAuthor(metadata)

Previously, the code was using imageInfo.user, which likely refers to the registered username of the person who uploaded the media. The new code uses getAuthor(metadata), which extracts the author information from the ExtMetadata object, likely referring to the custom author name. The purpose of this change is to ensure that the user profile shows the licensing name (custom author name) instead of the registered username. 

**Tests performed (required)**

Tested {ProdDebug} on {Pixel 3a emulator} with API level {34}.

**Screenshots (for UI changes only)**
The custom user name I set is 'tester', my registered username is 'Wikoliatest' 

<img width="195" alt="image" src="https://github.com/user-attachments/assets/c362566c-cd31-4992-a36c-6805230c88bb">

<img width="226" alt="image" src="https://github.com/user-attachments/assets/2e22cf60-fdfe-4d7d-98ed-049bf2b48dbb">

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
