### PR TITLE
Fixes #5806 Implemented "Refresh" button to clear the cache and reload the Nearby map

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,16 +1,12 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
-    <inspection_tool class="AndroidLintNewerVersionAvailable" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="AutoCloseableResource" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ClassWithOnlyPrivateConstructors" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingElse" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="reportWhenNoStatementFollow" value="true" />
     </inspection_tool>
     <inspection_tool class="ControlFlowStatementWithoutBraces" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DefaultNotLastCaseInSwitch" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ExplicitThis" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
-    <inspection_tool class="FieldMayBeFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="LocalCanBeFinal" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="REPORT_VARIABLES" value="true" />
       <option name="REPORT_PARAMETERS" value="true" />
@@ -25,13 +21,11 @@
       <option name="ignoreInMatchingInstanceof" value="false" />
     </inspection_tool>
     <inspection_tool class="ProblematicWhitespace" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ProtectedMemberInFinalClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="RedundantFieldInitialization" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="RedundantImplements" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreSerializable" value="false" />
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
-    <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SimplifiableEqualsExpression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TypeParameterExtendsFinalClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessarilyQualifiedStaticUsage" enabled="true" level="WARNING" enabled_by_default="true">
@@ -47,6 +41,5 @@
     <inspection_tool class="UnnecessaryQualifierForThis" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessarySuperConstructor" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessaryThis" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryToStringCall" enabled="true" level="WARNING" enabled_by_default="true" />
   </profile>
 </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -380,7 +380,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.3.2'
