### PR TITLE
Rephrase the string copy_image_caption_description

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -533,7 +533,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="images_featured_explanation">Featured pictures are images from highly skilled photographers and illustrators that the Wikimedia Commons community has chosen as some of the highest quality on the site.</string>
   <string name="images_via_nearby_explanation">Images Uploaded via Nearby places are the images which are uploaded by discovering places on the map.</string>
   <string name="thanks_received_explanation">This feature allows editors to send a Thank you notification to users who make useful edits – by using a small thank link on the history page or diff page.</string>
-  <string name="copy_image_caption_description">Copy to subsequent media</string>
+  <string name="copy_image_caption_description">Copy to the next items</string>
   <string name="copied_successfully">Copied</string>
   <string name="welcome_do_upload_content_description">Examples of good images to upload to Commons</string>
   <string name="welcome_dont_upload_content_description">Examples of images not to upload</string>


### PR DESCRIPTION
**Description (required)**

I was going over all the strings and documenting them (see #6457), and I had a very hard time understand what this message does. I read the code and finally figured it out. I added qq documentation for it so now it's clearer, but I also think that the English message can be clearer:
* "subsequent" changed to "the next" - shorter, easier word.
* "media" changed to "item" - "media" could mean a lot of things, and "item" is clearer in this context.

**Tests performed (required)**

Checked in the emulator in Android Studio.