### PR TITLE
Add multiline input for caption and description

### DIFF
--- a/app/src/main/res/layout/row_item_description.xml
+++ b/app/src/main/res/layout/row_item_description.xml
@@ -59,10 +59,12 @@
       <fr.free.nrw.commons.ui.PasteSensitiveTextInputEditText
         android:id="@+id/caption_item_edit_text"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
+        android:minLines="1"
+        android:maxLines="10"
         android:hint="@string/share_caption_hint"
         android:imeOptions="actionNext|flagNoExtractUi"
-        android:inputType="text"
+        android:inputType="textMultiLine"
         app:allowFormatting="false" />
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/row_item_description.xml
+++ b/app/src/main/res/layout/row_item_description.xml
@@ -103,7 +103,9 @@
       <fr.free.nrw.commons.ui.PasteSensitiveTextInputEditText
         android:id="@+id/description_item_edit_text"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
+        android:minLines="1"
+        android:maxLines="10"
         android:hint="@string/share_description_hint"
         android:imeOptions="actionNext|flagNoExtractUi"
         android:inputType="textMultiLine"


### PR DESCRIPTION
**Description (required)**

Fixes #6172

added multiline support for both caption and description fields

**Tests performed (required)**

Tested BetaDebug on Xiaomi Redmi Note 6 Pro with API level 30; seems to work. 
Debug `.apk` available here: https://github.com/mnalis/apps-android-commons/actions/runs/13127866012

**Screenshots (for UI changes only)**
![small_Screenshot_20250204-044843_Commons](https://github.com/user-attachments/assets/660f509c-51eb-44f7-8de5-f446faf6639a)

---


