### PR TITLE
Fix crash while uploading

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/FileUtilsWrapper.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileUtilsWrapper.kt
@@ -49,9 +49,10 @@ class FileUtilsWrapper @Inject constructor(private val context: Context) {
                 while ((bis.read(buffer).also { size = it }) > 0) {
                     buffers.add(
                         writeToFile(
-                            buffer.copyOf(size),
+                            buffer,
                             file.name ?: "",
-                            getFileExt(file.name)
+                            getFileExt(file.name),
+                            size
                         )
                     )
                 }
@@ -67,7 +68,7 @@ class FileUtilsWrapper @Inject constructor(private val context: Context) {
      * Create a temp file containing the passed byte data.
      */
     @Throws(IOException::class)
-    private fun writeToFile(data: ByteArray, fileName: String, fileExtension: String): File {
+    private fun writeToFile(data: ByteArray, fileName: String, fileExtension: String, size: Int): File {
         val file = File.createTempFile(fileName, fileExtension, context.cacheDir)
         try {
             if (!file.exists()) {
@@ -75,7 +76,7 @@ class FileUtilsWrapper @Inject constructor(private val context: Context) {
             }
 
             FileOutputStream(file).use { fos ->
-                fos.write(data)
+                fos.write(data, 0, size)
             }
         } catch (throwable: Exception) {
             Timber.e(throwable, "Failed to create file")


### PR DESCRIPTION
This potentially fixes #6053 
and, relates to #6014 

I notice that writing chunks to file was copying byte buffers for each of the chunks it was creating during an upload, rather than re-using the buffer that it had.  Although Ive not encountered a crash (Pixel 5 / Pixel 9 Pro XL) this is a likely root cause.  

Can someone who's seen the problem also test?

Tested on: Pixel 5, Pixel 9 Pro XL