### PR TITLE
Change "wikicode" to "wikitext" in a message

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -671,7 +671,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="wikipedia_instructions_step_5">5. Paste the wikitext in the appropriate place.</string>
   <string name="wikipedia_instructions_step_6">6. Edit the wikitext for appropriate positioning, if necessary. For more information, see &lt;a href="https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Images#How_to_place_an_image"&gt;here&lt;/a&gt;.</string>
   <string name="wikipedia_instructions_step_7">7. Publish the article</string>
-  <string name="copy_wikicode_to_clipboard">Copy wikicode to clipboard</string>
+  <string name="copy_wikicode_to_clipboard">Copy wikitext to clipboard</string>
   <string name="pause">pause</string>
   <string name="resume">resume</string>
   <string name="paused">Paused</string>


### PR DESCRIPTION
**Description (required)**

Change "wikicode" to "wikitext" in the `message copy_wikicode_to_clipboard`. (There's no strong need to change the message key.)

The usual English term is "wikitext". "Wikicode" is used in French and perhaps some other language, but English uses "wikitext".