### PR TITLE
FIX : Custom picker detect images that is already in commons

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/adapter/ImageAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/adapter/ImageAdapter.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.TreeMap
 import kotlin.collections.ArrayList
 
@@ -342,45 +343,36 @@ class ImageAdapter(
                 numberOfSelectedImagesMarkedAsNotForUpload--
             }
             notifyItemChanged(position, ImageUnselected())
-
-            // Getting index from all images index when switch is on
-            val indexes =
-                if (showAlreadyActionedImages) {
-                    ImageHelper.getIndexList(selectedImages, images)
-
-                    // Getting index from actionable images when switch is off
-                } else {
-                    ImageHelper.getIndexList(selectedImages, ArrayList(actionableImagesMap.values))
-                }
-            for (index in indexes) {
-                notifyItemChanged(index, ImageSelectedOrUpdated())
-            }
         } else {
+            val image = images[position]
+            scope.launch(ioDispatcher) {
+                val imageSHA1 = imageLoader.getSHA1(image, defaultDispatcher)
+                withContext(Dispatchers.Main) {
             if (holder.isItemUploaded()) {
                 Toast.makeText(context, R.string.custom_selector_already_uploaded_image_text, Toast.LENGTH_SHORT).show()
-            } else {
-                if (holder.isItemNotForUpload()) {
-                    numberOfSelectedImagesMarkedAsNotForUpload++
-                }
-
-                // Getting index from all images index when switch is on
-                val indexes: ArrayList<Int> =
-                    if (showAlreadyActionedImages) {
-                        selectedImages.add(images[position])
-                        ImageHelper.getIndexList(selectedImages, images)
-
-                        // Getting index from actionable images when switch is off
-                    } else {
-                        selectedImages.add(ArrayList(actionableImagesMap.values)[position])
-                        ImageHelper.getIndexList(selectedImages, ArrayList(actionableImagesMap.values))
+                        return@withContext
                     }
 
-                for (index in indexes) {
-                    notifyItemChanged(index, ImageSelectedOrUpdated())
+                if (imageSHA1.isNotEmpty() && imageLoader.getFromUploaded(imageSHA1) != null) {
+                        holder.itemUploaded()
+                        Toast.makeText(context, R.string.custom_selector_already_uploaded_image_text, Toast.LENGTH_SHORT).show()
+                        return@withContext
+                    }
+
+                    if (!holder.isItemUploaded() && imageSHA1.isNotEmpty() && imageLoader.getFromUploaded(imageSHA1) != null) {
+                        Toast.makeText(context, R.string.custom_selector_already_uploaded_image_text, Toast.LENGTH_SHORT).show()
+                    }
+
+                    if (holder.isItemNotForUpload()) {
+                        numberOfSelectedImagesMarkedAsNotForUpload++
+                    }
+                    selectedImages.add(image)
+                    notifyItemChanged(position, ImageSelectedOrUpdated())
+
+        imageSelectListener.onSelectedImagesChanged(selectedImages, numberOfSelectedImagesMarkedAsNotForUpload)
                 }
             }
         }
-        imageSelectListener.onSelectedImagesChanged(selectedImages, numberOfSelectedImagesMarkedAsNotForUpload)
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/CustomSelectorActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/CustomSelectorActivity.kt
@@ -638,17 +638,20 @@ class CustomSelectorActivity :
             finishPickImages(arrayListOf())
             return
         }
-        var i = 0
-        while (i < selectedImages.size) {
-            val path = selectedImages[i].path
-            val file = File(path)
-            if (!file.exists()) {
-                selectedImages.removeAt(i)
-                i--
+        scope.launch(ioDispatcher) {
+            val uniqueImages = selectedImages.distinctBy { image ->
+                CustomSelectorUtils.getImageSHA1(
+                    image.uri,
+                    ioDispatcher,
+                    fileUtilsWrapper,
+                    contentResolver
+                )
             }
-            i++
+
+            withContext(Dispatchers.Main) {
+                finishPickImages(ArrayList(uniqueImages))
+            }
         }
-        finishPickImages(selectedImages)
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/nearby/WikidataFeedback.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/WikidataFeedback.kt
@@ -72,11 +72,7 @@ class WikidataFeedback : BaseActivity() {
                         getString(R.string.please_enter_some_comments),
                         Toast.LENGTH_SHORT,
                     ).show()
-            }  else {
-                if (binding.radioGroup.checkedRadioButtonId == R.id.radioButton2) {
-                    val excludedText = getString(R.string.is_at_a_different_place_please_specify_the_correct_place_below_if_possible_tell_us_the_correct_latitude_longitude, place)
-                    desc = desc.toString().replace(excludedText, "").trim()
-                }
+            } else {
                 binding.radioGroup.clearCheck()
                 binding.detailsEditText.setText("")
                 Single

--- a/app/src/main/java/fr/free/nrw/commons/nearby/WikidataFeedback.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/WikidataFeedback.kt
@@ -72,7 +72,11 @@ class WikidataFeedback : BaseActivity() {
                         getString(R.string.please_enter_some_comments),
                         Toast.LENGTH_SHORT,
                     ).show()
-            } else {
+            }  else {
+                if (binding.radioGroup.checkedRadioButtonId == R.id.radioButton2) {
+                    val excludedText = getString(R.string.is_at_a_different_place_please_specify_the_correct_place_below_if_possible_tell_us_the_correct_latitude_longitude, place)
+                    desc = desc.toString().replace(excludedText, "").trim()
+                }
                 binding.radioGroup.clearCheck()
                 binding.detailsEditText.setText("")
                 Single


### PR DESCRIPTION
**Description (required)**

- Implemented SHA1-based detection to identify images already uploaded to Commons, ensuring consistency with the system picker.

- Ensured that images with the "already uploaded" icon  are not selectable in the custom picker.

Fixes #6280 

**Tests performed (required)**

Tested {build variant, BetaDebug} on {VIVO V25} with API level {34}.

