### PR TITLE
Navigation bar now visible in details page (#6316)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
@@ -132,6 +132,9 @@ import java.util.regex.Matcher
 import java.util.regex.Pattern
 import javax.inject.Inject
 import javax.inject.Named
+import fr.free.nrw.commons.navtab.NavTabLayout
+import fr.free.nrw.commons.contributions.MainActivity
+import fr.free.nrw.commons.navtab.NavTab
 
 class MediaDetailFragment : CommonsDaggerSupportFragment(), CategoryEditHelper.Callback {
     private var editable: Boolean = false
@@ -245,6 +248,8 @@ class MediaDetailFragment : CommonsDaggerSupportFragment(), CategoryEditHelper.C
         get() {
             initialListTop = binding.mediaDetailScrollView.scrollY
         }
+
+    private lateinit var navTabLayout: NavTabLayout
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -416,6 +421,40 @@ class MediaDetailFragment : CommonsDaggerSupportFragment(), CategoryEditHelper.C
         }
 
         return view
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // Hide MainActivity nav tabs when this fragment is open
+        (requireActivity() as MainActivity).hideTabs()
+
+        // Initialize NavTabLayout
+        navTabLayout = binding.fragmentMainNavTabLayout
+
+        navTabLayout.setOnNavigationItemSelectedListener { item ->
+            val navTab = NavTab.of(item.order)
+            when (navTab) {
+                NavTab.CONTRIBUTIONS -> {
+                    (requireActivity() as MainActivity).setSelectedItemId(NavTab.CONTRIBUTIONS.code())
+                    true
+                }
+                NavTab.NEARBY -> {
+                    (requireActivity() as MainActivity).setSelectedItemId(NavTab.NEARBY.code())
+                    true
+                }
+                NavTab.EXPLORE -> {
+                    (requireActivity() as MainActivity).setSelectedItemId(NavTab.EXPLORE.code())
+                    true
+                }
+                NavTab.MORE -> {
+                    (requireActivity() as MainActivity).setSelectedItemId(NavTab.MORE.code())
+                    true
+                }
+                else -> false
+            }
+        }
+
     }
 
     fun launchZoomActivity(view: View) {

--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -45,6 +45,7 @@
       android:id="@+id/mediaDetailScrollView"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:layout_marginBottom="?attr/actionBarSize"
       android:background="@android:color/transparent"
       android:cacheColorHint="@android:color/transparent"
       android:fillViewport="true">
@@ -511,5 +512,16 @@
             </LinearLayout>
         </LinearLayout>
     </ScrollView>
+
+    <fr.free.nrw.commons.navtab.NavTabLayout
+      android:id="@+id/fragment_main_nav_tab_layout"
+      android:layout_width="match_parent"
+      android:layout_height="?attr/actionBarSize"
+      android:layout_alignParentBottom="true"
+      android:layout_gravity="bottom"
+      android:background="?attr/nav_bar_background"
+      android:elevation="6dp"
+      app:itemIconTint="?attr/nav_tab_item_color_state"
+      app:itemTextColor="?attr/navbar_item_text_color" />
 
 </FrameLayout>


### PR DESCRIPTION
**Description (required)**

When the user navigates from Explore -> Map -> Details page, the bottom navigation bar is now visible and fully functional.

Fixes #6316 

**What changes did you make and why?**

Added the NavTabLayout tag to fragment_media_details.xml to include the UI element on the page, and implemented the navigation bar functionality in MediaDetailFragment.kt

**Tests performed (required)**

Tested ProdDebug on emulator with API level 36.0.

**Screenshots (for UI changes only)**
![screenshot_1749318687](https://github.com/user-attachments/assets/4cda9ef9-e091-465c-9056-33b9e8155f99)
