### PR TITLE
Disable vanishing option when logged out

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.kt
@@ -271,6 +271,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
             findPreference<Preference>("managed_exif_tags")?.isEnabled = false
             findPreference<Preference>("openDocumentPhotoPickerPref")?.isEnabled = false
             findPreference<Preference>("inAppCameraLocationPref")?.isEnabled = false
+            findPreference<Preference>("vanishAccount")?.isEnabled = false
         }
     }
 


### PR DESCRIPTION
**Description**

Fixes #6134

**What changes did you make and why?**

>  when the user is using the app without an account, it is confusing to be able to select Vanish Account in the Settings screen.

Disabled the vanishing option when the user isn't logged in, 
> in a similar way how some other setting entries are disabled when logged out.

**Tests performed (required)**

Tested ProdDebug on Samsung S20 FE with API level 33.

**Screenshots (for UI changes only)**

![image](https://github.com/user-attachments/assets/279d6f77-de69-4639-8b21-1f040d450ec7)
