### PR TITLE
Auto-mirror the arrow next to "Add location"

### DIFF
--- a/app/src/main/res/drawable/ic_arrow_16dp.xml
+++ b/app/src/main/res/drawable/ic_arrow_16dp.xml
@@ -1,4 +1,8 @@
-<vector android:height="16dp" android:viewportHeight="28"
-    android:viewportWidth="28" android:width="16dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#2D8BA4" android:pathData="M14,0L11.533,2.467L21.298,12.25H0V15.75H21.298L11.533,25.532L14,28L28,14L14,0Z"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+	android:width="16dp"
+	android:height="16dp"
+	android:viewportWidth="28"
+	android:viewportHeight="28"
+	android:autoMirrored="true">
+	<path android:fillColor="#2D8BA4" android:pathData="M14,0L11.533,2.467L21.298,12.25H0V15.75H21.298L11.533,25.532L14,28L28,14L14,0Z"/>
 </vector>


### PR DESCRIPTION
**Description (required)**

Auto-mirror the arrow next to "Add location" for RTL languages. It was shown incorrectly with Hebrew user interface. Here, auto-mirroring is added to the XML file of the vector image.

If this is a good solution, discard my other pull request that resolves the same issue: #6491.

**Tests performed (required)**

Tested in the Android Studio emulator. Everything seems to work, and the arrow points to the correct direction in both English and Hebrew.