### PR TITLE
Enable EmailAuth support.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/csrf/CsrfTokenClient.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/csrf/CsrfTokenClient.kt
@@ -32,7 +32,7 @@ class CsrfTokenClient(
             try {
                 if (retry > 0) {
                     // Log in explicitly
-                    loginClient.loginBlocking(userName, password, "")
+                    loginClient.loginBlocking(userName, password)
                 }
 
                 // Get CSRFToken response off the main thread.
@@ -92,6 +92,8 @@ class CsrfTokenClient(
                 override fun failure(caught: Throwable?) = retryWithLogin(cb) { caught }
 
                 override fun twoFactorPrompt() = cb.twoFactorPrompt()
+
+                override fun emailAuthPrompt() = cb.emailAuthPrompt()
             },
         )
 
@@ -165,9 +167,16 @@ class CsrfTokenClient(
             }
 
             override fun twoFactorPrompt(
+                loginResult: LoginResult,
                 caught: Throwable,
                 token: String?,
             ) = callback.twoFactorPrompt()
+
+            override fun emailAuthPrompt(
+                loginResult: LoginResult,
+                caught: Throwable,
+                token: String?,
+            ) = callback.emailAuthPrompt()
 
             // Should not happen here, but call the callback just in case.
             override fun passwordResetPrompt(token: String?) = callback.failure(LoginFailedException("Logged in with temporary password."))
@@ -190,6 +199,8 @@ class CsrfTokenClient(
         fun failure(caught: Throwable?)
 
         fun twoFactorPrompt()
+
+        fun emailAuthPrompt()
     }
 
     companion object {

--- a/app/src/main/java/fr/free/nrw/commons/auth/login/LoginCallback.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/login/LoginCallback.kt
@@ -4,6 +4,13 @@ interface LoginCallback {
     fun success(loginResult: LoginResult)
 
     fun twoFactorPrompt(
+        loginResult: LoginResult,
+        caught: Throwable,
+        token: String?,
+    )
+
+    fun emailAuthPrompt(
+        loginResult: LoginResult,
         caught: Throwable,
         token: String?,
     )

--- a/app/src/main/java/fr/free/nrw/commons/auth/login/LoginInterface.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/login/LoginInterface.kt
@@ -35,7 +35,8 @@ interface LoginInterface {
         @Field("password") pass: String?,
         @Field("retype") retypedPass: String?,
         @Field("OATHToken") twoFactorCode: String?,
-        @Field("logintoken") token: String?,
+        @Field("token") emailAuthToken: String?,
+        @Field("logintoken") loginToken: String?,
         @Field("uselang") userLanguage: String?,
         @Field("logincontinue") loginContinue: Boolean,
     ): Call<LoginResponse?>

--- a/app/src/main/java/fr/free/nrw/commons/auth/login/LoginResponse.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/login/LoginResponse.kt
@@ -2,6 +2,7 @@ package fr.free.nrw.commons.auth.login
 
 import com.google.gson.annotations.SerializedName
 import fr.free.nrw.commons.auth.login.LoginResult.OAuthResult
+import fr.free.nrw.commons.auth.login.LoginResult.EmailAuthResult
 import fr.free.nrw.commons.auth.login.LoginResult.ResetPasswordResult
 import fr.free.nrw.commons.auth.login.LoginResult.Result
 import fr.free.nrw.commons.wikidata.mwapi.MwServiceError
@@ -27,11 +28,13 @@ internal class ClientLogin {
     fun toLoginResult(password: String): LoginResult {
         var userMessage = message
         if ("UI" == status) {
-            if (requests != null) {
-                for (req in requests) {
-                    if ("MediaWiki\\Extension\\OATHAuth\\Auth\\TOTPAuthenticationRequest" == req.id()) {
+            requests?.forEach { request ->
+                request.id()?.let {
+                    if (it.endsWith("TOTPAuthenticationRequest")) {
                         return OAuthResult(status, userName, password, message)
-                    } else if ("MediaWiki\\Auth\\PasswordAuthenticationRequest" == req.id()) {
+                    } else if (it.endsWith("EmailAuthAuthenticationRequest")) {
+                        return EmailAuthResult(status, userName, password, message)
+                    } else if (it.endsWith("PasswordAuthenticationRequest")) {
                         return ResetPasswordResult(status, userName, password, message)
                     }
                 }
@@ -49,7 +52,7 @@ internal class Request {
     private val required: String? = null
     private val provider: String? = null
     private val account: String? = null
-    private val fields: Map<String, RequestField>? = null
+    internal val fields: Map<String, RequestField>? = null
 
     fun id(): String? = id
 }
@@ -57,5 +60,5 @@ internal class Request {
 internal class RequestField {
     private val type: String? = null
     private val label: String? = null
-    private val help: String? = null
+    internal val help: String? = null
 }

--- a/app/src/main/java/fr/free/nrw/commons/auth/login/LoginResult.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/login/LoginResult.kt
@@ -24,6 +24,13 @@ sealed class LoginResult(
         message: String?,
     ) : LoginResult(status, userName, password, message)
 
+    class EmailAuthResult(
+        status: String,
+        userName: String?,
+        password: String?,
+        message: String?,
+    ) : LoginResult(status, userName, password, message)
+
     class ResetPasswordResult(
         status: String,
         userName: String?,

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -146,6 +146,7 @@
             android:layout_marginEnd="@dimen/standard_gap"
             android:layout_marginRight="@dimen/standard_gap"
             android:layout_marginBottom="@dimen/standard_gap"
+            android:hint="@string/_2fa_code"
             android:visibility="gone"
             app:passwordToggleEnabled="false"
             tools:visibility="visible">
@@ -154,9 +155,7 @@
               android:id="@+id/login_two_factor"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
-              android:hint="@string/_2fa_code"
               android:imeOptions="flagNoExtractUi"
-              android:inputType="number"
               android:visibility="gone"
               tools:visibility="visible" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
   <string name="login_failed_throttled">Too many unsuccessful attempts. Please try again in a few minutes.</string>
   <string name="login_failed_blocked">Sorry, this user has been blocked on Commons</string>
   <string name="login_failed_2fa_needed">You must provide your two factor authentication code.</string>
+  <string name="login_failed_email_auth_needed">A login verification code has been sent to your email address. Please provide the code to log in.</string>
   <string name="login_failed_generic">Log-in failed</string>
   <string name="share_upload_button">Upload</string>
   <string name="multiple_share_base_title">Name this set</string>
@@ -218,6 +219,7 @@
   <string name="become_a_tester_description">Opt-in to our beta channel on Google Play and get early access to new features and bug fixes</string>
   <string name="beta_opt_in_link">https://play.google.com/apps/testing/fr.free.nrw.commons</string>
   <string name="_2fa_code">2FA Code</string>
+  <string name="email_auth_code">Email verification code</string>
   <string name="logout_verification">Do you really want to logout?</string>
   <string name="mediaimage_failed">Media Image Failed</string>
   <string name="no_subcategory_found">No subcategories found</string>


### PR DESCRIPTION
(👋  from the WMF Android team)
This enables integration with [EmailAuth](https://www.mediawiki.org/wiki/Extension:EmailAuth), where a login attempt might require a second factor (authorization code) that is sent to the user via email. 
This basically reuses much of the existing logic for 2FA ([OATHAuth](https://www.mediawiki.org/wiki/Extension:OATHAuth)), just with slightly different verbiage. (Regular logins, i.e. without a second factor, should not be impacted.)

Phabricator tasks:
https://phabricator.wikimedia.org/T390662
https://phabricator.wikimedia.org/T390820
(The latter task might be restricted to WMF staff, but the gist is that a small subset of users will be required to verify their login with an email authentication code, based on IP address, and this needs to be supported in the login workflow.)