### PR TITLE
Nearby: show cached pins even when internet is unavailable (fixes #6051)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/data/DBOpenHelper.kt
+++ b/app/src/main/java/fr/free/nrw/commons/data/DBOpenHelper.kt
@@ -18,7 +18,7 @@ class DBOpenHelper(
 
     companion object {
         private const val DATABASE_NAME = "commons.db"
-        private const val DATABASE_VERSION = 20
+        private const val DATABASE_VERSION = 21
         const val CONTRIBUTIONS_TABLE = "contributions"
         private const val DROP_TABLE_STATEMENT = "DROP TABLE IF EXISTS %s"
     }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
@@ -5,6 +5,7 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.room.Embedded;
 import androidx.room.Entity;
 import androidx.room.PrimaryKey;
 import fr.free.nrw.commons.location.LatLng;
@@ -24,6 +25,7 @@ public class Place implements Parcelable {
     public String name;
     private Label label;
     private String longDescription;
+    @Embedded
     public LatLng location;
     @PrimaryKey @NonNull
     public String entityID;

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceDao.java
@@ -33,7 +33,7 @@ public abstract class PlaceDao {
     @Query("SELECT * from place WHERE entityID=:entity")
     public abstract Place getPlace(String entity);
 
-    @Query("SELECT * from place WHERE latitude>=:latBegin AND longitude>=:lngBegin "
+    @Query("SELECT * from place WHERE name!='' AND latitude>=:latBegin AND longitude>=:lngBegin "
         + "AND latitude<:latEnd AND longitude<:lngEnd")
     public abstract List<Place> fetchPlaces(double latBegin, double lngBegin,
         double latEnd, double lngEnd);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceDao.java
@@ -33,6 +33,15 @@ public abstract class PlaceDao {
     @Query("SELECT * from place WHERE entityID=:entity")
     public abstract Place getPlace(String entity);
 
+    /**
+     * Retrieves a list of places within the specified rectangular area.
+     *
+     * @param latBegin Latitudinal lower bound
+     * @param lngBegin Longitudinal lower bound
+     * @param latEnd Latitudinal upper bound, should be greater than `latBegin`
+     * @param lngEnd Longitudinal upper bound, should be greater than `lngBegin`
+     * @return The list of places within the specified rectangular geographical area.
+     */
     @Query("SELECT * from place WHERE name!='' AND latitude>=:latBegin AND longitude>=:lngBegin "
         + "AND latitude<:latEnd AND longitude<:lngEnd")
     public abstract List<Place> fetchPlaces(double latBegin, double lngBegin,

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlaceDao.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlaceDao.java
@@ -5,6 +5,7 @@ import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
 import io.reactivex.Completable;
+import java.util.List;
 
 /**
  * Data Access Object (DAO) for accessing the Place entity in the database.
@@ -31,6 +32,11 @@ public abstract class PlaceDao {
      */
     @Query("SELECT * from place WHERE entityID=:entity")
     public abstract Place getPlace(String entity);
+
+    @Query("SELECT * from place WHERE latitude>=:latBegin AND longitude>=:lngBegin "
+        + "AND latitude<:latEnd AND longitude<:lngEnd")
+    public abstract List<Place> fetchPlaces(double latBegin, double lngBegin,
+        double latEnd, double lngEnd);
 
     /**
      * Saves a Place object asynchronously into the database.

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlacesLocalDataSource.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlacesLocalDataSource.java
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.nearby;
 
 import io.reactivex.Completable;
+import java.util.List;
 import javax.inject.Inject;
 
 /**
@@ -24,6 +25,11 @@ public class PlacesLocalDataSource {
      */
     public Place fetchPlace(String entityID){
         return placeDao.getPlace(entityID);
+    }
+
+    public List<Place> fetchPlaces(final double latBegin, final double lngBegin,
+        final double latEnd, final double lngEnd) {
+        return placeDao.fetchPlaces(latBegin, lngBegin, latEnd, lngEnd);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlacesLocalDataSource.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlacesLocalDataSource.java
@@ -30,6 +30,14 @@ public class PlacesLocalDataSource {
         return placeDao.getPlace(entityID);
     }
 
+    /**
+     * Retrieves a list of places from the database within the geographical area
+     * specified by map's opposite corners.
+     *
+     * @param mapBottomLeft Bottom left corner of the map.
+     * @param mapTopRight Top right corner of the map.
+     * @return The list of saved places within the map's view.
+     */
     public List<Place> fetchPlaces(final LatLng mapBottomLeft, final LatLng mapTopRight) {
         class Constraint {
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlacesLocalDataSource.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlacesLocalDataSource.java
@@ -5,6 +5,7 @@ import io.reactivex.Completable;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
+import timber.log.Timber;
 
 /**
  * The LocalDataSource class for Places
@@ -29,7 +30,7 @@ public class PlacesLocalDataSource {
         return placeDao.getPlace(entityID);
     }
 
-    public List<Place> fetchPlaces(final LatLng mapTopRight, final LatLng mapBottomLeft) {
+    public List<Place> fetchPlaces(final LatLng mapBottomLeft, final LatLng mapTopRight) {
         class Constraint {
 
             final double latBegin;

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlacesRepository.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlacesRepository.java
@@ -40,9 +40,8 @@ public class PlacesRepository {
         return localDataSource.fetchPlace(entityID);
     }
 
-    public List<Place> fetchPlaces(final double latBegin, final double lngBegin,
-        final double latEnd, final double lngEnd) {
-        return localDataSource.fetchPlaces(latBegin, lngBegin, latEnd, lngEnd);
+    public List<Place> fetchPlaces(final LatLng mapBottomLeft, final LatLng mapTopRight) {
+        return localDataSource.fetchPlaces(mapBottomLeft, mapTopRight);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlacesRepository.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlacesRepository.java
@@ -40,6 +40,13 @@ public class PlacesRepository {
         return localDataSource.fetchPlace(entityID);
     }
 
+    /**
+     * Retrieves a list of places within the geographical area specified by map's opposite corners.
+     *
+     * @param mapBottomLeft Bottom left corner of the map.
+     * @param mapTopRight Top right corner of the map.
+     * @return The list of saved places within the map's view.
+     */
     public List<Place> fetchPlaces(final LatLng mapBottomLeft, final LatLng mapTopRight) {
         return localDataSource.fetchPlaces(mapBottomLeft, mapTopRight);
     }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/PlacesRepository.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/PlacesRepository.java
@@ -4,6 +4,7 @@ import fr.free.nrw.commons.contributions.Contribution;
 import fr.free.nrw.commons.location.LatLng;
 import io.reactivex.Completable;
 import io.reactivex.schedulers.Schedulers;
+import java.util.List;
 import javax.inject.Inject;
 
 /**
@@ -37,6 +38,11 @@ public class PlacesRepository {
      */
     public Place fetchPlace(String entityID){
         return localDataSource.fetchPlace(entityID);
+    }
+
+    public List<Place> fetchPlaces(final double latBegin, final double lngBegin,
+        final double latEnd, final double lngEnd) {
+        return localDataSource.fetchPlaces(latBegin, lngBegin, latEnd, lngEnd);
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
@@ -91,6 +91,10 @@ public interface NearbyParentFragmentContract {
 
         LatLng getMapFocus();
 
+        LatLng getScreenTopRight();
+
+        LatLng getScreenBottomLeft();
+
         boolean isAdvancedQueryFragmentVisible();
 
         void showHideAdvancedQueryFragment(boolean shouldShow);
@@ -130,6 +134,6 @@ public interface NearbyParentFragmentContract {
 
         void toggleBookmarkedStatus(Place place);
 
-        void handleMapScrolled(LifecycleCoroutineScope scope);
+        void handleMapScrolled(LifecycleCoroutineScope scope, boolean isNetworkAvailable);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
@@ -18,6 +18,8 @@ public interface NearbyParentFragmentContract {
 
         boolean isNetworkConnectionEstablished();
 
+        void updateSnackbar(boolean offlinePinsShown);
+
         void listOptionMenuItemClicked();
 
         void populatePlaces(LatLng currentLatLng);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/contract/NearbyParentFragmentContract.java
@@ -122,8 +122,6 @@ public interface NearbyParentFragmentContract {
         void filterByMarkerType(List<Label> selectedLabels, int state, boolean filterForPlaceState,
             boolean filterForAllNoneType);
 
-        void updateMapMarkersToController(List<BaseMarker> baseMarkers);
-
         void searchViewGainedFocus();
 
         void setCheckboxUnknown();
@@ -131,5 +129,7 @@ public interface NearbyParentFragmentContract {
         void setAdvancedQuery(String query);
 
         void toggleBookmarkedStatus(Place place);
+
+        void handleMapScrolled(LifecycleCoroutineScope scope);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1852,20 +1852,24 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
                 clickedMarker.closeInfoWindow();
             }
             clickedMarker = marker1;
-            binding.bottomSheetDetails.dataCircularProgress.setVisibility(View.VISIBLE);
-            binding.bottomSheetDetails.icon.setVisibility(View.GONE);
-            binding.bottomSheetDetails.wikiDataLl.setVisibility(View.GONE);
-            if (Objects.equals(place.name, "")) {
-                getPlaceData(place.getWikiDataEntityId(), place, marker1, isBookMarked);
+            if (!isNetworkErrorOccurred) {
+                binding.bottomSheetDetails.dataCircularProgress.setVisibility(View.VISIBLE);
+                binding.bottomSheetDetails.icon.setVisibility(View.GONE);
+                binding.bottomSheetDetails.wikiDataLl.setVisibility(View.GONE);
+                if (Objects.equals(place.name, "")) {
+                    getPlaceData(place.getWikiDataEntityId(), place, marker1, isBookMarked);
+                } else {
+                    marker.showInfoWindow();
+                    binding.bottomSheetDetails.dataCircularProgress.setVisibility(View.GONE);
+                    binding.bottomSheetDetails.icon.setVisibility(View.VISIBLE);
+                    binding.bottomSheetDetails.wikiDataLl.setVisibility(View.VISIBLE);
+                    passInfoToSheet(place);
+                    hideBottomSheet();
+                }
+                bottomSheetDetailsBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
             } else {
                 marker.showInfoWindow();
-                binding.bottomSheetDetails.dataCircularProgress.setVisibility(View.GONE);
-                binding.bottomSheetDetails.icon.setVisibility(View.VISIBLE);
-                binding.bottomSheetDetails.wikiDataLl.setVisibility(View.VISIBLE);
-                passInfoToSheet(place);
-                hideBottomSheet();
             }
-            bottomSheetDetailsBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
             return true;
         });
         return marker;

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -65,7 +65,6 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCa
 import com.google.android.material.snackbar.Snackbar;
 import com.jakewharton.rxbinding2.view.RxView;
 import com.jakewharton.rxbinding3.appcompat.RxSearchView;
-import fr.free.nrw.commons.BaseMarker;
 import fr.free.nrw.commons.CommonsApplication;
 import fr.free.nrw.commons.CommonsApplication.BaseLogoutListener;
 import fr.free.nrw.commons.MapController.NearbyPlacesInfo;
@@ -1038,6 +1037,18 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
                 }
             }
         };
+    }
+
+    @Override
+    public void updateSnackbar(final boolean offlinePinsShown) {
+        if (!isNetworkErrorOccurred || snackbar == null) {
+            return;
+        }
+        if (offlinePinsShown) {
+            snackbar.setText(R.string.nearby_showing_pins_offline);
+        } else {
+            snackbar.setText(R.string.no_internet);
+        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -1039,6 +1039,11 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         };
     }
 
+    /**
+     * Updates the internet unavailable snackbar to reflect whether cached pins are shown.
+     *
+     * @param offlinePinsShown Whether there are pins currently being shown on map.
+     */
     @Override
     public void updateSnackbar(final boolean offlinePinsShown) {
         if (!isNetworkErrorOccurred || snackbar == null) {
@@ -1065,6 +1070,11 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         }
     }
 
+    /**
+     * Returns the location of the top right corner of the map view.
+     *
+     * @return a `LatLng` object denoting the location of the top right corner of the map.
+     */
     @Override
     public LatLng getScreenTopRight() {
         final IGeoPoint screenTopRight = binding.map.getProjection()
@@ -1073,6 +1083,11 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             screenTopRight.getLatitude(), screenTopRight.getLongitude(), 0);
     }
 
+    /**
+     * Returns the location of the bottom left corner of the map view.
+     *
+     * @return a `LatLng` object denoting the location of the bottom left corner of the map.
+     */
     @Override
     public LatLng getScreenBottomLeft() {
         final IGeoPoint screenBottomLeft = binding.map.getProjection()

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -472,7 +472,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
         binding.map.addMapListener(new MapListener() {
             @Override
             public boolean onScroll(ScrollEvent event) {
-                presenter.handleMapScrolled(scope);
+                presenter.handleMapScrolled(scope, !isNetworkErrorOccurred);
                 return true;
             }
 
@@ -1055,15 +1055,27 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     }
 
     @Override
-    public void populatePlaces(final LatLng currentLatLng) {
-            IGeoPoint screenTopRight = binding.map.getProjection()
+    public LatLng getScreenTopRight() {
+        final IGeoPoint screenTopRight = binding.map.getProjection()
             .fromPixels(binding.map.getWidth(), 0);
-        IGeoPoint screenBottomLeft = binding.map.getProjection()
-            .fromPixels(0, binding.map.getHeight());
-        LatLng screenTopRightLatLng = new LatLng(
-            screenBottomLeft.getLatitude(), screenBottomLeft.getLongitude(), 0);
-        LatLng screenBottomLeftLatLng = new LatLng(
+        return new LatLng(
             screenTopRight.getLatitude(), screenTopRight.getLongitude(), 0);
+    }
+
+    @Override
+    public LatLng getScreenBottomLeft() {
+        final IGeoPoint screenBottomLeft = binding.map.getProjection()
+            .fromPixels(0, binding.map.getHeight());
+        return new LatLng(
+            screenBottomLeft.getLatitude(), screenBottomLeft.getLongitude(), 0);
+    }
+
+    @Override
+    public void populatePlaces(final LatLng currentLatLng) {
+        // these two variables have historically been assigned values the opposite of what their
+        // names imply, and quite some existing code depends on this fact
+        LatLng screenTopRightLatLng = getScreenBottomLeft();
+        LatLng screenBottomLeftLatLng = getScreenTopRight();
 
         // When the nearby fragment is opened immediately upon app launch, the {screenTopRightLatLng}
         // and {screenBottomLeftLatLng} variables return {LatLng(0.0,0.0)} as output.
@@ -1116,14 +1128,10 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             populatePlaces(currentLatLng);
             return;
         }
-        IGeoPoint screenTopRight = binding.map.getProjection()
-            .fromPixels(binding.map.getWidth(), 0);
-        IGeoPoint screenBottomLeft = binding.map.getProjection()
-            .fromPixels(0, binding.map.getHeight());
-        LatLng screenTopRightLatLng = new LatLng(
-            screenBottomLeft.getLatitude(), screenBottomLeft.getLongitude(), 0);
-        LatLng screenBottomLeftLatLng = new LatLng(
-            screenTopRight.getLatitude(), screenTopRight.getLongitude(), 0);
+        // these two variables have historically been assigned values the opposite of what their
+        // names imply, and quite some existing code depends on this fact
+        final LatLng screenTopRightLatLng = getScreenBottomLeft();
+        final LatLng screenBottomLeftLatLng = getScreenTopRight();
 
         if (currentLatLng.equals(lastFocusLocation) || lastFocusLocation == null
             || recenterToUserLocation) { // Means we are checking around current location

--- a/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.kt
@@ -528,6 +528,9 @@ class NearbyParentFragmentPresenter
                 ensureActive()
                 NearbyController.currentLocation = mapFocus
                 schedulePlacesUpdate(markerPlaceGroups, force = true)
+                withContext(Dispatchers.Main) {
+                    nearbyParentFragmentView.updateSnackbar(!markerPlaceGroups.isEmpty())
+                }
             }
         }
     }

--- a/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.kt
@@ -4,7 +4,6 @@ import android.location.Location
 import android.view.View
 import androidx.annotation.MainThread
 import androidx.lifecycle.LifecycleCoroutineScope
-import fr.free.nrw.commons.BaseMarker
 import fr.free.nrw.commons.bookmarks.locations.BookmarkLocationsDao
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import fr.free.nrw.commons.location.LatLng

--- a/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.kt
@@ -492,6 +492,12 @@ class NearbyParentFragmentPresenter
         }
     }
 
+    /**
+     * Handles the map scroll user action for `NearbyParentFragment`
+     *
+     * @param scope The lifecycle scope of `nearbyParentFragment`'s `viewLifecycleOwner`
+     * @param isNetworkAvailable Whether to load pins from the internet or from the cache.
+     */
     @Override
     override fun handleMapScrolled(scope: LifecycleCoroutineScope?, isNetworkAvailable: Boolean) {
         scope ?: return

--- a/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.kt
@@ -54,6 +54,7 @@ class NearbyParentFragmentPresenter
 
     private var placeSearchJob: Job? = null
     private var isSearchInProgress = false
+    private var localPlaceSearchJob: Job? = null
 
     private val clickedPlaces = CopyOnWriteArrayList<Place>()
 
@@ -495,8 +496,9 @@ class NearbyParentFragmentPresenter
     @Override
     override fun handleMapScrolled(scope: LifecycleCoroutineScope?) {
         scope ?: return
+
         placeSearchJob?.cancel()
-        placeSearchJob = scope.launch {
+        placeSearchJob = scope.launch(Dispatchers.Main) {
             delay(SCROLL_DELAY)
             if (!isSearchInProgress) {
                 isSearchInProgress = true; // search executing flag
@@ -507,6 +509,12 @@ class NearbyParentFragmentPresenter
                     isSearchInProgress = false;
                 }
             }
+        }
+
+        localPlaceSearchJob?.cancel()
+        localPlaceSearchJob = scope.launch {
+            delay(LOCAL_SCROLL_DELAY)
+
         }
     }
 
@@ -583,6 +591,7 @@ class NearbyParentFragmentPresenter
 
     companion object {
         private const val SCROLL_DELAY = 800L; // Delay for debounce of onscroll, in milliseconds.
+        private const val LOCAL_SCROLL_DELAY = 200L; // SCROLL_DELAY but for local db place search
         private val DUMMY = Proxy.newProxyInstance(
             NearbyParentFragmentContract.View::class.java.getClassLoader(),
             arrayOf<Class<*>>(NearbyParentFragmentContract.View::class.java),

--- a/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.kt
@@ -494,27 +494,29 @@ class NearbyParentFragmentPresenter
     }
 
     @Override
-    override fun handleMapScrolled(scope: LifecycleCoroutineScope?) {
+    override fun handleMapScrolled(scope: LifecycleCoroutineScope?, isNetworkAvailable: Boolean) {
         scope ?: return
 
         placeSearchJob?.cancel()
-        placeSearchJob = scope.launch(Dispatchers.Main) {
-            delay(SCROLL_DELAY)
-            if (!isSearchInProgress) {
-                isSearchInProgress = true; // search executing flag
-                // Start Search
-                try {
-                    searchInTheArea();
-                } finally {
-                    isSearchInProgress = false;
+        localPlaceSearchJob?.cancel()
+        if (isNetworkAvailable) {
+            placeSearchJob = scope.launch(Dispatchers.Main) {
+                delay(SCROLL_DELAY)
+                if (!isSearchInProgress) {
+                    isSearchInProgress = true; // search executing flag
+                    // Start Search
+                    try {
+                        searchInTheArea();
+                    } finally {
+                        isSearchInProgress = false;
+                    }
                 }
             }
-        }
+        } else {
+            localPlaceSearchJob = scope.launch {
+                delay(LOCAL_SCROLL_DELAY)
 
-        localPlaceSearchJob?.cancel()
-        localPlaceSearchJob = scope.launch {
-            delay(LOCAL_SCROLL_DELAY)
-
+            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -282,6 +282,7 @@
   <string name="copy_wikicode">Copy the wikitext to the clipboard</string>
   <string name="wikicode_copied">The wikitext was copied to the clipboard</string>
   <string name="nearby_location_not_available">Nearby might not work properly, Location not available.</string>
+  <string name="nearby_showing_pins_offline">Internet unavailable. Showing only cached places.</string>
   <string name="upload_location_access_denied">Location access denied. Please set your location manually to use this feature.</string>
   <string name="location_permission_rationale_nearby">Permission required to display a list of nearby places</string>
   <string name="location_permission_rationale_explore">Permission required to display a list of nearby images</string>


### PR DESCRIPTION
**Description (required)**

Fixes #6051 

Cached pins are now shown when the internet is unavailable

**Tests performed (required)**

Tested BetaDebug on Medium Phone AVD and a physical device with API levels 34 and 33 respectively.

**Screenshots (for UI changes only)**

https://github.com/user-attachments/assets/3bdc8e71-8070-4b43-b335-4c5190a98ea4

---

Possible improvement: now that saved places can be fetched from the database using their location, they can be loaded this way even when internet is available, ahead of the fetching of places from internet, to simulate faster loading times.