### PR TITLE
Change Android "OK" string to app's own localization

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/license/MediaLicenseFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/license/MediaLicenseFragment.kt
@@ -70,7 +70,7 @@ class MediaLicenseFragment : UploadBaseFragment(), MediaLicenseContract.View {
                 requireActivity(),
                 getString(R.string.license_step_title),
                 getString(R.string.license_tooltip),
-                getString(android.R.string.ok),
+                getString(R.string.ok),
                 null
             )
         }


### PR DESCRIPTION
**Description (required)**

I changed `android.R.string.ok`, which shows "OK" in English even though my phone's language is Hebrew, to `R.string.ok`, which correctly shows the app's own localization.

This addresses one instance of an issue described in #6470, but more should probably be addressed.

**Tests performed (required)**

I tested it in the emulator in Android Studio.
