### PR TITLE
 Fixing #5755 with UI automator tests

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,16 +1,12 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
-    <inspection_tool class="AndroidLintNewerVersionAvailable" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="AutoCloseableResource" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ClassWithOnlyPrivateConstructors" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingElse" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="reportWhenNoStatementFollow" value="true" />
     </inspection_tool>
     <inspection_tool class="ControlFlowStatementWithoutBraces" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DefaultNotLastCaseInSwitch" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ExplicitThis" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
-    <inspection_tool class="FieldMayBeFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="LocalCanBeFinal" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="REPORT_VARIABLES" value="true" />
       <option name="REPORT_PARAMETERS" value="true" />
@@ -25,13 +21,11 @@
       <option name="ignoreInMatchingInstanceof" value="false" />
     </inspection_tool>
     <inspection_tool class="ProblematicWhitespace" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ProtectedMemberInFinalClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="RedundantFieldInitialization" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="RedundantImplements" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreSerializable" value="false" />
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
-    <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SimplifiableEqualsExpression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TypeParameterExtendsFinalClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessarilyQualifiedStaticUsage" enabled="true" level="WARNING" enabled_by_default="true">
@@ -47,6 +41,5 @@
     <inspection_tool class="UnnecessaryQualifierForThis" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessarySuperConstructor" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessaryThis" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryToStringCall" enabled="true" level="WARNING" enabled_by_default="true" />
   </profile>
 </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,11 @@ if (isRunningOnTravisAndIsNotPRBuild) {
 
 dependencies {
 
+    def appcompat_version = "1.7.0"
+    implementation "androidx.appcompat:appcompat:$appcompat_version"
+    // For loading and tinting drawables on older versions of the platform
+    implementation "androidx.appcompat:appcompat-resources:$appcompat_version"
+
     // Utils
     implementation 'in.yuvi:http.fluent:1.3'
     implementation 'com.google.code.gson:gson:2.8.5'
@@ -386,6 +391,9 @@ android {
     lint {
         abortOnError false
         disable 'MissingTranslation', 'ExtraTranslation'
+    }
+    androidResources {
+        generateLocaleConfig true
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -380,7 +380,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.3.2'
+        kotlinCompilerExtensionVersion '1.5.8'
     }
     namespace 'fr.free.nrw.commons'
     lint {

--- a/app/src/androidTest/java/fr/free/nrw/commons/ui/AppLanguagesSystemTest.java
+++ b/app/src/androidTest/java/fr/free/nrw/commons/ui/AppLanguagesSystemTest.java
@@ -1,0 +1,58 @@
+package fr.free.nrw.commons.ui;
+
+import androidx.test.uiautomator.UiScrollable;
+import androidx.test.uiautomator.UiSelector;
+import androidx.test.uiautomator.UiObject;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.platform.app.InstrumentationRegistry;
+import android.content.Intent;
+import android.provider.Settings;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class AppLanguagesSystemTest {
+
+    private UiDevice device;
+
+    @Before
+    public void setUp() {
+        // Initiate UI Automator
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+
+        // Use Intent to start system application
+        Intent intent = new Intent(Settings.ACTION_SETTINGS);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        InstrumentationRegistry.getInstrumentation().getContext().startActivity(intent);
+
+        // wait Settings starting
+        device.waitForIdle();
+    }
+
+    @Test
+    public void testCommonsAppLanguageOptionExists() throws Exception {
+        // 1. Find and click "System"
+        UiScrollable settingsList = new UiScrollable(new UiSelector().scrollable(true));
+        UiObject systemOption = settingsList.getChildByText(new UiSelector().text("System"), "System");
+        systemOption.click();
+
+        // 2. scroll and find "Languages & input"
+        UiObject languagesInputOption = device.findObject(new UiSelector()
+            .className("android.widget.TextView")
+            .textContains("Gboard"));
+        languagesInputOption.clickAndWaitForNewWindow();
+
+
+
+
+        // 3. detect "App languages" and click
+        UiObject appLanguagesOption = device.findObject(new UiSelector().text("App languages"));
+        appLanguagesOption.clickAndWaitForNewWindow();
+
+        // 4. detect "Commons" APP is there
+        UiScrollable appLanguagesList = new UiScrollable(new UiSelector().scrollable(true));
+        UiObject commonsAppOption = appLanguagesList.getChildByText(new UiSelector().text("Commons"), "Commons");
+
+        assert(commonsAppOption.exists());
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -193,6 +193,13 @@
     <service
       android:name="androidx.work.impl.foreground.SystemForegroundService"
       android:foregroundServiceType="dataSync" />
+    <service
+      android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
+      android:enabled="false">
+      <meta-data
+        android:name="autoStoreLocales"
+        android:value="true" />
+    </service>
 
     <provider
       android:name=".filepicker.ExtendedFileProvider"

--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -124,7 +124,7 @@ public class MainActivity extends BaseActivity
         setContentView(binding.getRoot());
         setSupportActionBar(binding.toolbarBinding.toolbar);
         tabLayout = binding.fragmentMainNavTabLayout;
-        loadLocale();
+//        loadLocale();
 
         binding.toolbarBinding.toolbar.setNavigationOnClickListener(view -> {
             onSupportNavigateUp();
@@ -485,13 +485,13 @@ public class MainActivity extends BaseActivity
     /**
      * Load default language in onCreate from SharedPreferences
      */
-    private void loadLocale() {
-        final SharedPreferences preferences = getSharedPreferences("Settings",
-            Activity.MODE_PRIVATE);
-        final String language = preferences.getString("language", "");
-        final SettingsFragment settingsFragment = new SettingsFragment();
-        settingsFragment.setLocale(this, language);
-    }
+//    private void loadLocale() {
+//        final SharedPreferences preferences = getSharedPreferences("Settings",
+//            Activity.MODE_PRIVATE);
+//        final String language = preferences.getString("language", "");
+//        final SettingsFragment settingsFragment = new SettingsFragment();
+//        settingsFragment.setLocale(this, language);
+//    }
 
     public NavTabLayout.OnNavigationItemSelectedListener getNavListener() {
         return navListener;

--- a/app/src/main/java/fr/free/nrw/commons/customselector/database/NotForUploadStatusDao.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/database/NotForUploadStatusDao.kt
@@ -15,19 +15,19 @@ abstract class NotForUploadStatusDao {
      * Insert into Not For Upload status.
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract suspend fun insert(notForUploadStatus: NotForUploadStatus)
+    abstract fun insert(notForUploadStatus: NotForUploadStatus)
 
     /**
      * Delete Not For Upload status entry.
      */
     @Delete
-    abstract suspend fun delete(notForUploadStatus: NotForUploadStatus)
+    abstract fun delete(notForUploadStatus: NotForUploadStatus)
 
     /**
      * Query Not For Upload status with image sha1.
      */
     @Query("SELECT * FROM images_not_for_upload_table WHERE imageSHA1 = (:imageSHA1) ")
-    abstract suspend fun getFromImageSHA1(imageSHA1: String): NotForUploadStatus?
+    abstract fun getFromImageSHA1(imageSHA1: String): NotForUploadStatus?
 
     /**
      * Asynchronous image sha1 query.
@@ -38,7 +38,7 @@ abstract class NotForUploadStatusDao {
      * Deletion Not For Upload status with image sha1.
      */
     @Query("DELETE FROM images_not_for_upload_table WHERE imageSHA1 = (:imageSHA1) ")
-    abstract suspend fun deleteWithImageSHA1(imageSHA1: String)
+    abstract fun deleteWithImageSHA1(imageSHA1: String)
 
     /**
      * Asynchronous image sha1 deletion.
@@ -49,5 +49,5 @@ abstract class NotForUploadStatusDao {
      * Check whether the imageSHA1 is present in database
      */
     @Query("SELECT COUNT() FROM images_not_for_upload_table WHERE imageSHA1 = (:imageSHA1) ")
-    abstract suspend fun find(imageSHA1: String): Int
+    abstract fun find(imageSHA1: String): Int
 }

--- a/app/src/main/java/fr/free/nrw/commons/customselector/database/UploadedStatusDao.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/database/UploadedStatusDao.kt
@@ -17,31 +17,31 @@ abstract class UploadedStatusDao {
      * Insert into uploaded status.
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract suspend fun insert(uploadedStatus: UploadedStatus)
+    abstract fun insert(uploadedStatus: UploadedStatus)
 
     /**
      * Update uploaded status entry.
      */
     @Update
-    abstract suspend fun update(uploadedStatus: UploadedStatus)
+    abstract fun update(uploadedStatus: UploadedStatus)
 
     /**
      * Delete uploaded status entry.
      */
     @Delete
-    abstract suspend fun delete(uploadedStatus: UploadedStatus)
+    abstract fun delete(uploadedStatus: UploadedStatus)
 
     /**
      * Query uploaded status with image sha1.
      */
     @Query("SELECT * FROM uploaded_table WHERE imageSHA1 = (:imageSHA1) ")
-    abstract suspend fun getFromImageSHA1(imageSHA1: String): UploadedStatus?
+    abstract fun getFromImageSHA1(imageSHA1: String): UploadedStatus?
 
     /**
      * Query uploaded status with modified image sha1.
      */
     @Query("SELECT * FROM uploaded_table WHERE modifiedImageSHA1 = (:modifiedImageSHA1) ")
-    abstract suspend fun getFromModifiedImageSHA1(modifiedImageSHA1: String): UploadedStatus?
+    abstract fun getFromModifiedImageSHA1(modifiedImageSHA1: String): UploadedStatus?
 
     /**
      * Asynchronous insert into uploaded status table.
@@ -55,7 +55,7 @@ abstract class UploadedStatusDao {
      * Check whether the imageSHA1 is present in database
      */
     @Query("SELECT COUNT() FROM uploaded_table WHERE imageSHA1 = (:imageSHA1) AND imageResult = (:imageResult) ")
-    abstract suspend fun findByImageSHA1(
+    abstract fun findByImageSHA1(
         imageSHA1: String,
         imageResult: Boolean,
     ): Int
@@ -66,7 +66,7 @@ abstract class UploadedStatusDao {
     @Query(
         "SELECT COUNT() FROM uploaded_table WHERE modifiedImageSHA1 = (:modifiedImageSHA1) AND modifiedImageResult = (:modifiedImageResult) ",
     )
-    abstract suspend fun findByModifiedImageSHA1(
+    abstract fun findByModifiedImageSHA1(
         modifiedImageSHA1: String,
         modifiedImageResult: Boolean,
     ): Int

--- a/app/src/main/java/fr/free/nrw/commons/recentlanguages/RecentLanguagesAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/recentlanguages/RecentLanguagesAdapter.kt
@@ -27,7 +27,8 @@ class RecentLanguagesAdapter constructor(
 
     override fun isEnabled(position: Int) =
         recentLanguages[position].languageCode.let {
-            it.isNotEmpty() && !selectedLanguages.containsValue(it) && it != selectedLangCode
+//            it.isNotEmpty() && !it.contains(selectedLanguages.values.first())
+            true
         }
 
     override fun getCount() = recentLanguages.size

--- a/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/Prefs.java
@@ -8,6 +8,8 @@ public class Prefs {
     public static final String UPLOADS_SHOWING = "uploadsshowing";
     public static final String MANAGED_EXIF_TAGS = "managed_exif_tags";
     public static final String DESCRIPTION_LANGUAGE = "languageDescription";
+    public static final String SECONDARY_LANGUAGE = "languageSecondary";
+
     public static final String APP_UI_LANGUAGE = "appUiLanguage";
     public static final String KEY_THEME_VALUE = "appThemePref";
 

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.settings;
 import static android.content.Context.MODE_PRIVATE;
 
 import android.Manifest.permission;
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.Intent;
@@ -21,6 +22,8 @@ import android.widget.TextView;
 import androidx.activity.result.ActivityResultCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.os.LocaleListCompat;
 import androidx.preference.ListPreference;
 import androidx.preference.MultiSelectListPreference;
 import androidx.preference.Preference;
@@ -267,6 +270,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         );
     }
 
+    @SuppressLint("RestrictedApi")
     @Override
     protected Adapter onCreateAdapter(final PreferenceScreen preferenceScreen) {
         return new PreferenceGroupAdapter(preferenceScreen) {
@@ -314,7 +318,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
 
             assert languageCode != null;
             if (languageCode.equals("")) {
-                selectedLanguages.put(0, Locale.getDefault().getLanguage());
+                selectedLanguages.put(0, AppCompatDelegate.getApplicationLocales().toLanguageTags());
             } else {
                 selectedLanguages.put(0, languageCode);
             }
@@ -396,14 +400,11 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                     recentLanguagesDao.deleteRecentLanguage(languageCode);
                 }
                 recentLanguagesDao.addRecentLanguage(new Language(languageName, languageCode));
-                saveLanguageValue(languageCode, keyListPreference);
                 Locale defLocale = createLocale(languageCode);
                 if(keyListPreference.equals("appUiDefaultLanguagePref")) {
                     appUiLanguageListPreference.setSummary(defLocale.getDisplayLanguage(defLocale));
-                    setLocale(requireActivity(), languageCode);
-                    getActivity().recreate();
-                    final Intent intent = new Intent(getActivity(), MainActivity.class);
-                    startActivity(intent);
+                    LocaleListCompat appLocale = LocaleListCompat.forLanguageTags(languageCode);
+                    AppCompatDelegate.setApplicationLocales(appLocale);
                 }else if(keyListPreference.equals("descriptionDefaultLanguagePref")){
                     descriptionLanguageListPreference.setSummary(defLocale.getDisplayLanguage(defLocale));
                 }
@@ -468,10 +469,8 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         final Locale defLocale = createLocale(recentLanguageCode);
         if (keyListPreference.equals("appUiDefaultLanguagePref")) {
             appUiLanguageListPreference.setSummary(defLocale.getDisplayLanguage(defLocale));
-            setLocale(requireActivity(), recentLanguageCode);
-            getActivity().recreate();
-            final Intent intent = new Intent(getActivity(), MainActivity.class);
-            startActivity(intent);
+            LocaleListCompat appLocale = LocaleListCompat.forLanguageTags(recentLanguageCode);
+            AppCompatDelegate.setApplicationLocales(appLocale);
         } else {
             descriptionLanguageListPreference.setSummary(defLocale.getDisplayLanguage(defLocale));
         }

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -79,6 +79,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
 
     private ListPreference themeListPreference;
     private Preference descriptionLanguageListPreference;
+    private Preference descriptionSecondaryLanguageListPreference;
     private Preference appUiLanguageListPreference;
     private String keyLanguageListPreference;
     private TextView recentLanguagesTextView;
@@ -152,6 +153,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         appUiLanguageListPreference.setOnPreferenceClickListener(new OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {
+                System.out.println("Clicked appui");
                 prepareAppLanguages(appUiLanguageListPreference.getKey());
                 return true;
             }
@@ -174,6 +176,28 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             @Override
             public boolean onPreferenceClick(Preference preference) {
                 prepareAppLanguages(descriptionLanguageListPreference.getKey());
+                return true;
+            }
+        });
+
+        descriptionSecondaryLanguageListPreference = findPreference("descriptionSecondaryLanguagePref");
+        assert descriptionSecondaryLanguageListPreference != null;
+        keyLanguageListPreference = descriptionSecondaryLanguageListPreference.getKey();
+        languageCode = getCurrentLanguageCode(keyLanguageListPreference);
+        assert languageCode != null;
+        if (languageCode.equals("")) {
+            // If current language code is empty, means none selected by user yet so use phone local
+            descriptionSecondaryLanguageListPreference.setSummary(Locale.getDefault().getDisplayLanguage());
+        } else {
+            // If any language is selected by user previously, use it
+            Locale defLocale = createLocale(languageCode);
+            descriptionSecondaryLanguageListPreference.setSummary(defLocale.getDisplayLanguage(defLocale));
+        }
+        descriptionSecondaryLanguageListPreference.setOnPreferenceClickListener(new OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                System.out.println("clickedseco");
+                prepareAppLanguages(descriptionSecondaryLanguageListPreference.getKey());
                 return true;
             }
         });
@@ -205,6 +229,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             findPreference("useAuthorName").setEnabled(false);
             findPreference("displayNearbyCardView").setEnabled(false);
             findPreference("descriptionDefaultLanguagePref").setEnabled(false);
+            findPreference("descriptionSecondaryLanguagePref").setEnabled(false);
             findPreference("displayLocationPermissionForCardView").setEnabled(false);
             findPreference(CampaignView.CAMPAIGNS_DEFAULT_PREFERENCE).setEnabled(false);
             findPreference("managed_exif_tags").setEnabled(false);
@@ -278,6 +303,8 @@ public class SettingsFragment extends PreferenceFragmentCompat {
      */
     private void prepareAppLanguages(final String keyListPreference) {
 
+        System.out.println("gets to prepare app languages");
+
         // Gets current language code from shared preferences
         final String languageCode = getCurrentLanguageCode(keyListPreference);
         final List<Language> recentLanguages = recentLanguagesDao.getRecentLanguages();
@@ -300,7 +327,16 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             } else {
                 selectedLanguages.put(0, languageCode);
             }
+        } else if (keyListPreference.equals("descriptionSecondaryLanguagePref")) {
+
+        assert languageCode != null;
+        if (languageCode.equals("")) {
+            selectedLanguages.put(0, Locale.getDefault().getLanguage());
+
+        } else {
+            selectedLanguages.put(0, languageCode);
         }
+    }
 
         LanguagesAdapter languagesAdapter = new LanguagesAdapter(
             getActivity(),
@@ -368,8 +404,11 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                     getActivity().recreate();
                     final Intent intent = new Intent(getActivity(), MainActivity.class);
                     startActivity(intent);
-                }else {
+                }else if(keyListPreference.equals("descriptionDefaultLanguagePref")){
                     descriptionLanguageListPreference.setSummary(defLocale.getDisplayLanguage(defLocale));
+                }
+                else{
+                    descriptionSecondaryLanguageListPreference.setSummary(defLocale.getDisplayLanguage(defLocale));
                 }
                 dialog.dismiss();
             }
@@ -496,6 +535,8 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             defaultKvStore.putString(Prefs.APP_UI_LANGUAGE, userSelectedValue);
         } else if (preferenceKey.equals("descriptionDefaultLanguagePref")) {
             defaultKvStore.putString(Prefs.DESCRIPTION_LANGUAGE, userSelectedValue);
+        } else if (preferenceKey.equals("descriptionSecondaryLanguagePref")) {
+            defaultKvStore.putString(Prefs.SECONDARY_LANGUAGE, userSelectedValue);
         }
     }
 
@@ -510,6 +551,9 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         }
         if (preferenceKey.equals("descriptionDefaultLanguagePref")) {
             return defaultKvStore.getString(Prefs.DESCRIPTION_LANGUAGE, "");
+        }
+        if (preferenceKey.equals("descriptionSecondaryLanguagePref")) {
+            return defaultKvStore.getString(Prefs.SECONDARY_LANGUAGE, "");
         }
         return null;
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/LanguagesAdapter.kt
@@ -51,7 +51,8 @@ class LanguagesAdapter constructor(
 
     override fun isEnabled(position: Int) =
         languageCodesList[position].let {
-            it.isNotEmpty() && !selectedLanguages.containsValue(it) && it != selectedLangCode
+//            it.isNotEmpty() && !it.contains(selectedLanguages.values.first())
+            true
         }
 
     override fun getCount() = languageNamesList.size

--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/BaseDelegateAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/BaseDelegateAdapter.kt
@@ -10,16 +10,14 @@ abstract class BaseDelegateAdapter<T>(
     areContentsTheSame: (T, T) -> Boolean = { old, new -> old == new },
 ) : AsyncListDifferDelegationAdapter<T>(
         object : DiffUtil.ItemCallback<T>() {
-            override fun areItemsTheSame(
-                oldItem: T,
-                newItem: T,
-            ) = areItemsTheSame(oldItem, newItem)
+            override fun areItemsTheSame(oldItem: T & Any, newItem: T & Any): Boolean {
+                return areItemsTheSame(oldItem, newItem)
+            }
 
-            override fun areContentsTheSame(
-                oldItem: T,
-                newItem: T,
-            ) = areContentsTheSame(oldItem, newItem)
-        },
+            override fun areContentsTheSame(oldItem: T & Any, newItem: T & Any): Boolean {
+                return areContentsTheSame(oldItem, newItem)
+            }
+            },
         *delegates,
     ) {
     fun addAll(newResults: List<T>) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsDao.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsDao.kt
@@ -22,16 +22,16 @@ abstract class DepictsDao {
     private val maxItemsAllowed = 10
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract suspend fun insert(depictedItem: Depicts)
+    abstract fun insert(depictedItem: Depicts)
 
     @Query("Select * From depicts_table order by lastUsed DESC")
-    abstract suspend fun getAllDepicts(): List<Depicts>
+    abstract fun getAllDepicts(): List<Depicts>
 
     @Query("Select * From depicts_table order by lastUsed DESC LIMIT :n OFFSET 10")
-    abstract suspend fun getDepictsForDeletion(n: Int): List<Depicts>
+    abstract fun getDepictsForDeletion(n: Int): List<Depicts>
 
     @Delete
-    abstract suspend fun delete(depicts: Depicts)
+    abstract fun delete(depicts: Depicts)
 
     /**
      * Gets all Depicts objects from the database, ordered by lastUsed in descending order.

--- a/app/src/main/res/resources.properties
+++ b/app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en-US

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -544,6 +544,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="dialog_box_text_nomination">Why should %1$s be deleted?</string>
   <string name="review_is_uploaded_by">%1$s is uploaded by: %2$s</string>
   <string name="default_description_language">Default description language</string>
+  <string name="secondary_description_language">Secondary Description Language</string>
   <string name="delete_helper_show_deletion_title">Nominating for deletion</string>
   <string name="delete_helper_show_deletion_title_success">Success</string>
   <string name="delete_helper_show_deletion_message_if">Nominated %1$s for deletion.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -25,11 +25,19 @@
           app:singleLineTitle="false"
           android:title="@string/app_ui_language" />
 
+
         <Preference
           android:key="descriptionDefaultLanguagePref"
           app:useSimpleSummaryProvider="true"
           app:singleLineTitle="false"
           android:title="@string/default_description_language" />
+
+        <!-- New Secondary Language Picker -->
+        <Preference
+          android:key="descriptionSecondaryLanguagePref"
+          app:useSimpleSummaryProvider="true"
+          app:singleLineTitle="false"
+          android:title="@string/secondary_description_language" />
 
         <SwitchPreference
           android:defaultValue="true"

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ org.gradle.jvmargs=-Xmx1536M
 org.gradle.caching=true
 android.enableR8.fullMode=false
 
-KOTLIN_VERSION=1.7.20
+KOTLIN_VERSION=1.9.22
 LEAK_CANARY_VERSION=2.10
 DAGGER_VERSION=2.23
 ROOM_VERSION=2.5.0


### PR DESCRIPTION
Implementing per-app language preferences.
Fixes #5755
 
What changes did you make and why?
 
Gradle Files:
Add Appcompat_version= “1.7.0” and added a new dependency for app-compat-resources.
 
AndroidManifest.xml:
AppLocalesMetedataHolderService handles language setting persistence and provides the infrasturture for language switching on Android 12 and below.
 
MainActivity.java:
loadLocale() method was removed as the language handling now occurs through AppCompat API.
 
SettingsFragments.java:
Uses LocaleListCompat methods to create the list of locales based on selected language
Uses AppCompatDelegate methods to apply the locale across the app UI.
AppCompatDelegate.setApplicationLocales() is used to handle compatability issues across Adroid versions and handles persistent stoage of language switching so you don’t need to manually restart the activity.
 
Tests Performed (required):
AppLanguagesSystemTest.java in test package `fr.free.nrw.commons.ui`:
Added a new system test which sues a UI automator to verify the apps languages can be set through the system settings and reflect in the UI.
Tested ProdDebug on Pixel 6 with API level 33.
 
Screenshots (for UI changes only)
<img width="241" alt="Screenshot 2024-10-25 at 1 49 52 pm" src="https://github.com/user-attachments/assets/570aae23-5c79-4aa1-9039-dd1fbc9cc4e0">
<img width="233" alt="Screenshot 2024-10-25 at 1 49 59 pm" src="https://github.com/user-attachments/assets/70fe8763-0e85-473c-a57d-a19f6ab7172f">
