### PR TITLE
Fixes Issue#5853 Tapping a "... sent you an email" notification has no effect

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -19,6 +19,7 @@ import fr.free.nrw.commons.databinding.ActivityNotificationBinding;
 import fr.free.nrw.commons.auth.SessionManager;
 import fr.free.nrw.commons.auth.csrf.InvalidLoginTokenException;
 import fr.free.nrw.commons.notification.models.Notification;
+import fr.free.nrw.commons.notification.models.NotificationType;
 import fr.free.nrw.commons.theme.BaseActivity;
 import fr.free.nrw.commons.utils.NetworkUtils;
 import fr.free.nrw.commons.utils.ViewUtil;
@@ -148,7 +149,11 @@ public class NotificationActivity extends BaseActivity {
         }
         adapter = new NotificatinAdapter(item -> {
             Timber.d("Notification clicked %s", item.getLink());
-            handleUrl(item.getLink());
+            if (item.getNotificationType() == NotificationType.EMAIL){
+                ViewUtil.showLongSnackbar(binding.container,getString(R.string.check_your_email_inbox));
+            } else {
+                handleUrl(item.getLink());
+            }
             removeNotification(item);
             return Unit.INSTANCE;
         });

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationClient.kt
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationClient.kt
@@ -51,13 +51,23 @@ class NotificationClient
                 }
             }
 
-        private fun WikimediaNotification.toCommonsNotification() =
-            Notification(
-                notificationType = NotificationType.UNKNOWN,
-                notificationText = contents?.compactHeader ?: "",
-                date = DateUtil.getMonthOnlyDateString(timestamp),
-                link = contents?.links?.primary?.url ?: "",
-                iconUrl = "",
-                notificationId = id().toString(),
-            )
+        private fun WikimediaNotification.toCommonsNotification() :
+            Notification {
+            val notificationText = contents?.compactHeader ?: ""
+            val notificationType =
+                if (notificationText.contains("Sent you an email", ignoreCase = true)) {
+                    NotificationType.EMAIL
+                } else {
+                    NotificationType.UNKNOWN
+                }
+
+                return Notification(
+                    notificationType = notificationType,
+                    notificationText = notificationText,
+                    date = DateUtil.getMonthOnlyDateString(timestamp),
+                    link = contents?.links?.primary?.url ?: "",
+                    iconUrl = "",
+                    notificationId = id().toString(),
+                )
+        }
     }

--- a/app/src/main/java/fr/free/nrw/commons/notification/models/NotificationType.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/models/NotificationType.java
@@ -4,6 +4,7 @@ public enum NotificationType {
     THANK_YOU_EDIT("thank-you-edit"),
     EDIT_USER_TALK("edit-user-talk"),
     MENTION("mention"),
+    EMAIL("email"),
     WELCOME("welcome"),
     UNKNOWN("unknown");
     private String type;

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -679,6 +679,7 @@
   <string name="error_sending_thanks">作者への感謝の送信エラー。</string>
   <string name="invalid_login_message">ログインが期限切れになりました。もう一度ログインしてください。</string>
   <string name="no_application_available_to_open_gpx_files">GPXファイルを開くことができるアプリケーションがありません</string>
+  <string name="check_your_email_inbox">メールをご確認ください</string>
   <plurals name="custom_picker_images_selected_title_appendix">
     <item quantity="other">%d件の画像が選択されました</item>
   </plurals>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -111,4 +111,5 @@
   <string name="detail_description_empty">没有说明</string>
   <string name="detail_license_empty">未知授权协议</string>
   <string name="menu_refresh">刷新</string>
+  <string name="check_your_email_inbox">请查看你的电子邮箱</string>
 </resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -215,4 +215,5 @@
   <string name="description_info">請盡可能描述媒體內容：拍攝於何處？是顯示什麼事物？有什麼脈絡？請描述對象或人物。透露出一些較不易猜測的訊息，例如是風景的話，可以是一天裡的時間。如果媒體顯示出了一些不尋常的事物，請說明不尋常原因。</string>
   <string name="learn_how_to_write_a_useful_description">學習如何編寫有用的描述</string>
   <string name="learn_how_to_write_a_useful_caption">學習如何編寫有用的標題</string>
+  <string name="check_your_email_inbox">請查看你的電子郵件信箱</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -805,4 +805,5 @@
   <string name="pending">待處理</string>
   <string name="failed">失敗</string>
   <string name="could_not_load_place_data">無法載入地點資料</string>
+  <string name="check_your_email_inbox">請查看你的電子郵件信箱</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -834,4 +834,5 @@
   <string name="pending">待处理</string>
   <string name="failed">失败</string>
   <string name="could_not_load_place_data">无法加载地点数据</string>
+  <string name="check_your_email_inbox">请查看你的电子邮箱</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -504,6 +504,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="no_notification">You have no unread notifications</string>
   <string name="no_read_notification">You have no read notifications</string>
   <string name="share_logs_using">Share logs using</string>
+  <string name="check_your_email_inbox">Check your email inbox</string>
   <string name="menu_option_read">View read</string>
   <string name="menu_option_unread">View unread</string>
 


### PR DESCRIPTION
This change improves the user experience by ensuring email notifications are properly categorized and provides useful feedback when they are clicked.

**Description (required)**

Fixes #5853 

What changes did you make and why?

This Pull request adds logic to classify notifications as "email" type when the notification text contains "sent you an email". This change ensures that email notifications are properly categorized, which was previously missing, leading to all email notifications being marked as UNKNOWN type.

Previously, email-related notifications from the backend were missing a URL. As a result, when users clicked on these notifications, there was no link to open, and the notifications were categorized as UNKNOWN. This led to a poor user experience since there was no feedback provided when the user clicked on an email notification.

Changes:

- **NotificationClient:**

    - Modified `WikimediaNotification.toCommonsNotification()` to check if the notification text contains "sent you an email". If it does, the notification is classified as `EMAIL` instead of the default `UNKNOWN`.

- **NotificationActivity:**

  - In the `NotificatinAdapter` click handler, added a check for `EMAI` type. When an email-type notification is clicked, a "Check your mail box" prompt is shown using `Snackbar`, instead of attempting to open a URL (which is typically missing for such notifications).

- **NotificationType:**

   - Added a new `EMAIL` type to categorize email-related notifications.

- **Localization:**

  - Added localized translations for "Check your email inbox" in `values-zh/strings.xml`, `values-zh-rhk/strings.xml`, `values-zh-rcn/strings.xml`, `values-zh-rtw/strings.xml`, and `values-ja/string.xml` to improve user experience for non-English speakers.
   
**Tests performed (required)**

Tested {build variant} on {Galaxy s20 SM-G9810} with API level {33}.

**Screenshots (for UI changes only)**
![image](https://github.com/user-attachments/assets/5f9144d7-309e-4db4-b007-6f335b5b505c)
![image](https://github.com/user-attachments/assets/d5ea1590-4165-47aa-9463-4132a05719fd)
![image](https://github.com/user-attachments/assets/786b81b8-eea4-44e7-8e10-77e50b1fe067)
