### PR TITLE
Remove commented out code and associated strings

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.kt
@@ -153,21 +153,7 @@ after opening the app.
                 }
             }
             setUpPager()
-            /**
-             * Ask the user for media location access just after login
-             * so that location in the EXIF metadata of the images shared by the user
-             * is retained on devices running Android 10 or above
-             */
-//            if (VERSION.SDK_INT >= VERSION_CODES.Q) {
-//                ActivityCompat.requestPermissions(this,
-//                    new String[]{Manifest.permission.ACCESS_MEDIA_LOCATION}, 0);
-//                PermissionUtils.checkPermissionsAndPerformAction(
-//                    this,
-//                    () -> {},
-//                    R.string.media_location_permission_denied,
-//                    R.string.add_location_manually,
-//                    permission.ACCESS_MEDIA_LOCATION);
-//            }
+
             checkAndResumeStuckUploads()
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -551,9 +551,6 @@ Upload your first media by tapping on the add button.</string>
   <string name="exif_tag_name_serialNumbers">Serial Numbers</string>
   <string name="exif_tag_name_software">Software</string>
 
-  <string name="media_location_permission_denied">Media location access denied</string>
-  <string name="add_location_manually">We may not be able to automatically obtain location data from pictures you upload. Please add the appropriate location for each picture before submitting</string>
-
   <string name="share_text">Upload photos to Wikimedia Commons directly from your phone. Download the Commons App now: %1$s</string>
   <string name="share_via">Share app via...</string>
   <string name="image_info">Image Info</string>


### PR DESCRIPTION
**Description (required)**

As I was documenting undocumented strings (see #6457), I noticed that two messages are only used once in a few lines of code that were commented out in 2023.

To clean up the messages, I am removing them from the strings list and deleting the commented-out code.

**Tests performed (required)**

It builds, and as far as I can tell, no more testing is necessary.