### PR TITLE
FilePicker: Fix error when multiple images are returned from Documents based picker

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.kt
@@ -263,17 +263,8 @@ object FilePicker : Constants {
     ) {
         if (result.resultCode == Activity.RESULT_OK && !isPhoto(result.data)) {
             try {
-                val photoPath = result.data?.data
-                val photoFile = PickedFiles.pickedExistingPicture(activity, photoPath!!)
-                callbacks.onImagesPicked(
-                    singleFileList(photoFile),
-                    ImageSource.DOCUMENTS,
-                    restoreType(activity)
-                )
-
-                if (configuration(activity).shouldCopyPickedImagesToPublicGalleryAppFolder()) {
-                    PickedFiles.copyFilesInSeparateThread(activity, singleFileList(photoFile))
-                }
+                val files = getFilesFromGalleryPictures(result.data, activity)
+                callbacks.onImagesPicked(files, ImageSource.DOCUMENTS, restoreType(activity))
             } catch (e: Exception) {
                 e.printStackTrace()
                 callbacks.onImagePickerError(e, ImageSource.DOCUMENTS, restoreType(activity))


### PR DESCRIPTION
**Description (required)**

Fixes #5953
> The issue appears because of improper handling of the result data when documents based photo picker is used. The other cases (camera, gallery and custom selector) are properly handled.

The result data is now properly handled.

**Tests performed (required)**

Tested BetaDebug on Medium Phone with API level 34.
