### PR TITLE
Fix caption lost after accepting "Is this a picture of..."

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.java
@@ -398,7 +398,7 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
                 final boolean response = UploadActivity.nearbyPopupAnswers.get(nearbyPlace);
                 if (response) {
                     if (callback != null) {
-                        presenter.onUserConfirmedUploadIsOfPlace(nearbyPlace);
+                        presenter.onUserConfirmedUploadIsOfPlace(nearbyPlace, indexOfFragment);
                     }
                 }
             } else {
@@ -445,7 +445,7 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
                 () -> {
                     // Execute when user confirms the upload is of the specified place
                     UploadActivity.nearbyPopupAnswers.put(place, true);
-                    presenter.onUserConfirmedUploadIsOfPlace(place);
+                    presenter.onUserConfirmedUploadIsOfPlace(place, indexOfFragment);
                 },
                 () -> {
                     // Execute when user cancels the upload of the specified place
@@ -486,7 +486,7 @@ public class UploadMediaDetailFragment extends UploadBaseFragment implements
             if (UploadActivity.nearbyPopupAnswers.containsKey(nearbyPlace)) {
                 final boolean response = UploadActivity.nearbyPopupAnswers.get(nearbyPlace);
                 if (response) {
-                    presenter.onUserConfirmedUploadIsOfPlace(nearbyPlace);
+                    presenter.onUserConfirmedUploadIsOfPlace(nearbyPlace, indexOfFragment);
                 }
             } else {
                 showNearbyPlaceFound(nearbyPlace);

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailsContract.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailsContract.kt
@@ -117,6 +117,6 @@ interface UploadMediaDetailsContract {
 
         fun onEditButtonClicked(indexInViewFlipper: Int)
 
-        fun onUserConfirmedUploadIsOfPlace(place: Place?)
+        fun onUserConfirmedUploadIsOfPlace(place: Place?, uploadItemIndex: Int)
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.java
@@ -322,23 +322,24 @@ public class UploadMediaPresenter implements UserActionListener, SimilarImageInt
   }
 
   /**
-   * Updates the information regarding the specified place for uploads
+   * Updates the information regarding the specified place for the specified upload item
    * when the user confirms the suggested nearby place.
    *
    * @param place The place to be associated with the uploads.
+   * @param uploadItemIndex Index of the uploadItem whose detected place has been confirmed
    */
   @Override
-  public void onUserConfirmedUploadIsOfPlace(final Place place) {
-      final List<UploadItem> uploads = repository.getUploads();
-      for (final UploadItem uploadItem : uploads) {
-          uploadItem.setPlace(place);
-          final List<UploadMediaDetail> uploadMediaDetails = uploadItem.getUploadMediaDetails();
-          // Update UploadMediaDetail object for this UploadItem
-          uploadMediaDetails.set(0, new UploadMediaDetail(place));
-      }
-      // Now that all UploadItems and their associated UploadMediaDetail objects have been updated,
+  public void onUserConfirmedUploadIsOfPlace(final Place place, final int uploadItemIndex) {
+      final UploadItem uploadItem = repository.getUploads().get(uploadItemIndex);
+
+      uploadItem.setPlace(place);
+      final List<UploadMediaDetail> uploadMediaDetails = uploadItem.getUploadMediaDetails();
+      // Update UploadMediaDetail object for this UploadItem
+      uploadMediaDetails.set(0, new UploadMediaDetail(place));
+
+      // Now that the UploadItem and its associated UploadMediaDetail objects have been updated,
       // update the view with the modified media details of the first upload item
-      view.updateMediaDetails(uploads.get(0).getUploadMediaDetails());
+      view.updateMediaDetails(uploadMediaDetails);
       UploadActivity.setUploadIsOfAPlace(true);
   }
 


### PR DESCRIPTION
**Description (required)**

Fixes #5842 by correcting the implementation of onUserConfirmedUploadIsOfPlace to apply the detected place's caption, language and description only on the upload item whose place is detected as being near a Wikidata item (and not other items)

**Tests performed (required)**

Tested BetaDebug on Medium Phone with API level 34.


https://github.com/user-attachments/assets/51fdddb6-9fc2-410f-9a93-44b142a21c5e

