### PR TITLE
Fix: Allow back button functionality to dismiss language selection dialog #6066

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.kt
@@ -11,6 +11,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.view.KeyEvent
 import android.view.View
 import android.widget.AdapterView
 import android.widget.EditText
@@ -332,11 +333,20 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
         val dialog = Dialog(requireActivity())
         dialog.setContentView(R.layout.dialog_select_language)
-        dialog.setCancelable(false)
+        dialog.setCancelable(true)// Allow dialog to close with the back button
         dialog.window?.setLayout(
             (resources.displayMetrics.widthPixels * 0.90).toInt(),
             (resources.displayMetrics.heightPixels * 0.90).toInt()
         )
+        // Handle back button explicitly to dismiss the dialog
+        dialog.setOnKeyListener { _, keyCode, event ->
+            if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
+                dialog.dismiss() // Close the dialog when the back button is pressed
+                true
+            } else {
+                false
+            }
+        }
         dialog.show()
 
         val editText: EditText = dialog.findViewById(R.id.search_language)
@@ -378,10 +388,12 @@ class SettingsFragment : PreferenceFragmentCompat() {
             if (keyListPreference == "appUiDefaultLanguagePref") {
                 appUiLanguageListPreference?.summary = defLocale.getDisplayLanguage(defLocale)
                 setLocale(requireActivity(), lCode)
-                requireActivity().recreate()
                 val intent = Intent(requireActivity(), MainActivity::class.java)
+                intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                requireActivity().finish()
                 startActivity(intent)
-            } else {
+            }
+                else {
                 descriptionLanguageListPreference?.summary = defLocale.getDisplayLanguage(defLocale)
             }
             dialog.dismiss()


### PR DESCRIPTION
**Description:**
This pull request addresses an issue where the back button was not functioning correctly after selecting a language for the app UI or description language. When the user selects a language and decides not to proceed, clicking the back button would not navigate them to the previous screen.
___________________________________________________________________________________________________________

**Fixes** #6066 
___________________________________________________________________________________________________________
**Changes made:**
Implemented a fix to ensure that pressing the back button after selecting the app UI language or description language will return the user to the previous screen.
Ensured that no language selection allows the user to navigate back without issues.

___________________________________________________________________________________________________________
**Tests performed **

1-Tested the back button functionality after selecting and canceling the language selection.
2-Verified that the back button works correctly without applying any language change.

Tested {build variant -testBetaDebugUnitTest} on {Vivo V25} with API level {API 34}.


https://github.com/user-attachments/assets/0da414ea-8c66-4270-81d3-bb9f298681b3
