### PR TITLE
Remove temporary String.strip() implementation

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
@@ -302,8 +302,9 @@ public class UploadMediaDetailAdapter extends
 
             removeButton.setOnClickListener(v -> removeDescription(uploadMediaDetail, position));
             captionListener = new AbstractTextWatcher(
-                captionText -> uploadMediaDetail.setCaptionText(convertIdeographicSpaceToLatinSpace(
-                        removeLeadingAndTrailingWhitespace(captionText))));
+                captionText -> uploadMediaDetail.setCaptionText(
+                    convertIdeographicSpaceToLatinSpace(captionText.strip()))
+            );
             descriptionListener = new AbstractTextWatcher(
                 descriptionText -> uploadMediaDetail.setDescriptionText(descriptionText));
             captionItemEditText.addTextChangedListener(captionListener);
@@ -545,39 +546,6 @@ public class UploadMediaDetailAdapter extends
                     languageHistoryListView.setAdapter(recentLanguagesAdapter);
                 }
             }
-        }
-
-        /**
-         * Removes any leading and trailing whitespace from the source text.
-         *
-         * @param source input string
-         * @return a string without leading and trailing whitespace
-         */
-        public String removeLeadingAndTrailingWhitespace(String source) {
-            // This method can be replaced with the inbuilt String::strip when updated to JDK 11.
-            // Note that String::trim does not adequately remove all whitespace chars.
-            int firstNonWhitespaceIndex = 0;
-            while (firstNonWhitespaceIndex < source.length()) {
-                if (Character.isWhitespace(source.charAt(firstNonWhitespaceIndex))) {
-                    firstNonWhitespaceIndex++;
-                } else {
-                    break;
-                }
-            }
-            if (firstNonWhitespaceIndex == source.length()) {
-                return "";
-            }
-
-            int lastNonWhitespaceIndex = source.length() - 1;
-            while (lastNonWhitespaceIndex > firstNonWhitespaceIndex) {
-                if (Character.isWhitespace(source.charAt(lastNonWhitespaceIndex))) {
-                    lastNonWhitespaceIndex--;
-                } else {
-                    break;
-                }
-            }
-
-            return source.substring(firstNonWhitespaceIndex, lastNonWhitespaceIndex + 1);
         }
 
         /**

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
@@ -270,49 +270,9 @@ class UploadMediaDetailAdapterUnitTest {
     }
 
     @Test
-    fun testRemoveLeadingAndTrailingWhitespace() {
-        // empty space
-        val test1 = "  test  "
-        val expected1 = "test"
-        Assert.assertEquals(expected1, viewHolder.removeLeadingAndTrailingWhitespace(test1))
-
-        val test2 = "  test test "
-        val expected2 = "test test"
-        Assert.assertEquals(expected2, viewHolder.removeLeadingAndTrailingWhitespace(test2))
-
-        // No whitespace
-        val test3 = "No trailing space"
-        val expected3 = "No trailing space"
-        Assert.assertEquals(expected3, viewHolder.removeLeadingAndTrailingWhitespace(test3))
-
-        // blank string
-        val test4 = " \r \t  "
-        val expected4 = ""
-        Assert.assertEquals(expected4, viewHolder.removeLeadingAndTrailingWhitespace(test4))
-    }
-
-    @Test
-    fun testRemoveLeadingAndTrailingInstanceTab() {
-        val test = "\ttest\t"
-        val expected = "test"
-        Assert.assertEquals(expected, viewHolder.removeLeadingAndTrailingWhitespace(test))
-    }
-
-    @Test
-    fun testRemoveLeadingAndTrailingCarriageReturn() {
-        val test = "\rtest\r"
-        val expected = "test"
-        Assert.assertEquals(expected, viewHolder.removeLeadingAndTrailingWhitespace(test))
-    }
-
-    @Test
     fun testCaptionJapaneseCharacters() {
         val test1 = "テスト　テスト"
         val expected1 = "テスト テスト"
         Assert.assertEquals(expected1, viewHolder.convertIdeographicSpaceToLatinSpace(test1))
-
-        val test2 = "　\r　\t　テスト　\r　\t　"
-        val expected2 = "テスト"
-        Assert.assertEquals(expected2, viewHolder.removeLeadingAndTrailingWhitespace(test2))
     }
 }


### PR DESCRIPTION
What changes did you make and why?

Context: #5141 this PR fixed the problem about white space characters not being trimmed properly when using `java.lang.String#trim()` by implementing String#strip() internal implementation because it was introduced in JDK 11. Since, we're at 17 we can remove this one with the actual one.