### PR TITLE
[Bug fix] Check if duplicate exist using both original and modified file's checksum

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsPresenter.java
@@ -62,7 +62,10 @@ public class ContributionsPresenter implements UserActionListener {
      */
     public void checkDuplicateImageAndRestartContribution(Contribution contribution) {
         compositeDisposable.add(uploadRepository
-            .checkDuplicateImage(contribution.getLocalUriPath().getPath())
+            .checkDuplicateImage(
+                contribution.getContentUri(),
+                contribution.getLocalUri()
+            )
             .subscribeOn(ioThreadScheduler)
             .subscribe(imageCheckResult -> {
                 if (imageCheckResult == IMAGE_OK) {

--- a/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.kt
+++ b/app/src/main/java/fr/free/nrw/commons/repository/UploadRepository.kt
@@ -1,5 +1,6 @@
 package fr.free.nrw.commons.repository
 
+import android.net.Uri
 import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.category.CategoriesModel
 import fr.free.nrw.commons.category.CategoryItem
@@ -203,8 +204,8 @@ class UploadRepository @Inject constructor(
      * @param filePath file to be checked
      * @return IMAGE_DUPLICATE or IMAGE_OK
      */
-    fun checkDuplicateImage(filePath: String): Single<Int> {
-        return uploadModel.checkDuplicateImage(filePath)
+    fun checkDuplicateImage(originalFilePath: Uri, modifiedFilePath: Uri): Single<Int> {
+        return uploadModel.checkDuplicateImage(originalFilePath, modifiedFilePath)
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/PendingUploadsPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/PendingUploadsPresenter.kt
@@ -149,7 +149,10 @@ class PendingUploadsPresenter @Inject internal constructor(
             }
             compositeDisposable.add(
                 uploadRepository
-                    .checkDuplicateImage(contribution.localUriPath!!.path)
+                    .checkDuplicateImage(
+                        originalFilePath = contribution.contentUri!!,
+                        modifiedFilePath = contribution.localUri!!
+                    )
                     .subscribeOn(ioThreadScheduler)
                     .subscribe({ imageCheckResult: Int ->
                         if (imageCheckResult == IMAGE_OK) {
@@ -218,7 +221,10 @@ class PendingUploadsPresenter @Inject internal constructor(
             }
             compositeDisposable.add(
                 uploadRepository
-                    .checkDuplicateImage(contribution.localUriPath!!.path)
+                    .checkDuplicateImage(
+                        originalFilePath = contribution.contentUri!!,
+                        modifiedFilePath = contribution.localUri!!
+                    )
                     .subscribeOn(ioThreadScheduler)
                     .subscribe { imageCheckResult: Int ->
                         if (imageCheckResult == IMAGE_OK) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.kt
@@ -103,8 +103,11 @@ class UploadModel @Inject internal constructor(
      * @param filePath file to be checked
      * @return IMAGE_DUPLICATE or IMAGE_OK
      */
-    fun checkDuplicateImage(filePath: String?): Single<Int> =
-        imageProcessingService.checkDuplicateImage(filePath)
+    fun checkDuplicateImage(originalFilePath: Uri?, modifiedFilePath: Uri?): Single<Int> =
+        imageProcessingService.checkIfFileAlreadyExists(
+            originalFilePath = originalFilePath!!,
+            modifiedFilePath = modifiedFilePath!!
+        )
 
     /**
      * Calls validateCaption() of ImageProcessingService to check caption of image


### PR DESCRIPTION
Fixes #5800

What changes did you make and why?

Before this, we were only checking checksum of modified file to see if file exists or not. But, we needed for both because when file is uploaded from web interface it stores the original file's checksum, so our check never truly checked for duplicates. 

Now, we check both original and modified file's checksum when user chooses a file to upload.

 <img src="https://github.com/user-attachments/assets/8879fada-20f1-4793-8f11-a9933deb1291" width="300"> 