### PR TITLE
Refactor variable names to adhere to naming conventions

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,39 +2,11 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="ClassWithOnlyPrivateConstructors" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
-    </inspection_tool>
     <inspection_tool class="ConfusingElse" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="reportWhenNoStatementFollow" value="true" />
     </inspection_tool>
     <inspection_tool class="ControlFlowStatementWithoutBraces" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ExplicitThis" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
-    <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="GlancePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="GlancePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="GlancePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
     <inspection_tool class="LocalCanBeFinal" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="REPORT_VARIABLES" value="true" />
       <option name="REPORT_PARAMETERS" value="true" />
@@ -47,30 +19,6 @@
     <inspection_tool class="NonFinalUtilityClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="OverlyStrongTypeCast" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreInMatchingInstanceof" value="false" />
-    </inspection_tool>
-    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="ProblematicWhitespace" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="RedundantFieldInitialization" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,11 +2,39 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="ClassWithOnlyPrivateConstructors" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="ConfusingElse" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="reportWhenNoStatementFollow" value="true" />
     </inspection_tool>
     <inspection_tool class="ControlFlowStatementWithoutBraces" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ExplicitThis" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="LocalCanBeFinal" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="REPORT_VARIABLES" value="true" />
       <option name="REPORT_PARAMETERS" value="true" />
@@ -19,6 +47,30 @@
     <inspection_tool class="NonFinalUtilityClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="OverlyStrongTypeCast" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreInMatchingInstanceof" value="false" />
