### PR TITLE
Revert back to MainScope for database and ui updates

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/ImageLoader.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/ImageLoader.kt
@@ -18,6 +18,7 @@ import fr.free.nrw.commons.utils.CustomSelectorUtils.Companion.checkWhetherFileE
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
@@ -65,7 +66,7 @@ class ImageLoader
         /**
          * Coroutine Scope.
          */
-        private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+        private val scope: CoroutineScope = MainScope()
 
         /**
          * Query image and setUp the view.


### PR DESCRIPTION
**Description (required)**

Fixes #5898 

What changes did you make and why?
Revert back to **MainScope()** in the `ImageLoader.kt` file because that code block contains both UI and database operations.

**Tests performed (required)**

Tested prodDebug on Samsung A14 with API level 34.

**Screenshots (for UI changes only)**
None
