### PR TITLE
fix: logout user after account deletion by navigating to login screen

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/activity/SingleWebViewActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/activity/SingleWebViewActivity.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
+import fr.free.nrw.commons.CommonsApplication
+import fr.free.nrw.commons.CommonsApplication.ActivityLogoutListener
 import fr.free.nrw.commons.R
 import timber.log.Timber
 
@@ -72,7 +74,12 @@ class SingleWebViewActivity : ComponentActivity() {
                         url = url,
                         successUrl = successUrl,
                         onSuccess = {
-                            // TODO Redirect the user to login screen like we do when the user logout's
+                            //Redirect the user to login screen like we do when the user logout's
+                            val app = applicationContext as CommonsApplication
+                            app.clearApplicationData(
+                                applicationContext,
+                                ActivityLogoutListener(activity = this, ctx = applicationContext)
+                            )
                             finish()
                         },
                         modifier = Modifier


### PR DESCRIPTION

Fixes #6112 


Resolved a bug where the app did not log out the user after they deleted their account, causing the session to remain active. Now, the app navigates to the login screen immediately after account deletion to ensure proper session handling.

**Tests performed (required)**

Tested ProdDebug on Vivo2334 with API level 35.

**Screenshots (for UI changes only)**


https://github.com/user-attachments/assets/6bbb9094-a2d4-402b-925e-83d216149cf4


https://github.com/user-attachments/assets/3e2fc465-5b1d-47fe-bfac-c4c2b4639a0a


