### PR TITLE
Refactor location handling in UploadMediaDetailFragment and related classes

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.kt
@@ -21,8 +21,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.exifinterface.media.ExifInterface
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.viewpager.widget.ViewPager
-import androidx.viewpager2.widget.ViewPager2
 import fr.free.nrw.commons.CameraPosition
 import fr.free.nrw.commons.R
 import fr.free.nrw.commons.contributions.MainActivity

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailsContract.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailsContract.kt
@@ -124,5 +124,7 @@ interface UploadMediaDetailsContract {
         fun onEditButtonClicked(indexInViewFlipper: Int)
 
         fun onUserConfirmedUploadIsOfPlace(place: Place?, uploadItemIndex: Int)
+
+        fun getUploadItem(index: Int): UploadItem?
     }
 }


### PR DESCRIPTION
Fixes #6252 

* Copy Title, description and location to subsequent media

* Show message on success

* Refresh UI immediately after location update

Refactor location handling in UploadMediaDetailFragment and related classes



https://github.com/user-attachments/assets/0b869dc7-a087-4c6a-a84e-3486a2e31290



