### PR TITLE
fix: logo getting cropped in landscape mode of login page

### DIFF
--- a/app/src/main/res/layout-land/activity_login.xml
+++ b/app/src/main/res/layout-land/activity_login.xml
@@ -12,7 +12,7 @@
         android:layout_width="@dimen/landscape_width"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:layout_marginTop="@dimen/small_gap">
+        android:layout_marginTop="20dp">
 
         <androidx.cardview.widget.CardView
             android:layout_width="match_parent"

--- a/app/src/main/res/layout-land/activity_login.xml
+++ b/app/src/main/res/layout-land/activity_login.xml
@@ -12,7 +12,7 @@
         android:layout_width="@dimen/landscape_width"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:layout_marginTop="20dp">
+        android:layout_marginTop="@dimen/login_gap">
 
         <androidx.cardview.widget.CardView
             android:layout_width="match_parent"

--- a/app/src/main/res/layout-xlarge/activity_login.xml
+++ b/app/src/main/res/layout-xlarge/activity_login.xml
@@ -2,12 +2,14 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:layout_gravity="center_vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+      android:layout_gravity="center_vertical">
 
         <FrameLayout
             android:layout_width="@dimen/landscape_width"

--- a/app/src/main/res/layout-xlarge/activity_login.xml
+++ b/app/src/main/res/layout-xlarge/activity_login.xml
@@ -9,7 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-      android:layout_gravity="center_vertical">
+        android:layout_gravity="center_vertical">
 
         <FrameLayout
             android:layout_width="@dimen/landscape_width"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,13 +1,15 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="wrap_content"
-  android:layout_height="wrap_content">
+  android:layout_height="wrap_content"
+  android:layout_gravity="center_vertical">
 
   <LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:fillViewport="true"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:layout_gravity="center_vertical">
 
     <FrameLayout
       android:layout_width="wrap_content"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -20,6 +20,7 @@
     <dimen name="gigantic_gap">64dp</dimen>
     <dimen name="standard_gap">16dp</dimen>
     <dimen name="small_gap">8dp</dimen>
+    <dimen name="login_gap">20dp</dimen>
     <dimen name="small_height">7dp</dimen>
     <dimen name="tiny_gap">4dp</dimen>
     <dimen name="very_tiny_gap">2dp</dimen>


### PR DESCRIPTION
**Description**
Type of change: Bug fix (non-breaking change which fixes an issue)
Fixed logo getting cropped when the device is in landscape mode.
The login frame is moved to the center for better visuals in vertical mode.

* Fixes #1159 

**What changes did I made and why?**
1. Added `android:layout_gravity="center_vertical"` to `ScrollView` and `LinearLayout`
2. The Login `FrameLayout` will always appear at the centre of the screen for better visuals **_irrespective of screen size._**
3. After rotating the screen, the logo will not get cropped **_irrespective of screen size._**

**Tests performed (required)**
- [X] Code is Tested and Verified by myself.
- [X] Testing Devices:
- Samsung A21s
- Samsung M14

**Screenshots (for UI changes only)**
BEFORE:
![36306482-ebe0c0d8-133d-11e8-8873-9a1b751d273e](https://github.com/user-attachments/assets/64e7e552-077c-474d-b96d-7f3e897f2b85)

AFTER:
![Screenshot_20250105-174440_Commons](https://github.com/user-attachments/assets/5358b377-42e3-4800-ba8e-acb5d1942aad)
![Screenshot_20250105-174434_Commons](https://github.com/user-attachments/assets/c00f70f9-bef6-4c9a-912f-4171e5a7523e)

