### PR TITLE
Issue #5996 - Fix Android Studio warnings in LocationPickerActivity.kt

### DIFF
--- a/app/src/androidTest/java/fr/free/nrw/commons/UploadCancelledTest.kt
+++ b/app/src/androidTest/java/fr/free/nrw/commons/UploadCancelledTest.kt
@@ -18,7 +18,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
-import fr.free.nrw.commons.LocationPicker.LocationPickerActivity
+import fr.free.nrw.commons.locationpicker.LocationPickerActivity
 import fr.free.nrw.commons.UITestHelper.Companion.childAtPosition
 import fr.free.nrw.commons.auth.LoginActivity
 import org.hamcrest.CoreMatchers

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -171,7 +171,7 @@
       android:name=".review.ReviewActivity"
       android:label="@string/title_activity_review" />
     <activity
-      android:name=".LocationPicker.LocationPickerActivity"
+      android:name=".locationpicker.LocationPickerActivity"
       android:label="Location Picker" />
 
     <service

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.kt
@@ -8,8 +8,7 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.location.LocationManager
 import android.os.Bundle
-import android.preference.PreferenceManager
-import android.text.Html
+import androidx.preference.PreferenceManager
 import android.text.method.LinkMovementMethod
 import android.view.MotionEvent
 import android.view.View
