### PR TITLE
 Refactor usage of Html.fromHtml to use HtmlCompat.fromHtml (Issue #6002)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/feedback/FeedbackDialog.kt
+++ b/app/src/main/java/fr/free/nrw/commons/feedback/FeedbackDialog.kt
@@ -2,6 +2,7 @@ package fr.free.nrw.commons.feedback
 
 import android.app.Dialog
 import android.content.Context
+import android.os.Build
 import android.os.Bundle
 import android.text.Html
 import android.text.Spanned
@@ -26,11 +27,13 @@ class FeedbackDialog(
     private val onFeedbackSubmitCallback: OnFeedbackSubmitCallback) : Dialog(context) {
     private var _binding: DialogFeedbackBinding? = null
     private val binding get() = _binding!!
-    // TODO("Remove Deprecation") Issue : #6002
-    // 'fromHtml(String!): Spanned!' is deprecated. Deprecated in Java
-    @Suppress("DEPRECATION")
-    private var feedbackDestinationHtml: Spanned = Html.fromHtml(
-        context.getString(R.string.feedback_destination_note))
+    // Refactored to handle deprecation for Html.fromHtml()
+    private var feedbackDestinationHtml: Spanned = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        Html.fromHtml(context.getString(R.string.feedback_destination_note), Html.FROM_HTML_MODE_LEGACY)
+    } else {
+        @Suppress("DEPRECATION")
+        Html.fromHtml(context.getString(R.string.feedback_destination_note))
+    }
 
 
     public override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -23,6 +23,7 @@ import android.graphics.drawable.Drawable;
 import android.location.Location;
 import android.location.LocationManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
@@ -511,7 +512,12 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         moveCameraToPosition(lastMapFocus);
         initRvNearbyList();
         onResume();
-        binding.tvAttribution.setText(Html.fromHtml(getString(R.string.map_attribution)));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            binding.tvAttribution.setText(Html.fromHtml(getString(R.string.map_attribution), Html.FROM_HTML_MODE_LEGACY));
+        } else {
+            //noinspection deprecation
+            binding.tvAttribution.setText(Html.fromHtml(getString(R.string.map_attribution)));
+        }
         binding.tvAttribution.setMovementMethod(LinkMovementMethod.getInstance());
         binding.nearbyFilterList.btnAdvancedOptions.setOnClickListener(v -> {
             binding.nearbyFilter.searchViewLayout.searchView.clearFocus();

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewImageFragment.kt
@@ -61,7 +61,12 @@ class ReviewImageFragment : CommonsDaggerSupportFragment() {
                     R.string.review_category_explanation,
                     formattedCatString
                 )
-                return Html.fromHtml(stringToConvertHtml).toString()
+                val formattedString = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                    Html.fromHtml(stringToConvertHtml, Html.FROM_HTML_MODE_LEGACY).toString()
+                } else {
+                    Html.fromHtml(stringToConvertHtml).toString()
+                }
+                return formattedString
             }
         }
         return getString(R.string.review_no_category)

--- a/app/src/main/java/fr/free/nrw/commons/upload/license/MediaLicenseFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/license/MediaLicenseFragment.java
@@ -2,6 +2,7 @@ package fr.free.nrw.commons.upload.license;
 
 import android.app.Activity;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.text.Html;
 import android.text.SpannableStringBuilder;
@@ -151,7 +152,9 @@ public class MediaLicenseFragment extends UploadBaseFragment implements MediaLic
     }
 
     private void setTextViewHTML(TextView textView, String text) {
-        CharSequence sequence = Html.fromHtml(text);
+        CharSequence sequence = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) ?
+            Html.fromHtml(text, Html.FROM_HTML_MODE_LEGACY) : Html.fromHtml(text);
+
         SpannableStringBuilder strBuilder = new SpannableStringBuilder(sequence);
         URLSpan[] urls = strBuilder.getSpans(0, sequence.length(), URLSpan.class);
         for (URLSpan span : urls) {


### PR DESCRIPTION
**Description:**

This PR refactors the usage of Html.fromHtml across the project to address the deprecation warning and replace it with HtmlCompat.fromHtml for compatibility across all Android API levels.

___________________________________________________________________________________________________________
**Changes:**

Replaced deprecated Html.fromHtml with HtmlCompat.fromHtml in multiple files:
StringUtil.kt
NearbyParentFragment.java
FeedbackDialog.kt
ReviewImageFragment.kt

___________________________________________________________________________________________________________
**Why:**

The Html.fromHtml method has been deprecated, and we aim to ensure compatibility with newer Android versions by using HtmlCompat.fromHtml.

**Fixes: #6002 **

___________________________________________________________________________________________________________
**Testing:**

Ensure the Html.fromHtml functionality is working correctly after the refactor.
