### PR TITLE
Show placeholder and display depiction section when no depictions are available (#6163)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
@@ -650,10 +650,8 @@ class MediaDetailFragment : CommonsDaggerSupportFragment(), CategoryEditHelper.C
     }
 
     private fun onDepictionsLoaded(idAndCaptions: List<IdAndCaptions>) {
-        binding.depictsLayout.visibility =
-            if (idAndCaptions.isEmpty()) View.GONE else View.VISIBLE
-        binding.depictionsEditButton.visibility =
-            if (idAndCaptions.isEmpty()) View.GONE else View.VISIBLE
+        binding.depictsLayout.visibility = View.VISIBLE
+        binding.depictionsEditButton.visibility = View.VISIBLE
         buildDepictionList(idAndCaptions)
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
@@ -201,7 +201,7 @@ class MediaDetailFragment : CommonsDaggerSupportFragment(), CategoryEditHelper.C
     /**
      * Depicts is a feature part of Structured data.
      * Multiple Depictions can be added for an image just like categories.
-     * However unlike categories depictions is multi-lingualmedia
+     * However unlike categories depictions is multi-lingual
      * Ex: key: en value: monument
      */
     private var imageInfoCache: ImageInfo? = null

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
@@ -201,7 +201,7 @@ class MediaDetailFragment : CommonsDaggerSupportFragment(), CategoryEditHelper.C
     /**
      * Depicts is a feature part of Structured data.
      * Multiple Depictions can be added for an image just like categories.
-     * However unlike categories depictions is multi-lingual
+     * However unlike categories depictions is multi-lingualmedia
      * Ex: key: en value: monument
      */
     private var imageInfoCache: ImageInfo? = null
@@ -861,8 +861,22 @@ class MediaDetailFragment : CommonsDaggerSupportFragment(), CategoryEditHelper.C
      */
     private fun buildDepictionList(idAndCaptions: List<IdAndCaptions>) {
         binding.mediaDetailDepictionContainer.removeAllViews()
+
+        // Create a mutable list from the original list
+        val mutableIdAndCaptions = idAndCaptions.toMutableList()
+
+        if (mutableIdAndCaptions.isEmpty()) {
+            // Create a placeholder IdAndCaptions object and add it to the list
+            mutableIdAndCaptions.add(
+                IdAndCaptions(
+                    id = media?.pageId ?: "", // Use an empty string if media?.pageId is null
+                    captions = mapOf(Locale.getDefault().language to getString(R.string.detail_panel_cats_none)) // Create a Map with the language as the key and the message as the value
+                )
+            )
+        }
+
         val locale: String = Locale.getDefault().language
-        for (idAndCaption: IdAndCaptions in idAndCaptions) {
+        for (idAndCaption: IdAndCaptions in mutableIdAndCaptions) {
             binding.mediaDetailDepictionContainer.addView(
                 buildDepictLabel(
                     getDepictionCaption(idAndCaption, locale),
@@ -872,6 +886,7 @@ class MediaDetailFragment : CommonsDaggerSupportFragment(), CategoryEditHelper.C
             )
         }
     }
+
 
     private fun getDepictionCaption(idAndCaption: IdAndCaptions, locale: String): String? {
         // Check if the Depiction Caption is available in user's locale


### PR DESCRIPTION
**Description (required)**

Fixes #6163 

#### What changes did you make and why?  
- Updated the `buildDepictionList` function to handle empty `idAndCaptions` lists by displaying a placeholder.  
- Used a localized string (`R.string.detail_panel_cats_none`) as a fallback caption to inform users that no depictions are available.  
- Ensured the `captions` field is provided as a map to match the `IdAndCaptions` data structure.  
- Now, the depiction section is always visible, even if there are no depictions, improving the overall UI and user experience.  