### PR TITLE
Fix nominate for deletion

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/delete/ReasonBuilder.kt
+++ b/app/src/main/java/fr/free/nrw/commons/delete/ReasonBuilder.kt
@@ -14,6 +14,7 @@ import fr.free.nrw.commons.R
 import fr.free.nrw.commons.profile.achievements.FeedbackResponse
 import fr.free.nrw.commons.auth.SessionManager
 import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient
+import fr.free.nrw.commons.utils.ConfigUtils
 import fr.free.nrw.commons.utils.ViewUtilWrapper
 import io.reactivex.Single
 import timber.log.Timber
@@ -55,6 +56,10 @@ class ReasonBuilder @Inject constructor(
     }
 
     private fun fetchArticleNumber(media: Media, reason: String): Single<String> {
+        if (ConfigUtils.isBetaFlavour) {
+            return Single.just(appendArticlesUsed(null, media, reason))
+        }
+
         return if (checkAccount()) {
             okHttpJsonApiClient
                 .getAchievements(sessionManager.userName)
@@ -72,9 +77,9 @@ class ReasonBuilder @Inject constructor(
      * @param reason
      */
     @SuppressLint("StringFormatInvalid")
-    private fun appendArticlesUsed(feedBack: FeedbackResponse, media: Media, reason: String): String {
+    private fun appendArticlesUsed(feedBack: FeedbackResponse?, media: Media, reason: String): String {
         val reason1Template = context.getString(R.string.uploaded_by_myself)
-        return reason + String.format(Locale.getDefault(), reason1Template, prettyUploadedDate(media), feedBack.articlesUsingImages)
+        return reason + String.format(Locale.getDefault(), reason1Template, prettyUploadedDate(media), feedBack?.articlesUsingImages ?: 0)
             .also { Timber.i("New Reason %s", it) }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
@@ -140,7 +140,7 @@ class MediaDetailFragment : CommonsDaggerSupportFragment(), CategoryEditHelper.C
     private var index: Int = 0
     private var isDeleted: Boolean = false
     private var isWikipediaButtonDisplayed: Boolean = false
-    private val callback: Callback? = null
+    private var callback: Callback? = null
 
     @Inject
     lateinit var mediaDetailViewModelFactory: MediaDetailViewModel.MediaDetailViewModelProviderFactory
@@ -2072,7 +2072,8 @@ class MediaDetailFragment : CommonsDaggerSupportFragment(), CategoryEditHelper.C
             index: Int,
             editable: Boolean,
             isCategoryImage: Boolean,
-            isWikipediaButtonDisplayed: Boolean
+            isWikipediaButtonDisplayed: Boolean,
+            callback: Callback
         ): MediaDetailFragment {
             val mf = MediaDetailFragment()
             val state = Bundle()
@@ -2083,6 +2084,7 @@ class MediaDetailFragment : CommonsDaggerSupportFragment(), CategoryEditHelper.C
             state.putInt("listTop", 0)
             state.putBoolean("isWikipediaButtonDisplayed", isWikipediaButtonDisplayed)
             mf.arguments = state
+            mf.callback = callback
 
             return mf
         }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -621,9 +621,9 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                 binding.mediaDetailsPager.postDelayed(() -> getActivity().invalidateOptionsMenu(), 5);
             }
             if (isFromFeaturedRootFragment) {
-                return MediaDetailFragment.forMedia(position+i, editable, isFeaturedImage, isWikipediaButtonDisplayed);
+                return MediaDetailFragment.forMedia(position+i, editable, isFeaturedImage, isWikipediaButtonDisplayed, MediaDetailPagerFragment.this);
             } else {
-                return MediaDetailFragment.forMedia(i, editable, isFeaturedImage, isWikipediaButtonDisplayed);
+                return MediaDetailFragment.forMedia(i, editable, isFeaturedImage, isWikipediaButtonDisplayed, MediaDetailPagerFragment.this);
             }
         }
 


### PR DESCRIPTION
Fixes #6192

What changes did you make and why?
- put a condition to not fetch achievements in `beta` variant.
- passed callback to fragment to trigger refresh after `nominate to delete` call finishes.

**Tests performed (required)**
Tested on both `beta` and `prod`.
Device: Oneplust 9RT 5G, Android 14