### PR TITLE
Fix crash when tapping on search icon on the Nearby screen

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
@@ -223,7 +223,7 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
     private var view: View? = null
     private var scope: LifecycleCoroutineScope? = null
     private var presenter: NearbyParentFragmentPresenter? = null
-    private var isDarkTheme = false
+    private var _isDarkTheme = false
     private var isFABsExpanded = false
     private var selectedPlace: Place? = null
     private var clickedMarker: Marker? = null
@@ -461,7 +461,7 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
                     }
                 }
             }
-        isDarkTheme = systemThemeUtils?.isDeviceInNightMode() == true
+        _isDarkTheme = systemThemeUtils?.isDeviceInNightMode() == true
         if (Utils.isMonumentsEnabled(Date())) {
             binding?.rlContainerWlmMonthMessage?.visibility = View.VISIBLE
         } else {
@@ -631,7 +631,7 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
      * another refactor
      */
     private fun initThemePreferences() {
-        if (isDarkTheme) {
+        if (_isDarkTheme) {
             binding!!.bottomSheetNearby.rvNearbyList.setBackgroundColor(
                 requireContext().resources.getColor(fr.free.nrw.commons.R.color.contributionListDarkBackground)
             )
@@ -915,7 +915,7 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
                 }
 
                 override fun isDarkTheme(): Boolean {
-                    return isDarkTheme
+                    return _isDarkTheme
                 }
             })
         binding!!.nearbyFilterList.root


### PR DESCRIPTION
**Description (required)**

Fixes #6230

What changes did you make and why?
The override of the `isDarkTheme()` method from `NearbyFilterSearchRecyclerViewAdapter.Callback` was supposed to return the `isDarkTheme` property of the `NearbyParentFragment` class as it was doing in the java file.

But in Kotlin syntax when we write `return isDarkTheme`, we're actually calling the getter of the isDarkTheme property. But the getter is the isDarkTheme() method itself! This creates an infinite loop.
So, I renamed the `isDarkTheme` property.

**Tests performed (required)**

Tested prodDebug on Samsung A14 with API level 34.

**Screenshots (for UI changes only)**
None