### PR TITLE
Rename an identifier with a non-ASCII character

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFilterState.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFilterState.java
@@ -9,7 +9,7 @@ public class NearbyFilterState {
     private int checkBoxTriState;
     private ArrayList<Label> selectedLabels;
 
-    private static NearbyFilterState nearbyFılterStateInstance;
+    private static NearbyFilterState nearbyFilterStateInstance;
 
     /**
      * Define initial filter values here
@@ -23,10 +23,10 @@ public class NearbyFilterState {
     }
 
     public static NearbyFilterState getInstance() {
-        if (nearbyFılterStateInstance == null) {
-            nearbyFılterStateInstance = new NearbyFilterState();
+        if (nearbyFilterStateInstance == null) {
+            nearbyFilterStateInstance = new NearbyFilterState();
         }
-        return nearbyFılterStateInstance;
+        return nearbyFilterStateInstance;
     }
 
     public static void setSelectedLabels(ArrayList<Label> selectedLabels) {


### PR DESCRIPTION
**Description (required)**

Android Studio reported that there's an identifier with a non-ASCII letter. It was nearbyFılterStateInstance, with a Turkish dotless i. I renamed to ASCII dotted i.

This brings the number of Internationalization issues in Inspect Code to zero. Since I'm a bit of an internationalization nerd, I wanted this to be perfect.

**Tests performed (required)**

To be honest, I wasn't sure how to fully test it. The feature that uses this code appears to work only when WLM is enabled, and I don't know how to enable it. For what it's worth, the app builds and runs. This is just an identifier renaming, so I hope that this is fine.