### PR TITLE
Update fragment_media_detail.xml

### DIFF
--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -147,6 +147,47 @@
                 </LinearLayout>
 
                 <LinearLayout
+                  style="@style/MediaDetailContainer"
+                  android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:orientation="horizontal">
+
+                    <TextView
+                      style="@style/MediaDetailTextLabelGeneric"
+                      android:layout_width="@dimen/widget_margin"
+                      android:layout_height="match_parent"
+                      android:text="Source" />
+
+                    <TextView
+                      style="@style/MediaDetailTextBody"
+                      android:id="@+id/mediaDetailSource"
+                      android:layout_width="@dimen/widget_margin"
+                      android:layout_height="match_parent"
+                      tools:text="Source of media" />
+                </LinearLayout>
+
+                <LinearLayout
+                  style="@style/MediaDetailContainer"
+                  android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:orientation="horizontal">
+
+                    <TextView
+                      style="@style/MediaDetailTextLabelGeneric"
+                      android:layout_width="@dimen/widget_margin"
+                      android:layout_height="match_parent"
+                      android:text="Uploader" />
+
+                    <TextView
+                      style="@style/MediaDetailTextBody"
+                      android:id="@+id/mediaDetailUploader"
+                      android:layout_width="@dimen/widget_margin"
+                      android:layout_height="match_parent"
+                      tools:text="Uploader of media" />
+                </LinearLayout>
+
+
+                <LinearLayout
                   android:id="@+id/caption_layout"
                   style="@style/MediaDetailContainer"
                   android:layout_width="match_parent"


### PR DESCRIPTION
**Description (required)**

Fixes #6265

What changes did you make and why?
I worked on displaying missing metadata (author, source, and uploader) on the media detail page. These fields were not previously visible when available in the media object. The XML layout was updated to include TextViews for this information, ensuring that if the data is present, it is shown correctly to users.

**Tests performed (required)**

Tested ProdDebug on Pixel 6 emulator with API level 30..

**Screenshots (for UI changes only)**

![image](https://github.com/user-attachments/assets/146bb3c9-7e77-4398-8af9-10643cd6fc2b)


---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
