### PR TITLE
Fix #6054: Rename SAVEPROGRESSDAILOG to SAVEPROGRESSDIALOG

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.kt
@@ -182,11 +182,11 @@ class LoginActivity : AccountAuthenticatorActivity() {
 
     override fun onSaveInstanceState(outState: Bundle) {
         // if progressDialog is visible during the configuration change  then store state as  true else false so that
-        // we maintain visibility of progressDailog after configuration change
+        // we maintain visibility of progressDialog after configuration change
         if (progressDialog != null && progressDialog!!.isShowing) {
-            outState.putBoolean(saveProgressDailog, true)
+            outState.putBoolean(saveProgressDialog, true)
         } else {
-            outState.putBoolean(saveProgressDailog, false)
+            outState.putBoolean(saveProgressDialog, false)
         }
         outState.putString(
             saveErrorMessage,
@@ -206,7 +206,7 @@ class LoginActivity : AccountAuthenticatorActivity() {
         super.onRestoreInstanceState(savedInstanceState)
         binding!!.loginUsername.setText(savedInstanceState.getString(saveUsername))
         binding!!.loginPassword.setText(savedInstanceState.getString(savePassword))
-        if (savedInstanceState.getBoolean(saveProgressDailog)) {
+        if (savedInstanceState.getBoolean(saveProgressDialog)) {
             performLogin()
         }
         val errorMessage = savedInstanceState.getString(saveErrorMessage)
@@ -396,7 +396,7 @@ class LoginActivity : AccountAuthenticatorActivity() {
         fun startYourself(context: Context) =
             context.startActivity(Intent(context, LoginActivity::class.java))
 
-        const val saveProgressDailog: String = "ProgressDailog_state"
+        const val saveProgressDialog: String = "ProgressDialog_state"
         const val saveErrorMessage: String = "errorMessage"
         const val saveUsername: String = "username"
         const val savePassword: String = "password"


### PR DESCRIPTION
Fixes #6054 

Hello,
As per the request in #6054, I made sure the possible occurrences of this dailog in the entire project and changed it to dialog.
Apparently, only `app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.kt` had the incorrect spelling.

**What changes did you make and why?**
- Corrected spelling from dailog to dialog wherever visible in the entire project

**Tests performed**
N.A.

If at all there's anything required from my end, then do let me know.

Thanks and Regards,
Mohit Kambli


