### PR TITLE
Optimise SPARQL query for single entity metadata using wikibase:label

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/model/NearbyResultItem.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/model/NearbyResultItem.kt
@@ -7,6 +7,7 @@ class NearbyResultItem(
     private val wikipediaArticle: ResultTuple?,
     private val commonsArticle: ResultTuple?,
     private val location: ResultTuple?,
+    @field:SerializedName("itemLabel")
     private val label: ResultTuple?,
     @field:SerializedName("streetAddress") private val address: ResultTuple?,
     private val icon: ResultTuple?,
@@ -15,7 +16,7 @@ class NearbyResultItem(
     @field:SerializedName("commonsCategory") private val commonsCategory: ResultTuple?,
     @field:SerializedName("pic") private val pic: ResultTuple?,
     @field:SerializedName("destroyed") private val destroyed: ResultTuple?,
-    @field:SerializedName("description") private val description: ResultTuple?,
+    @field:SerializedName("itemDescription") private val description: ResultTuple?,
     @field:SerializedName("endTime") private val endTime: ResultTuple?,
     @field:SerializedName("monument") private val monument: ResultTuple?,
     @field:SerializedName("dateOfOfficialClosure") private val dateOfOfficialClosure: ResultTuple?,

--- a/app/src/main/resources/queries/query_for_item.rq
+++ b/app/src/main/resources/queries/query_for_item.rq
@@ -34,10 +34,16 @@ WHERE {
   # Get Commons category
   OPTIONAL {?item wdt:P373 ?commonsCategory}
 
-  # Get Wikipedia article
-  OPTIONAL { ?wikipediaArticle schema:about ?item;schema:isPartOf <https://en.wikipedia.org/>. }
+ # Get Wikipedia article
+  OPTIONAL {
+    ?wikipediaArticle schema:about ?item.
+    ?wikipediaArticle schema:isPartOf <https://en.wikipedia.org/>. # TODO internationalization
+  }
 
   # Get Commons article
-  OPTIONAL { ?commonsArticle schema:about ?item; schema:isPartOf <https://commons.wikimedia.org/>. }
-
+  OPTIONAL {
+    ?commonsArticle schema:about ?item.
+    ?commonsArticle schema:isPartOf <https://commons.wikimedia.org/>.
+  }
+  
 }

--- a/app/src/main/resources/queries/query_for_item.rq
+++ b/app/src/main/resources/queries/query_for_item.rq
@@ -18,7 +18,7 @@ WHERE {
   }
 
   # Get item label/class label/description in the preferred language of the user
-   SERVICE wikibase:label { bd:serviceParam wikibase:language "${LANG},en". }
+   SERVICE wikibase:label { bd:serviceParam wikibase:language "${LANG},en,aa,ab,ae,af,ak,am,an,ar,as,av,ay,az,ba,be,bg,bh,bi,bm,bn,bo,br,bs,ca,ce,ch,co,cr,cs,cu,cv,cy,da,de,dv,dz,ee,el,en,eo,es,et,eu,fa,ff,fi,fj,fo,fr,fy,ga,gd,gl,gn,gu,gv,ha,he,hi,ho,hr,ht,hu,hy,hz,ia,id,ie,ig,ii,ik,io,is,it,iu,ja,jv,ka,kg,ki,kj,kk,kl,km,kn,ko,kr,ks,ku,kv,kw,ky,la,lb,lg,li,ln,lo,lt,lu,lv,mg,mh,mi,mk,ml,mn,mo,mr,ms,mt,my,na,nb,nd,ne,ng,nl,nn,no,ny,oc,oj,om,or,os,pa,pi,pl,ps,pt,qu,rm,rn,ro,ru,rw,sa,sc,sd,se,sg,sh,si,sk,sl,sm,sn,so,sq,sr,ss,st,su,sv,sw,ta,te,tg,th,ti,tk,tl,tn,to,tr,ts,tt,tw,ty,ug,uk,ur,uz,ve,vi,vo,wa,wo,xh,yi,yo,za,zh,zu". }
 
   OPTIONAL { ?item p:P31/ps:P31 ?class. }
 

--- a/app/src/main/resources/queries/query_for_item.rq
+++ b/app/src/main/resources/queries/query_for_item.rq
@@ -1,45 +1,26 @@
 SELECT
   ?item
-  (SAMPLE(?label) AS ?label)
-  (SAMPLE(?class) AS ?class)
-  (SAMPLE(?description) AS ?description)
-  (SAMPLE(?classLabel) AS ?classLabel)
-  (SAMPLE(?pic) AS ?pic)
-  (SAMPLE(?destroyed) AS ?destroyed)
-  (SAMPLE(?endTime) AS ?endTime)
-  (SAMPLE(?wikipediaArticle) AS ?wikipediaArticle)
-  (SAMPLE(?commonsArticle) AS ?commonsArticle)
-  (SAMPLE(?commonsCategory) AS ?commonsCategory)
-  (SAMPLE(?dateOfOfficialClosure) AS ?dateOfOfficialClosure)
-  (SAMPLE(?pointInTime) AS ?pointInTime)
+  ?itemLabel
+  ?itemDescription
+  ?class
+  ?classLabel
+  ?pic
+  ?destroyed
+  ?endTime
+  ?wikipediaArticle
+  ?commonsArticle
+  ?commonsCategory
+  ?dateOfOfficialClosure
+  ?pointInTime
 WHERE {
   SERVICE <https://query.wikidata.org/sparql> {
-    values ?item {
-      ${ENTITY}
-    }
+    VALUES ?item { ${ENTITY} }
   }
 
-  # Get the label in the preferred language of the user, or any other language if no label is available in that language.
-  OPTIONAL {?item rdfs:label ?itemLabelPreferredLanguage. FILTER (lang(?itemLabelPreferredLanguage) = "${LANG}")}
-  OPTIONAL {?item rdfs:label ?itemLabelAnyLanguage}
-  BIND(COALESCE(?itemLabelPreferredLanguage, ?itemLabelAnyLanguage, "?") as ?label)
+  # Get item label/class label/description in the preferred language of the user
+   SERVICE wikibase:label { bd:serviceParam wikibase:language "${LANG},en". }
 
-  # Get the description in the preferred language of the user, or any other language if no description is available in that language.
-  OPTIONAL {?item schema:description ?itemDescriptionPreferredLanguage. FILTER (lang(?itemDescriptionPreferredLanguage) = "${LANG}")}
-  OPTIONAL {?item schema:description ?itemDescriptionAnyLanguage}
-  BIND(COALESCE(?itemDescriptionPreferredLanguage, ?itemDescriptionAnyLanguage, "?") as ?description)
-
-  # Get the class label in the preferred language of the user, or any other language if no label is available in that language.
-  OPTIONAL {
-  ?item p:P31/ps:P31 ?class.
-    OPTIONAL {?class rdfs:label ?classLabelPreferredLanguage. FILTER (lang(?classLabelPreferredLanguage) = "${LANG}")}
-    OPTIONAL {?class rdfs:label ?classLabelAnyLanguage}
-    BIND(COALESCE(?classLabelPreferredLanguage, ?classLabelAnyLanguage, "?") as ?classLabel)
-  }
-
-  OPTIONAL {
-  ?item p:P31/ps:P31 ?class.
-  }
+  OPTIONAL { ?item p:P31/ps:P31 ?class. }
 
   # Get picture
   OPTIONAL {?item wdt:P18 ?pic}
@@ -54,15 +35,9 @@ WHERE {
   OPTIONAL {?item wdt:P373 ?commonsCategory}
 
   # Get Wikipedia article
-  OPTIONAL {
-    ?wikipediaArticle schema:about ?item.
-    ?wikipediaArticle schema:isPartOf <https://en.wikipedia.org/>. # TODO internationalization
-  }
+  OPTIONAL { ?wikipediaArticle schema:about ?item;schema:isPartOf <https://en.wikipedia.org/>. }
 
   # Get Commons article
-  OPTIONAL {
-    ?commonsArticle schema:about ?item.
-    ?commonsArticle schema:isPartOf <https://commons.wikimedia.org/>.
-  }
+  OPTIONAL { ?commonsArticle schema:about ?item; schema:isPartOf <https://commons.wikimedia.org/>. }
+
 }
-GROUP BY ?item

--- a/app/src/main/resources/queries/query_for_item.rq
+++ b/app/src/main/resources/queries/query_for_item.rq
@@ -18,7 +18,7 @@ WHERE {
   }
 
   # Get item label/class label/description in the preferred language of the user
-   SERVICE wikibase:label { bd:serviceParam wikibase:language "${LANG},en,aa,ab,ae,af,ak,am,an,ar,as,av,ay,az,ba,be,bg,bh,bi,bm,bn,bo,br,bs,ca,ce,ch,co,cr,cs,cu,cv,cy,da,de,dv,dz,ee,el,en,eo,es,et,eu,fa,ff,fi,fj,fo,fr,fy,ga,gd,gl,gn,gu,gv,ha,he,hi,ho,hr,ht,hu,hy,hz,ia,id,ie,ig,ii,ik,io,is,it,iu,ja,jv,ka,kg,ki,kj,kk,kl,km,kn,ko,kr,ks,ku,kv,kw,ky,la,lb,lg,li,ln,lo,lt,lu,lv,mg,mh,mi,mk,ml,mn,mo,mr,ms,mt,my,na,nb,nd,ne,ng,nl,nn,no,ny,oc,oj,om,or,os,pa,pi,pl,ps,pt,qu,rm,rn,ro,ru,rw,sa,sc,sd,se,sg,sh,si,sk,sl,sm,sn,so,sq,sr,ss,st,su,sv,sw,ta,te,tg,th,ti,tk,tl,tn,to,tr,ts,tt,tw,ty,ug,uk,ur,uz,ve,vi,vo,wa,wo,xh,yi,yo,za,zh,zu". }
+   SERVICE wikibase:label { bd:serviceParam wikibase:language "${LANG},en,aa,ab,ae,af,ak,am,an,ar,as,av,ay,az,ba,be,bg,bh,bi,bm,bn,bo,br,bs,ca,ce,ch,co,cr,cs,cu,cv,cy,da,de,dv,dz,ee,el,eo,es,et,eu,fa,ff,fi,fj,fo,fr,fy,ga,gd,gl,gn,gu,gv,ha,he,hi,ho,hr,ht,hu,hy,hz,ia,id,ie,ig,ii,ik,io,is,it,iu,ja,jv,ka,kg,ki,kj,kk,kl,km,kn,ko,kr,ks,ku,kv,kw,ky,la,lb,lg,li,ln,lo,lt,lu,lv,mg,mh,mi,mk,ml,mn,mo,mr,ms,mt,my,na,nb,nd,ne,ng,nl,nn,no,ny,oc,oj,om,or,os,pa,pi,pl,ps,pt,qu,rm,rn,ro,ru,rw,sa,sc,sd,se,sg,sh,si,sk,sl,sm,sn,so,sq,sr,ss,st,su,sv,sw,ta,te,tg,th,ti,tk,tl,tn,to,tr,ts,tt,tw,ty,ug,uk,ur,uz,ve,vi,vo,wa,wo,xh,yi,yo,za,zh,zu". }
 
   OPTIONAL { ?item p:P31/ps:P31 ?class. }
 

--- a/app/src/main/resources/queries/query_for_item.rq
+++ b/app/src/main/resources/queries/query_for_item.rq
@@ -14,18 +14,19 @@ SELECT
   ?pointInTime
 WHERE {
   SERVICE <https://query.wikidata.org/sparql> {
-    VALUES ?item { ${ENTITY} }
+    VALUES ?item {${ENTITY}}
   }
 
-  # Get item label/class label/description in the preferred language of the user
-   SERVICE wikibase:label { bd:serviceParam wikibase:language "${LANG},en,aa,ab,ae,af,ak,am,an,ar,as,av,ay,az,ba,be,bg,bh,bi,bm,bn,bo,br,bs,ca,ce,ch,co,cr,cs,cu,cv,cy,da,de,dv,dz,ee,el,eo,es,et,eu,fa,ff,fi,fj,fo,fr,fy,ga,gd,gl,gn,gu,gv,ha,he,hi,ho,hr,ht,hu,hy,hz,ia,id,ie,ig,ii,ik,io,is,it,iu,ja,jv,ka,kg,ki,kj,kk,kl,km,kn,ko,kr,ks,ku,kv,kw,ky,la,lb,lg,li,ln,lo,lt,lu,lv,mg,mh,mi,mk,ml,mn,mo,mr,ms,mt,my,na,nb,nd,ne,ng,nl,nn,no,ny,oc,oj,om,or,os,pa,pi,pl,ps,pt,qu,rm,rn,ro,ru,rw,sa,sc,sd,se,sg,sh,si,sk,sl,sm,sn,so,sq,sr,ss,st,su,sv,sw,ta,te,tg,th,ti,tk,tl,tn,to,tr,ts,tt,tw,ty,ug,uk,ur,uz,ve,vi,vo,wa,wo,xh,yi,yo,za,zh,zu". }
+  # Get item label/class label/description in the preferred language of the user, or fallback.
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "${LANG},en,aa,ab,ae,af,ak,am,an,ar,as,av,ay,az,ba,be,bg,bh,bi,bm,bn,bo,br,bs,ca,ce,ch,co,cr,cs,cu,cv,cy,da,de,dv,dz,ee,el,eo,es,et,eu,fa,ff,fi,fj,fo,fr,fy,ga,gd,gl,gn,gu,gv,ha,he,hi,ho,hr,ht,hu,hy,hz,ia,id,ie,ig,ii,ik,io,is,it,iu,ja,jv,ka,kg,ki,kj,kk,kl,km,kn,ko,kr,ks,ku,kv,kw,ky,la,lb,lg,li,ln,lo,lt,lu,lv,mg,mh,mi,mk,ml,mn,mo,mr,ms,mt,my,na,nb,nd,ne,ng,nl,nn,no,ny,oc,oj,om,or,os,pa,pi,pl,ps,pt,qu,rm,rn,ro,ru,rw,sa,sc,sd,se,sg,sh,si,sk,sl,sm,sn,so,sq,sr,ss,st,su,sv,sw,ta,te,tg,th,ti,tk,tl,tn,to,tr,ts,tt,tw,ty,ug,uk,ur,uz,ve,vi,vo,wa,wo,xh,yi,yo,za,zh,zu". }
 
-  OPTIONAL { ?item p:P31/ps:P31 ?class. }
+  # Get class (such as forest or bridge)
+  OPTIONAL {?item p:P31/ps:P31 ?class}
 
-  # Get picture
+  # Get picture (items without a picture will be shown in red on the Nearby map)
   OPTIONAL {?item wdt:P18 ?pic}
 
-  # Get existence
+  # Get existence (whether an item still exists or not)
   OPTIONAL {?item wdt:P576 ?destroyed}
   OPTIONAL {?item wdt:P582 ?endTime}
   OPTIONAL {?item wdt:P3999 ?dateOfOfficialClosure}
@@ -34,7 +35,7 @@ WHERE {
   # Get Commons category
   OPTIONAL {?item wdt:P373 ?commonsCategory}
 
- # Get Wikipedia article
+  # Get Wikipedia article
   OPTIONAL {
     ?wikipediaArticle schema:about ?item.
     ?wikipediaArticle schema:isPartOf <https://en.wikipedia.org/>. # TODO internationalization
@@ -45,5 +46,4 @@ WHERE {
     ?commonsArticle schema:about ?item.
     ?commonsArticle schema:isPartOf <https://commons.wikimedia.org/>.
   }
-  
 }


### PR DESCRIPTION

**Description (required)**
Previously, super-popular items (e.g., Eiffel Tower) caused SPARQL query timeouts due to inefficient label and description fetching, resulting in grey pins and missing metadata in the app.

Fixes #6064 

What changes did you make and why?

Optimized the SPARQL query for single entity metadata by using the wikibase:label service for efficient retrieval of labels and descriptions in the user's preferred language. Removed redundant label/description fetching logic to prevent Cartesian product and improve query performance, especially for super-popular items.


**Tests performed (required)**

Tested {build variant, ProdDebug} on {VIVO V25} with API level {35}.

![1000115059](https://github.com/user-attachments/assets/8d16da5d-8273-4cec-95db-46fe7e6a4e12)

