### PR TITLE
Added the wiki prefix to titles in GlobalFileUsage for issue #6416

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/fileusages/FileUsagesUiModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/fileusages/FileUsagesUiModel.kt
@@ -4,45 +4,65 @@ import android.net.Uri
 import timber.log.Timber
 
 /**
- * shows where file is being used on Commons and other wikis.
+ * Data model for displaying file usage information in the UI, including the title and link to the page.
  */
 data class FileUsagesUiModel(
     val title: String,
     val link: String?
 )
 
+/**
+ * Converts a FileUsage object to a UI model for Commons file usages.
+ * Creates a link to the file's page on Commons.
+ */
 fun FileUsage.toUiModel(): FileUsagesUiModel {
+    // Replace spaces with underscores and URL-encode the title for the link
+    val encodedTitle = Uri.encode(title.replace(" ", "_"))
     return FileUsagesUiModel(
         title = title,
-        link = "https://commons.wikimedia.org/wiki/${Uri.encode(title.replace(" ", "_"))}"
+        link = "https://commons.wikimedia.org/wiki/$encodedTitle"
     )
 }
 
+/**
+ * Converts a GlobalFileUsage object to a UI model for file usages on other wikis.
+ * Generates a link to the page and prefixes the title with the wiki code (e.g., "(en) Title").
+ */
 fun GlobalFileUsage.toUiModel(): FileUsagesUiModel {
-    Timber.d("GlobalFileUsage: wiki=%s, title=%s", wiki, title)
+    // Log input values for debugging
+    Timber.d("Converting GlobalFileUsage: wiki=$wiki, title=$title")
 
-    // handles the  empty or invalid wiki/title
-    if (wiki.isEmpty() || title.isEmpty()) {
-        Timber.w("Invalid GlobalFileUsage: wiki=%s, title=%s", wiki, title)
+    // Check for invalid or empty inputs
+    if (wiki.isBlank() || title.isBlank()) {
+        Timber.w("Invalid input: wiki=$wiki, title=$title")
         return FileUsagesUiModel(title = title, link = null)
     }
 
-    // determines the domain
-    val domain = when {
-        wiki.contains(".") -> wiki // Already a full domain like "en.wikipedia.org"
-        wiki == "commonswiki" -> "commons.wikimedia.org"
-        wiki.endsWith("wiki") -> {
-            val code = wiki.removeSuffix("wiki")
-            "$code.wikipedia.org"
-        }
-        else -> "$wiki.wikipedia.org" // fallback for codes like "en"
+    // Extract wiki code for prefix (e.g., "en" from "en.wikipedia.org" or "enwiki")
+    val wikiCode = when {
+        wiki.contains(".") -> wiki.substringBefore(".") // e.g., "en" from "en.wikipedia.org"
+        wiki == "commonswiki" -> "commons"
+        wiki.endsWith("wiki") -> wiki.removeSuffix("wiki")
+        else -> wiki
     }
 
-    val normalizedTitle = Uri.encode(title.replace(" ", "_"))
+    // Create prefixed title, e.g., "(en) Changi East Depot"
+    val prefixedTitle = "($wikiCode) $title"
 
-    // construct full URL
-    val url = "https://$domain/wiki/$normalizedTitle"
-    Timber.d("Generated URL for GlobalFileUsage: %s", url)
+    // Determine the domain for the URL
+    val domain = when {
+        wiki.contains(".") -> wiki // Already a full domain, e.g., "en.wikipedia.org"
+        wiki == "commonswiki" -> "commons.wikimedia.org"
+        wiki.endsWith("wiki") -> wiki.removeSuffix("wiki") + ".wikipedia.org"
+        else -> "$wiki.wikipedia.org" // Fallback for simple codes like "en"
+    }
 
-    return FileUsagesUiModel(title = title, link = url)
+    // Normalize title: replace spaces with underscores and URL-encode
+    val encodedTitle = Uri.encode(title.replace(" ", "_"))
+
+    // Build the full URL
+    val url = "https://$domain/wiki/$encodedTitle"
+    Timber.d("Generated URL: $url")
+
+    return FileUsagesUiModel(title = prefixedTitle, link = url)
 }


### PR DESCRIPTION
This pull request fixes issue #6416 by adding wiki prefixes (e.g., "(en)", "(fr)") to titles in the "Usages on Other Wikis" section to show which Wikipedia the page belongs to.

Changes:
- Updated `FileUsagesUiModel.kt` to prefix titles with the wiki code (e.g., "(en) Changi East Depot").
- Verified that `MediaDetailFragment.kt` correctly displays the prefixed titles, keeping clickable functionality from #6307.
- Tested with images like `File:Changi_East_Depot_site_080525.jpg` to ensure prefixes appear and links work.

UI :
- 
<img width="400" height="855" alt="image" src="https://github.com/user-attachments/assets/ed692b86-f8cf-4e00-a741-796a9d7a6f63" />


Closes #6416.

Thank You : )