### PR TITLE
Fixes #5918: Hide edit options for logged-out users in Explore screen

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.java
@@ -272,6 +272,12 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
 
         if (!sessionManager.isUserLoggedIn()) {
             binding.categoryEditButton.setVisibility(GONE);
+            binding.descriptionEdit.setVisibility(GONE);
+            binding.depictionsEditButton.setVisibility(GONE);
+        } else {
+            binding.categoryEditButton.setVisibility(VISIBLE);
+            binding.descriptionEdit.setVisibility(VISIBLE);
+            binding.depictionsEditButton.setVisibility(VISIBLE);
         }
 
         if(applicationKvStore.getBoolean("login_skipped")){
@@ -400,7 +406,6 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             }
         );
         binding.progressBarEdit.setVisibility(GONE);
-        binding.descriptionEdit.setVisibility(VISIBLE);
     }
 
     @Override
@@ -678,7 +683,9 @@ public class MediaDetailFragment extends CommonsDaggerSupportFragment implements
             // Stick in a filler element.
             allCategories.add(getString(R.string.detail_panel_cats_none));
         }
-        binding.categoryEditButton.setVisibility(VISIBLE);
+        if(sessionManager.isUserLoggedIn()) {
+            binding.categoryEditButton.setVisibility(VISIBLE);
+        }
         rebuildCatList(allCategories);
     }
 


### PR DESCRIPTION
Fixes #5918 

What changes did you make and why?

Updated the logic with conditions to prevent triggering/showing the edit functionality if the user is not authenticated.

**Tests performed (required)**
Manually compiled and tested the changes


**Screenshots (for UI changes only)**

Before: 

| Logged-In | Logged-Out|
|---|---|
| ![before logged](https://github.com/user-attachments/assets/aecc5c12-8b29-492b-8d75-7ccab08a0a8c) | ![before logged-out](https://github.com/user-attachments/assets/78c4e3f0-c104-42ac-a439-ac97f66ffa12)


After:

| Logged-In | Logged-Out|
|---|---|
| ![after logged-in](https://github.com/user-attachments/assets/3c3839a5-2fef-4550-bc1d-884afcb19548) | ![after logged-out](https://github.com/user-attachments/assets/dd156340-f9d9-40d1-b90d-05e95dbdeb09)
