### PR TITLE
fix: add User-Agent to NetworkingModule http client

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/OkHttpConnectionFactory.kt
+++ b/app/src/main/java/fr/free/nrw/commons/OkHttpConnectionFactory.kt
@@ -50,7 +50,7 @@ object OkHttpConnectionFactory {
     }
 }
 
-private class CommonHeaderRequestInterceptor : Interceptor {
+public class CommonHeaderRequestInterceptor : Interceptor {
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request().newBuilder()

--- a/app/src/main/java/fr/free/nrw/commons/OkHttpConnectionFactory.kt
+++ b/app/src/main/java/fr/free/nrw/commons/OkHttpConnectionFactory.kt
@@ -50,7 +50,7 @@ object OkHttpConnectionFactory {
     }
 }
 
-public class CommonHeaderRequestInterceptor : Interceptor {
+class CommonHeaderRequestInterceptor : Interceptor {
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request().newBuilder()

--- a/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.kt
+++ b/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.kt
@@ -7,6 +7,7 @@ import dagger.Provides
 import fr.free.nrw.commons.BetaConstants
 import fr.free.nrw.commons.BuildConfig
 import fr.free.nrw.commons.OkHttpConnectionFactory
+import fr.free.nrw.commons.OkHttpConnectionFactory.CommonHeaderRequestInterceptor
 import fr.free.nrw.commons.actions.PageEditClient
 import fr.free.nrw.commons.actions.PageEditInterface
 import fr.free.nrw.commons.actions.ThanksInterface
@@ -60,6 +61,7 @@ class NetworkingModule {
         .connectTimeout(120, TimeUnit.SECONDS)
         .writeTimeout(120, TimeUnit.SECONDS)
         .addInterceptor(httpLoggingInterceptor)
+        .addInterceptor(CommonHeaderRequestInterceptor())
         .readTimeout(120, TimeUnit.SECONDS)
         .cache(Cache(File(context.cacheDir, "okHttpCache"), OK_HTTP_CACHE_SIZE))
         .build()

--- a/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.kt
+++ b/app/src/main/java/fr/free/nrw/commons/di/NetworkingModule.kt
@@ -7,7 +7,7 @@ import dagger.Provides
 import fr.free.nrw.commons.BetaConstants
 import fr.free.nrw.commons.BuildConfig
 import fr.free.nrw.commons.OkHttpConnectionFactory
-import fr.free.nrw.commons.OkHttpConnectionFactory.CommonHeaderRequestInterceptor
+import fr.free.nrw.commons.CommonHeaderRequestInterceptor
 import fr.free.nrw.commons.actions.PageEditClient
 import fr.free.nrw.commons.actions.PageEditInterface
 import fr.free.nrw.commons.actions.ThanksInterface


### PR DESCRIPTION
**Description (required)**

Fixes #6411 

What changes did you make and why?

For one of the OkHttpClient.Builder()s used inside the app, the one in OkHttpConnectionFactory.kt, there's a CommonHeaderRequestInterceptor class that adds User-Agent to outgoing requests.

The same isn't true of NetworkingModule.kt.  So let's try adding it there.

**Tests performed (required)**

None, sorry.

I don't know Kotlin, do not have Android Studio installed, and really just want to see if this builds OK using the Github Actions flow (which I tried to run locally using `act`, but ran into emulator issues I couldn't quickly diagnose).

