### PR TITLE
fixed issue #5829

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/PendingUploadsFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/PendingUploadsFragment.kt
@@ -116,6 +116,7 @@ class PendingUploadsFragment :
 
     /**
      * Cancels a specific upload after getting a confirmation from the user using Dialog.
+     * And if the deleted upload is the last one, will set app off paused, allowing a fresh new start for future uploads.
      */
     override fun deleteUpload(contribution: Contribution?) {
         showAlertDialog(
@@ -131,6 +132,8 @@ class PendingUploadsFragment :
             String.format(Locale.getDefault(), requireActivity().getString(R.string.yes)),
             String.format(Locale.getDefault(), requireActivity().getString(R.string.no)),
             {
+                if(contributionsList.size== 1)
+                {CommonsApplication.isPaused = false}
                 ViewUtil.showShortToast(context, R.string.cancelling_upload)
                 pendingUploadsPresenter.deleteUpload(
                     contribution,


### PR DESCRIPTION
**Description (required)**

Fixes #5829

What changes did you make and why?
Since currently when you pause all the upload and delete them, the app is still at paused state, making future uploads unable to start automatically(you need to click the restart button after creating new uploads)
i modified deleteUpload() in PendingUploadsFragment.kt.
To give future uploads a fresh start after pausing and deleting all the pending upload, I added some code to check if the deleted upload is the last one, if yes, set the app off paused. 

**Tests performed (required)**

Tested ProdDebug build variant on Pixel 3a emulator with API level 34.

I manually tested the changes by pausing all uploads, deleting them, and confirming that new uploads start automatically without needing to click the restart button. Since this change only affects a small part of the code, I believe manual testing is sufficient to verify the functionality.

**Screenshots (for UI changes only)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
