### PR TITLE
Nearby: Fix disappearing of pins loaded from cache (#6052)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/MarkerPlaceGroup.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/MarkerPlaceGroup.java
@@ -20,4 +20,8 @@ public class MarkerPlaceGroup {
     public boolean getIsBookmarked() {
         return isBookmarked;
     }
+
+    public void setIsBookmarked(boolean isBookmarked) {
+        this.isBookmarked = isBookmarked;
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1839,7 +1839,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         );
     }
 
-    public Marker convertToMarker(Place place, Boolean isBookMarked) {
+    public Marker convertToMarker(Place place, boolean isBookMarked) {
         Drawable icon = ContextCompat.getDrawable(getContext(), getIconFor(place, isBookMarked));
         GeoPoint point = new GeoPoint(place.location.getLatitude(), place.location.getLongitude());
         Marker marker = new Marker(binding.map);

--- a/app/src/test/kotlin/fr/free/nrw/commons/nearby/NearbyParentFragmentPresenterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/nearby/NearbyParentFragmentPresenterTest.kt
@@ -465,8 +465,6 @@ class NearbyParentFragmentPresenterTest {
 
         whenever(bookmarkLocationsDao.allBookmarksLocations).thenReturn(Collections.emptyList())
         nearbyPresenter.updateMapMarkers(nearbyPlacesInfo.placeList, latestLocation, null)
-        Mockito.verify(nearbyParentFragmentView).setFilterState()
         Mockito.verify(nearbyParentFragmentView).setProgressBarVisibility(false)
-        Mockito.verify(nearbyParentFragmentView).updateListFragment(nearbyPlacesInfo.placeList)
     }
 }


### PR DESCRIPTION
Fixes #6052 

The references to Place objects fetched from the repository appear to be unreliable (which caused the above issue), so I now copy its fields to the place member of existing MarkerPlaceGroup objects.

**Tests performed (required)**

Tested BetaDebug on Medium Phone AVD (API 34) and a Physical device (API 33)