### PR TITLE
Fix crash when opening Leaderboard Tab

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.kt
@@ -500,7 +500,7 @@ class ContributionsFragment
 
     private fun setUploadCount() {
         okHttpJsonApiClient
-            ?.getUploadCount((activity as MainActivity).sessionManager?.currentAccount!!.name)
+            ?.getUploadCount(sessionManager?.currentAccount!!.name)
             ?.subscribeOn(Schedulers.io())
             ?.observeOn(AndroidSchedulers.mainThread())?.let {
                 compositeDisposable.add(


### PR DESCRIPTION
**Description (required)**

Fixes #6217 

What changes did you make and why?
We were using the session manager from `MainActivity` to retrieve the username, despite having it in the `ContributionsFragment`. So, I refactor it to use its own class `session manager` property.

**Tests performed (required)**

Tested prodDebug on Samsung A14 with API level 34.

**Screenshots (for UI changes only)**
None