### PR TITLE
Consistent spelling of "screenshots" in the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -70,7 +70,7 @@ body:
       required: false
   - type: textarea
     attributes:
-      label: Screen-shots
+      label: Screenshots
       description: Add screenshots related to the issue (if available). Can be created by pressing the Volume Down and Power Button at the same time on Android 4.0 and higher.
     validations:
       required: false


### PR DESCRIPTION
**Description (required)**

Removed a hyphen from *Screen-shots in the section heading of the GitHub issue template. "Screenshot" is written as one word without a hyphen everywhere else in this app's code, and generally in the English language, so it threw me off a bit every time I reported a bug.