### PR TITLE
Fix: Use concise Wikidata feedback message while keeping full UI text

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/WikidataFeedback.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/WikidataFeedback.kt
@@ -63,7 +63,10 @@ class WikidataFeedback : BaseActivity() {
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
 
         binding.appCompatButton.setOnClickListener {
-            var desc = findViewById<RadioButton>(binding.radioGroup.checkedRadioButtonId).text
+            var desc = when (binding.radioGroup.checkedRadioButtonId) {
+                R.id.radioButton2 -> getString(R.string.is_at_a_different_place_wikidata, place)
+                else -> findViewById<RadioButton>(binding.radioGroup.checkedRadioButtonId).text
+            }
             var det = binding.detailsEditText.text.toString()
             if (binding.radioGroup.checkedRadioButtonId == R.id.radioButton3 && binding.detailsEditText.text.isNullOrEmpty()) {
                 Toast

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -832,6 +832,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="talk">Talk</string>
   <string name="write_something_about_the_item">Write something about the \'%1$s\' item. It will be publicly visible.</string>
   <string name="does_not_exist_anymore_no_picture_can_ever_be_taken_of_it">\'%1$s\' does not exist anymore, no picture can ever be taken of it.</string>
+  <string name="is_at_a_different_place_wikidata">\'%1$s\' is at a different place.</string>
   <string name="is_at_a_different_place_please_specify_the_correct_place_below_if_possible_tell_us_the_correct_latitude_longitude">\'%1$s\' is at a different place. Please specify the correct place below, and if possible, write the correct latitude and longitude.</string>
   <string name="other_problem_or_information_please_explain_below">Other problem or information (please explain below).</string>
   <string name="feedback_destination_note">Your feedback gets posted to the following wiki page: <![CDATA[ <a href="https://commons.wikimedia.org/wiki/Commons:Mobile_app/Feedback">Commons:Mobile app/Feedback</a> ]]></string>


### PR DESCRIPTION
**Description (required)**
When users report "item is at different place" through the app, the full instructional text gets posted to Wikidata talk pages, making them unnecessarily verbose.

Fixes #6183 

What changes did you make and why?
-Added new string resource `is_at_a_different_place_wikidata` with concise message
- Modified posting logic to use short version for Wikidata while keeping full instructions in UI
- Maintained all existing functionality

**Tests performed (required)**

Tested {build variant, ProdDebug} on {VIVO V25} with API level {34}.

**Screenshots (for UI changes only)**

https://github.com/user-attachments/assets/5cb79bf0-cb2e-41ef-9b7c-2a77e6898f11

