### PR TITLE
GitHub workflow to build betaDebug

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -1,0 +1,41 @@
+name: Build beta only
+
+on: [workflow_dispatch]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Access test login credentials
+      run: |
+        echo "TEST_USER_NAME=${{ secrets.TEST_USER_NAME }}" >> local.properties
+        echo "TEST_USER_PASSWORD=${{ secrets.TEST_USER_PASSWORD }}" >> local.properties
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Set env
+      run: echo "COMMIT_SHA=$(git log -n 1 --format='%h')" >> $GITHUB_ENV
+
+    - name: Generate betaDebug APK
+      run: ./gradlew assembleBetaDebug --stacktrace
+
+    - name: Rename betaDebug APK
+      run: mv app/build/outputs/apk/beta/debug/app-*.apk app/build/outputs/apk/beta/debug/apps-android-commons-betaDebug-$COMMIT_SHA.apk
+
+    - name: Upload betaDebug APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: apps-android-commons-betaDebugAPK-${{ env.COMMIT_SHA }}
+        path: app/build/outputs/apk/beta/debug/*.apk
+        retention-days: 30


### PR DESCRIPTION
**Description (required)**

Allows users without android development environment on their machine to build betaDebug `.apk` using simple manually triggered GitHub workflow, so they can test their changes.

Has helped me make and test https://github.com/commons-app/apps-android-commons/pull/6173 for example.

**Tests performed (required)**

Here is example build, which has debug `.apk` attached in artifacts:
https://github.com/mnalis/apps-android-commons/actions/runs/13128111003

