### PR TITLE
fix: the description language set to bug by default when uploading image in nearby

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/model/ResultTuple.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/model/ResultTuple.kt
@@ -1,6 +1,7 @@
 package fr.free.nrw.commons.nearby.model
 
 import com.google.gson.annotations.SerializedName
+import java.util.Locale
 
 class ResultTuple {
     @SerializedName("xml:lang")
@@ -15,7 +16,7 @@ class ResultTuple {
     }
 
     constructor() {
-        language = "bug" // Basa Ugi language -  TODO Respect the `Default description language`　setting.
+        language = Locale.getDefault().language
         type = ""
         value = ""
     }


### PR DESCRIPTION
**Description (required)**

Fixes #6191 

Removed the hardcoded "bug" string set as the default language when uploading an image in the Nearby feature. Now, the app correctly selects the user's default language instead.

**Tests performed (required)**

Tested ProdDebug on vivo2334 with API level 35.

**Screenshots (for UI changes only)**

https://github.com/user-attachments/assets/3d11e9ca-97cf-4789-8b05-4b43a19ba548

