### PR TITLE
Fix edit button shown when image has no location

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.kt
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.kt
@@ -10,6 +10,7 @@ import android.os.Parcelable
 import androidx.exifinterface.media.ExifInterface
 
 import fr.free.nrw.commons.upload.FileUtils
+import fr.free.nrw.commons.upload.ImageCoordinates
 import java.io.File
 import java.io.IOException
 import java.util.Date
@@ -87,9 +88,7 @@ class UploadableFile : Parcelable {
     fun hasLocation(): Boolean {
         return try {
             val exif = ExifInterface(file.absolutePath)
-            val latitude = exif.getAttribute(ExifInterface.TAG_GPS_LATITUDE)
-            val longitude = exif.getAttribute(ExifInterface.TAG_GPS_LONGITUDE)
-            latitude != null && longitude != null
+            ImageCoordinates(exif, null).imageCoordsExists
         } catch (e: IOException) {
             Timber.tag("UploadableFile").d(e)
             false


### PR DESCRIPTION
Changed the commons.filepicker.UploadableFile's hasLocation method to use the existing ImageCoordinates class for detecting the presence of geolocation in an image's exif

**Description (required)**

Fixes #5908

Changed the `hasLocation` method (added in commit f7164d0b7873adb054d37f72743af1ab0f00f3e0) to use the existing `ImageCoordinates` class (which has a more exhaustive logic for the same task) to resolve the inconsistency reported in #5908.

More context: https://github.com/commons-app/apps-android-commons/issues/5908#issuecomment-2541454952


**Tests performed (required)**

Tested BetaDebug on Medium Phone with API level 34.