### PR TITLE
Nearby: Fix map moving by itself after scrolling if a list item has previously been clicked.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceAdapterDelegate.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceAdapterDelegate.kt
@@ -5,10 +5,12 @@ import android.view.View
 import android.view.View.GONE
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
+import android.widget.RelativeLayout
 import androidx.activity.result.ActivityResultLauncher
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.transition.TransitionManager
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.hannesdorfmann.adapterdelegates4.dsl.AdapterDelegateViewBindingViewHolder
 import com.hannesdorfmann.adapterdelegates4.dsl.adapterDelegateViewBinding
 import fr.free.nrw.commons.R
@@ -42,7 +44,10 @@ fun placeAdapterDelegate(
         root.setOnFocusChangeListener { view1: View?, hasFocus: Boolean ->
             if (!hasFocus && nearbyButtonLayout.buttonLayout.isShown) {
                 nearbyButtonLayout.buttonLayout.visibility = GONE
-            } else if (hasFocus && !nearbyButtonLayout.buttonLayout.isShown) {
+            } else if (hasFocus && !nearbyButtonLayout.buttonLayout.isShown &&
+                BottomSheetBehavior.from(root.parent.parent.parent as RelativeLayout).state !=
+                BottomSheetBehavior.STATE_HIDDEN
+            ) {
                 showOrHideAndScrollToIfLast()
                 onItemClick?.invoke(item)
             }


### PR DESCRIPTION
Fixes #6046

**Description (required)**

the OnFocusChangeListener for nearby place list items sometimes gets invoked when new items are set, even when the list is hidden, if an item had previously been clicked in it. This in turn causes the onItemClick to be called. This commit adds a check to make sure the list is not hidden when onItemClick is invoked this way.

**Tests performed (required)**

Tested BetaDebug  on Medium Phone AVD with API level 34.