### PR TITLE
feat: show the proper message in the custom picker when all images are either uploaded or marked.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/adapter/ImageAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/adapter/ImageAdapter.kt
@@ -7,6 +7,8 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.Toast
 import androidx.constraintlayout.widget.Group
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
@@ -102,6 +104,12 @@ class ImageAdapter(
      * Helps to maintain the increasing sequence of the position. eg- 0, 1, 2, 3
      */
     private var imagePositionAsPerIncreasingOrder = 0
+
+    /**
+     * Stores the number of images currently visible on the screen
+     */
+    private val _currentImagesCount = MutableLiveData(0)
+    val currentImagesCountLiveData: LiveData<Int> = _currentImagesCount
 
     /**
      * Coroutine Dispatchers and Scope.
@@ -252,6 +260,7 @@ class ImageAdapter(
                 actionableImagesMap[next] = allImages[next]
                 alreadyAddedPositions.add(imagePositionAsPerIncreasingOrder)
                 imagePositionAsPerIncreasingOrder++
+                _currentImagesCount.value = imagePositionAsPerIncreasingOrder
                 Glide
                     .with(holder.image)
                     .load(allImages[next].uri)
@@ -382,6 +391,7 @@ class ImageAdapter(
         reachedEndOfFolder = false
         selectedImages = ArrayList()
         imagePositionAsPerIncreasingOrder = 0
+        _currentImagesCount.value = imagePositionAsPerIncreasingOrder
         val diffResult =
             DiffUtil.calculateDiff(
                 ImagesDiffCallback(oldImageList, newImageList),
@@ -441,6 +451,7 @@ class ImageAdapter(
                 val entry = iterator.next()
                 if (entry.value == image) {
                     imagePositionAsPerIncreasingOrder -= 1
+                    _currentImagesCount.value = imagePositionAsPerIncreasingOrder
                     iterator.remove()
                     alreadyAddedPositions.removeAt(alreadyAddedPositions.size - 1)
                     notifyItemRemoved(index)

--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/ImageFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/ImageFragment.kt
@@ -12,6 +12,7 @@ import android.widget.ProgressBar
 import android.widget.Switch
 import androidx.appcompat.app.AlertDialog
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.GridLayoutManager
@@ -215,6 +216,14 @@ class ImageFragment :
         switch = binding?.switchWidget
         switch?.visibility = View.VISIBLE
         switch?.setOnCheckedChangeListener { _, isChecked -> onChangeSwitchState(isChecked) }
+        imageAdapter.currentImagesCountLiveData.observe(viewLifecycleOwner, Observer {
+            if(switch!= null && switch?.isChecked == false && it==0&& switch?.isVisible==true) {
+                binding?.allImagesUploadedOrMarked?.isVisible = true
+            }
+            else {
+                binding?.allImagesUploadedOrMarked?.isVisible = false
+            }
+        })
         selectorRV = binding?.selectorRv
         loader = binding?.loader
         progressLayout = binding?.progressLayout

--- a/app/src/main/res/layout/fragment_custom_selector.xml
+++ b/app/src/main/res/layout/fragment_custom_selector.xml
@@ -49,6 +49,20 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
 
+  <TextView
+    android:id="@+id/all_images_uploaded_or_marked"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:visibility="gone"
+    android:textSize="16sp"
+    android:padding="@dimen/standard_gap"
+    android:textColor="@color/text_color_selector"
+    android:text="Congratulations, all pictures in this album have been either uploaded or marked as not for upload."
+    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    />
 
   <ProgressBar
     android:id="@+id/loader"


### PR DESCRIPTION

Fixes #5696 

Added  a message "Congratulations, all pictures in this album have been either uploaded or marked as not for upload" in the custom image picker when the user have either uploaded or marked all the images in an album.

**Tests performed**

Tested ProdDebug on Vivo2334 with API level 34.

**Screenshots (for UI changes only)**

https://github.com/user-attachments/assets/4ece58cb-c4c5-4c48-b217-6b002408bfcd

