### PR TITLE
Fix NullPointerException in onBackPressed()

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.kt
@@ -387,35 +387,40 @@ after opening the app.
     }
 
     override fun onBackPressed() {
-        if (contributionsFragment != null && activeFragment == ActiveFragment.CONTRIBUTIONS) {
+        when (activeFragment) {
+            ActiveFragment.CONTRIBUTIONS -> {
             // Means that contribution fragment is visible
-            if (!contributionsFragment!!.backButtonClicked()) { //If this one does not wan't to handle
+            if (contributionsFragment?.backButtonClicked() != true) { //If this one does not want to handle
                 // the back press, let the activity do so
                 super.onBackPressed()
+                }
             }
-        } else if (nearbyParentFragment != null && activeFragment == ActiveFragment.NEARBY) {
+        ActiveFragment.NEARBY -> {
             // Means that nearby fragment is visible
-            /* If function nearbyParentFragment.backButtonClick() returns false, it means that the bottomsheet is
-              not expanded. So if the back button is pressed, then go back to the Contributions tab */
-            if (!nearbyParentFragment!!.backButtonClicked()) {
-                supportFragmentManager.beginTransaction().remove(nearbyParentFragment!!)
-                    .commit()
+            if (nearbyParentFragment?.backButtonClicked() != true) {
+            nearbyParentFragment?.let {
+                supportFragmentManager.beginTransaction().remove(it).commit()
+                    }
                 setSelectedItemId(NavTab.CONTRIBUTIONS.code())
+                }
             }
-        } else if (exploreFragment != null && activeFragment == ActiveFragment.EXPLORE) {
-            // Means that explore fragment is visible
-            if (!exploreFragment!!.onBackPressed()) {
-                if (applicationKvStore!!.getBoolean("login_skipped")) {
+         ActiveFragment.EXPLORE -> {
+            // Explore Fragment is visible
+            if (exploreFragment?.onBackPressed() != true) {
+                if (applicationKvStore?.getBoolean("login_skipped") == true) {
                     super.onBackPressed()
                 } else {
                     setSelectedItemId(NavTab.CONTRIBUTIONS.code())
+                    }
                 }
             }
-        } else if (bookmarkFragment != null && activeFragment == ActiveFragment.BOOKMARK) {
+         ActiveFragment.BOOKMARK -> {
             // Means that bookmark fragment is visible
-            bookmarkFragment!!.onBackPressed()
-        } else {
+            bookmarkFragment?.onBackPressed()
+            }
+         else -> {
             super.onBackPressed()
+            }
         }
     }
 


### PR DESCRIPTION
**Description (required)**

Fixes #6214 

What changes did you make and why?

- Fixed a `NullPointerException` crash in `MainActivity.kt` caused by `contributionsFragment` being null.  
- Added null checks to prevent app crashes when pressing the back button on the Contributions tab.  

**Tests performed (required)**

Tested {BetaDebug} on {VIVO V 25} with API level {34}.

**Screenshots (for UI changes only)**

https://github.com/user-attachments/assets/d6093be7-5f5c-4b67-b924-e74bd82804a6