@@ -23,6 +22,8 @@ import androidx.appcompat.widget.AppCompatTextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.core.content.IntentCompat
+import androidx.core.os.BundleCompat
 import androidx.core.text.HtmlCompat
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import fr.free.nrw.commons.CameraPosition
@@ -182,13 +183,25 @@ class LocationPickerActivity : BaseActivity(), LocationPermissionCallback {
         setContentView(R.layout.activity_location_picker)
 
         if (savedInstanceState == null) {
-            cameraPosition = intent.getParcelableExtra(LocationPickerConstants.MAP_CAMERA_POSITION)
+            cameraPosition = IntentCompat.getParcelableExtra(
+                intent,
+                LocationPickerConstants.MAP_CAMERA_POSITION,
+                CameraPosition::class.java
+            )
             activity = intent.getStringExtra(LocationPickerConstants.ACTIVITY_KEY)
-            media = intent.getParcelableExtra(LocationPickerConstants.MEDIA)
+            media = IntentCompat.getParcelableExtra(
+                intent,
+                LocationPickerConstants.MEDIA,
+                Media::class.java
+            )
         } else {
-            cameraPosition = savedInstanceState.getParcelable(CAMERA_POS)
+            cameraPosition = BundleCompat.getParcelable(
+                savedInstanceState,
+                CAMERA_POS,
+                CameraPosition::class.java
+            )
             activity = savedInstanceState.getString(ACTIVITY)
-            media = savedInstanceState.getParcelable("sMedia")
+            media = BundleCompat.getParcelable(savedInstanceState, "sMedia", Media::class.java)
         }
 
         bindViews()

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.kt
@@ -413,7 +413,11 @@ class LocationPickerActivity : BaseActivity(), LocationPermissionCallback {
         val position = when {
             //location metadata is available
             activity == "UploadActivity" && cameraPosition != null -> {
-                fr.free.nrw.commons.location.LatLng(cameraPosition!!.latitude, cameraPosition!!.longitude, 0.0f)
+                fr.free.nrw.commons.location.LatLng(
+                    cameraPosition!!.latitude,
+                    cameraPosition!!.longitude,
+                    0.0f
+                )
             }
             //location metadata is not available
             mapView != null -> {
@@ -471,7 +475,11 @@ class LocationPickerActivity : BaseActivity(), LocationPermissionCallback {
             val intent = Intent().apply {
                 putExtra(
                     LocationPickerConstants.MAP_CAMERA_POSITION,
-                    CameraPosition(mapView?.mapCenter?.latitude!!, mapView?.mapCenter?.longitude!!, 14.0)
+                    CameraPosition(
+                        mapView?.mapCenter?.latitude!!,
+                        mapView?.mapCenter?.longitude!!,
+                        14.0
+                    )
                 )
             }
             setResult(RESULT_OK, intent)
@@ -573,8 +581,15 @@ class LocationPickerActivity : BaseActivity(), LocationPermissionCallback {
         )
     }
 
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
-        if (requestCode == Constants.RequestCodes.LOCATION && grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        if (requestCode == Constants.RequestCodes.LOCATION &&
+            grantResults.isNotEmpty() &&
+            grantResults[0] == PackageManager.PERMISSION_GRANTED
+        ) {
             onLocationPermissionGranted()
         } else {
             onLocationPermissionDenied(getString(R.string.upload_map_location_access))
@@ -594,12 +609,18 @@ class LocationPickerActivity : BaseActivity(), LocationPermissionCallback {
 
     override fun onLocationPermissionDenied(toastMessage: String) {
         val isDeniedBefore = store.getBoolean("isPermissionDenied", false)
-        val showRationale = ActivityCompat.shouldShowRequestPermissionRationale(this, permission.ACCESS_FINE_LOCATION)
+        val showRationale = ActivityCompat.shouldShowRequestPermissionRationale(
+            this,
+            permission.ACCESS_FINE_LOCATION
+        )
 
         if (!showRationale) {
             if (!locationPermissionsHelper.checkLocationPermission(this)) {
                 if (isDeniedBefore) {
-                    locationPermissionsHelper.showAppSettingsDialog(this, R.string.upload_map_location_access)
+                    locationPermissionsHelper.showAppSettingsDialog(
+                        this,
+                        R.string.upload_map_location_access
+                    )
                 } else {
                     Toast.makeText(this, toastMessage, Toast.LENGTH_LONG).show()
                 }
@@ -618,7 +639,10 @@ class LocationPickerActivity : BaseActivity(), LocationPermissionCallback {
                 addMarkerAtGPSLocation()
             } else {
                 addMarkerAtGPSLocation()
-                locationPermissionsHelper.showLocationOffDialog(this, R.string.ask_to_turn_location_on_text)
+                locationPermissionsHelper.showLocationOffDialog(
+                    this,
+                    R.string.ask_to_turn_location_on_text
+                )
             }
         }
     }
@@ -669,7 +693,10 @@ class LocationPickerActivity : BaseActivity(), LocationPermissionCallback {
                 Marker.ANCHOR_CENTER,
                 Marker.ANCHOR_BOTTOM
             )
-            icon = ContextCompat.getDrawable(this@LocationPickerActivity, R.drawable.current_location_marker)
+            icon = ContextCompat.getDrawable(
+                this@LocationPickerActivity,
+                R.drawable.current_location_marker
+            )
             title = "Your Location"
             textLabelFontSize = 24
         }

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.kt
@@ -23,6 +23,7 @@ import androidx.appcompat.widget.AppCompatTextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.core.text.HtmlCompat
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import fr.free.nrw.commons.CameraPosition
 import fr.free.nrw.commons.CommonsApplication
@@ -270,7 +271,10 @@ class LocationPickerActivity : BaseActivity(), LocationPermissionCallback {
      * For showing credits
      */
     private fun addCredits() {
-        tvAttribution.text = Html.fromHtml(getString(R.string.map_attribution))
+        tvAttribution.text = HtmlCompat.fromHtml(
+            getString(R.string.map_attribution),
+            HtmlCompat.FROM_HTML_MODE_LEGACY
+        )
         tvAttribution.movementMethod = LinkMovementMethod.getInstance()
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.kt
@@ -447,7 +447,7 @@ class LocationPickerActivity : BaseActivity(), LocationPermissionCallback {
                 LAST_LOCATION,
                 "${mapView?.mapCenter?.latitude},${mapView?.mapCenter?.longitude}"
             )
-            applicationKvStore.putString(LAST_ZOOM, mapView?.zoomLevel?.toString()!!)
+            applicationKvStore.putString(LAST_ZOOM, mapView?.zoomLevelDouble?.toString()!!)
         }
 
         if (media == null) {

--- a/app/src/main/java/fr/free/nrw/commons/di/ActivityBuilderModule.kt
+++ b/app/src/main/java/fr/free/nrw/commons/di/ActivityBuilderModule.kt
@@ -3,7 +3,7 @@ package fr.free.nrw.commons.di
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
 import fr.free.nrw.commons.AboutActivity
-import fr.free.nrw.commons.LocationPicker.LocationPickerActivity
+import fr.free.nrw.commons.locationpicker.LocationPickerActivity
 import fr.free.nrw.commons.WelcomeActivity
 import fr.free.nrw.commons.auth.LoginActivity
 import fr.free.nrw.commons.auth.SignupActivity

--- a/app/src/main/java/fr/free/nrw/commons/locationpicker/LocationPicker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/locationpicker/LocationPicker.kt
@@ -1,4 +1,4 @@
-package fr.free.nrw.commons.LocationPicker
+package fr.free.nrw.commons.locationpicker
 
 import android.app.Activity
 import android.content.Intent
@@ -32,7 +32,7 @@ object LocationPicker {
         /**
          * Gets and puts location in intent
          * @param position CameraPosition
-         * @return LocationPicker.IntentBuilder
+         * @return locationpicker.IntentBuilder
          */
         fun defaultLocation(position: CameraPosition): IntentBuilder {
             intent.putExtra(LocationPickerConstants.MAP_CAMERA_POSITION, position)
@@ -42,7 +42,7 @@ object LocationPicker {
         /**
          * Gets and puts activity name in intent
          * @param activity activity key
-         * @return LocationPicker.IntentBuilder
+         * @return locationpicker.IntentBuilder
          */
         fun activityKey(activity: String): IntentBuilder {
             intent.putExtra(LocationPickerConstants.ACTIVITY_KEY, activity)
@@ -52,7 +52,7 @@ object LocationPicker {
         /**
          * Gets and puts media in intent
          * @param media Media
-         * @return LocationPicker.IntentBuilder
+         * @return locationpicker.IntentBuilder
          */
         fun media(media: Media): IntentBuilder {
             intent.putExtra(LocationPickerConstants.MEDIA, media)

--- a/app/src/main/java/fr/free/nrw/commons/locationpicker/LocationPickerActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/locationpicker/LocationPickerActivity.kt
@@ -1,4 +1,4 @@
-package fr.free.nrw.commons.LocationPicker
+package fr.free.nrw.commons.locationpicker
 
 import android.Manifest.permission
 import android.annotation.SuppressLint

--- a/app/src/main/java/fr/free/nrw/commons/locationpicker/LocationPickerConstants.kt
+++ b/app/src/main/java/fr/free/nrw/commons/locationpicker/LocationPickerConstants.kt
@@ -1,4 +1,4 @@
-package fr.free.nrw.commons.LocationPicker
+package fr.free.nrw.commons.locationpicker
 
 /**
  * Constants need for location picking

--- a/app/src/main/java/fr/free/nrw/commons/locationpicker/LocationPickerViewModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/locationpicker/LocationPickerViewModel.kt
@@ -1,4 +1,4 @@
-package fr.free.nrw.commons.LocationPicker
+package fr.free.nrw.commons.locationpicker
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
@@ -74,7 +74,7 @@ import fr.free.nrw.commons.BuildConfig
 import fr.free.nrw.commons.CameraPosition
 import fr.free.nrw.commons.CommonsApplication
 import fr.free.nrw.commons.CommonsApplication.Companion.instance
-import fr.free.nrw.commons.LocationPicker.LocationPicker
+import fr.free.nrw.commons.locationpicker.LocationPicker
 import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.MediaDataExtractor
 import fr.free.nrw.commons.R

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -25,7 +25,7 @@ import androidx.annotation.Nullable;
 import androidx.exifinterface.media.ExifInterface;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import fr.free.nrw.commons.CameraPosition;
-import fr.free.nrw.commons.LocationPicker.LocationPicker;
+import fr.free.nrw.commons.locationpicker.LocationPicker;
 import fr.free.nrw.commons.R;
 import fr.free.nrw.commons.contributions.MainActivity;
 import fr.free.nrw.commons.databinding.FragmentUploadMediaDetailFragmentBinding;

--- a/app/src/main/res/layout/activity_location_picker.xml
+++ b/app/src/main/res/layout/activity_location_picker.xml
@@ -4,7 +4,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  tools:context=".LocationPicker.LocationPickerActivity">
+  tools:context=".locationpicker.LocationPickerActivity">
 
   <com.google.android.material.appbar.AppBarLayout
     android:id="@+id/location_picker_app_bar_layout"

--- a/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
@@ -11,7 +11,6 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import fr.free.nrw.commons.CameraPosition
-import fr.free.nrw.commons.LocationPicker.LocationPickerActivity
 import fr.free.nrw.commons.TestCommonsApplication
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.LAST_LOCATION

--- a/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerActivityUnitTests.kt
@@ -165,13 +165,13 @@ class LocationPickerActivityUnitTests {
                 "placeSelected",
             )
         `when`(mapView.mapCenter).thenReturn(position)
-        `when`(mapView.zoomLevel).thenReturn(15)
+        `when`(mapView.zoomLevelDouble).thenReturn(15.0)
         method.isAccessible = true
         method.invoke(activity)
         verify(applicationKvStore, times(1)).putString(
             LAST_LOCATION,
             position.latitude.toString() + "," + position.longitude.toString(),
         )
-        verify(applicationKvStore, times(1)).putString(LAST_ZOOM, mapView.zoomLevel.toString())
+        verify(applicationKvStore, times(1)).putString(LAST_ZOOM, mapView.zoomLevelDouble.toString())
     }
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerViewModelUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/locationpicker/LocationPickerViewModelUnitTests.kt
@@ -7,7 +7,6 @@ import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import fr.free.nrw.commons.CameraPosition
-import fr.free.nrw.commons.LocationPicker.LocationPickerViewModel
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock

--- a/app/src/test/kotlin/fr/free/nrw/commons/media/MediaDetailFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/media/MediaDetailFragmentUnitTests.kt
@@ -1,6 +1,5 @@
 package fr.free.nrw.commons.media
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
@@ -19,7 +18,6 @@ import android.widget.ProgressBar
 import android.widget.ScrollView
 import android.widget.Spinner
 import android.widget.TextView
-import androidx.activity.result.ActivityResult
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.test.core.app.ApplicationProvider
@@ -27,10 +25,9 @@ import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.drawee.generic.GenericDraweeHierarchy
 import com.facebook.drawee.view.SimpleDraweeView
 import com.facebook.soloader.SoLoader
-import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.whenever
-import fr.free.nrw.commons.LocationPicker.LocationPickerActivity
+import fr.free.nrw.commons.locationpicker.LocationPickerActivity
 import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.OkHttpConnectionFactory
 import fr.free.nrw.commons.TestCommonsApplication

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
@@ -21,8 +21,8 @@ import androidx.test.core.app.ApplicationProvider
 import com.github.chrisbanes.photoview.PhotoView
 import com.nhaarman.mockitokotlin2.mock
 import fr.free.nrw.commons.CameraPosition
-import fr.free.nrw.commons.LocationPicker.LocationPicker
-import fr.free.nrw.commons.LocationPicker.LocationPickerActivity
+import fr.free.nrw.commons.locationpicker.LocationPicker
+import fr.free.nrw.commons.locationpicker.LocationPickerActivity
 import fr.free.nrw.commons.OkHttpConnectionFactory
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.TestCommonsApplication


### PR DESCRIPTION
**Description (required)**

This fixes Android Studio warnings in _app/src/main/java/fr/free/nrw/commons/LocationPicker/LocationPickerActivity.kt_, as described in #5996 

---

~~Note that just **one weak warning remains**:~~
> ~~Package name 'fr.free.nrw.commons.LocationPicker' part should not start with an uppercase letter~~

~~I didn't try to fix this because I believe that renaming the package falls outside of the scope of this issue (#5996). I request the reviewer to clarify whether this is the case or not.~~

Edit: fixed. No warning or weak warning remains.

---

The changes made include:
- Replacing deprecated `Html.fromHtml(String)` call with `HtmlCompat.fromHtml(String, HtmlCompat.FROM_HTML_MODE_LEGACY)`
- Replacing deprecated `getParcelableExtra` method calls (for `Intent` and `Bundle`) with corresponding calls in `IntentCompat` and `BundleCompat`.
- Replacing deprecated `getZoomLevel` call with `getZoomLevelDouble` (for `org.osmdroid.views.MapView`)
- Reformatting lines longer than 100 characters so as to comply with the code style.
- Renamed `fr.free.nrw.commons.LocationPicker` to `fr.free.nrw.commons.locationpicker`.

**Tests performed (required)**

Tested BetaDebug on Medium Phone (AVD) with API level 34 and on a physical device with API Level 33. Also made sure _LocationPickerActivityUnitTests_ pass.
