### PR TITLE
feat: Long-pressing a row in "Uploads" copies the caption to clipboard, and displays a snack saying "Caption copied to clipboard"

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/FailedUploadsAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FailedUploadsAdapter.kt
@@ -1,5 +1,8 @@
 package fr.free.nrw.commons.upload
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context.CLIPBOARD_SERVICE
 import android.net.Uri
 import android.text.TextUtils
 import android.view.LayoutInflater
@@ -13,6 +16,7 @@ import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.facebook.imagepipeline.request.ImageRequest
+import com.google.android.material.snackbar.Snackbar
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.contributions.Contribution
 import java.io.File
@@ -51,6 +55,17 @@ class FailedUploadsAdapter(
         position: Int,
     ) {
         val item: Contribution? = getItem(position)
+        val itemView = holder.itemView
+        val clipboardManager =
+            itemView.context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+
+        itemView.setOnLongClickListener {
+            val clip = ClipData.newPlainText("Caption", item?.media?.displayTitle)
+            clipboardManager.setPrimaryClip(clip)
+            Snackbar.make(itemView, "Caption copied to clipboard", Snackbar.LENGTH_SHORT).show()
+            true
+        }
+
         if (item != null) {
             holder.titleTextView.setText(item.media.displayTitle)
         }

--- a/app/src/main/java/fr/free/nrw/commons/upload/FailedUploadsAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FailedUploadsAdapter.kt
@@ -60,9 +60,16 @@ class FailedUploadsAdapter(
             itemView.context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
 
         itemView.setOnLongClickListener {
-            val clip = ClipData.newPlainText("Caption", item?.media?.displayTitle)
+            val clip = ClipData.newPlainText(
+                itemView.context.getString(R.string.caption),
+                item?.media?.displayTitle
+            )
             clipboardManager.setPrimaryClip(clip)
-            Snackbar.make(itemView, "Caption copied to clipboard", Snackbar.LENGTH_SHORT).show()
+            Snackbar.make(
+                itemView,
+                itemView.context.getString(R.string.caption_copied_to_clipboard),
+                Snackbar.LENGTH_SHORT
+            ).show()
             true
         }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/PendingUploadsAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/PendingUploadsAdapter.kt
@@ -1,5 +1,8 @@
 package fr.free.nrw.commons.upload
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context.CLIPBOARD_SERVICE
 import android.net.Uri
 import android.text.TextUtils
 import android.view.LayoutInflater
@@ -13,6 +16,7 @@ import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.facebook.imagepipeline.request.ImageRequest
+import com.google.android.material.snackbar.Snackbar
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.contributions.Contribution
 import java.io.File
@@ -99,6 +103,15 @@ class PendingUploadsAdapter(
 
         fun bind(contribution: Contribution) {
             titleTextView.text = contribution.media.displayTitle
+            val clipboardManager =
+                itemView.context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+
+            itemView.setOnLongClickListener {
+                val clip = ClipData.newPlainText("Caption", titleTextView.text)
+                clipboardManager.setPrimaryClip(clip)
+                Snackbar.make(itemView, "Caption copied to clipboard", Snackbar.LENGTH_SHORT).show()
+                true
+            }
 
             val imageSource: String = contribution.localUri.toString()
             var imageRequest: ImageRequest? = null

--- a/app/src/main/java/fr/free/nrw/commons/upload/PendingUploadsAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/PendingUploadsAdapter.kt
@@ -107,9 +107,16 @@ class PendingUploadsAdapter(
                 itemView.context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
 
             itemView.setOnLongClickListener {
-                val clip = ClipData.newPlainText("Caption", titleTextView.text)
+                val clip = ClipData.newPlainText(
+                    itemView.context.getString(R.string.caption),
+                    titleTextView.text
+                )
                 clipboardManager.setPrimaryClip(clip)
-                Snackbar.make(itemView, "Caption copied to clipboard", Snackbar.LENGTH_SHORT).show()
+                Snackbar.make(
+                    itemView,
+                    itemView.context.getString(R.string.caption_copied_to_clipboard),
+                    Snackbar.LENGTH_SHORT
+                ).show()
                 true
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -860,5 +860,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="usages_on_other_wikis_heading">Other wikis</string>
   <string name="bullet_point">•</string>
   <string name="file_usages_container_heading">File usages</string>
+  <string name="caption">Caption</string>
+  <string name="caption_copied_to_clipboard">Caption copied to clipboard</string>
 
 </resources>


### PR DESCRIPTION

Fixes #6102 

On long pressing any item in Uploads, its caption will be copied in the user's clipboard and a snack will be displayed saying "Caption copied to clipboard".

**Tests performed (required)**

Tested BetaDebug on Vivo2334 with API level 34.

**Screenshots (for UI changes only)**

https://github.com/user-attachments/assets/4566b56e-dd2a-42c3-851d-b8e7519372a8
