### PR TITLE
 Correct NearbyResultItem label mapping for place name display

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/model/NearbyResultItem.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/model/NearbyResultItem.kt
@@ -7,7 +7,7 @@ class NearbyResultItem(
     private val wikipediaArticle: ResultTuple?,
     private val commonsArticle: ResultTuple?,
     private val location: ResultTuple?,
-    @field:SerializedName("Label")
+    @field:SerializedName("label")
     private val label: ResultTuple?,
     @field:SerializedName("streetAddress") private val address: ResultTuple?,
     private val icon: ResultTuple?,


### PR DESCRIPTION
**Description (required)**

Fixes #6379 

What changes did you make and why?
1)Updated the NearbyResultItem model to correctly map the `label` field from the API response using `@SerializedName("label")`.

2)This ensures that the place name is properly parsed and displayed in the Nearby popup and related UI.

**Tests performed (required)**

Tested {build variant,  ProdDebug} on {VIVO V25} with API level {35}.

