### PR TITLE
Exclude past locations (P585) from Nearby query

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
@@ -154,7 +154,8 @@ public class Place implements Parcelable {
             item.getPic().getValue(),
             // Checking if the place exists or not
             (item.getDestroyed().getValue() == "") && (item.getEndTime().getValue() == "")
-                && (item.getDateOfOfficialClosure().getValue() == ""),
+                && (item.getDateOfOfficialClosure().getValue() == "")
+                && (item.getPointInTime().getValue()==""),
             entityId);
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/model/NearbyResultItem.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/model/NearbyResultItem.kt
@@ -19,6 +19,7 @@ class NearbyResultItem(
     @field:SerializedName("endTime") private val endTime: ResultTuple?,
     @field:SerializedName("monument") private val monument: ResultTuple?,
     @field:SerializedName("dateOfOfficialClosure") private val dateOfOfficialClosure: ResultTuple?,
+    @field:SerializedName("pointInTime") private val pointInTime: ResultTuple?,
 ) {
     fun getItem(): ResultTuple = item ?: ResultTuple()
 
@@ -51,5 +52,7 @@ class NearbyResultItem(
     fun getAddress(): String = address?.value ?: ""
 
     fun getMonument(): ResultTuple? = monument
+
+    fun getPointInTime(): ResultTuple = pointInTime ?: ResultTuple()
 
 }

--- a/app/src/main/resources/queries/query_for_item.rq
+++ b/app/src/main/resources/queries/query_for_item.rq
@@ -11,6 +11,7 @@ SELECT
   (SAMPLE(?commonsArticle) AS ?commonsArticle)
   (SAMPLE(?commonsCategory) AS ?commonsCategory)
   (SAMPLE(?dateOfOfficialClosure) AS ?dateOfOfficialClosure)
+  (SAMPLE(?pointInTime) AS ?pointInTime)
 WHERE {
   SERVICE <https://query.wikidata.org/sparql> {
     values ?item {
@@ -47,6 +48,7 @@ WHERE {
   OPTIONAL {?item wdt:P576 ?destroyed}
   OPTIONAL {?item wdt:P582 ?endTime}
   OPTIONAL {?item wdt:P3999 ?dateOfOfficialClosure}
+  OPTIONAL {?item wdt:P585 ?pointInTime}
 
   # Get Commons category
   OPTIONAL {?item wdt:P373 ?commonsCategory}


### PR DESCRIPTION
**Description (required)**

Fixes Items with a "point in time" (P585) as not existing anymore(#4207)


What changes did you make and why?
- For past events added a query related to (point in time ) in query_for_item.rq  so that it can fetch the data related to P585 property  and check for existence in place.java 
- Items marked with P585 (pointInTime) should be excluded from Nearby results,  because a picture can not really be taken of them in the present.


**Tests performed (required)**

Tested {build variant :-betaDebug} on {OnePlus Nord CE4 Lite} with API level {35}.


