### PR TITLE
Fix: IndexOutOfBoundsException crash when removing last two images of multiupload

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.kt
@@ -146,34 +146,31 @@ class UploadPresenter @Inject internal constructor(
 
     override fun deletePictureAtIndex(index: Int) {
         val uploadableFiles = view.getUploadableFiles()
-        if (index == uploadableFiles!!.size - 1) {
-            // If the next fragment to be shown is not one of the MediaDetailsFragment
-            // lets hide the top card so that it doesn't appear on the other fragments
-            view.showHideTopCard(false)
-        }
-        view.setImageCancelled(true)
-        repository.deletePicture(uploadableFiles[index].getFilePath())
-        if (uploadableFiles.size == 1) {
-            view.showMessage(R.string.upload_cancelled)
-            view.finish()
-            return
-        }
-
-        presenter.updateImageQualitiesJSON(uploadableFiles.size, index)
-        view.onUploadMediaDeleted(index)
-        if (index != uploadableFiles.size && index != 0) {
-            // if the deleted image was not the last item to be uploaded, check quality of next
-            repository.getUploadItem(index)?.let {
-                presenter.checkImageQuality(it, index)
+        uploadableFiles?.let {
+            view.setImageCancelled(true)
+            repository.deletePicture(uploadableFiles[index].getFilePath())
+            if (uploadableFiles.size == 1) {
+                view.showMessage(R.string.upload_cancelled)
+                view.finish()
+                return
             }
-        }
 
-        if (uploadableFiles.size < 2) {
-            view.showHideTopCard(false)
-        }
+            presenter.updateImageQualitiesJSON(uploadableFiles.size, index)
+            view.onUploadMediaDeleted(index)
+            if (index != uploadableFiles.size && index != 0) {
+                // if the deleted image was not the last item to be uploaded, check quality of next
+                repository.getUploadItem(index)?.let {
+                    presenter.checkImageQuality(it, index)
+                }
+            }
 
-        //In case lets update the number of uploadable media
-        view.updateTopCardTitle()
+            if (uploadableFiles.size < 2) {
+                view.showHideTopCard(false)
+            }
+
+            //In case lets update the number of uploadable media
+            view.updateTopCardTitle()
+        }
     }
 
     override fun onAttachView(view: UploadContract.View) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.kt
@@ -532,7 +532,7 @@ class UploadMediaDetailFragment : UploadBaseFragment(), UploadMediaDetailsContra
                         basicKvStore!!.putBoolean(keyForShowingAlertDialog, false)
                         if (isInternetConnectionEstablished(requireActivity())) {
                             val sizeOfUploads = basicKvStore!!.getInt(
-                                UploadActivity.keyForCurrentUploadImagesSize
+                                UploadActivity.KEY_FOR_CURRENT_UPLOAD_IMAGE_SIZE
                             )
                             for (i in indexOfFragment until sizeOfUploads) {
                                 presenter.getImageQuality(

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.kt
@@ -310,7 +310,7 @@ class UploadMediaPresenter @Inject constructor(
     private fun storeImageQuality(
         imageResult: Int, uploadItemIndex: Int, activity: Activity, uploadItem: UploadItem
     ) {
-        val store = BasicKvStore(activity, UploadActivity.storeNameForCurrentUploadImagesSize)
+        val store = BasicKvStore(activity, UploadActivity.STORE_NAME_FOR_CURRENT_UPLOAD_IMAGE_SIZE)
         val value = store.getString(UPLOAD_QUALITIES_KEY, null)
         try {
             val jsonObject = value.asJsonObject().apply {
@@ -339,8 +339,10 @@ class UploadMediaPresenter @Inject constructor(
      */
     override fun checkImageQuality(uploadItem: UploadItem, index: Int) {
         if ((uploadItem.imageQuality != IMAGE_OK) && (uploadItem.imageQuality != IMAGE_KEEP)) {
-            val value = basicKvStoreFactory?.let { it(UploadActivity.storeNameForCurrentUploadImagesSize) }
+          
+            val value = basicKvStoreFactory?.let { it(UploadActivity.STORE_NAME_FOR_CURRENT_UPLOAD_IMAGE_SIZE) }
                 ?.getString(UPLOAD_QUALITIES_KEY, null)
+                
             try {
                 val imageQuality = value.asJsonObject()["UploadItem$index"] as Int
                 view.showProgress(false)
@@ -363,8 +365,9 @@ class UploadMediaPresenter @Inject constructor(
      * @param index Index of the UploadItem which was deleted
      */
     override fun updateImageQualitiesJSON(size: Int, index: Int) {
-        val value = basicKvStoreFactory?.let { it(UploadActivity.storeNameForCurrentUploadImagesSize) }
+        val value = basicKvStoreFactory?.let { it(UploadActivity.STORE_NAME_FOR_CURRENT_UPLOAD_IMAGE_SIZE) }
             ?.getString(UPLOAD_QUALITIES_KEY, null)
+
         try {
             val jsonObject = value.asJsonObject().apply {
                 for (i in index until (size - 1)) {
@@ -372,7 +375,8 @@ class UploadMediaPresenter @Inject constructor(
                 }
                 remove("UploadItem" + (size - 1))
             }
-            basicKvStoreFactory?.let { it(UploadActivity.storeNameForCurrentUploadImagesSize) }
+
+            basicKvStoreFactory?.let { it(UploadActivity.STORE_NAME_FOR_CURRENT_UPLOAD_IMAGE_SIZE) }
                 ?.putString(UPLOAD_QUALITIES_KEY, jsonObject.toString())
         } catch (e: Exception) {
             Timber.e(e)

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadActivityUnitTests.kt
@@ -262,15 +262,4 @@ class UploadActivityUnitTests {
         method.isAccessible = true
         method.invoke(activity)
     }
-
-    @Test
-    @Throws(Exception::class)
-    fun testOnBackPressed() {
-        val method: Method =
-            UploadActivity::class.java.getDeclaredMethod(
-                "onBackPressed",
-            )
-        method.isAccessible = true
-        method.invoke(activity)
-    }
 }


### PR DESCRIPTION
**Description (required)**

Fixes #6122 

What changes did you make and why?
When removing images from `Thumbnails Row`, the uploadableImages property inside `ThubnailsAdapter` was not updating. It results in the image being removed at an invalid index and sometimes `IndexOutOfBoundsException`.
So, I added the code to notify the adapter that the image was removed.

**Tests performed (required)**

Tested ProdDebug on Samsung A14 with API level 34.

**Screenshots (for UI changes only)**
Screencast after fix

https://github.com/user-attachments/assets/fa3aeeec-a4e1-46d4-af7d-b105ab1d8cf3


