### PR TITLE
Fix email verification input

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.kt
@@ -348,12 +348,31 @@ class LoginActivity : AccountAuthenticatorActivity() {
 
     @VisibleForTesting
     fun askUserForTwoFactorAuth() {
+        if (binding == null) {
+            Timber.w("Binding is null, reinitializing in askUserForTwoFactorAuth")
+            binding = ActivityLoginBinding.inflate(layoutInflater)
+            setContentView(binding!!.root)
+        }
         progressDialog!!.dismiss()
-        with(binding!!) {
-            twoFactorContainer.visibility = View.VISIBLE
-            twoFactorContainer.hint = getString(if (lastLoginResult is LoginResult.EmailAuthResult) R.string.email_auth_code else R.string._2fa_code)
-            loginTwoFactor.visibility = View.VISIBLE
-            loginTwoFactor.requestFocus()
+        if (binding != null) {
+            with(binding!!) {
+                twoFactorContainer.visibility = View.VISIBLE
+                twoFactorContainer.hint = getString(if (lastLoginResult is LoginResult.EmailAuthResult) R.string.email_auth_code else R.string._2fa_code)
+                loginTwoFactor.visibility = View.VISIBLE
+                loginTwoFactor.requestFocus()
+
+                loginTwoFactor.setOnEditorActionListener { _, actionId, event ->
+                    if (actionId == EditorInfo.IME_ACTION_DONE ||
+                        (event != null && event.keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN)) {
+                        performLogin()
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+        } else {
+            Timber.e("Binding is null in askUserForTwoFactorAuth after reinitialization attempt")
         }
         val imm = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
         imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, InputMethodManager.HIDE_IMPLICIT_ONLY)

--- a/app/src/main/res/layout-land/activity_login.xml
+++ b/app/src/main/res/layout-land/activity_login.xml
@@ -148,9 +148,10 @@
                         android:id="@+id/login_two_factor"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:hint="@string/_2fa_code"
-                        android:imeOptions="flagNoExtractUi"
+                        android:imeOptions="actionDone"
                         android:inputType="number"
+                        android:singleLine="true"
+                        android:maxLines="1"
                         android:visibility="gone"
                         tools:visibility="visible" />
 

--- a/app/src/main/res/layout-land/activity_login.xml
+++ b/app/src/main/res/layout-land/activity_login.xml
@@ -125,7 +125,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:hint="@string/password"
-                        android:imeOptions="flagNoExtractUi"
+                        android:imeOptions="actionNext"
                         android:inputType="textPassword" />
 
                 </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout-land/activity_login.xml
+++ b/app/src/main/res/layout-land/activity_login.xml
@@ -150,7 +150,6 @@
                         android:layout_height="wrap_content"
                         android:imeOptions="actionDone"
                         android:inputType="number"
-                        android:singleLine="true"
                         android:maxLines="1"
                         android:visibility="gone"
                         tools:visibility="visible" />

--- a/app/src/main/res/layout-xlarge/activity_login.xml
+++ b/app/src/main/res/layout-xlarge/activity_login.xml
@@ -153,7 +153,6 @@
                             android:layout_height="wrap_content"
                             android:imeOptions="actionDone"
                             android:inputType="number"
-                            android:singleLine="true"
                             android:maxLines="1"
                             android:visibility="gone"
                             tools:visibility="visible" />

--- a/app/src/main/res/layout-xlarge/activity_login.xml
+++ b/app/src/main/res/layout-xlarge/activity_login.xml
@@ -128,7 +128,7 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:hint="@string/password"
-                            android:imeOptions="flagNoExtractUi"
+                            android:imeOptions="actionNext"
                             android:inputType="textPassword" />
 
                     </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout-xlarge/activity_login.xml
+++ b/app/src/main/res/layout-xlarge/activity_login.xml
@@ -151,9 +151,10 @@
                             android:id="@+id/login_two_factor"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="@string/_2fa_code"
-                            android:imeOptions="flagNoExtractUi"
+                            android:imeOptions="actionDone"
                             android:inputType="number"
+                            android:singleLine="true"
+                            android:maxLines="1"
                             android:visibility="gone"
                             tools:visibility="visible" />
 

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -131,7 +131,7 @@
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:hint="@string/password"
-              android:imeOptions="flagNoExtractUi"
+              android:imeOptions="actionNext"
               android:inputType="textPassword" />
 
           </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -155,7 +155,10 @@
               android:id="@+id/login_two_factor"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
-              android:imeOptions="flagNoExtractUi"
+              android:imeOptions="actionDone"
+              android:inputType="number"
+              android:singleLine="true"
+              android:maxLines="1"
               android:visibility="gone"
               tools:visibility="visible" />
 

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -157,7 +157,6 @@
               android:layout_height="wrap_content"
               android:imeOptions="actionDone"
               android:inputType="number"
-              android:singleLine="true"
               android:maxLines="1"
               android:visibility="gone"
               tools:visibility="visible" />


### PR DESCRIPTION
- Resolved issue where the email verification input field height increased when pressing the Enter key on the soft keyboard.
- Updated `LoginActivity.kt` to handle IME_ACTION_DONE in `askUserForTwoFactorAuth`, ensuring `performLogin` is triggered correctly.
- Modified `activity_login.xml`, `layout-land/activity_login.xml`, and `layout-xlarge/activity_login.xml` to set `imeOptions` to `actionDone` and enforce `singleLine` to prevent height expansion.
- Tested on emulator to verify "Done" submits the verification code without layout issues.
- #6348 .
- BEFORE : 
![image](https://github.com/user-attachments/assets/193a6162-8c3f-4c7c-8587-2c3f778c1529)
- AFTER : 
![Screenshot from 2025-07-06 13-32-08](https://github.com/user-attachments/assets/f605c30b-7da1-4685-8eb3-b28a8140ffd6)
