### PR TITLE
Fix: prevent showing NearbyCard when seeing our contributions from Profile screen

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.kt
@@ -139,7 +139,7 @@ class ContributionsFragment : CommonsDaggerSupportFragment(), FragmentManager.On
 
     private var wlmCampaign: Campaign? = null
 
-    var userName: String? = null
+    private var userName: String? = null
     private var isUserProfile = false
 
     private var mSensorManager: SensorManager? = null


### PR DESCRIPTION
**Description (required)**

Fixes #6332 

What changes did you make and why?
We shouldn't show `NearbyCard` when seeing our `Contributions` from `ProfileActivity`
- We already have conditions to check if we are on the Profile screen by checking `userName != null` as we show our username on the Profile screen
https://github.com/commons-app/apps-android-commons/blob/06a613e8550391c3982ace2845a63dd84eff664d/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.kt#L182-L185
The above conditions set values some values if we are on the profile screen which is further used to conditionally show `NearbyCardView`:
https://github.com/commons-app/apps-android-commons/blob/06a613e8550391c3982ace2845a63dd84eff664d/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.kt#L402

- We were passing `KEY_USERNAME` from `ProfileAcitivity` so that it won't be null when creating `ContributionsFragment`
https://github.com/commons-app/apps-android-commons/blob/06a613e8550391c3982ace2845a63dd84eff664d/app/src/main/java/fr/free/nrw/commons/profile/ProfileActivity.kt#L108-L111
- However, inside the apply block, we are indirectly accessing & passing the `userName` property of `ContributionsFragment`, which is null initially,  instead of the `ProfileActivity's` property which leads to unexpected behaviors.

**To fix this we can either:**
- Pass the `userName` property like this: `putString(KEY_USERNAME, this@ProfileActivity.userName)`
- Or make the `userName` property private in `ContributionsFragment` as it's being used there only


So, I make that property private because it also promotes encapsulation :)

**Tests performed (required)**

Tested prodDebug on Samsung A14 5G with API level 34.

**Screenshots (for UI changes only)**

Note that `NearbyCardView` correctly shows on the main `Contributions` screen but not on the `Profile` screen

https://github.com/user-attachments/assets/443580f4-0546-4c21-a213-5d552823987c


