### PR TITLE
Add cancel button to dialogs with no button

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/customselector/helper/FolderDeletionHelper.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/helper/FolderDeletionHelper.kt
@@ -42,6 +42,7 @@ object FolderDeletionHelper {
 
             AlertDialog.Builder(context)
                 .setTitle(context.getString(R.string.custom_selector_confirm_deletion_title))
+                .setCancelable(false)
                 .setMessage(
                     context.getString(
                         R.string.custom_selector_confirm_deletion_message,

--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/CustomSelectorActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/CustomSelectorActivity.kt
@@ -268,6 +268,7 @@ class CustomSelectorActivity :
      */
     private fun showWelcomeDialog() {
         val dialog = Dialog(this)
+        dialog.setCancelable(false)
         dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
         dialog.setContentView(R.layout.custom_selector_info_dialog)
         (dialog.findViewById(R.id.btn_ok) as Button).setOnClickListener { dialog.dismiss() }
@@ -683,6 +684,7 @@ class CustomSelectorActivity :
      */
     private fun displayUploadLimitWarning() {
         val dialog = Dialog(this)
+        dialog.setCancelable(false)
         dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
         dialog.setContentView(R.layout.custom_selector_limit_dialog)
         (dialog.findViewById(R.id.btn_dismiss_limit_warning) as Button).setOnClickListener { dialog.dismiss() }

--- a/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.java
@@ -67,6 +67,7 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
             .setPositiveButton(android.R.string.yes,
                 (dialog, which) -> setDeleteRecentPositiveButton(context, dialog))
             .setNegativeButton(android.R.string.no, null)
+            .setCancelable(false)
             .create()
             .show();
     }
@@ -94,6 +95,7 @@ public class RecentSearchesFragment extends CommonsDaggerSupportFragment {
             .setPositiveButton(getString(R.string.delete).toUpperCase(Locale.ROOT),
                 ((dialog, which) -> setDeletePositiveButton(context, dialog, position)))
             .setNegativeButton(android.R.string.cancel, null)
+            .setCancelable(false)
             .create()
             .show();
     }

--- a/app/src/main/java/fr/free/nrw/commons/feedback/FeedbackDialog.kt
+++ b/app/src/main/java/fr/free/nrw/commons/feedback/FeedbackDialog.kt
@@ -46,6 +46,7 @@ class FeedbackDialog(
         // 'SOFT_INPUT_ADJUST_RESIZE: Int' is deprecated. Deprecated in Java
         @Suppress("DEPRECATION")
         window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        binding.btnCancel.setOnClickListener { dismiss() }
         binding.btnSubmitFeedback.setOnClickListener {
             try {
                 submitFeedback()

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -291,6 +291,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
         builder.setItems(R.array.report_violation_options, (dialog, which) -> {
             sendReportEmail(media, values[which]);
         });
+        builder.setNegativeButton(R.string.cancel, (dialog, which) -> {});
         builder.setCancelable(false);
         builder.show();
     }

--- a/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetFragment.kt
@@ -161,7 +161,10 @@ class MoreBottomSheetFragment : BottomSheetDialogFragment() {
             override fun onFeedbackSubmit(feedback: Feedback) {
                 uploadFeedback(feedback)
             }
-        }).show()
+        }).apply {
+            setCancelable(false)
+            show()
+        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetLoggedOutFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/navtab/MoreBottomSheetLoggedOutFragment.kt
@@ -94,6 +94,7 @@ class MoreBottomSheetLoggedOutFragment : BottomSheetDialogFragment() {
             .setMessage(R.string.feedback_sharing_data_alert)
             .setCancelable(false)
             .setPositiveButton(R.string.ok) { _, _ -> sendFeedback() }
+            .setNegativeButton(R.string.cancel){_,_ -> }
             .show()
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/CommonPlaceClickActions.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/CommonPlaceClickActions.kt
@@ -128,6 +128,8 @@ class CommonPlaceClickActions
             AlertDialog
                 .Builder(activity)
                 .setMessage(R.string.login_alert_message)
+                .setCancelable(false)
+                .setNegativeButton(R.string.cancel){_,_ -> }
                 .setPositiveButton(R.string.login) { dialog, which ->
                     setPositiveButton()
                 }.show()

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1614,6 +1614,8 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             // prompt the user to login
             new Builder(getContext())
                 .setMessage(R.string.login_alert_message)
+                .setCancelable(false)
+                .setNegativeButton(R.string.cancel, (dialog, which) -> {})
                 .setPositiveButton(R.string.login, (dialog, which) -> {
                     // logout of the app
                     BaseLogoutListener logoutListener = new BaseLogoutListener(getActivity());

--- a/app/src/main/java/fr/free/nrw/commons/quiz/QuizActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/quiz/QuizActivity.kt
@@ -139,6 +139,7 @@ class QuizActivity : AppCompatActivity() {
             .setTitle(title)
             .setMessage(message)
             .setCancelable(false)
+            .setNegativeButton(R.string.cancel){_,_ -> }
             .setPositiveButton(R.string.continue_message) { dialog, _ ->
                 questionIndex++
                 if (questionIndex == quiz.size) {

--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.kt
@@ -14,6 +14,7 @@ import android.text.TextWatcher
 import android.view.KeyEvent
 import android.view.View
 import android.widget.AdapterView
+import android.widget.Button
 import android.widget.EditText
 import android.widget.ListView
 import android.widget.TextView
@@ -333,24 +334,16 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
         val dialog = Dialog(requireActivity())
         dialog.setContentView(R.layout.dialog_select_language)
-        dialog.setCancelable(true)// Allow dialog to close with the back button
+        dialog.setCancelable(false)
         dialog.window?.setLayout(
             (resources.displayMetrics.widthPixels * 0.90).toInt(),
             (resources.displayMetrics.heightPixels * 0.90).toInt()
         )
-        // Handle back button explicitly to dismiss the dialog
-        dialog.setOnKeyListener { _, keyCode, event ->
-            if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
-                dialog.dismiss() // Close the dialog when the back button is pressed
-                true
-            } else {
-                false
-            }
-        }
         dialog.show()
 
         val editText: EditText = dialog.findViewById(R.id.search_language)
         val listView: ListView = dialog.findViewById(R.id.language_list)
+        val cancelButton = dialog.findViewById<Button>(R.id.cancel_button)
         languageHistoryListView = dialog.findViewById(R.id.language_history_list)
         recentLanguagesTextView = dialog.findViewById(R.id.recent_searches)
         separator = dialog.findViewById(R.id.separator)
@@ -358,6 +351,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
         setUpRecentLanguagesSection(recentLanguages, selectedLanguages)
 
         listView.adapter = languagesAdapter
+
+        cancelButton.setOnClickListener { dialog.dismiss() }
 
         editText.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(charSequence: CharSequence, start: Int, count: Int, after: Int) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.java
@@ -898,6 +898,7 @@ public class UploadActivity extends BaseActivity implements
             .setView(view)
             .setTitle(getString(R.string.multiple_files_depiction_header))
             .setMessage(getString(R.string.multiple_files_depiction))
+            .setCancelable(false)
             .setPositiveButton("OK", (dialog, which) -> {
                 if (checkBox.isChecked()) {
                     // Save the user's choice to not show the dialog again

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
@@ -14,6 +14,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
+import android.widget.Button;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
@@ -357,12 +358,15 @@ public class UploadMediaDetailAdapter extends
 
                     EditText editText = dialog.findViewById(R.id.search_language);
                     ListView listView = dialog.findViewById(R.id.language_list);
+                    final Button cancelButton = dialog.findViewById(R.id.cancel_button);
                     languageHistoryListView = dialog.findViewById(R.id.language_history_list);
                     recentLanguagesTextView = dialog.findViewById(R.id.recent_searches);
                     separator = dialog.findViewById(R.id.separator);
                     setUpRecentLanguagesSection(recentLanguages);
 
                     listView.setAdapter(languagesAdapter);
+
+                    cancelButton.setOnClickListener(v -> dialog.dismiss());
 
                     editText.addTextChangedListener(new TextWatcher() {
                         @Override

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.kt
@@ -285,6 +285,7 @@ class DepictsFragment : UploadBaseFragment(), DepictsContract.View {
     override fun showProgressDialog() {
         progressDialog = ProgressDialog(requireContext())
         progressDialog!!.setMessage(getString(R.string.please_wait))
+        progressDialog!!.setCancelable(false)
         progressDialog!!.show()
     }
 

--- a/app/src/main/res/layout/dialog_feedback.xml
+++ b/app/src/main/res/layout/dialog_feedback.xml
@@ -132,15 +132,32 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content" />
 
-    <Button
-      android:id="@+id/btn_submit_feedback"
-      android:textColor="@color/white"
-      android:layout_marginBottom="@dimen/dimen_10"
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="@dimen/dimen_10"
       android:gravity="center"
-      android:layout_gravity="center"
-      android:text="@string/submit"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content" />
+      android:orientation="horizontal">
+
+      <Button
+        android:id="@+id/btn_cancel"
+        android:textColor="@color/white"
+        android:layout_gravity="center"
+        android:layout_weight="1"
+        android:text="@string/cancel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+      <Button
+        android:id="@+id/btn_submit_feedback"
+        android:textColor="@color/white"
+        android:layout_weight="1"
+        android:layout_gravity="center"
+        android:text="@string/submit"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    </LinearLayout>
 
   </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/dialog_select_language.xml
+++ b/app/src/main/res/layout/dialog_select_language.xml
@@ -66,9 +66,18 @@
     android:layout_height="0dp"
     android:layout_marginTop="8dp"
     android:id="@+id/language_list"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintBottom_toTopOf="@id/cancel_button"
     app:layout_constraintTop_toBottomOf="@+id/all_languages" />
+
+
+  <Button
+    android:id="@+id/cancel_button"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/cancel"
+    android:textColor="@color/primaryColor"
+    android:background="@android:color/transparent"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #6076

What changes did you make and why?

- Added a `cancel` button to dialogs which didn't have any button because dialogs are modal (non dismissable).

- Also, I have made dialogs modal which were missed earlier (my IDE had some filter applied so missed some) in this PR #6015