### PR TITLE
Share cookies with SingleWebViewActivity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/di/CommonsApplicationComponent.kt
+++ b/app/src/main/java/fr/free/nrw/commons/di/CommonsApplicationComponent.kt
@@ -6,6 +6,7 @@ import dagger.android.AndroidInjectionModule
 import dagger.android.AndroidInjector
 import dagger.android.support.AndroidSupportInjectionModule
 import fr.free.nrw.commons.CommonsApplication
+import fr.free.nrw.commons.activity.SingleWebViewActivity
 import fr.free.nrw.commons.auth.LoginActivity
 import fr.free.nrw.commons.contributions.ContributionsModule
 import fr.free.nrw.commons.explore.SearchModule
@@ -50,6 +51,8 @@ interface CommonsApplicationComponent : AndroidInjector<ApplicationlessInjection
     fun inject(worker: UploadWorker)
 
     fun inject(activity: LoginActivity)
+
+    fun inject(activity: SingleWebViewActivity)
 
     fun inject(fragment: SettingsFragment)
 


### PR DESCRIPTION
**Description (required)**

Fixes #6133

**Changes made**
Load cookies for every url that is loaded inside SingleWebViewActivity into android.webkit.CookieManager (from CommonsCookieJar), in the same manner as done in the wikipedia mobile app.

**Tests performed (required)**

Tested ProdDebug on Samsung S20FE with API level 33.
 
 ---

**Before this change:** Login to the app, go to settings, click on "Vanish Account". You'll be prompted to login in the resulting webview (provided you haven't previously logged in to the same "Vanish Account" screen before).

**Aftter this change:** Login to the app, go to settings, click on "Vanish Account". You'll be presented with the [confirmation page](https://meta.m.wikimedia.org/wiki/Special:GlobalVanishRequest) directly.