### PR TITLE
Fixes issue #6242: Explore>Map: Two pin labels appear at the same time

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
@@ -775,7 +775,11 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
      * @param nearbyBaseMarker The NearbyBaseMarker object representing the marker to be removed.
      */
     private void removeMarker(BaseMarker nearbyBaseMarker) {
-        Place place = nearbyBaseMarker.getPlace();
+        if (nearbyBaseMarker == null || nearbyBaseMarker.getPlace().getName() == null) {
+            return;
+        }
+
+        String target = nearbyBaseMarker.getPlace().getName();
         List<Overlay> overlays = binding.mapView.getOverlays();
         ItemizedOverlayWithFocus item;
 
@@ -784,8 +788,7 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
                 item = (ItemizedOverlayWithFocus) overlays.get(i);
                 OverlayItem overlayItem = item.getItem(0);
 
-                if (place.location.getLatitude() == overlayItem.getPoint().getLatitude()
-                    && place.location.getLongitude() == overlayItem.getPoint().getLongitude()) {
+                if (overlayItem.getTitle().equals(target)) {
                     binding.mapView.getOverlays().remove(i);
                     binding.mapView.invalidate();
                     break;


### PR DESCRIPTION
**Description (required)**

Fixes #6242 

What changes did you make and why?

The removeMarker() method was changed to match the Overlay's title with the BaseMarker's Place name during the linear search for the correct overlay. This causes the correct marker to be removed along with the label when a new marker is selected.

Prior to this change, the Place coordinates were used to find the overlay. However, since multiple images may be taken at the same Place, the wrong overlay could be removed. This results in multiple pin labels appearing at the same time since the labels are hidden by deleting the Overlay and creating a new one with the label hidden.

Also, null checking was added to the removeMarker() method.

**Tests performed (required)**

To test, find multiple images in the Explore map that are taken at the same place and tap each of them. On main, multiple labels will display. On this PR, a maximum of one label will appear.

Tested ProdDebug on Android Studio Emulator with API level 34.

