### PR TITLE
Fix issue #5873

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/ImageFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/ImageFragment.kt
@@ -285,9 +285,11 @@ class ImageFragment :
                 imageAdapter.notifyDataSetChanged()
                 selectorRV?.let {
                     it.visibility = View.VISIBLE
-                    lastItemId?.let { pos ->
-                        (it.layoutManager as GridLayoutManager)
-                            .scrollToPosition(ImageHelper.getIndexFromId(filteredImages, pos))
+                    if (switch?.isChecked == false) {
+                        lastItemId?.let { pos ->
+                            (it.layoutManager as GridLayoutManager)
+                                .scrollToPosition(ImageHelper.getIndexFromId(filteredImages, pos))
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
Resolved an issue where RecyclerView would incorrectly scroll to the top after exiting fullscreen preview. Adjusted scroll behavior to maintain position unless actioned images are filtered. Implemented observer logic adjustments to handle dataset updates more efficiently.

https://github.com/user-attachments/assets/31c428fd-2db8-4a93-9b4a-7e49078f4d2c


Closes #5873 