### PR TITLE
Nearby: Make refreshing map simply reload pin details instead of reloading the entire map

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.java
@@ -92,6 +92,7 @@ import fr.free.nrw.commons.nearby.NearbyFilterSearchRecyclerViewAdapter;
 import fr.free.nrw.commons.nearby.NearbyFilterState;
 import fr.free.nrw.commons.nearby.Place;
 import fr.free.nrw.commons.nearby.PlacesRepository;
+import fr.free.nrw.commons.nearby.Sitelinks;
 import fr.free.nrw.commons.nearby.WikidataFeedback;
 import fr.free.nrw.commons.nearby.contract.NearbyParentFragmentContract;
 import fr.free.nrw.commons.nearby.fragments.AdvanceQueryFragment.Callback;
@@ -1173,27 +1174,7 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
     }
 
     /**
-     *  Reloads the Nearby map
-     *  Clears all location markers, refreshes them, reinserts them into the map.
-     *
-     */
-    private void reloadMap() {
-        clearAllMarkers(); // Clear the list of markers
-        binding.map.getController().setZoom(ZOOM_LEVEL); // Reset the zoom level
-        binding.map.getController().setCenter(lastMapFocus); // Recenter the focus
-        if (locationPermissionsHelper.checkLocationPermission(getActivity())) {
-            locationPermissionGranted(); // Reload map with user's location
-        } else {
-            startMapWithoutPermission(); // Reload map without user's location
-        }
-        binding.map.invalidate(); // Invalidate the map
-        presenter.updateMapAndList(LOCATION_SIGNIFICANTLY_CHANGED); // Restart the map
-        Timber.d("Reloaded Map Successfully");
-    }
-
-
-    /**
-     * Clears the Nearby local cache and then calls for the map to be reloaded
+     * Clears the Nearby local cache and then calls for pin details to be fetched afresh.
      *
      */
     private void emptyCache() {
@@ -1202,7 +1183,22 @@ public class NearbyParentFragment extends CommonsDaggerSupportFragment
             placesRepository.clearCache()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .andThen(Completable.fromAction(this::reloadMap))
+                .andThen(Completable.fromAction(() -> {
+                    // reload only the pin details, by making all loaded pins gray:
+                    ArrayList<MarkerPlaceGroup> newPlaceGroups = new ArrayList<>(
+                        NearbyController.markerLabelList.size());
+                    for (final MarkerPlaceGroup placeGroup : NearbyController.markerLabelList) {
+                        final Place place = new Place("", "", placeGroup.getPlace().getLabel(), "",
+                            placeGroup.getPlace().getLocation(), "",
+                            placeGroup.getPlace().siteLinks, "", placeGroup.getPlace().exists,
+                            placeGroup.getPlace().entityID);
+                        place.setDistance(placeGroup.getPlace().distance);
+                        place.setMonument(placeGroup.getPlace().isMonument());
+                        newPlaceGroups.add(
+                            new MarkerPlaceGroup(placeGroup.getIsBookmarked(), place));
+                    }
+                    presenter.loadPlacesDataAsync(newPlaceGroups, scope);
+                }))
                 .subscribe(
                     () -> {
                         Timber.d("Nearby Cache cleared successfully.");

--- a/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/presenter/NearbyParentFragmentPresenter.kt
@@ -300,10 +300,27 @@ class NearbyParentFragmentPresenter
                 }
                 ?: return
 
-        loadPlacesDataAyncJob?.cancel()
         lockUnlockNearby(false) // So that new location updates wont come
         nearbyParentFragmentView.setProgressBarVisibility(false)
+        loadPlacesDataAsync(nearbyPlaceGroups, scope)
+    }
 
+    /**
+     * Load the places' details from cache and Wikidata query, and update these details on the map
+     * as and when they arrive.
+     *
+     * @param nearbyPlaceGroups The list of `MarkerPlaceGroup` objects to be rendered on the map.
+     * Note that the supplied objects' `isBookmarked` property can be set false as the actual
+     * value is retrieved from the bookmarks db eventually.
+     * @param scope the lifecycle scope of `nearbyParentFragment`'s `viewLifecycleOwner`
+     *
+     * @see LoadPlacesAsyncOptions
+     */
+    fun loadPlacesDataAsync(
+        nearbyPlaceGroups: List<MarkerPlaceGroup>,
+        scope: LifecycleCoroutineScope?
+    ) {
+        loadPlacesDataAyncJob?.cancel()
         loadPlacesDataAyncJob = scope?.launch(Dispatchers.IO) {
             // clear past clicks and bookmarkChanged queues
             clickedPlaces.clear()


### PR DESCRIPTION
**Description (required)**

Fixes #5906

**Changes made**

Earlier, upon successful clearing of places cache, the entire map was reloaded, which included moving it (to the user's location or the last focused location) as a side effect.

Now, upon clearing the cache, simply the pin details are loaded.

**Tests performed (required)**

Tested BetaDebug on Samsung S20 FE with API level 33.