### PR TITLE
FooterAdapter.kt: changed enum access of FooterItem

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/paging/FooterAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/paging/FooterAdapter.kt
@@ -32,7 +32,7 @@ class FooterAdapter(
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
-    ) = when (FooterItem.values()[viewType]) {
+    ) = when (FooterItem.entries[viewType]) {
         FooterItem.LoadingItem ->
             LoadingViewHolder(
                 parent.inflate(R.layout.list_item_progress),


### PR DESCRIPTION

Fixes #5996 : Fix one of android studio warnings

What changes did you make and why?
FooterAdapter.kt: changed enum access of FooterItem, from FooterItem.values() to FooterItem.entries(), this is the more efficient way of accessing Enum values as introduced in kotlin 1.9

**Tests performed (required)**

Tested the Debug Beta on Android (Samsung Galaxy A21s), Api level 31
