### PR TITLE
Resolve crash when submitting feedback without internet access 

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetFragment.kt
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.net.ConnectivityManager
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -170,6 +171,11 @@ class MoreBottomSheetFragment : BottomSheetDialogFragment() {
     fun uploadFeedback(feedback: Feedback) {
         val feedbackContentCreator = FeedbackContentCreator(requireContext(), feedback)
 
+        if (!isNetworkAvailable(requireContext())) {
+            Toast.makeText(requireContext(), R.string.error_feedback, Toast.LENGTH_LONG).show()
+            return
+        }
+
         val single = pageEditClient.createNewSection(
             "Commons:Mobile_app/Feedback",
             feedbackContentCreator.getSectionTitle(),
@@ -190,6 +196,15 @@ class MoreBottomSheetFragment : BottomSheetDialogFragment() {
                 }
                 Toast.makeText(requireContext(), getString(messageResId), Toast.LENGTH_SHORT).show()
             }
+    }
+
+    /**
+     * This method is to check whether internet connection is available or not
+     */
+    fun isNetworkAvailable(context: Context): Boolean {
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val activeNetwork = connectivityManager.activeNetworkInfo
+        return activeNetwork != null && activeNetwork.isConnected
     }
 
     /**


### PR DESCRIPTION
**Description (required)**

Fixes #6003 

What changes did you make and why?
When the internet connection was disabled, the feedback page on submission would crash. This was because there were no conditions that would gracefully handle the absence of an internet connection when the request was being sent. To address this issue, I implemented a check to verify the availability of the internet connection within the uploadFeedback function. If there was no active connection, We would exit the loop and display a Toast with an error description. 

**Tests performed (required)**

Tested prodRelease on Medium Phone with API level 35.