### PR TITLE
Remove the unused message "statistics"

### DIFF
--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -374,7 +374,6 @@
   <string name="Achievements">Menu item.</string>
   <string name="Profile">Menu item.</string>
   <string name="badges">Title on Profile page.</string>
-  <string name="statistics">Seems to be unused.</string>
   <string name="statistics_thanks">Title on Profile page.</string>
   <string name="statistics_featured">To see the correct translation for your language, please go to https://commons.wikimedia.org/wiki/Commons:Featured_pictures and select your language in \"This project page in other languages\".</string>
   <string name="statistics_wikidata_edits">Item in statistics.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -384,7 +384,6 @@
   <string name="Achievements">Achievements</string>
   <string name="Profile">Profile</string>
   <string name="badges">Badges</string>
-  <string name="statistics">Statistics</string>
   <string name="statistics_thanks">Thanks Received</string>
   <string name="statistics_featured">Featured Images</string>
   <string name="statistics_wikidata_edits">Images via \"Nearby Places\"</string>


### PR DESCRIPTION
**Description (required)**

Remove the unused message "statistics"

Its usage was removed from the file
app/src/main/res/layout/fragment_achievements.xml in a8387f0,
but the message remained in the strings file.

Resolves #6456.

**Tests performed (required)**

I grepped for `"statistics"`, `\.statistics`, and `/statistics`, and couldn't find any current usages.