### PR TITLE
Fix: Crash When Clicking on Bookmarked Locations

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceAdapterDelegate.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceAdapterDelegate.kt
@@ -41,15 +41,18 @@ fun placeAdapterDelegate(
             showOrHideAndScrollToIfLast()
             onItemClick?.invoke(item)
         }
-        root.setOnFocusChangeListener { view1: View?, hasFocus: Boolean ->
+        root.setOnFocusChangeListener { _: View?, hasFocus: Boolean ->
+            val parentView = root.parent.parent.parent as? RelativeLayout
+            val bottomSheetBehavior = parentView?.let { BottomSheetBehavior.from(it) }
+
+            // Hide button layout if focus is lost, otherwise show it if it's not already visible
             if (!hasFocus && nearbyButtonLayout.buttonLayout.isShown) {
                 nearbyButtonLayout.buttonLayout.visibility = GONE
-            } else if (hasFocus && !nearbyButtonLayout.buttonLayout.isShown &&
-                BottomSheetBehavior.from(root.parent.parent.parent as RelativeLayout).state !=
-                BottomSheetBehavior.STATE_HIDDEN
-            ) {
-                showOrHideAndScrollToIfLast()
-                onItemClick?.invoke(item)
+            } else if (hasFocus && !nearbyButtonLayout.buttonLayout.isShown) {
+                if (bottomSheetBehavior?.state != BottomSheetBehavior.STATE_HIDDEN) {
+                    showOrHideAndScrollToIfLast()
+                    onItemClick?.invoke(item)
+                }
             }
         }
         nearbyButtonLayout.cameraButton.setOnClickListener { onCameraClicked(item, inAppCameraLocationPermissionLauncher, cameraPickLauncherForResult) }


### PR DESCRIPTION
**Description **

This PR resolves the ClassCastException encountered when interacting with bookmarked locations.
Cause:
The crash was caused by an incorrect cast from FrameLayout to RelativeLayout in PlaceAdapterDelegate.kt.

**Fixes #6077** 

__________________________________________________________________________________________________________
**CHANGES MADE**

-Updated the property to be nullable to handle cases where the layout is not as expected.
-Corrected the logic to handle the layout type safely.

___________________________________________________________________________________________________________
**Tests performed**

Tested {build variant, betaDebug} on {Vivo v25} with API level {34}.


https://github.com/user-attachments/assets/d04784a8-835a-470f-a5d4-1c59d1f949ba

