### PR TITLE
Description Edit Button bug fixed

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
@@ -541,6 +541,7 @@ class MediaDetailFragment : CommonsDaggerSupportFragment(), CategoryEditHelper.C
             }
         )
         binding.progressBarEdit.visibility = View.GONE
+        binding.descriptionEdit.visibility = View.VISIBLE
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {


### PR DESCRIPTION
**Description**

Fixes #6407 

What changes did you make and why?

When the user clicks on the description edit button in a contribution, the button changes to the progress bar icon and then it goes into the edit menu. When going back to the contribution either with submit or cancel, onResume flagged the progress bar icon as GONE but there was no call to flag the description edit button back to VISIBLE, so the only required change was to add the VISIBLE flag to the description edit button inside the onResume function.

**Tests performed**

Tested ProdDebug on CUBOT X70 (Android 13) with API level 35.
