### PR TITLE
Nearby: No longer keeps loading until timeout when map is zoomed out

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.kt
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.kt
@@ -359,7 +359,7 @@ class OkHttpJsonApiClient @Inject constructor(
                         "\${LONG}",
                         String.format(Locale.ROOT, "%.4f", queryParams.center.longitude)
                     )
-                    .replace("\${RAD}", String.format(Locale.ROOT, "%.2f", queryParams.radius))
+                    .replace("\${RAD}", String.format(Locale.ROOT, "%.2f", queryParams.radiusInKm))
             }
         }
 
@@ -425,7 +425,7 @@ class OkHttpJsonApiClient @Inject constructor(
                     ).replace(
                         "\${LONG}", String.format(locale, "%.4f", queryParams.center.longitude)
                     )
-                    .replace("\${RAD}", String.format(locale, "%.2f", queryParams.radius))
+                    .replace("\${RAD}", String.format(locale, "%.2f", queryParams.radiusInKm))
             }
 
             is NearbyQueryParams.Rectangular -> {

--- a/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.kt
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/OkHttpJsonApiClient.kt
@@ -362,7 +362,7 @@ class OkHttpJsonApiClient @Inject constructor(
         if (response.body != null && response.isSuccessful) {
             val json = response.body!!.string()
             return JsonParser.parseString(json).getAsJsonObject().getAsJsonObject("results")
-                .getAsJsonArray("bindings").get(0).getAsJsonObject().getAsJsonObject("count")
+                .getAsJsonArray("bindings").get(0).getAsJsonObject().getAsJsonObject("itemCount")
                 .get("value").asInt
         }
         throw Exception(response.message)
@@ -370,7 +370,7 @@ class OkHttpJsonApiClient @Inject constructor(
 
     @Throws(Exception::class)
     fun getNearbyItemCount(
-        center: LatLng, radius: Double
+        center: LatLng, radius: Float
     ): Int {
         val wikidataQuery: String =
             FileUtils.readFromResource("/queries/radius_query_for_item_count.rq")
@@ -393,7 +393,7 @@ class OkHttpJsonApiClient @Inject constructor(
         if (response.body != null && response.isSuccessful) {
             val json = response.body!!.string()
             return JsonParser.parseString(json).getAsJsonObject().getAsJsonObject("results")
-                .getAsJsonArray("bindings").get(0).getAsJsonObject().getAsJsonObject("count")
+                .getAsJsonArray("bindings").get(0).getAsJsonObject().getAsJsonObject("itemCount")
                 .get("value").asInt
         }
         throw Exception(response.message)

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyController.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyController.java
@@ -196,8 +196,9 @@ public class NearbyController extends MapController {
             return null;
         }
 
-        List<Place> places = nearbyPlaces.getFromWikidataQuery(screenTopRight, screenBottomLeft,
-            Locale.getDefault().getLanguage(), shouldQueryForMonuments, customQuery);
+        List<Place> places = nearbyPlaces.getFromWikidataQuery(currentLatLng, screenTopRight,
+            screenBottomLeft, Locale.getDefault().getLanguage(), shouldQueryForMonuments,
+            customQuery);
 
         if (null != places && places.size() > 0) {
             LatLng[] boundaryCoordinates = {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
@@ -147,7 +147,9 @@ public class NearbyPlaces {
             }
         }
 
-        int minRadius = 0, maxRadius = Math.round(Math.min(100f, Math.min(longGap, latGap))) * 100;
+        // minRadius, targetRadius and maxRadius are radii in decameters
+        // unlike other
+        int minRadius = 0, maxRadius = Math.round(Math.min(300f, Math.min(longGap, latGap))) * 100;
         int targetRadius = maxRadius / 2;
         while (minRadius < maxRadius) {
             targetRadius = minRadius + (maxRadius - minRadius + 1) / 2;
@@ -156,8 +158,14 @@ public class NearbyPlaces {
             if (itemCount >= lowerLimit && itemCount < upperLimit) {
                 break;
             }
-            if (targetRadius > maxRadius / 2 && itemCount < lowerLimit / 5) {
-                minRadius = targetRadius + (maxRadius - targetRadius + 1) / 2;
+            if (targetRadius > maxRadius / 2 && itemCount < lowerLimit / 5) { // fast forward
+                minRadius = targetRadius;
+                targetRadius = minRadius + (maxRadius - minRadius + 1) / 2;
+                minRadius = targetRadius;
+                if (itemCount < lowerLimit / 10 && minRadius < maxRadius) { // fast forward again
+                    targetRadius = minRadius + (maxRadius - minRadius + 1) / 2;
+                    minRadius = targetRadius;
+                }
                 continue;
             }
             if (itemCount < upperLimit) {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
@@ -2,6 +2,7 @@ package fr.free.nrw.commons.nearby;
 
 import android.location.Location;
 import androidx.annotation.Nullable;
+import fr.free.nrw.commons.nearby.model.NearbyQueryParams;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -135,8 +136,8 @@ public class NearbyPlaces {
         final float latGap = results[0]/1000f;
 
         if (Math.max(longGap,latGap)<100f){
-            final int itemCount = okHttpJsonApiClient.getNearbyItemCount(screenTopRight,
-                screenBottomLeft);
+            final int itemCount = okHttpJsonApiClient.getNearbyItemCount(
+                new NearbyQueryParams.Rectangular(screenTopRight, screenBottomLeft));
             if(itemCount<upperLimit) {
                 return okHttpJsonApiClient.getNearbyPlaces(screenTopRight, screenBottomLeft, lang,
                     shouldQueryForMonuments, null);
@@ -147,8 +148,8 @@ public class NearbyPlaces {
         int targetRadius = maxRadius/2;
         while (minRadius<maxRadius) {
             targetRadius = minRadius + (maxRadius - minRadius + 1) / 2;
-            final int itemCount = okHttpJsonApiClient.getNearbyItemCount(centerPoint,
-                targetRadius / 100f);
+            final int itemCount = okHttpJsonApiClient.getNearbyItemCount(
+                new NearbyQueryParams.Radial(centerPoint, targetRadius / 100f));
             if (itemCount >= lowerLimit && itemCount < upperLimit){
                 break;
             }
@@ -162,7 +163,7 @@ public class NearbyPlaces {
                  maxRadius = targetRadius - 1;
             }
         }
-        return new java.util.ArrayList<Place>(); // TODO make actual query
+        return new java.util.ArrayList<Place>();
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
@@ -119,51 +119,56 @@ public class NearbyPlaces {
         final fr.free.nrw.commons.location.LatLng screenBottomLeft, final String lang,
         final boolean shouldQueryForMonuments,
         @Nullable final String customQuery) throws Exception {
-        if (customQuery != null){
+        if (customQuery != null) {
             return okHttpJsonApiClient
-                .getNearbyPlaces(screenTopRight, screenBottomLeft, lang, shouldQueryForMonuments,
+                .getNearbyPlaces(
+                    new NearbyQueryParams.Rectangular(screenTopRight, screenBottomLeft), lang,
+                    shouldQueryForMonuments,
                     customQuery);
         }
 
-        final int lowerLimit = 1000, upperLimit=1500;
+        final int lowerLimit = 1000, upperLimit = 1500;
 
         final float[] results = new float[1];
         Location.distanceBetween(centerPoint.getLatitude(), screenTopRight.getLongitude(),
             centerPoint.getLatitude(), screenBottomLeft.getLongitude(), results);
-        final float longGap = results[0]/1000f;
+        final float longGap = results[0] / 1000f;
         Location.distanceBetween(screenTopRight.getLatitude(), centerPoint.getLongitude(),
             screenBottomLeft.getLatitude(), centerPoint.getLongitude(), results);
-        final float latGap = results[0]/1000f;
+        final float latGap = results[0] / 1000f;
 
-        if (Math.max(longGap,latGap)<100f){
+        if (Math.max(longGap, latGap) < 100f) {
             final int itemCount = okHttpJsonApiClient.getNearbyItemCount(
                 new NearbyQueryParams.Rectangular(screenTopRight, screenBottomLeft));
-            if(itemCount<upperLimit) {
-                return okHttpJsonApiClient.getNearbyPlaces(screenTopRight, screenBottomLeft, lang,
+            if (itemCount < upperLimit) {
+                return okHttpJsonApiClient.getNearbyPlaces(
+                    new NearbyQueryParams.Rectangular(screenTopRight, screenBottomLeft), lang,
                     shouldQueryForMonuments, null);
             }
         }
 
-        int minRadius = 0, maxRadius = Math.round(Math.min(100f, Math.min(longGap, latGap)))*100;
-        int targetRadius = maxRadius/2;
-        while (minRadius<maxRadius) {
+        int minRadius = 0, maxRadius = Math.round(Math.min(100f, Math.min(longGap, latGap))) * 100;
+        int targetRadius = maxRadius / 2;
+        while (minRadius < maxRadius) {
             targetRadius = minRadius + (maxRadius - minRadius + 1) / 2;
             final int itemCount = okHttpJsonApiClient.getNearbyItemCount(
                 new NearbyQueryParams.Radial(centerPoint, targetRadius / 100f));
-            if (itemCount >= lowerLimit && itemCount < upperLimit){
+            if (itemCount >= lowerLimit && itemCount < upperLimit) {
                 break;
             }
-            if (targetRadius>maxRadius/2 && itemCount<lowerLimit/5) {
+            if (targetRadius > maxRadius / 2 && itemCount < lowerLimit / 5) {
                 minRadius = targetRadius + (maxRadius - targetRadius + 1) / 2;
                 continue;
             }
-            if (itemCount<upperLimit) {
+            if (itemCount < upperLimit) {
                 minRadius = targetRadius;
             } else {
-                 maxRadius = targetRadius - 1;
+                maxRadius = targetRadius - 1;
             }
         }
-        return new java.util.ArrayList<Place>();
+        return okHttpJsonApiClient.getNearbyPlaces(
+            new NearbyQueryParams.Radial(centerPoint, targetRadius / 100f), lang, shouldQueryForMonuments,
+            null);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyPlaces.java
@@ -101,6 +101,7 @@ public class NearbyPlaces {
      * Retrieves a list of places from a Wikidata query based on screen coordinates and optional
      * parameters.
      *
+     * @param centerPoint             The center of the map, used for radius queries if required.
      * @param screenTopRight          The top right corner of the screen (latitude, longitude).
      * @param screenBottomLeft        The bottom left corner of the screen (latitude, longitude).
      * @param lang                    The language for the query.
@@ -111,13 +112,22 @@ public class NearbyPlaces {
      * @throws Exception If an error occurs during the retrieval process.
      */
     public List<Place> getFromWikidataQuery(
+        final fr.free.nrw.commons.location.LatLng centerPoint,
         final fr.free.nrw.commons.location.LatLng screenTopRight,
         final fr.free.nrw.commons.location.LatLng screenBottomLeft, final String lang,
         final boolean shouldQueryForMonuments,
         @Nullable final String customQuery) throws Exception {
-        return okHttpJsonApiClient
-            .getNearbyPlaces(screenTopRight, screenBottomLeft, lang, shouldQueryForMonuments,
-                customQuery);
+        if (customQuery != null){
+            return okHttpJsonApiClient
+                .getNearbyPlaces(screenTopRight, screenBottomLeft, lang, shouldQueryForMonuments,
+                    customQuery);
+        }
+        final double east = screenTopRight.getLongitude();
+        final double west = screenBottomLeft.getLongitude();
+        final double north = screenTopRight.getLatitude();
+        final double south = screenBottomLeft.getLatitude();
+
+        return new java.util.ArrayList<Place>(); // TODO replace with actual method call
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1101,19 +1101,19 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
                 eastCornerLong, 0);
             if (currentLatLng.equals(
                 getLastMapFocus())) { // Means we are checking around current location
-                populatePlacesForCurrentLocation(getLastMapFocus(), screenTopRightLatLng,
+                populatePlacesForCurrentLocation(getMapFocus(), screenTopRightLatLng,
                     screenBottomLeftLatLng, currentLatLng, null);
             } else {
-                populatePlacesForAnotherLocation(getLastMapFocus(), screenTopRightLatLng,
+                populatePlacesForAnotherLocation(getMapFocus(), screenTopRightLatLng,
                     screenBottomLeftLatLng, currentLatLng, null);
             }
         } else {
             if (currentLatLng.equals(
                 getLastMapFocus())) { // Means we are checking around current location
-                populatePlacesForCurrentLocation(getLastMapFocus(), screenTopRightLatLng,
+                populatePlacesForCurrentLocation(getMapFocus(), screenTopRightLatLng,
                     screenBottomLeftLatLng, currentLatLng, null);
             } else {
-                populatePlacesForAnotherLocation(getLastMapFocus(), screenTopRightLatLng,
+                populatePlacesForAnotherLocation(getMapFocus(), screenTopRightLatLng,
                     screenBottomLeftLatLng, currentLatLng, null);
             }
         }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1887,9 +1887,12 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     @Override
     public void replaceMarkerOverlays(final List<MarkerPlaceGroup> markerPlaceGroups) {
         ArrayList<Marker> newMarkers = new ArrayList<>(markerPlaceGroups.size());
-        for (MarkerPlaceGroup markerPlaceGroup : markerPlaceGroups) {
+        // iterate in reverse so that the nearest pins get rendered on top
+        for (int i = markerPlaceGroups.size() - 1; i >= 0; i--) {
             newMarkers.add(
-                convertToMarker(markerPlaceGroup.getPlace(), markerPlaceGroup.getIsBookmarked()));
+                convertToMarker(markerPlaceGroups.get(i).getPlace(),
+                markerPlaceGroups.get(i).getIsBookmarked())
+            );
         }
         clearAllMarkers();
         binding.map.getOverlays().addAll(newMarkers);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/model/NearbyQueryParams.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/model/NearbyQueryParams.kt
@@ -6,5 +6,5 @@ sealed class NearbyQueryParams {
     class Rectangular(val screenTopRight: LatLng, val screenBottomLeft: LatLng) :
         NearbyQueryParams()
 
-    class Radial(val center: LatLng, val radius: Float) : NearbyQueryParams()
+    class Radial(val center: LatLng, val radiusInKm: Float) : NearbyQueryParams()
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/model/NearbyQueryParams.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/model/NearbyQueryParams.kt
@@ -1,0 +1,10 @@
+package fr.free.nrw.commons.nearby.model
+
+import fr.free.nrw.commons.location.LatLng
+
+sealed class NearbyQueryParams {
+    class Rectangular(val screenTopRight: LatLng, val screenBottomLeft: LatLng) :
+        NearbyQueryParams()
+
+    class Radial(val center: LatLng, val radius: Float) : NearbyQueryParams()
+}

--- a/app/src/main/resources/queries/radius_query_for_item_count.rq
+++ b/app/src/main/resources/queries/radius_query_for_item_count.rq
@@ -1,0 +1,9 @@
+SELECT (COUNT(?item) AS ?itemCount)
+WHERE {
+  # Around given location.
+  SERVICE wikibase:around {
+    ?item wdt:P625 ?location.
+    bd:serviceParam wikibase:center "Point(${LONG} ${LAT})"^^geo:wktLiteral.
+    bd:serviceParam wikibase:radius "${RAD}" . # Radius in kilometers.
+  }
+}

--- a/app/src/main/resources/queries/radius_query_for_nearby.rq
+++ b/app/src/main/resources/queries/radius_query_for_nearby.rq
@@ -1,0 +1,12 @@
+SELECT
+  ?item
+  (SAMPLE(?location) as ?location)
+WHERE {
+  # Around given location.
+  SERVICE wikibase:around {
+    ?item wdt:P625 ?location.
+    bd:serviceParam wikibase:center "Point(${LONG} ${LAT})"^^geo:wktLiteral.
+    bd:serviceParam wikibase:radius "${RAD}" . # Radius in kilometers.
+  }
+}
+GROUP BY ?item

--- a/app/src/main/resources/queries/radius_query_for_nearby_monuments.rq
+++ b/app/src/main/resources/queries/radius_query_for_nearby_monuments.rq
@@ -1,0 +1,25 @@
+SELECT
+  ?item
+  (SAMPLE(?location) as ?location)
+  (SAMPLE(?monument) AS ?monument)
+WHERE {
+  # Around given location.
+  SERVICE wikibase:around {
+    ?item wdt:P625 ?location.
+    bd:serviceParam wikibase:center "Point(${LONG} ${LAT})"^^geo:wktLiteral.
+    bd:serviceParam wikibase:radius "${RAD}" . # Radius in kilometers.
+  }
+
+  # Wiki Loves Monuments
+  OPTIONAL {?item p:P1435 ?monument}
+  OPTIONAL {?item p:P2186 ?monument}
+  OPTIONAL {?item p:P1459 ?monument}
+  OPTIONAL {?item p:P1460 ?monument}
+  OPTIONAL {?item p:P1216 ?monument}
+  OPTIONAL {?item p:P709 ?monument}
+  OPTIONAL {?item p:P718 ?monument}
+  OPTIONAL {?item p:P5694 ?monument}
+  OPTIONAL {?item p:P3426 ?monument}
+
+}
+GROUP BY ?item

--- a/app/src/main/resources/queries/rectangle_query_for_item_count.rq
+++ b/app/src/main/resources/queries/rectangle_query_for_item_count.rq
@@ -1,4 +1,4 @@
-SELECT (COUNT(DISTINCT ?item) AS ?count)
+SELECT (COUNT(?item) AS ?itemCount)
 WHERE {
   SERVICE wikibase:box {
     ?item wdt:P625 ?location.
@@ -6,4 +6,3 @@ WHERE {
     bd:serviceParam wikibase:cornerEast "Point(${LONG_EAST} ${LAT_EAST})"^^geo:wktLiteral.
   }
 }
-&format=json

--- a/app/src/main/resources/queries/rectangle_query_for_item_count.rq
+++ b/app/src/main/resources/queries/rectangle_query_for_item_count.rq
@@ -1,0 +1,9 @@
+SELECT (COUNT(DISTINCT ?item) AS ?count)
+WHERE {
+  SERVICE wikibase:box {
+    ?item wdt:P625 ?location.
+    bd:serviceParam wikibase:cornerWest "Point(${LONG_WEST} ${LAT_WEST})"^^geo:wktLiteral.
+    bd:serviceParam wikibase:cornerEast "Point(${LONG_EAST} ${LAT_EAST})"^^geo:wktLiteral.
+  }
+}
+&format=json

--- a/app/src/main/resources/queries/rectangle_query_for_nearby.rq
+++ b/app/src/main/resources/queries/rectangle_query_for_nearby.rq
@@ -8,6 +8,5 @@ WHERE {
      bd:serviceParam wikibase:cornerWest "Point(${LONG_WEST} ${LAT_WEST})"^^geo:wktLiteral.
      bd:serviceParam wikibase:cornerEast "Point(${LONG_EAST} ${LAT_EAST})"^^geo:wktLiteral.
   }
-
 }
 GROUP BY ?item

--- a/app/src/test/kotlin/fr/free/nrw/commons/OkHttpJsonApiClientTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/OkHttpJsonApiClientTests.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockitokotlin2.verify
 import fr.free.nrw.commons.explore.depictions.DepictsClient
 import fr.free.nrw.commons.location.LatLng
 import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient
+import fr.free.nrw.commons.nearby.model.NearbyQueryParams
 import okhttp3.Call
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
@@ -14,6 +15,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito
+import org.mockito.Mockito.times
 import org.mockito.MockitoAnnotations
 import java.lang.Exception
 
@@ -64,12 +66,16 @@ class OkHttpJsonApiClientTests {
         Mockito.`when`(response.message).thenReturn("test")
         try {
             okHttpJsonApiClient.getNearbyPlaces(latLng, "test", 10.0, "test")
-            okHttpJsonApiClient.getNearbyPlaces(latLng, latLng, "test", true, "test")
         } catch (e: Exception) {
             assert(e.message.equals("test"))
         }
-        verify(okhttpClient).newCall(any())
-        verify(call).execute()
+        try {
+            okHttpJsonApiClient.getNearbyPlaces(NearbyQueryParams.Rectangular(latLng, latLng), "test", true, "test")
+        } catch (e: Exception) {
+            assert(e.message.equals("test"))
+        }
+        verify(okhttpClient, times(2)).newCall(any())
+        verify(call, times(2)).execute()
     }
 
     @Test
@@ -77,11 +83,48 @@ class OkHttpJsonApiClientTests {
         Mockito.`when`(response.message).thenReturn("test")
         try {
             okHttpJsonApiClient.getNearbyPlaces(latLng, "test", 10.0, null)
-            okHttpJsonApiClient.getNearbyPlaces(latLng, latLng, "test", true, null)
         } catch (e: Exception) {
             assert(e.message.equals("test"))
         }
-        verify(okhttpClient).newCall(any())
-        verify(call).execute()
+        try {
+            okHttpJsonApiClient.getNearbyPlaces(
+                NearbyQueryParams.Rectangular(latLng, latLng),
+                "test",
+                true,
+                null
+            )
+
+        } catch (e: Exception) {
+            assert(e.message.equals("test"))
+        }
+        try {
+            okHttpJsonApiClient.getNearbyPlaces(
+                NearbyQueryParams.Radial(latLng, 10f),
+                "test",
+                true,
+                null
+            )
+        } catch (e: Exception) {
+            assert(e.message.equals("test"))
+        }
+        verify(okhttpClient, times(3)).newCall(any())
+        verify(call, times(3)).execute()
+    }
+
+    @Test
+    fun testGetNearbyItemCount() {
+        Mockito.`when`(response.message).thenReturn("test")
+        try {
+            okHttpJsonApiClient.getNearbyItemCount(NearbyQueryParams.Radial(latLng, 10f))
+        } catch (e: Exception) {
+            assert(e.message.equals("test"))
+        }
+        try {
+            okHttpJsonApiClient.getNearbyItemCount(NearbyQueryParams.Rectangular(latLng, latLng))
+        } catch (e: Exception) {
+            assert(e.message.equals("test"))
+        }
+        verify(okhttpClient, times(2)).newCall(any())
+        verify(call, times(2)).execute()
     }
 }


### PR DESCRIPTION
**Description (required)**

Fixes #6044

Put briefly, the map now only searches in up to 300km radius centered on the screen's center.

The change wasnn't that simple, as loading the list of items even for a 50km radius can result in timeout for some locations, so I implemented an algorithm based on binary search to figure out the appropriate radius to list items inside, by first making some COUNT queries. Also, the centermost pins now appear on top.

**Tests performed (required)**

Tested BetaDebug on Medium Phone AVD and a Physical Device with API levels 34 and 33 respectively.

**Screenshots (for UI changes only)**

https://github.com/user-attachments/assets/e589876f-2853-4677-81d9-556eb358d4b0