### PR TITLE
Enhance filtering criteria for category search

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoriesModel.kt
@@ -36,37 +36,35 @@ class CategoriesModel
          * @return
          */
         fun isSpammyCategory(item: String): Boolean {
-            // Check for current and previous year to exclude these categories from removal
-            val now = Calendar.getInstance()
-            val curYear = now[Calendar.YEAR]
-            val curYearInString = curYear.toString()
-            val prevYear = curYear - 1
-            val prevYearInString = prevYear.toString()
-            Timber.d("Previous year: %s", prevYearInString)
-
-            val mentionsDecade = item.matches(".*0s.*".toRegex())
-            val recentDecade = item.matches(".*20[0-2]0s.*".toRegex())
-            val spammyCategory =
-                item.matches("(.*)needing(.*)".toRegex()) ||
-                    item.matches("(.*)taken on(.*)".toRegex())
 
             // always skip irrelevant categories such as Media_needing_categories_as_of_16_June_2017(Issue #750)
+            val spammyCategory = item.matches("(.*)needing(.*)".toRegex())
+                    || item.matches("(.*)taken on(.*)".toRegex())
+
+            // checks for
+            // dd/mm/yyyy or yy
+            // yyyy or yy/mm/dd
+            // yyyy or yy/mm
+            // mm/yyyy or yy
+            // for `yy` it is assumed that 20XX is implicit.
+            // with separators [., /, -]
+            val isIrrelevantCategory =
+                item.contains("""\d{1,2}[-/.]\d{1,2}[-/.]\d{2,4}|\d{2,4}[-/.]\d{1,2}[-/.]\d{1,2}|\d{2,4}[-/.]\d{1,2}|\d{1,2}[-/.]\d{2,4}""".toRegex())
+
+
             if (spammyCategory) {
                 return true
             }
 
-            if (mentionsDecade) {
-                // Check if the year in the form of XX(X)0s is recent/relevant, i.e. in the 2000s or 2010s/2020s as stated in Issue #1029
-                // Example: "2020s" is OK, but "1920s" is not (and should be skipped)
-                return !recentDecade
-            } else {
-                // If it is not an year in decade form (e.g. 19xxs/20xxs), then check if item contains a 4-digit year
-                // anywhere within the string (.* is wildcard) (Issue #47)
-                // And that item does not equal the current year or previous year
-                return item.matches(".*(19|20)\\d{2}.*".toRegex()) &&
-                    !item.contains(curYearInString) &&
-                    !item.contains(prevYearInString)
+            if(isIrrelevantCategory){
+                return true
             }
+
+            val hasYear = item.matches("(.*\\d{4}.*)".toRegex())
+            val validYearsRange = item.matches(".*(20[0-9]{2}).*".toRegex())
+
+            // finally if there's 4 digits year exists in XXXX it should only be in 20XX range.
+            return  hasYear && !validYearsRange
         }
 
         /**

--- a/app/src/test/kotlin/fr/free/nrw/commons/category/CategoriesModelTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/category/CategoriesModelTest.kt
@@ -11,6 +11,7 @@ import fr.free.nrw.commons.upload.GpsCategoryModel
 import io.reactivex.Single
 import io.reactivex.subjects.BehaviorSubject
 import media
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers
@@ -331,4 +332,42 @@ class CategoriesModelTest {
             media(),
         )
     }
+
+    @Test
+    fun `test valid input with XXXX in it between the expected range 20XX`() {
+        val input = categoriesModel.isSpammyCategory("Amavenita (ship, 2014)")
+        Assert.assertFalse(input)
+    }
+
+    @Test
+    fun `test valid input with XXXXs in it between the expected range 20XXs`() {
+        val input = categoriesModel.isSpammyCategory("Amavenita (ship, 2014s)")
+        Assert.assertFalse(input)
+    }
+
+    @Test
+    fun `test invalid category when have needing in the input`() {
+        val input = categoriesModel.isSpammyCategory("Media needing categories as of 30 March 2017")
+        Assert.assertTrue(input)
+    }
+
+    @Test
+    fun `test invalid category when have taken on in the input`() {
+        val input = categoriesModel.isSpammyCategory("Photographs taken on 2015-12-08")
+        Assert.assertTrue(input)
+    }
+
+    @Test
+    fun `test invalid category when have yy mm or yy mm dd in the input`() {
+        // filtering based on [., /, -]  separators between the dates.
+        val input = categoriesModel.isSpammyCategory("Image class 09.14")
+        Assert.assertTrue(input)
+    }
+
+    @Test
+    fun `test invalid category when have years not in 20XX range`() {
+        val input = categoriesModel.isSpammyCategory("Japan in the 1400s")
+        Assert.assertTrue(input)
+    }
+
 }


### PR DESCRIPTION
Fixes #4901

What changes did you make and why?

This PR is an extension of #4902 PR. refer to [comment](https://github.com/commons-app/apps-android-commons/issues/4901#issuecomment-2592110652). Conflicting changes were made while this PR was open making changes introduced outdated. Also, some of the checks were redundant so that's why started fresh with this PR.

Now, spam filtering function filter these strings ->

- that contains `needing` or `taken on`
- that contains dates in format `dd mm yyyy or yy`  and `mm/yyyy or yy`  (in any order possible)  with separators `/` `.` `-` in between.
- that contains years that doesn't come in 20XX range.

- [X] Wrote tests.

**Example input and output (true if filtered) ->** 
```

Media_needing_categories_as_of_16_June_2017 -> true
Photo_taken on_23_March_2009 -> true
Photo_taken_12/10/2023 -> true
Event_on_25-12-19 -> true
Image_in_22/04/17 -> true
Video_in_2023-05 -> true
Pic_taken_20-12 -> true
Article_in_2024 -> false
Photo_in_1998 -> true
No_date_category -> false
17/04/2021 -> true
Captured_in_1980 -> true
File_uploaded_in_18-05 -> true
Shot_2019/10/15 -> true
Just_some_random_text -> false
Updated_in_21/07 -> true

```
 

