### PR TITLE
Fix crash when opening in-app Camera for the very first time

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/utils/PermissionUtils.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/PermissionUtils.kt
@@ -16,6 +16,9 @@ import com.karumi.dexter.listener.PermissionRequest
 import com.karumi.dexter.listener.multi.MultiplePermissionsListener
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.upload.UploadActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 
 object PermissionUtils {
@@ -166,13 +169,15 @@ object PermissionUtils {
         rationaleMessage: Int,
         vararg permissions: String
     ) {
+        val scope = CoroutineScope(Dispatchers.Main)
+
         Dexter.withActivity(activity)
             .withPermissions(*permissions)
             .withListener(object : MultiplePermissionsListener {
                 override fun onPermissionsChecked(report: MultiplePermissionsReport) {
                     when {
                         report.areAllPermissionsGranted() || hasPartialAccess(activity) ->
-                            Thread(onPermissionGranted).start()
+                            scope.launch { onPermissionGranted.run() }
                         report.isAnyPermissionPermanentlyDenied -> {
                             DialogUtil.showAlertDialog(
                                 activity,
@@ -189,7 +194,7 @@ object PermissionUtils {
                                 null, null
                             )
                         }
-                        else -> Thread(onPermissionDenied).start()
+                        else -> scope.launch { onPermissionDenied?.run() }
                     }
                 }
 


### PR DESCRIPTION
**Description (required)**

Fixes #6137 

What changes did you make and why?
Previously, the callbacks passed to the `checkPermissionAndPerformAction()` method were executing on a background `Thread`, leading to `Handler` error when trying to show `AlertDialog`. So, I make them execute in a `coroutine` on the `Main` thread.

**Tests performed (required)**

Tested prodDebug on Samsung A14 with API level 34.

**Screenshots (for UI changes only)**
> Before Fix

https://github.com/user-attachments/assets/f8a1215c-6ac8-4cfc-8c08-85a6a9ffe70f

> After Fix

https://github.com/user-attachments/assets/8ccf75b5-3f21-4a69-9c96-7a2d1fe266d4




