### PR TITLE
Added padding inset for mapview

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/locationpicker/LocationPickerActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/locationpicker/LocationPickerActivity.kt
@@ -46,6 +46,7 @@ import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.Compani
 import fr.free.nrw.commons.utils.DialogUtil
 import fr.free.nrw.commons.utils.MapUtils.ZOOM_LEVEL
 import fr.free.nrw.commons.utils.applyEdgeToEdgeBottomInsets
+import fr.free.nrw.commons.utils.applyEdgeToEdgeBottomPaddingInsets
 import fr.free.nrw.commons.utils.applyEdgeToEdgeTopPaddingInsets
 import fr.free.nrw.commons.utils.handleGeoCoordinates
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -342,6 +343,10 @@ class LocationPickerActivity : BaseActivity(), LocationPermissionCallback {
     }
 
     private fun setupMapView() {
+
+        val mapBottomLayout: ConstraintLayout = findViewById(R.id.map_bottom_layout)
+        mapBottomLayout.applyEdgeToEdgeBottomPaddingInsets()
+
         requestLocationPermissions()
 
         //If location metadata is available, move map to that location.


### PR DESCRIPTION
Added bottom padding inset for the map view that shows up when edit location is pressed after uploading an image.

Fixes #6426

Bottom padding inset was added for setupMapView() so that the bottom navigation bar does not obscure the "Remove Location" and "Edit Location" buttons anymore.

Tests performed

Tested prodDebug on Pixel 5 Android Studio emulator with API level 36.0.


<img width="313" height="202" alt="Screenshot 2025-09-22 at 5 28 01 PM" src="https://github.com/user-attachments/assets/10f9999e-0fc7-466c-beaa-a179f11b48ea" />



