### PR TITLE
Improve string formatting in OkHttpJsonApiClient.java

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.java
@@ -285,7 +285,7 @@ public class OkHttpJsonApiClient {
         throws Exception {
 
         Timber.d("Fetching nearby items at radius %s", radius);
-        Timber.d("CUSTOM_SPARQL%s", String.valueOf(customQuery != null));
+        Timber.d("CUSTOM_SPARQL: %s", String.valueOf(customQuery != null));
         final String wikidataQuery;
         if (customQuery != null) {
             wikidataQuery = customQuery;
@@ -344,7 +344,7 @@ public class OkHttpJsonApiClient {
         final boolean shouldQueryForMonuments, final String customQuery)
         throws Exception {
 
-        Timber.d("CUSTOM_SPARQL%s", String.valueOf(customQuery != null));
+        Timber.d("CUSTOM_SPARQL: %s", String.valueOf(customQuery != null));
 
         final String wikidataQuery;
         if (customQuery != null) {


### PR DESCRIPTION
**Description (required)**

Fixes #5912

What changes did you make and why?  
I updated the logging statements in `OkHttpJsonApiClient.java` to improve string formatting. Specifically, I changed the log message from `"CUSTOM_SPARQL%s"` to `"CUSTOM_SPARQL: %s"` in two instances. 
