### PR TITLE
ui: make recenter FAB theme-aware using Material attributes

### DIFF
--- a/app/src/main/res/layout/fragment_explore_map.xml
+++ b/app/src/main/res/layout/fragment_explore_map.xml
@@ -26,10 +26,11 @@
       android:clickable="true"
       android:focusable="true"
       android:visibility="visible"
-      app:backgroundTint="@color/main_background_light"
+      app:backgroundTint="?attr/colorSurface"
       app:elevation="@dimen/dimen_6"
       app:fabSize="normal"
       app:srcCompat="@drawable/ic_my_location_black_24dp"
+      app:tint="?attr/colorOnSurface"
       app:useCompatPadding="true" />
 
     <View


### PR DESCRIPTION
Fixes:#6267

Updated the FloatingActionButton to use theme-aware attributes for background (`?attr/colorSurface`) and icon tint (`?attr/colorOnSurface`). This improves visual consistency and readability across light and dark themes, addressing poor visibility of the icon in dark mode.

This change follows Material Design guidelines and removes hardcoded values to ensure the FAB dynamically adapts to the app's current theme.

Currently it look's like this: 
![image](https://github.com/user-attachments/assets/d562513f-a6a4-4aaa-9f20-0c6dd4a3d2fb)

