### PR TITLE
Fix empty username

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/Media.kt
+++ b/app/src/main/java/fr/free/nrw/commons/Media.kt
@@ -126,6 +126,19 @@ class Media constructor(
     )
 
     /**
+     * Returns Author if it's not null or empty, otherwise
+     * returns user
+     * @return Author or User
+     */
+    fun getAuthorOrUser(): String? {
+        return if (!author.isNullOrEmpty()) {
+            author
+        } else{
+            user
+        }
+    }
+
+    /**
      * Gets media display title
      * @return Media title
      */

--- a/app/src/main/java/fr/free/nrw/commons/category/GridViewAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/GridViewAdapter.kt
@@ -98,14 +98,9 @@ class GridViewAdapter(
      */
     @SuppressLint("StringFormatInvalid")
     private fun setUploaderView(item: Media, uploader: TextView) {
-        if (!item.author.isNullOrEmpty()) {
-            uploader.visibility = View.VISIBLE
-            uploader.text = context.getString(
-                R.string.image_uploaded_by,
-                item.user
-            )
-        } else {
-            uploader.visibility = View.GONE
-        }
+        uploader.text = context.getString(
+            R.string.image_uploaded_by,
+            item.getAuthorOrUser()
+        )
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionViewHolder.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionViewHolder.kt
@@ -54,7 +54,7 @@ an upload might take a dozen seconds. */
         this.contribution = contribution
         this.position = position
         binding.contributionTitle.text = contribution.media.mostRelevantCaption
-        binding.authorView.text = contribution.media.author
+        binding.authorView.text = contribution.media.getAuthorOrUser()
 
         //Removes flicker of loading image.
         binding.contributionImage.hierarchy.fadeDuration = 0

--- a/app/src/main/java/fr/free/nrw/commons/delete/DeleteHelper.kt
+++ b/app/src/main/java/fr/free/nrw/commons/delete/DeleteHelper.kt
@@ -111,7 +111,7 @@ class DeleteHelper @Inject constructor(
 
         val userPageString = "\n{{subst:idw|${media.filename}}} ~~~~"
 
-        val creator = media.author
+        val creator = media.getAuthorOrUser()
             ?: throw RuntimeException("Failed to nominate for deletion")
 
         return pageEditClient.prependEdit(

--- a/app/src/main/java/fr/free/nrw/commons/explore/media/MediaConverter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/media/MediaConverter.kt
@@ -39,7 +39,7 @@ class MediaConverter
                 metadata.licenseShortName(),
                 metadata.prefixedLicenseUrl,
                 getAuthor(metadata),
-                getAuthor(metadata),
+                imageInfo.getUser(),
                 MediaDataExtractorUtil.extractCategoriesFromList(metadata.categories()),
                 metadata.latLng,
                 entity.labels().mapValues { it.value.value() },

--- a/app/src/main/java/fr/free/nrw/commons/explore/media/PagedMediaAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/media/PagedMediaAdapter.kt
@@ -55,7 +55,7 @@ class SearchImagesViewHolder(
         if (media.author?.isNotEmpty() == true) {
             binding.categoryImageAuthor.visibility = View.VISIBLE
             binding.categoryImageAuthor.text =
-                containerView.context.getString(R.string.image_uploaded_by, media.user)
+                containerView.context.getString(R.string.image_uploaded_by, media.author)
         } else {
             binding.categoryImageAuthor.visibility = View.GONE
         }

--- a/app/src/main/java/fr/free/nrw/commons/explore/media/PagedMediaAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/media/PagedMediaAdapter.kt
@@ -52,12 +52,7 @@ class SearchImagesViewHolder(
         binding.categoryImageView.setOnClickListener { onImageClicked(item.second) }
         binding.categoryImageTitle.text = media.mostRelevantCaption
         binding.categoryImageView.setImageURI(media.thumbUrl)
-        if (media.author?.isNotEmpty() == true) {
-            binding.categoryImageAuthor.visibility = View.VISIBLE
-            binding.categoryImageAuthor.text =
-                containerView.context.getString(R.string.image_uploaded_by, media.author)
-        } else {
-            binding.categoryImageAuthor.visibility = View.GONE
-        }
+        binding.categoryImageAuthor.text =
+            containerView.context.getString(R.string.image_uploaded_by, media.getAuthorOrUser())
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailPagerFragment.java
@@ -328,7 +328,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
             .append("\n\n");
 
         builder.append("User that you want to report: ")
-            .append(media.getAuthor())
+            .append(media.getUser())
             .append("\n\n");
 
         if (sessionManager.getUserName() != null) {
@@ -423,7 +423,7 @@ public class MediaDetailPagerFragment extends CommonsDaggerSupportFragment imple
                     // Initialize bookmark object
                     bookmark = new Bookmark(
                             m.getFilename(),
-                            m.getAuthor(),
+                            m.getAuthorOrUser(),
                             BookmarkPicturesContentProvider.uriForName(m.getFilename())
                     );
                     updateBookmarkState(menu.findItem(R.id.menu_bookmark_current_image));

--- a/app/src/test/kotlin/fr/free/nrw/commons/delete/DeleteHelperTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/delete/DeleteHelperTest.kt
@@ -96,7 +96,7 @@ class DeleteHelperTest {
         ).thenReturn("Media successfully deleted: Test Media Title")
 
         val creatorName = "Creator"
-        whenever(media.author).thenReturn("$creatorName")
+        whenever(media.getAuthorOrUser()).thenReturn("$creatorName")
         whenever(media.filename).thenReturn("Test file.jpg")
         val makeDeletion = deleteHelper.makeDeletion(
             context,
@@ -133,7 +133,7 @@ class DeleteHelperTest {
 
         whenever(media.displayTitle).thenReturn("Test file")
         whenever(media.filename).thenReturn("Test file.jpg")
-        whenever(media.author).thenReturn("Creator (page does not exist)")
+        whenever(media.getAuthorOrUser()).thenReturn("Creator (page does not exist)")
 
         deleteHelper.makeDeletion(context, media, "Test reason")?.blockingGet()
     }
@@ -148,7 +148,7 @@ class DeleteHelperTest {
             .thenReturn(Observable.just(false))
         whenever(media.displayTitle).thenReturn("Test file")
         whenever(media.filename).thenReturn("Test file.jpg")
-        whenever(media.author).thenReturn("Creator (page does not exist)")
+        whenever(media.getAuthorOrUser()).thenReturn("Creator (page does not exist)")
 
         deleteHelper.makeDeletion(context, media, "Test reason")?.blockingGet()
     }
@@ -163,7 +163,7 @@ class DeleteHelperTest {
             .thenReturn(Observable.just(true))
         whenever(media.displayTitle).thenReturn("Test file")
         whenever(media.filename).thenReturn("Test file.jpg")
-        whenever(media.author).thenReturn("Creator (page does not exist)")
+        whenever(media.getAuthorOrUser()).thenReturn("Creator (page does not exist)")
 
         deleteHelper.makeDeletion(context, media, "Test reason")?.blockingGet()
     }
@@ -221,7 +221,7 @@ class DeleteHelperTest {
         whenever(media.displayTitle).thenReturn("Test file")
         whenever(media.filename).thenReturn("Test file.jpg")
 
-        whenever(media.author).thenReturn(null)
+        whenever(media.getAuthorOrUser()).thenReturn(null)
 
         deleteHelper.makeDeletion(context, media, "Test reason")?.blockingGet()
     }


### PR DESCRIPTION
Fixes #6198

What changes did you make and why?

Revert changes of #5860;
The bug was due to reading the wrong property but this PR changed the data in the model `Media` instead. Reverted the change and made it read the correct prop instead.

<table>
  <tr>
   <td><img src="https://github.com/user-attachments/assets/6edf272f-d875-4529-963b-7cd743694acf" width="200"></td>
   <td><img src="https://github.com/user-attachments/assets/632c5a1c-1267-474e-98d7-a9da979d4f46" width="200"></td>
  </tr>
</table>

Correct custom `author` name in both `contributions` and `explore` screens (bug was it was incorrect in the `explore`)

-----------------------

Fixed empty author field; Use `user` if `author` is null or empty.

<table>
  <tr>
   <td><img src="https://github.com/user-attachments/assets/2076cf38-5730-42e9-8151-90422e98f408" width="200"></td>
   <td><img src="https://github.com/user-attachments/assets/fd821580-c355-44bb-8e84-0fb0223db1fe" width="200"></td>
  </tr>
</table>



