### PR TITLE
+ button on pending uploads screen

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.kt
@@ -50,7 +50,7 @@ import javax.inject.Named
 /**
  * Created by root on 01.06.2018.
  */
-class ContributionsListFragment : CommonsDaggerSupportFragment(), ContributionsListContract.View,
+open class ContributionsListFragment : CommonsDaggerSupportFragment(), ContributionsListContract.View,
     ContributionsListAdapter.Callback, WikipediaInstructionsDialogFragment.Callback {
     @JvmField
     @Inject
@@ -179,7 +179,7 @@ class ContributionsListFragment : CommonsDaggerSupportFragment(), ContributionsL
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         binding = FragmentContributionsListBinding.inflate(
             inflater, container, false
         )
@@ -187,8 +187,8 @@ class ContributionsListFragment : CommonsDaggerSupportFragment(), ContributionsL
 
         contributionsListPresenter!!.onAttachView(this)
         binding!!.fabCustomGallery.setOnClickListener { v: View? -> launchCustomSelector() }
-        binding!!.fabCustomGallery.setOnLongClickListener { view: View? ->
-            showShortToast(context, fr.free.nrw.commons.R.string.custom_selector_title)
+        binding!!.fabCustomGallery.setOnLongClickListener {
+            showShortToast(context, R.string.custom_selector_title)
             true
         }
 
@@ -198,7 +198,7 @@ class ContributionsListFragment : CommonsDaggerSupportFragment(), ContributionsL
         } else {
             binding!!.tvContributionsOfUser.visibility = View.VISIBLE
             binding!!.tvContributionsOfUser.text =
-                getString(fr.free.nrw.commons.R.string.contributions_of_user, userName)
+                getString(R.string.contributions_of_user, userName)
             binding!!.fabLayout.visibility = View.GONE
         }
 
@@ -358,15 +358,15 @@ class ContributionsListFragment : CommonsDaggerSupportFragment(), ContributionsL
     }
 
     private fun initializeAnimations() {
-        fab_open = AnimationUtils.loadAnimation(activity, fr.free.nrw.commons.R.anim.fab_open)
-        fab_close = AnimationUtils.loadAnimation(activity, fr.free.nrw.commons.R.anim.fab_close)
-        rotate_forward = AnimationUtils.loadAnimation(activity, fr.free.nrw.commons.R.anim.rotate_forward)
-        rotate_backward = AnimationUtils.loadAnimation(activity, fr.free.nrw.commons.R.anim.rotate_backward)
+        fab_open = AnimationUtils.loadAnimation(activity, R.anim.fab_open)
+        fab_close = AnimationUtils.loadAnimation(activity, R.anim.fab_close)
+        rotate_forward = AnimationUtils.loadAnimation(activity,R.anim.rotate_forward)
+        rotate_backward = AnimationUtils.loadAnimation(activity,R.anim.rotate_backward)
     }
 
     private fun setListeners() {
-        binding!!.fabPlus.setOnClickListener { view: View? -> animateFAB(isFabOpen) }
-        binding!!.fabCamera.setOnClickListener { view: View? ->
+        binding!!.fabPlus.setOnClickListener { animateFAB(isFabOpen) }
+        binding!!.fabCamera.setOnClickListener {
             controller!!.initiateCameraPick(
                 requireActivity(),
                 inAppCameraLocationPermissionLauncher,
@@ -374,19 +374,19 @@ class ContributionsListFragment : CommonsDaggerSupportFragment(), ContributionsL
             )
             animateFAB(isFabOpen)
         }
-        binding!!.fabCamera.setOnLongClickListener { view: View? ->
+        binding!!.fabCamera.setOnLongClickListener {
             showShortToast(
                 context,
-                fr.free.nrw.commons.R.string.add_contribution_from_camera
+                R.string.add_contribution_from_camera
             )
             true
         }
-        binding!!.fabGallery.setOnClickListener { view: View? ->
+        binding!!.fabGallery.setOnClickListener {
             controller!!.initiateGalleryPick(requireActivity(), galleryPickLauncherForResult, true)
             animateFAB(isFabOpen)
         }
-        binding!!.fabGallery.setOnLongClickListener { view: View? ->
-            showShortToast(context, fr.free.nrw.commons.R.string.menu_from_gallery)
+        binding!!.fabGallery.setOnLongClickListener {
+            showShortToast(context, R.string.menu_from_gallery)
             true
         }
     }
@@ -394,7 +394,7 @@ class ContributionsListFragment : CommonsDaggerSupportFragment(), ContributionsL
     /**
      * Launch Custom Selector.
      */
-    protected fun launchCustomSelector() {
+    private fun launchCustomSelector() {
         controller!!.initiateCustomGalleryPickWithPermission(
             requireActivity(),
             customSelectorLauncherForResult
@@ -433,9 +433,9 @@ class ContributionsListFragment : CommonsDaggerSupportFragment(), ContributionsL
     /**
      * Shows welcome message if user has no contributions yet i.e. new user.
      */
-    override fun showWelcomeTip(shouldShow: Boolean) {
+    override fun showWelcomeTip(numberOfUploads: Boolean) {
         binding!!.noContributionsYet.visibility =
-            if (shouldShow) View.VISIBLE else View.GONE
+            if (numberOfUploads) View.VISIBLE else View.GONE
     }
 
     /**
@@ -468,9 +468,9 @@ class ContributionsListFragment : CommonsDaggerSupportFragment(), ContributionsL
         }
     }
 
-    override fun openMediaDetail(position: Int, isWikipediaButtonDisplayed: Boolean) {
+    override fun openMediaDetail(contribution: Int, isWikipediaPageExists: Boolean) {
         if (null != callback) { //Just being safe, ideally they won't be called when detached
-            callback!!.showDetail(position, isWikipediaButtonDisplayed)
+            callback!!.showDetail(contribution, isWikipediaPageExists)
         }
     }
 
@@ -482,8 +482,8 @@ class ContributionsListFragment : CommonsDaggerSupportFragment(), ContributionsL
     override fun addImageToWikipedia(contribution: Contribution?) {
         showAlertDialog(
             requireActivity(),
-            getString(fr.free.nrw.commons.R.string.add_picture_to_wikipedia_article_title),
-            getString(fr.free.nrw.commons.R.string.add_picture_to_wikipedia_article_desc),
+            getString(R.string.add_picture_to_wikipedia_article_title),
+            getString(R.string.add_picture_to_wikipedia_article_desc),
             {
                 if (contribution != null) {
                     showAddImageToWikipediaInstructions(contribution)
@@ -501,7 +501,7 @@ class ContributionsListFragment : CommonsDaggerSupportFragment(), ContributionsL
         val fragment = newInstance(contribution)
         fragment.callback =
             WikipediaInstructionsDialogFragment.Callback { contribution: Contribution?, copyWikicode: Boolean ->
-                this.onConfirmClicked(
+                onConfirmClicked(
                     contribution,
                     copyWikicode
                 )

--- a/app/src/main/java/fr/free/nrw/commons/upload/PendingUploadsFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/PendingUploadsFragment.kt
@@ -1,10 +1,19 @@
 package fr.free.nrw.commons.upload
 
+import android.Manifest.permission
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
+import android.os.Build
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.Animation
+import android.view.animation.AnimationUtils
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts.RequestMultiplePermissions
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.paging.PagedList
 import androidx.recyclerview.widget.LinearLayoutManager
 import fr.free.nrw.commons.CommonsApplication
@@ -13,10 +22,13 @@ import fr.free.nrw.commons.contributions.Contribution
 import fr.free.nrw.commons.contributions.Contribution.Companion.STATE_IN_PROGRESS
 import fr.free.nrw.commons.contributions.Contribution.Companion.STATE_PAUSED
 import fr.free.nrw.commons.contributions.Contribution.Companion.STATE_QUEUED
+import fr.free.nrw.commons.contributions.ContributionController
 import fr.free.nrw.commons.databinding.FragmentPendingUploadsBinding
 import fr.free.nrw.commons.di.CommonsDaggerSupportFragment
+import fr.free.nrw.commons.filepicker.FilePicker
 import fr.free.nrw.commons.utils.DialogUtil.showAlertDialog
 import fr.free.nrw.commons.utils.ViewUtil
+import fr.free.nrw.commons.utils.ViewUtil.showShortToast
 import java.util.Locale
 import javax.inject.Inject
 
@@ -30,16 +42,45 @@ class PendingUploadsFragment :
     PendingUploadsAdapter.Callback {
     @Inject
     lateinit var pendingUploadsPresenter: PendingUploadsPresenter
-
     private lateinit var binding: FragmentPendingUploadsBinding
-
     private lateinit var uploadProgressActivity: UploadProgressActivity
-
     private lateinit var adapter: PendingUploadsAdapter
-
     private var contributionsSize = 0
-
     private var contributionsList = mutableListOf<Contribution>()
+
+    @JvmField
+    @Inject
+    var controller: ContributionController? = null
+
+    private var fab_close: Animation? = null
+    private var fab_open: Animation? = null
+    private var rotate_forward: Animation? = null
+    private var rotate_backward: Animation? = null
+    private var isFabOpen = false
+
+    private lateinit var inAppCameraLocationPermissionLauncher: ActivityResultLauncher<Array<String>>
+
+    private val cameraPickLauncherForResult = registerForActivityResult<Intent, ActivityResult>(
+        StartActivityForResult()
+    ) { result: ActivityResult? ->
+        controller!!.handleActivityResultWithCallback(requireActivity()
+        ) { callbacks: FilePicker.Callbacks? ->
+            controller!!.onPictureReturnedFromCamera(
+                result!!, requireActivity(), callbacks!!
+            )
+        }
+    }
+    private val galleryPickLauncherForResult = registerForActivityResult<Intent, ActivityResult>(
+        StartActivityForResult()
+    ) { result: ActivityResult? ->
+        controller!!.handleActivityResultWithCallback(requireActivity()
+        ) { callbacks: FilePicker.Callbacks? ->
+            controller!!.onPictureReturnedFromGallery(
+                result!!, requireActivity(), callbacks!!
+            )
+        }
+    }
+
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -54,13 +95,43 @@ class PendingUploadsFragment :
         savedInstanceState: Bundle?,
     ): View {
         super.onCreate(savedInstanceState)
+        inAppCameraLocationPermissionLauncher =
+            registerForActivityResult(RequestMultiplePermissions()) { result ->
+                val areAllGranted = result.values.all { it }
+
+                if (areAllGranted) {
+                    controller?.locationPermissionCallback?.onLocationPermissionGranted()
+                } else {
+                    activity?.let { currentActivity ->
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                            currentActivity.shouldShowRequestPermissionRationale(permission.ACCESS_FINE_LOCATION)
+                        ) {
+                            controller?.handleShowRationaleFlowCameraLocation(
+                                currentActivity,
+                                inAppCameraLocationPermissionLauncher,
+                                cameraPickLauncherForResult
+                            )
+                        } else {
+                            controller?.locationPermissionCallback?.onLocationPermissionDenied(
+                                currentActivity.getString(R.string.in_app_camera_location_permission_denied)
+                            )
+                        }
+                    }
+                }
+            }
+
         binding = FragmentPendingUploadsBinding.inflate(inflater, container, false)
+        binding.fabCustomGallery.setOnClickListener { launchCustomSelector() }
+        binding.fabCustomGallery.setOnLongClickListener {
+            showShortToast(context, R.string.custom_selector_title)
+            true
+        }
         pendingUploadsPresenter.onAttachView(this)
         initAdapter()
         return binding.root
     }
 
-    fun initAdapter() {
+    private fun initAdapter() {
         adapter = PendingUploadsAdapter(this)
     }
 
@@ -70,6 +141,8 @@ class PendingUploadsFragment :
     ) {
         super.onViewCreated(view, savedInstanceState)
         initRecyclerView()
+        initializeAnimations()
+        setListeners()
     }
 
     /**
@@ -98,12 +171,12 @@ class PendingUploadsFragment :
                 }
             }
             if (contributionsSize == 0) {
-                binding.nopendingTextView.visibility = View.VISIBLE
-                binding.pendingUplaodsLl.visibility = View.GONE
+                binding.noPendingTextView.visibility = View.VISIBLE
+                binding.pendingUploadsLl.visibility = View.GONE
                 uploadProgressActivity.hidePendingIcons()
             } else {
-                binding.nopendingTextView.visibility = View.GONE
-                binding.pendingUplaodsLl.visibility = View.VISIBLE
+                binding.noPendingTextView.visibility = View.GONE
+                binding.pendingUploadsLl.visibility = View.VISIBLE
                 adapter.submitList(list)
                 binding.progressTextView.setText("$contributionsSize uploads left")
                 if ((pausedOrQueuedUploads == contributionsSize) || CommonsApplication.isPaused) {
@@ -112,6 +185,81 @@ class PendingUploadsFragment :
                     uploadProgressActivity.setPausedIcon(false)
                 }
             }
+        }
+    }
+
+    private fun initializeAnimations() {
+        fab_open = AnimationUtils.loadAnimation(activity, R.anim.fab_open)
+        fab_close = AnimationUtils.loadAnimation(activity, R.anim.fab_close)
+        rotate_forward = AnimationUtils.loadAnimation(activity, R.anim.rotate_forward)
+        rotate_backward = AnimationUtils.loadAnimation(activity, R.anim.rotate_backward)
+    }
+    private fun setListeners() {
+        binding.fabPlus.setOnClickListener { animateFAB(isFabOpen) }
+        binding.fabCamera.setOnClickListener {
+            controller!!.initiateCameraPick(
+                requireActivity(),
+                inAppCameraLocationPermissionLauncher,
+                cameraPickLauncherForResult
+            )
+            animateFAB(isFabOpen)
+        }
+        binding.fabCamera.setOnLongClickListener {
+            showShortToast(
+                context,
+                R.string.add_contribution_from_camera
+            )
+            true
+        }
+        binding.fabGallery.setOnClickListener {
+            controller!!.initiateGalleryPick(requireActivity(), galleryPickLauncherForResult, true)
+            animateFAB(isFabOpen)
+        }
+        binding.fabGallery.setOnLongClickListener {
+            showShortToast(context, R.string.menu_from_gallery)
+            true
+        }
+    }
+
+    private val customSelectorLauncherForResult = registerForActivityResult<Intent, ActivityResult>(
+        StartActivityForResult()
+    ) { result: ActivityResult? ->
+        controller!!.handleActivityResultWithCallback(requireActivity()
+        ) { callbacks: FilePicker.Callbacks? ->
+            controller!!.onPictureReturnedFromCustomSelector(
+                result!!, requireActivity(), callbacks!!
+            )
+        }
+    }
+    protected fun launchCustomSelector() {
+        controller!!.initiateCustomGalleryPickWithPermission(
+            requireActivity(),
+            customSelectorLauncherForResult
+        )
+        animateFAB(isFabOpen)
+    }
+
+    private fun animateFAB(isFabOpen: Boolean) {
+        this.isFabOpen = !isFabOpen
+        if (binding.fabPlus.isShown) {
+            if (isFabOpen) {
+                binding.fabPlus.startAnimation(rotate_backward)
+                binding.fabCamera.startAnimation(fab_close)
+                binding.fabGallery.startAnimation(fab_close)
+                binding.fabCustomGallery.startAnimation(fab_close)
+                binding.fabCamera.hide()
+                binding.fabGallery.hide()
+                binding.fabCustomGallery.hide()
+            } else {
+                binding.fabPlus.startAnimation(rotate_forward)
+                binding.fabCamera.startAnimation(fab_open)
+                binding.fabGallery.startAnimation(fab_open)
+                binding.fabCustomGallery.startAnimation(fab_open)
+                binding.fabCamera.show()
+                binding.fabGallery.show()
+                binding.fabCustomGallery.show()
+            }
+            this.isFabOpen = !isFabOpen
         }
     }
 
@@ -162,7 +310,7 @@ class PendingUploadsFragment :
             String.format(locale, activity.getString(R.string.yes)),
             String.format(locale, activity.getString(R.string.no)),
             {
-                ViewUtil.showShortToast(context, R.string.cancelling_upload)
+                showShortToast(context, R.string.cancelling_upload)
                 uploadProgressActivity.hidePendingIcons()
                 pendingUploadsPresenter.deleteUploads(
                     listOf(

--- a/app/src/main/res/layout/fragment_pending_uploads.xml
+++ b/app/src/main/res/layout/fragment_pending_uploads.xml
@@ -1,67 +1,132 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  android:gravity="center"
-  android:orientation="vertical"
   tools:context=".upload.PendingUploadsFragment">
 
-  <TextView
-    android:id="@+id/nopendingTextView"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:gravity="center"
-    android:text="You do not have any pending Uploads!"
-    android:visibility="gone" />
-
   <LinearLayout
-    android:id="@+id/pendingUplaodsLl"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:visibility="visible">
+    android:gravity="center"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <TextView
+      android:id="@+id/noPendingTextView"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_margin="10dp"
-      android:gravity="bottom"
-      android:orientation="horizontal">
+      android:gravity="center"
+      android:text="@string/no_pending_uploads"
+      android:visibility="gone" />
 
-      <TextView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:text="Progress:"
-        android:textSize="22sp" />
+    <LinearLayout
+      android:id="@+id/pendingUploadsLl"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:orientation="vertical"
+      android:visibility="visible">
 
       <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:gravity="center"
-        android:orientation="vertical">
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        android:gravity="bottom"
+        android:orientation="horizontal">
 
         <TextView
-          android:id="@+id/progress_text_view"
           android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:gravity="right"
-          android:text=""
-          android:textSize="21sp" />
+          android:layout_height="match_parent"
+          android:layout_weight="1"
+          android:text="@string/progress"
+          android:textSize="22sp" />
 
+        <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="match_parent"
+          android:layout_weight="1"
+          android:gravity="center"
+          android:orientation="vertical">
+
+          <TextView
+            android:id="@+id/progress_text_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="end"
+            android:text=""
+            android:textSize="21sp" />
+
+        </LinearLayout>
       </LinearLayout>
 
+      <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/pending_uploads_recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginHorizontal="10dp" />
+
     </LinearLayout>
-
-    <androidx.recyclerview.widget.RecyclerView
-      android:id="@+id/pending_uploads_recycler_view"
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:layout_marginHorizontal="10dp" />
-
   </LinearLayout>
 
+  <LinearLayout
+    android:id="@+id/fab_layout"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom|end"
+    android:layout_margin="16dp"
+    android:orientation="vertical"
+    android:focusableInTouchMode="true"
+    android:gravity="center_horizontal">
 
-</LinearLayout>
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+      android:id="@+id/fab_camera"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:contentDescription="@string/add_contribution_from_camera"
+      android:tint="@color/button_blue"
+      android:visibility="gone"
+      app:backgroundTint="@color/main_background_light"
+      app:elevation="@dimen/tiny_margin"
+      app:fabSize="mini"
+      app:srcCompat="@drawable/ic_photo_camera_white_24dp"
+      app:useCompatPadding="true" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+      android:id="@+id/fab_gallery"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:contentDescription="@string/add_contribution_from_photos"
+      android:tint="@color/button_blue"
+      android:visibility="gone"
+      app:backgroundTint="@color/main_background_light"
+      app:elevation="@dimen/tiny_margin"
+      app:fabSize="mini"
+      app:srcCompat="@drawable/ic_photo_white_24dp"
+      app:useCompatPadding="true" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+      android:id="@+id/fab_custom_gallery"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:background="@drawable/commons"
+      android:contentDescription="@string/add_contribution_from_contributions_gallery"
+      android:tint="@color/button_blue"
+      android:visibility="gone"
+      app:backgroundTint="@color/main_background_light"
+      app:elevation="@dimen/tiny_margin"
+      app:fabSize="mini"
+      app:srcCompat="@drawable/ic_custom_image_picker"
+      app:useCompatPadding="true" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+      android:id="@+id/fab_plus"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:contentDescription="@string/add_new_contribution"
+      android:visibility="visible"
+      app:elevation="@dimen/tiny_margin"
+      app:backgroundTint="@color/status_bar_blue"
+      app:srcCompat="@drawable/ic_add_white_24dp"
+      app:useCompatPadding="true" />
+  </LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
   <string name="add_another_description">Add another description</string>
   <string name="add_new_contribution">Add new contribution</string>
   <string name="add_contribution_from_camera">Add contribution from camera</string>
+  <string name="add_upload">Add Upload</string>
   <string name="add_contribution_from_photos">Add contribution from Photos</string>
   <string name="add_contribution_from_contributions_gallery">Add contribution from previous contributions gallery</string>
   <string name="show_captions">Captions</string>
@@ -22,6 +23,8 @@
   <string name="nearby_filter_search">Search View</string>
   <string name="nearby_filter_state">Place State</string>
   <string name="appwidget_img">Pic of the Day</string>
+  <string name="progress">Progress</string>
+  <string name="no_pending_uploads">You do not have any pending Uploads!</string>
 
   <!--Other strings-->
   <plurals name="uploads_pending_notification_indicator">


### PR DESCRIPTION
**Description (required)**

The button allows users to 
- Upload from Camera
- Upload from Gallery
- Custom Upload

Fixes #6278 

**What changes did you make and why?**

Refactored PendingUploadsFragment to include the missing + button which enables users to upload Images even when current uploads are pending

**Tests performed (required)**

Tested ProdDebug build on a real device (Vivo T1x) running API level 30. Verified that:
- Location permission prompts appear as expected.
- Camera launches successfully after permission is granted.
- Permission denial is handled gracefully.

**Screenshots (for UI changes only)**

![image](https://github.com/user-attachments/assets/31271c75-e922-487c-afaa-cfa14fcc3ccb)


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