+        kotlinCompilerExtensionVersion '1.5.8'
     }
     namespace 'fr.free.nrw.commons'
     lint {

--- a/app/src/main/java/fr/free/nrw/commons/customselector/database/NotForUploadStatusDao.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/database/NotForUploadStatusDao.kt
@@ -15,19 +15,19 @@ abstract class NotForUploadStatusDao {
      * Insert into Not For Upload status.
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract suspend fun insert(notForUploadStatus: NotForUploadStatus)
+    abstract fun insert(notForUploadStatus: NotForUploadStatus)
 
     /**
      * Delete Not For Upload status entry.
      */
     @Delete
-    abstract suspend fun delete(notForUploadStatus: NotForUploadStatus)
+    abstract fun delete(notForUploadStatus: NotForUploadStatus)
 
     /**
      * Query Not For Upload status with image sha1.
      */
     @Query("SELECT * FROM images_not_for_upload_table WHERE imageSHA1 = (:imageSHA1) ")
-    abstract suspend fun getFromImageSHA1(imageSHA1: String): NotForUploadStatus?
+    abstract fun getFromImageSHA1(imageSHA1: String): NotForUploadStatus?
 
     /**
      * Asynchronous image sha1 query.
@@ -38,7 +38,7 @@ abstract class NotForUploadStatusDao {
      * Deletion Not For Upload status with image sha1.
      */
     @Query("DELETE FROM images_not_for_upload_table WHERE imageSHA1 = (:imageSHA1) ")
-    abstract suspend fun deleteWithImageSHA1(imageSHA1: String)
+    abstract fun deleteWithImageSHA1(imageSHA1: String)
 
     /**
      * Asynchronous image sha1 deletion.
@@ -49,5 +49,5 @@ abstract class NotForUploadStatusDao {
      * Check whether the imageSHA1 is present in database
      */
     @Query("SELECT COUNT() FROM images_not_for_upload_table WHERE imageSHA1 = (:imageSHA1) ")
-    abstract suspend fun find(imageSHA1: String): Int
+    abstract fun find(imageSHA1: String): Int
 }

--- a/app/src/main/java/fr/free/nrw/commons/customselector/database/UploadedStatusDao.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/database/UploadedStatusDao.kt
@@ -17,31 +17,31 @@ abstract class UploadedStatusDao {
      * Insert into uploaded status.
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract suspend fun insert(uploadedStatus: UploadedStatus)
+    abstract fun insert(uploadedStatus: UploadedStatus)
 
     /**
      * Update uploaded status entry.
      */
     @Update
-    abstract suspend fun update(uploadedStatus: UploadedStatus)
+    abstract fun update(uploadedStatus: UploadedStatus)
 
     /**
      * Delete uploaded status entry.
      */
     @Delete
-    abstract suspend fun delete(uploadedStatus: UploadedStatus)
+    abstract fun delete(uploadedStatus: UploadedStatus)
 
     /**
      * Query uploaded status with image sha1.
      */
     @Query("SELECT * FROM uploaded_table WHERE imageSHA1 = (:imageSHA1) ")
-    abstract suspend fun getFromImageSHA1(imageSHA1: String): UploadedStatus?
+    abstract fun getFromImageSHA1(imageSHA1: String): UploadedStatus?
 
     /**
      * Query uploaded status with modified image sha1.
      */
     @Query("SELECT * FROM uploaded_table WHERE modifiedImageSHA1 = (:modifiedImageSHA1) ")
-    abstract suspend fun getFromModifiedImageSHA1(modifiedImageSHA1: String): UploadedStatus?
+    abstract fun getFromModifiedImageSHA1(modifiedImageSHA1: String): UploadedStatus?
 
     /**
      * Asynchronous insert into uploaded status table.
@@ -55,7 +55,7 @@ abstract class UploadedStatusDao {
      * Check whether the imageSHA1 is present in database
      */
     @Query("SELECT COUNT() FROM uploaded_table WHERE imageSHA1 = (:imageSHA1) AND imageResult = (:imageResult) ")
-    abstract suspend fun findByImageSHA1(
+    abstract fun findByImageSHA1(
         imageSHA1: String,
         imageResult: Boolean,
     ): Int
@@ -66,7 +66,7 @@ abstract class UploadedStatusDao {
     @Query(
         "SELECT COUNT() FROM uploaded_table WHERE modifiedImageSHA1 = (:modifiedImageSHA1) AND modifiedImageResult = (:modifiedImageResult) ",
     )
-    abstract suspend fun findByModifiedImageSHA1(
+    abstract fun findByModifiedImageSHA1(
         modifiedImageSHA1: String,
         modifiedImageResult: Boolean,
     ): Int

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceDao.java
@@ -42,4 +42,24 @@ public abstract class PlaceDao {
                 saveSynchronous(place);
             });
     }
+
+    /**
+     * Deletes all Place objects from the database.
+     *
+     * @return A Completable that completes once the deletion operation is done.
+     */
+    @Query("DELETE FROM place")
+    public abstract void deleteAllSynchronous();
+
+    /**
+     * Deletes all Place objects asynchronously from the database.
+     *
+     * @return A Completable that completes once the deletion operation is done.
+     */
+    public Completable deleteAll() {
+        return Completable
+            .fromAction(() -> {
+                deleteAllSynchronous();
+            });
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceDao.java
@@ -52,9 +52,8 @@ public abstract class PlaceDao {
     public abstract void deleteAllSynchronous();
 
     /**
-     * Deletes all Place objects asynchronously from the database.
+     * Deletes all Place objects from the database.
      *
-     * @return A Completable that completes once the deletion operation is done.
      */
     public Completable deleteAll() {
         return Completable

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlacesLocalDataSource.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlacesLocalDataSource.java
@@ -36,4 +36,8 @@ public class PlacesLocalDataSource {
     public Completable savePlace(Place place) {
         return placeDao.save(place);
     }
+
+    public Completable clearCache() {
+        return placeDao.deleteAll();
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlacesRepository.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlacesRepository.java
@@ -3,6 +3,7 @@ package fr.free.nrw.commons.nearby;
 import fr.free.nrw.commons.contributions.Contribution;
 import fr.free.nrw.commons.location.LatLng;
 import io.reactivex.Completable;
+import io.reactivex.schedulers.Schedulers;
 import javax.inject.Inject;
 
 /**
@@ -38,7 +39,13 @@ public class PlacesRepository {
         return localDataSource.fetchPlace(entityID);
     }
 
+    /**
+     * Clears the Nearby cache on an IO thread.
+     *
+     * @return A Completable that completes once the cache has been successfully cleared.
+     */
     public Completable clearCache() {
-        return localDataSource.clearCache();
+        return localDataSource.clearCache()
+            .subscribeOn(Schedulers.io()); // Ensure it runs on IO thread
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlacesRepository.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlacesRepository.java
@@ -38,4 +38,7 @@ public class PlacesRepository {
         return localDataSource.fetchPlace(entityID);
     }
 
+    public Completable clearCache() {
+        return localDataSource.clearCache();
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -320,7 +320,8 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             public boolean onMenuItemClick(MenuItem item) {
                 try {
                     // REFRESH BUTTON FUNCTIONALITY HERE
-                    refresh(); // handle functionality of refreshing
+                    emptyCache();
+                    reloadMap();
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
@@ -1129,18 +1130,18 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     }
 
     /**
-     *  Empties the Nearby local cache and reloads the Nearby map
+     *  Reloads the Nearby map
      */
-    private void refresh(){
-        // can either use this sort of progressDialog to display while page is refreshing
-        // or, we can put a big fat refresh icon on the page.
-        // If we stick with the progressDialog, we should make a new one called refreshDialog,
-        // since itll interfere with the one used to save as GPX/KML
+    private void reloadMap(){
 
-        // When the map initially loads, there is already a big fat refresh circle that is displayed so maybe itll be good to use that instead of dialog
-//        progressDialog.setTitle("REFRESHING NEARBY"); // PLACEHOLDER UNTIL WE
-//        progressDialog.show();
-//        progressDialog.hide();
+    }
+
+
+    /**
+     *  Empties the Nearby local cache
+     */
+    private void emptyCache(){
+
     }
 
     private void savePlacesAsKML() {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -311,9 +311,22 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     public void onCreateOptionsMenu(@NonNull final Menu menu,
         @NonNull final MenuInflater inflater) {
         inflater.inflate(R.menu.nearby_fragment_menu, menu);
+        MenuItem refreshButton = menu.findItem(R.id.item_refresh);
         MenuItem listMenu = menu.findItem(R.id.list_sheet);
         MenuItem saveAsGPXButton = menu.findItem(R.id.list_item_gpx);
         MenuItem saveAsKMLButton = menu.findItem(R.id.list_item_kml);
+        refreshButton.setOnMenuItemClickListener(new OnMenuItemClickListener() {
+            @Override
+            public boolean onMenuItemClick(MenuItem item) {
+                try {
+                    // REFRESH BUTTON FUNCTIONALITY HERE
+                    refresh(); // handle functionality of refreshing
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                return false;
+            }
+        });
         listMenu.setOnMenuItemClickListener(new OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
@@ -1113,6 +1126,21 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         if (recenterToUserLocation) {
             recenterToUserLocation = false;
         }
+    }
+
+    /**
+     *  Empties the Nearby local cache and reloads the Nearby map
+     */
+    private void refresh(){
+        // can either use this sort of progressDialog to display while page is refreshing
+        // or, we can put a big fat refresh icon on the page.
+        // If we stick with the progressDialog, we should make a new one called refreshDialog,
+        // since itll interfere with the one used to save as GPX/KML
+
+        // When the map initially loads, there is already a big fat refresh circle that is displayed so maybe itll be good to use that instead of dialog
+//        progressDialog.setTitle("REFRESHING NEARBY"); // PLACEHOLDER UNTIL WE
+//        progressDialog.show();
+//        progressDialog.hide();
     }
 
     private void savePlacesAsKML() {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -32,6 +32,7 @@ import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -319,6 +320,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             @Override
             public boolean onMenuItemClick(MenuItem item) {
                 try {
+                    Timber.d("Reload: menuItem");
                     // REFRESH BUTTON FUNCTIONALITY HERE
                     emptyCache();
                     reloadMap();
@@ -1130,7 +1132,8 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     }
 
     /**
-     *  Reloads the Nearby map
+     * Reloads the Nearby map.
+     * This method clears the existing markers, resets the map state, and repopulates the map with the latest data.
      */
     private void reloadMap(){
 
@@ -1141,7 +1144,13 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
      *  Empties the Nearby local cache
      */
     private void emptyCache(){
+        Timber.d("Reload: emptyCache");
 
+        placesRepository.clearCache();
+
+        // Optionally, clear any in-memory cache or state
+        updatedPlacesList.clear();
+        updatedLatLng = null;
     }
 
     private void savePlacesAsKML() {

--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/BaseDelegateAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/BaseDelegateAdapter.kt
@@ -10,15 +10,13 @@ abstract class BaseDelegateAdapter<T>(
     areContentsTheSame: (T, T) -> Boolean = { old, new -> old == new },
 ) : AsyncListDifferDelegationAdapter<T>(
         object : DiffUtil.ItemCallback<T>() {
-            override fun areItemsTheSame(
-                oldItem: T,
-                newItem: T,
-            ) = areItemsTheSame(oldItem, newItem)
+            override fun areItemsTheSame(oldItem: T & Any, newItem: T & Any): Boolean {
+                return areItemsTheSame(oldItem, newItem)
+            }
 
-            override fun areContentsTheSame(
-                oldItem: T,
-                newItem: T,
-            ) = areContentsTheSame(oldItem, newItem)
+            override fun areContentsTheSame(oldItem: T & Any, newItem: T & Any): Boolean {
+                return areContentsTheSame(oldItem, newItem)
+            }
         },
         *delegates,
     ) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsDao.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsDao.kt
@@ -22,16 +22,16 @@ abstract class DepictsDao {
     private val maxItemsAllowed = 10
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract suspend fun insert(depictedItem: Depicts)
+    abstract fun insert(depictedItem: Depicts)
 
     @Query("Select * From depicts_table order by lastUsed DESC")
-    abstract suspend fun getAllDepicts(): List<Depicts>
+    abstract fun getAllDepicts(): List<Depicts>
 
     @Query("Select * From depicts_table order by lastUsed DESC LIMIT :n OFFSET 10")
-    abstract suspend fun getDepictsForDeletion(n: Int): List<Depicts>
+    abstract fun getDepictsForDeletion(n: Int): List<Depicts>
 
     @Delete
-    abstract suspend fun delete(depicts: Depicts)
+    abstract fun delete(depicts: Depicts)
 
     /**
      * Gets all Depicts objects from the database, ordered by lastUsed in descending order.

--- a/app/src/main/res/drawable/ic_refresh_24dp_nearby.xml
+++ b/app/src/main/res/drawable/ic_refresh_24dp_nearby.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="@dimen/half_standard_height"
+  android:height="@dimen/half_standard_height"
+  android:viewportHeight="24.0"
+  android:viewportWidth="24.0">
+
+    <group
+      android:scaleX="1.0"
+    android:scaleY="1.0"
+    android:translateX="-0.0"
+    android:translateY="-0.0">
+
+    <path
+      android:fillColor="?attr/menu_item_tint"
+      android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+
+</group>
+  </vector>

--- a/app/src/main/res/menu/nearby_fragment_menu.xml
+++ b/app/src/main/res/menu/nearby_fragment_menu.xml
@@ -1,17 +1,25 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
+  <item android:id="@+id/item_refresh"
+    android:title="Refresh"
+    app:showAsAction="ifRoom"
+    android:icon="@drawable/ic_refresh_24dp_nearby" />
+
   <item android:id="@+id/list_sheet"
     android:title="@string/list_sheet"
     app:showAsAction="ifRoom|withText"
     android:icon="@drawable/ic_list_white_24dp"
     />
+
   <item android:id="@+id/list_item_gpx"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:title="Save as GPX file" />
+
   <item android:id="@+id/list_item_kml"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:title="Save as KML file" />
+
 </menu>

--- a/app/src/main/res/values-ce/strings.xml
+++ b/app/src/main/res/values-ce/strings.xml
@@ -106,7 +106,7 @@
   <string name="menu_view_file_page">Хьажа файлан агӀоне</string>
   <string name="share_title_hint">Куьг йазор (ТIедилина ду)</string>
   <string name="add_caption_toast">Дехар ду, хӀокху файлан цIе гайта</string>
-  <string name="share_description_hint">Цунах лаьцна</string>
+  <string name="share_description_hint">Цуьнах лаьцна</string>
   <string name="share_caption_hint">Куьг</string>
   <string name="login_failed_network">Чувала(йала) тара цало — сетан гӀалат</string>
   <string name="login_failed_throttled">ТӀех дукха кхиаме боцу гӀертарш. Дехар ду масех минот йаьлча йуха а хьажа.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -29,6 +29,7 @@
 * Sujan
 * Sushi
 * Tacsipacsi
+* TheRabbit22
 * ThisCarthing
 * Tobi 406
 * TomatoCake
@@ -802,4 +803,17 @@
   <string name="multiple_files_depiction">Bitte beachte, dass bei einem Multiupload alle Bilder die gleichen Kategorien und Bezeichnungen erhalten. Sollten die Bilder keine gemeinsamen Bezeichnungen und Kategorien haben, führe bitte mehrere separate Uploads durch.</string>
   <string name="multiple_files_depiction_header">Hinweis zu Mehrfach-Uploads</string>
   <string name="nearby_wikitalk">Melde ein Problem mit diesem Datenobjekt an Wikidata</string>
+  <string name="please_enter_some_comments">Bitte gib einige Kommentare ein</string>
+  <string name="talk">Diskussion</string>
+  <string name="write_something_about_the_item">Schreibe etwas über das Objekt ‚%1$s‘. Deine Beschreibung wird öffentlich sichtbar sein.</string>
+  <string name="does_not_exist_anymore_no_picture_can_ever_be_taken_of_it">‚%1$s‘ existiert nicht mehr, es kann kein Foto mehr davon gemacht werden.</string>
+  <string name="is_at_a_different_place_please_specify_the_correct_place_below_if_possible_tell_us_the_correct_latitude_longitude">‚%1$s‘ ist jetzt an einem anderen Ort. Bitte gib den richtigen Ort und, wenn möglich, den Breiten- und Längengrad an.</string>
+  <string name="other_problem_or_information_please_explain_below">Sonstiges Problem oder Information (bitte unten erläutern).</string>
+  <string name="feedback_destination_note">Dein Feedback wird auf der folgenden Wiki-Seite veröffentlicht werden: &lt;a href=\"https://commons.wikimedia.org/wiki/Commons:Mobile_app/Feedback\"&gt;Commons:Mobile app/Feedback&lt;/a&gt;</string>
+  <string name="are_you_sure_that_you_want_cancel_all_the_uploads">Möchtest du wirklich alle Uploads abbrechen?</string>
+  <string name="cancelling_all_the_uploads">Alle Uploads werden abgebrochen…</string>
+  <string name="uploads">Hochgeladene Dateien</string>
+  <string name="pending">Ausstehend</string>
+  <string name="failed">Fehlgeschlagen</string>
+  <string name="could_not_load_place_data">Ortsdaten konnten nicht geladen werden</string>
 </resources>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -126,6 +126,7 @@
   <string name="welcome_copyright_subtext">ਇੰਟਰਨੈੱਟ ਉੱਤੇ ਮਿਲੀ ਕਾਪੀਰਾਈਟ ਸਮੱਗਰੀ ਅਤੇ ਪੋਸਟਰਾਂ, ਕਿਤਾਬਾਂ ਦੀਆਂ ਜਿਲਦਾਂ ਦੀਆਂ ਤਸਵੀਆਂ ਆਦਿ ਤੋਂ ਪਰਹੇਜ਼ ਰੱਖੋ।</string>
   <string name="welcome_final_text">ਤੁਹਾਨੂੰ ਲੱਗਦਾ ਹੈ ਕਿ ਤੁਹਾਡੇ ਕੋਲ ਹੈ?</string>
   <string name="welcome_final_button_text">ਹਾਂ!</string>
+  <string name="welcome_help_button_text">ਹੋਰ ਜਾਣਕਾਰੀ</string>
   <string name="detail_panel_cats_label">ਸ਼੍ਰੇਣੀਆਂ</string>
   <string name="detail_panel_cats_loading">ਲੱਦ ਰਿਹਾ ਹੈ...</string>
   <string name="detail_panel_cats_none">ਕੋਈ ਵੀ ਨਹੀਂ ਚੁਣਿਆ</string>
@@ -199,6 +200,7 @@
   <string name="copied_successfully">ਉਤਾਰਾ ਕੀਤਾ</string>
   <string name="exif_tag_name_location">ਟਿਕਾਣਾ</string>
   <string name="wikipedia_instructions_step_7">ਲਿਖਤ ਛਾਪੋ</string>
+  <string name="leaderboard_tab_title">ਮੁਹਰੈਲ</string>
   <string name="leaderboard_column_user">ਵਰਤੋਂਕਾਰ</string>
   <string name="invalid_login_message">ਤੁਹਾਡੇ ਦਾਖਲੇ ਦੀ ਮਿਆਦ ਪੁੱਗ ਗਈ ਹੈ। ਕਿਰਪਾ ਕਰਕੇ ਦੁਬਾਰਾ ਦਾਖਲ ਹੋਵੋ।</string>
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ org.gradle.jvmargs=-Xmx1536M
 org.gradle.caching=true
 android.enableR8.fullMode=false
 
-KOTLIN_VERSION=1.7.20
+KOTLIN_VERSION=1.9.22
 LEAK_CANARY_VERSION=2.10
 DAGGER_VERSION=2.23
 ROOM_VERSION=2.5.0


### PR DESCRIPTION
The nearby map can be buggy, and a reload feature is much more efficient than reloading the whole app.
This pull request solves this by adding a refresh button which will empty the nearby cache, and then reload the map.

Fixes #5806

**What changes did you make and why?**
1. After cloning the app would not run in my environment, and I have noticed that this is a common issue with other new maintainers. To solve this I had to: Removed suspend from affected DAO files and funcs, and changed to (Kotlin v1.9.22) and (Kotlin compiler v1.5.8)

2. `NearbyParentFragment.java`
    This is where the clicking of the refresh button is handled, which calls `emptyCache()`, which will then call `reloadMap()` to complete the refresh. Main functionality has been implemented here.

4. `nearby_fragment_menu.xml`, `ic_refresh_24dp_nearby.xml`
    Created new refresh icon and added it to the nearby menu, so that it is displayed in the top header.

5. `NearbyParentFragment.java`, `PlacesRepository.java`, `PlacesLocalDataSource.java`, `PlaceDao.java`
    These files were changed to implement emptying the nearby cache

6. `NearbyParentFragment.java`
    Functionality for reloading the map is inside `reloadMap()`

**Tests performed (required)**

1. Tested  'app' profile on Huawei Pura 70 with API level 32
3. Tested  'app' profile on Virtual Device "Medium Phone" with API level 34


**Screenshots (for UI changes only)**
[Screen_recording_20241025_152616.webm](https://github.com/user-attachments/assets/dac0029c-ee91-4af8-baf2-9af21958b1ba)


