### PR TITLE
Fix : UninitializedPropertyAccessException

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.kt
@@ -34,8 +34,7 @@ class UploadPresenter @Inject internal constructor(
 
     private val compositeDisposable = CompositeDisposable()
 
-    lateinit var basicKvStoreFactory: (String) -> BasicKvStore
-
+    private var basicKvStoreFactory: ((String) -> BasicKvStore)? = null
     /**
      * Called by the submit button in [UploadActivity]
      */
@@ -132,6 +131,10 @@ class UploadPresenter @Inject internal constructor(
         basicKvStoreFactory = factory
     }
 
+    private fun getBasicKvStoreFactory(): (String) -> BasicKvStore {
+        return basicKvStoreFactory ?: throw IllegalStateException("basicKvStoreFactory has not been initialized")
+    }
+
     /**
      * Calls checkImageQuality of UploadMediaPresenter to check image quality of next image
      *
@@ -139,7 +142,7 @@ class UploadPresenter @Inject internal constructor(
      */
     override fun checkImageQuality(uploadItemIndex: Int) {
         repository.getUploadItem(uploadItemIndex)?.let {
-            presenter.setupBasicKvStoreFactory(basicKvStoreFactory)
+            presenter.setupBasicKvStoreFactory(getBasicKvStoreFactory())
             presenter.checkImageQuality(it, uploadItemIndex)
         }
     }


### PR DESCRIPTION
**Description (required)**

 When a user uploads a file with a name that already exists, they get a warning about the duplicate file. Clicking "Upload" after this caused a crash.

Fixes #6247 

What changes did you make and why?

(1) Fixed crash when uploading after a duplicate filename warning by adding proper checks and error handling.

(2) Ensured the warning message displays correctly and does not interfere with the upload process.


**Tests performed (required)**

Tested {build variant (BetaDebug)} on {VIVO V25} with API level {34}.

**Screenshots (for UI changes only)**

https://github.com/user-attachments/assets/e049fc35-4f9e-412a-b9f2-004c03db05ca

