### PR TITLE
Fix: enable H/W acceleration for UploadActivity to resolve keyboard not showing on Upload Screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -101,7 +101,6 @@
       android:name=".upload.UploadActivity"
       android:configChanges="orientation|screenSize|keyboard"
       android:exported="true"
-      android:hardwareAccelerated="false"
       android:icon="@mipmap/ic_launcher"
       android:windowSoftInputMode="adjustResize">
       <intent-filter android:label="@string/intent_share_upload_label">


### PR DESCRIPTION
**Description (required)**

Fixes #6412 

What changes did you make and why?
- After targeting SDK 35, we had to handle keyboard IME insets manually and push the input fields upwards. But I also added animations while pushing the content upwards when showing the keyboard in this PR #6393.
- Showing animations may require hardware acceleration on some devices, and we previously disabled the H/W acceleration for the `UploadActivity`, causing the Keyboard to not show on some devices and flickers while showing on some
- So, I removed the `hardwareAccelerated=false` in the `AndroidManifest.xml` file for `UploadActivity` as it is enabled by default.

**Tests performed (required)**

Tested prodDebug on Samsung A14 and Pixel 6 Emulator with API level 35 and 31 respectively.

**Screenshots (for UI changes only)**

**Pixel 6 Emulator(API 31):**

[Screen_recording_20250906_181712.webm](https://github.com/user-attachments/assets/0cce7764-adc6-45d8-838f-ce65c18e5c5d)

