### PR TITLE
Fix for #5846: After uploading via Nearby, I am sent back to Nearby, where I am mislead into thinking that I must upload again #5846

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -321,6 +321,14 @@ public class UploadActivity extends BaseActivity implements UploadContract.View,
     }
 
     /**
+     * go to the uploadProgress activity to check the status of uploading
+     */
+    @Override
+    public void goToUploadProgressActivity() {
+        startActivity(new Intent(this, UploadProgressActivity.class));
+    }
+
+    /**
      * Show/Hide the progress dialog
      */
     @Override

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadContract.java
@@ -18,6 +18,13 @@ public interface UploadContract {
 
         void returnToMainActivity();
 
+        /**
+         * When submission successful, go to the loadProgressActivity to hint the user this
+         * submission is valid. And the user will see the upload progress in this activity;
+         * Fixes: <a href="https://github.com/commons-app/apps-android-commons/issues/5846">Issue</a>
+         */
+        void goToUploadProgressActivity();
+
         void askUserToLogIn();
 
         /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.java
@@ -123,6 +123,9 @@ public class UploadPresenter implements UploadContract.UserActionListener {
                             view.returnToMainActivity();
                             compositeDisposable.clear();
                             Timber.e("failed to upload: " + e.getMessage());
+
+                            //is submission error, not need to go to the uploadActivity
+                            //not start the uploading progress
                         }
 
                         @Override
@@ -131,6 +134,10 @@ public class UploadPresenter implements UploadContract.UserActionListener {
                             repository.cleanup();
                             view.returnToMainActivity();
                             compositeDisposable.clear();
+
+                            //after finish the uploadActivity, if successful,
+                            //directly go to the upload progress activity
+                            view.goToUploadProgressActivity();
                         }
                     });
         } else {


### PR DESCRIPTION
fixes https://github.com/commons-app/apps-android-commons/issues/5846

**Description**
1. Add the method (**goToUploadProgressActivity**()) in the **UploadContract** interface.
2. Use the implementation in the **UploadPresenter** class after the successful submission of photo.
3. Fix the BUG and the app can directly go to the upload progress after submission.



https://github.com/user-attachments/assets/57aa64f4-1483-41f1-9bb5-bad0993d0666






