### PR TITLE
Nearby List: Only show place cards with loaded names

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
@@ -1064,7 +1064,7 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
 
     override fun updateListFragment(placeList: List<Place>) {
         adapter!!.clear()
-        adapter!!.items = placeList
+        adapter!!.items = placeList.filter{ it.name.isNotEmpty() }
         binding!!.bottomSheetNearby.noResultsMessage.visibility =
             if (placeList.isEmpty()) View.VISIBLE else View.GONE
     }


### PR DESCRIPTION
This pr fixes the empty place cards that sometimes appeared in the Nearby list while places were loading.

Fixes #6268

**Changes made**
- NearbyParentFragment: The places list is now always filtered to ensure the RV adapter only gets places with names. 

**Tests performed**

Tested prodDebug, betaDebug on a TECNO Spark 10c with API level 31.
