### PR TITLE
Fixes Issue 6308: Explore map shows image at my location rather than at shown location

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.java
@@ -120,6 +120,7 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
     private double prevZoom;
     private double prevLatitude;
     private double prevLongitude;
+    private boolean recentlyCameFromNearbyMap;
 
     private ExploreMapPresenter presenter;
 
@@ -371,6 +372,16 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
             prevLatitude = getArguments().getDouble("prev_latitude");
             prevLongitude = getArguments().getDouble("prev_longitude");
         }
+
+        setRecentlyCameFromNearbyMap(isCameFromNearbyMap());
+    }
+
+    /**
+     * @return The LatLng from the previous Fragment's map center or (0,0,0) coordinates
+     * if that information is not available/applicable.
+     */
+    public LatLng getPreviousLatLng() {
+        return new LatLng(prevLatitude, prevLongitude, (float)prevZoom);
     }
 
     /**
@@ -381,6 +392,23 @@ public class ExploreMapFragment extends CommonsDaggerSupportFragment
      **/
     public boolean isCameFromNearbyMap() {
         return prevZoom != 0.0 || prevLatitude != 0.0 || prevLongitude != 0.0;
+    }
+
+    /**
+     * Gets the value that indicates if the user navigated from "Show in Explore" in Nearby and
+     * that the LatLng from Nearby has yet to be searched for map markers.
+     */
+    public boolean recentlyCameFromNearbyMap() {
+        return recentlyCameFromNearbyMap;
+    }
+
+    /**
+     * Sets the value that indicates if the user navigated from "Show in Explore" in Nearby and
+     * that the LatLng from Nearby has yet to be searched for map markers.
+     * @param newValue The value to set.
+     */
+    public void setRecentlyCameFromNearbyMap(boolean newValue) {
+        recentlyCameFromNearbyMap = newValue;
     }
 
     public void loadNearbyMapFromExplore() {

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapPresenter.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapPresenter.java
@@ -74,9 +74,22 @@ public class ExploreMapPresenter
          */
         if (locationChangeType.equals(LOCATION_SIGNIFICANTLY_CHANGED)) {
             Timber.d("LOCATION_SIGNIFICANTLY_CHANGED");
+            LatLng populateLatLng = exploreMapFragmentView.getMapCenter();
+
+            //If "Show in Explore" was selected in Nearby, use the previous LatLng
+            if (exploreMapFragmentView instanceof ExploreMapFragment) {
+                ExploreMapFragment exploreMapFragment = (ExploreMapFragment)exploreMapFragmentView;
+                if (exploreMapFragment.recentlyCameFromNearbyMap()) {
+                    //Ensure this LatLng will not be used again if user searches their GPS location
+                    exploreMapFragment.setRecentlyCameFromNearbyMap(false);
+
+                    populateLatLng = exploreMapFragment.getPreviousLatLng();
+                }
+            }
+
             lockUnlockNearby(true);
             exploreMapFragmentView.setProgressBarVisibility(true);
-            exploreMapFragmentView.populatePlaces(exploreMapFragmentView.getMapCenter());
+            exploreMapFragmentView.populatePlaces(populateLatLng);
         } else if (locationChangeType.equals(SEARCH_CUSTOM_AREA)) {
             Timber.d("SEARCH_CUSTOM_AREA");
             lockUnlockNearby(true);


### PR DESCRIPTION
**Description (required)**

Fixes #6308

What changes did you make and why?

The primary change I made was to `ExploreMapPresenter.updateMap()`. In this method, a check was added to see if the user had selected "See in Explore" from Nearby recently. If so, the stored coordinates from Nearby is used to search for markers. If not, the user's GPS coordinates are used instead.

A boolean flag `recentlyCameFromNearbyMap` is used to prevent the Nearby map coordinates from being used again if the user presses the GPS button to focus on their current GPS location.

Methods to simplify access and modification of data were also added.

**Tests performed (required)**

Tested ProdDebug on Android Studio Emulator with API level 36.

**Screenshots (for UI changes only)**
[issue_6308_compress.webm](https://github.com/user-attachments/assets/ae48f81f-8623-4e7b-bed9-1bc4be2d3507)

