### PR TITLE
Fix: Show captions instead of filenames in Explore > Map (Fixes #6294)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapController.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapController.java
@@ -154,8 +154,12 @@ public class ExploreMapController extends MapController {
                 String distance = formatDistanceBetween(currentLatLng, explorePlace.location);
                 explorePlace.setDistance(distance);
 
-                baseMarker.setTitle(
-                    explorePlace.name.substring(5, explorePlace.name.lastIndexOf(".")));
+                if (explorePlace.caption != null && !explorePlace.caption.isEmpty()) {
+    baseMarker.setTitle(explorePlace.caption);
+} else {
+    baseMarker.setTitle(
+        explorePlace.name.substring(5, explorePlace.name.lastIndexOf(".")));
+}
                 baseMarker.setPosition(
                     new fr.free.nrw.commons.location.LatLng(
                         explorePlace.location.getLatitude(),

--- a/app/src/main/java/fr/free/nrw/commons/utils/PlaceUtils.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/PlaceUtils.kt
@@ -19,31 +19,30 @@ object PlaceUtils {
         }
     }
 
-    /**
-     * Turns a Media list to a Place list by creating a new list in Place type
-     * @param mediaList
-     * @return
-     */
     @JvmStatic
     fun mediaToExplorePlace(mediaList: List<Media>): List<Place> {
         val explorePlaceList = mutableListOf<Place>()
         for (media in mediaList) {
-            explorePlaceList.add(
-                Place(
-                    media.filename,
-                    media.fallbackDescription,
-                    media.coordinates,
-                    media.categories.toString(),
-                    Sitelinks.Builder()
-                        .setCommonsLink(media.pageTitle.canonicalUri)
-                        .setWikipediaLink("") // we don't necessarily have them, can be fetched later
-                        .setWikidataLink("") // we don't necessarily have them, can be fetched later
-                        .build(),
-                    media.imageUrl,
-                    media.thumbUrl,
-                    ""
-                )
+            val place = Place(
+                media.filename ?: "",
+                media.fallbackDescription ?: "",
+                media.coordinates,
+                media.categories.toString(),
+                Sitelinks.Builder()
+                    .setCommonsLink(media.pageTitle?.canonicalUri ?: "")
+                    .setWikipediaLink("")
+                    .setWikidataLink("")
+                    .build(),
+                media.imageUrl ?: "",
+                media.thumbUrl ?: "",
+                ""
             )
+            // Set caption, with fallback
+            place.caption = media.captions?.values?.firstOrNull()
+                ?: media.filename?.removePrefix("File:")?.replace('_', ' ')
+                ?: "Unknown"
+
+            explorePlaceList.add(place)
         }
         return explorePlaceList
     }


### PR DESCRIPTION
**Description (required)**
**Fixes #6294**

**What changes did you make and why?**

Updated the Explore > Map view to display the caption (in the user's language) instead of the filename on green pins.

If a caption is unavailable, the app falls back to showing the filename.

Improves usability and localization, matching the behavior in Explore > Featured.

**Tests performed (required)**

Tested ProdDebug build variant on Medium Emulator (API 36) and Pixel 7 Emulator (API 34).

Verified:

Captions appear correctly on green pins when available.

Filenames are shown when captions are missing.

Clicking pins opens the bottom sheet without crashes.

Behavior verified even when some media items lack captions.

**Screenshots (for UI changes only)**

No UI layout changes.

Only the text label of the green pins was updated based on available captions.