+    </inspection_tool>
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="ProblematicWhitespace" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="RedundantFieldInitialization" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.kt
@@ -184,32 +184,32 @@ class LoginActivity : AccountAuthenticatorActivity() {
         // if progressDialog is visible during the configuration change  then store state as  true else false so that
         // we maintain visibility of progressDialog after configuration change
         if (progressDialog != null && progressDialog!!.isShowing) {
-            outState.putBoolean(saveProgressDialog, true)
+            outState.putBoolean(SAVE_PROGRESS_DIALOG, true)
         } else {
-            outState.putBoolean(saveProgressDialog, false)
+            outState.putBoolean(SAVE_PROGRESS_DIALOG, false)
         }
         outState.putString(
-            saveErrorMessage,
+            SAVE_ERROR_MESSAGE,
             binding!!.errorMessage.text.toString()
         ) //Save the errorMessage
         outState.putString(
-            saveUsername,
+            SAVE_USERNAME,
             binding!!.loginUsername.text.toString()
         ) // Save the username
         outState.putString(
-            savePassword,
+            SAVE_PASSWORD,
             binding!!.loginPassword.text.toString()
         ) // Save the password
     }
 
     override fun onRestoreInstanceState(savedInstanceState: Bundle) {
         super.onRestoreInstanceState(savedInstanceState)
-        binding!!.loginUsername.setText(savedInstanceState.getString(saveUsername))
-        binding!!.loginPassword.setText(savedInstanceState.getString(savePassword))
-        if (savedInstanceState.getBoolean(saveProgressDialog)) {
+        binding!!.loginUsername.setText(savedInstanceState.getString(SAVE_USERNAME))
+        binding!!.loginPassword.setText(savedInstanceState.getString(SAVE_PASSWORD))
+        if (savedInstanceState.getBoolean(SAVE_PROGRESS_DIALOG)) {
             performLogin()
         }
-        val errorMessage = savedInstanceState.getString(saveErrorMessage)
+        val errorMessage = savedInstanceState.getString(SAVE_ERROR_MESSAGE)
         if (sessionManager.isUserLoggedIn) {
             showMessage(R.string.login_success, R.color.primaryDarkColor)
         } else {
@@ -396,9 +396,9 @@ class LoginActivity : AccountAuthenticatorActivity() {
         fun startYourself(context: Context) =
             context.startActivity(Intent(context, LoginActivity::class.java))
 
-        const val saveProgressDialog: String = "ProgressDialog_state"
-        const val saveErrorMessage: String = "errorMessage"
-        const val saveUsername: String = "username"
-        const val savePassword: String = "password"
+        const val SAVE_PROGRESS_DIALOG: String = "ProgressDialog_state"
+        const val SAVE_ERROR_MESSAGE: String = "errorMessage"
+        const val SAVE_USERNAME: String = "username"
+        const val SAVE_PASSWORD: String = "password"
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/coordinates/CoordinateEditHelper.kt
+++ b/app/src/main/java/fr/free/nrw/commons/coordinates/CoordinateEditHelper.kt
@@ -61,16 +61,16 @@ class CoordinateEditHelper @Inject constructor(
     /**
      * Replaces new coordinates
      * @param media to be added
-     * @param Latitude to be added
-     * @param Longitude to be added
-     * @param Accuracy to be added
+     * @param latitude to be added
+     * @param longitude to be added
+     * @param accuracy to be added
      * @return Observable<Boolean>
      */
     private fun addCoordinates(
         media: Media,
-        Latitude: String,
-        Longitude: String,
-        Accuracy: String
+        latitude: String,
+        longitude: String,
+        accuracy: String
     ): Observable<Boolean>? {
         Timber.d("thread is coordinates adding %s", Thread.currentThread().getName())
         val summary = "Adding Coordinates"
@@ -83,9 +83,9 @@ class CoordinateEditHelper @Inject constructor(
                 .blockingGet()
         }
 
-        if (Latitude != null) {
-            buffer.append("\n{{Location|").append(Latitude).append("|").append(Longitude)
-                .append("|").append(Accuracy).append("}}")
+        if (latitude != null) {
+            buffer.append("\n{{Location|").append(latitude).append("|").append(longitude)
+                .append("|").append(accuracy).append("}}")
         }
 
         val editedLocation = buffer.toString()
@@ -141,7 +141,7 @@ class CoordinateEditHelper @Inject constructor(
      * @param media to be added
      * @param latitude to be added
      * @param longitude to be added
-     * @param Accuracy to be added
+     * @param accuracy to be added
      * @param result to be added
      * @return boolean
      */
@@ -150,7 +150,7 @@ class CoordinateEditHelper @Inject constructor(
         media: Media,
         latitude: String,
         longitude: String,
-        Accuracy: String,
+        accuracy: String,
         result: Boolean
     ): Boolean {
         val message: String
@@ -160,7 +160,7 @@ class CoordinateEditHelper @Inject constructor(
             media.coordinates = fr.free.nrw.commons.location.LatLng(
                 latitude.toDouble(),
                 longitude.toDouble(),
-                Accuracy.toFloat()
+                accuracy.toFloat()
             )
             title += ": " + context.getString(R.string.coordinates_edit_helper_show_edit_title_success)
             val coordinatesInMessage = StringBuilder()

--- a/app/src/main/java/fr/free/nrw/commons/quiz/QuizChecker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/quiz/QuizChecker.kt
@@ -40,10 +40,10 @@ class QuizChecker @Inject constructor(
 
     private val compositeDisposable = CompositeDisposable()
 
-    private val UPLOAD_COUNT_THRESHOLD = 5
-    private val REVERT_PERCENTAGE_FOR_MESSAGE = "50%"
-    private val REVERT_SHARED_PREFERENCE = "revertCount"
-    private val UPLOAD_SHARED_PREFERENCE = "uploadCount"
+    private val uploadCountThreshold = 5
+    private val revertPercentageForMessage = "50%"
+    private val revertSharedPreference = "revertCount"
+    private val uploadSharedPreference = "uploadCount"
 
     /**
      * Initializes quiz check by calculating revert parameters and showing quiz if necessary
@@ -80,12 +80,12 @@ class QuizChecker @Inject constructor(
      */
     private fun setTotalUploadCount(uploadCount: Int) {
         totalUploadCount = uploadCount - revertKvStore.getInt(
-            UPLOAD_SHARED_PREFERENCE,
+            uploadSharedPreference,
             0
         )
         if (totalUploadCount < 0) {
             totalUploadCount = 0
-            revertKvStore.putInt(UPLOAD_SHARED_PREFERENCE, 0)
+            revertKvStore.putInt(uploadSharedPreference, 0)
         }
         isUploadCountFetched = true
     }
@@ -112,10 +112,10 @@ class QuizChecker @Inject constructor(
      * @param revertCountFetched Count of deleted uploads
      */
     private fun setRevertParameter(revertCountFetched: Int) {
-        revertCount = revertCountFetched - revertKvStore.getInt(REVERT_SHARED_PREFERENCE, 0)
+        revertCount = revertCountFetched - revertKvStore.getInt(revertSharedPreference, 0)
         if (revertCount < 0) {
             revertCount = 0
-            revertKvStore.putInt(REVERT_SHARED_PREFERENCE, 0)
+            revertKvStore.putInt(revertSharedPreference, 0)
         }
         isRevertCountFetched = true
     }
@@ -128,13 +128,13 @@ class QuizChecker @Inject constructor(
         setRevertCount()
 
         if (revertCount < 0 || totalUploadCount < 0) {
-            revertKvStore.putInt(REVERT_SHARED_PREFERENCE, 0)
-            revertKvStore.putInt(UPLOAD_SHARED_PREFERENCE, 0)
+            revertKvStore.putInt(revertSharedPreference, 0)
+            revertKvStore.putInt(uploadSharedPreference, 0)
             return
         }
 
         if (isRevertCountFetched && isUploadCountFetched &&
-            totalUploadCount >= UPLOAD_COUNT_THRESHOLD &&
+            totalUploadCount >= uploadCountThreshold &&
             (revertCount * 100) / totalUploadCount >= 50
         ) {
             callQuiz(activity)
@@ -149,7 +149,7 @@ class QuizChecker @Inject constructor(
         DialogUtil.showAlertDialog(
             activity,
             activity.getString(R.string.quiz),
-            activity.getString(R.string.quiz_alert_message, REVERT_PERCENTAGE_FOR_MESSAGE),
+            activity.getString(R.string.quiz_alert_message, revertPercentageForMessage),
             activity.getString(R.string.about_translate_proceed),
             activity.getString(android.R.string.cancel),
             { startQuizActivity(activity) },
@@ -161,11 +161,11 @@ class QuizChecker @Inject constructor(
      * Starts the quiz activity and updates preferences for revert and upload counts
      */
     private fun startQuizActivity(activity: Activity) {
-        val newRevertSharedPrefs = revertCount + revertKvStore.getInt(REVERT_SHARED_PREFERENCE, 0)
-        revertKvStore.putInt(REVERT_SHARED_PREFERENCE, newRevertSharedPrefs)
+        val newRevertSharedPrefs = revertCount + revertKvStore.getInt(revertSharedPreference, 0)
+        revertKvStore.putInt(revertSharedPreference, newRevertSharedPrefs)
 
-        val newUploadCount = totalUploadCount + revertKvStore.getInt(UPLOAD_SHARED_PREFERENCE, 0)
-        revertKvStore.putInt(UPLOAD_SHARED_PREFERENCE, newUploadCount)
+        val newUploadCount = totalUploadCount + revertKvStore.getInt(uploadSharedPreference, 0)
+        revertKvStore.putInt(uploadSharedPreference, newUploadCount)
 
         val intent = Intent(activity, WelcomeActivity::class.java).apply {
             putExtra("isQuiz", true)

--- a/app/src/main/java/fr/free/nrw/commons/quiz/QuizResultActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/quiz/QuizResultActivity.kt
@@ -30,8 +30,8 @@ import fr.free.nrw.commons.contributions.MainActivity
 class QuizResultActivity : AppCompatActivity() {
 
     private var binding: ActivityQuizResultBinding? = null
-    private val NUMBER_OF_QUESTIONS = 5
-    private val MULTIPLIER_TO_GET_PERCENTAGE = 20
+    private val numberOfQuestions = 5
+    private val multiplierToGetPercentage = 20
 
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -67,9 +67,9 @@ class QuizResultActivity : AppCompatActivity() {
      */
     @SuppressLint("StringFormatInvalid", "SetTextI18n")
     fun setScore(score: Int) {
-        val scorePercent = score * MULTIPLIER_TO_GET_PERCENTAGE
+        val scorePercent = score * multiplierToGetPercentage
         binding?.resultProgressBar?.progress = scorePercent
-        binding?.tvResultProgress?.text = "$score / $NUMBER_OF_QUESTIONS"
+        binding?.tvResultProgress?.text = "$score / $numberOfQuestions"
         val message = resources.getString(R.string.congratulatory_message_quiz, "$scorePercent%")
         binding?.congratulatoryMessage?.text = message
     }


### PR DESCRIPTION

Renamed variables to use camel case:
-UPLOAD_COUNT_THRESHOLD → uploadCountThreshold
-REVERT_PERCENTAGE_FOR_MESSAGE → revertPercentageForMessage
-REVERT_SHARED_PREFERENCE → revertSharedPreference
-UPLOAD_SHARED_PREFERENCE → uploadSharedPreference

Renamed variables with uppercase initials to lowercase for alignment with Kotlin conventions:
-Latitude → latitude
-Longitude → longitude
-Accuracy → accuracy

Refactored the following variable names:
-NUMBER_OF_QUESTIONS → numberOfQuestions
-MULTIPLIER_TO_GET_PERCENTAGE → multiplierToGetPercentage