### PR TITLE
Fix handling of shared files in intent and improve error handling

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.kt
@@ -684,17 +684,64 @@ class UploadActivity : BaseActivity(), UploadContract.View, UploadBaseFragment.C
 
     private fun receiveInternalSharedItems() {
         val intent = intent
+        Timber.d("Intent has EXTRA_FILES: ${EXTRA_FILES}")
+        uploadableFiles = try {
+            // Check if intent has the extra before trying to read it
+            if (!intent.hasExtra(EXTRA_FILES)) {
+                Timber.w("No EXTRA_FILES found in intent")
+                mutableListOf()
+            } else {
+                // Try to get the files as Parcelable array
+                val files = if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+                    intent.getParcelableArrayListExtra(EXTRA_FILES, UploadableFile::class.java)
+                } else {
+                    @Suppress("DEPRECATION")
+                    intent.getParcelableArrayListExtra<UploadableFile>(EXTRA_FILES)
+                }
 
-        Timber.d("Received intent %s with action %s", intent.toString(), intent.action)
-
-        uploadableFiles = mutableListOf<UploadableFile>().apply {
-            addAll(intent.getParcelableArrayListExtra(EXTRA_FILES) ?: emptyList())
+                // Convert to mutable list or return empty list if null
+                files?.toMutableList() ?: run {
+                    Timber.w("Files array was null")
+                    mutableListOf()
+                }
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Error reading files from intent")
+            mutableListOf()
         }
-        isMultipleFilesSelected = uploadableFiles!!.size > 1
-        Timber.i("Received multiple upload %s", uploadableFiles!!.size)
 
-        place = intent.getParcelableExtra<Place>(PLACE_OBJECT)
-        prevLocation = intent.getParcelableExtra(LOCATION_BEFORE_IMAGE_CAPTURE)
+        // Log the result for debugging
+        isMultipleFilesSelected = uploadableFiles.size > 1
+        Timber.i("Received files count: ${uploadableFiles.size}")
+        uploadableFiles.forEachIndexed { index, file ->
+            Timber.d("File $index path: ${file.getFilePath()}")
+        }
+
+        // Handle other extras with null safety
+        place = try {
+            if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+                intent.getParcelableExtra(PLACE_OBJECT, Place::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                intent.getParcelableExtra(PLACE_OBJECT)
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Error reading place")
+            null
+        }
+
+        prevLocation = try {
+            if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+                intent.getParcelableExtra(LOCATION_BEFORE_IMAGE_CAPTURE, LatLng::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                intent.getParcelableExtra(LOCATION_BEFORE_IMAGE_CAPTURE)
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Error reading location")
+            null
+        }
+
         isInAppCameraUpload = intent.getBooleanExtra(IN_APP_CAMERA_UPLOAD, false)
         resetDirectPrefs()
     }
@@ -803,6 +850,7 @@ class UploadActivity : BaseActivity(), UploadContract.View, UploadBaseFragment.C
     /**
      * Overrides the back button to make sure the user is prepared to lose their progress
      */
+    @SuppressLint("MissingSuperCall")
     override fun onBackPressed() {
         showAlertDialog(
             this,
@@ -920,7 +968,7 @@ class UploadActivity : BaseActivity(), UploadContract.View, UploadBaseFragment.C
 
     companion object {
         private var uploadIsOfAPlace = false
-        const val EXTRA_FILES: String = "commons_image_exta"
+        const val EXTRA_FILES: String = "commons_image_extra"
         const val LOCATION_BEFORE_IMAGE_CAPTURE: String = "user_location_before_image_capture"
         const val IN_APP_CAMERA_UPLOAD: String = "in_app_camera_upload"
 


### PR DESCRIPTION
### Changes:
- Corrected the constant for the extra key from `commons_image_exta` to `commons_image_extra`.
- Updated the `receiveInternalSharedItems()` method to improve handling of shared files:
  - Added null safety checks and proper handling of missing or malformed extras (`EXTRA_FILES`).
  - Added version-specific logic to handle different Android SDK versions (API 33 and above).
  - Enhanced logging for debugging shared file paths.
  - Incorporated error handling for potential exceptions when reading extras (`PLACE_OBJECT` and `LOCATION_BEFORE_IMAGE_CAPTURE`).
  - **Replaced deprecated methods** for API 33+ with their latest alternatives, ensuring compatibility with both older and newer versions of Android.

### Benefits:
- **More robust file handling** with better error logging to avoid crashes caused by missing or malformed intent extras.
- **Improved backward compatibility** by ensuring that both older and newer Android versions (API 33+) can correctly retrieve intent extras.
- **Avoids deprecated method usage**, replacing old API calls with modern alternatives to maintain future compatibility.
- **Clearer logging output** for debugging file paths and shared items, making troubleshooting easier.
