### PR TITLE
category: resolve redirects while querying categories

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryInterface.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryInterface.kt
@@ -34,7 +34,7 @@ interface CategoryInterface {
      * @return
      */
     @GET(
-        "w/api.php?action=query&format=json&formatversion=2&generator=allcategories&prop=categoryinfo|description|pageimages&piprop=thumbnail&pithumbsize=70",
+        "w/api.php?action=query&format=json&formatversion=2&redirects=true&generator=allcategories&prop=categoryinfo|description|pageimages&piprop=thumbnail&pithumbsize=70",
     )
     fun searchCategoriesForPrefix(
         @Query("gacprefix") prefix: String?,


### PR DESCRIPTION

**Description (required)**
It seems that redirects were not happening while fetching category results. Fix the same.

Fixes #6146

**Tests performed (required)**

Nexus 4 on API 22

**Screenshots (for UI changes only)**

![image](https://github.com/user-attachments/assets/270c18a5-9940-41a3-9422-715bf9afc60d)

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
