### PR TITLE
Remove the arrow next to "Add location"

### DIFF
--- a/app/src/main/res/drawable/ic_arrow_16dp.xml
+++ b/app/src/main/res/drawable/ic_arrow_16dp.xml
@@ -1,4 +1,0 @@
-<vector android:height="16dp" android:viewportHeight="28"
-    android:viewportWidth="28" android:width="16dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#2D8BA4" android:pathData="M14,0L11.533,2.467L21.298,12.25H0V15.75H21.298L11.533,25.532L14,28L28,14L14,0Z"/>
-</vector>

--- a/app/src/main/res/layout/fragment_upload_media_detail_fragment.xml
+++ b/app/src/main/res/layout/fragment_upload_media_detail_fragment.xml
@@ -149,13 +149,6 @@
                           android:textColor="#2D8BA4"
                           android:textSize="@dimen/normal_text"
                           android:textStyle="bold" />
-
-                        <ImageView
-                          android:layout_width="wrap_content"
-                          android:layout_height="wrap_content"
-                          android:layout_marginEnd="@dimen/tiny_margin"
-                          android:layout_weight="1"
-                          android:src="@drawable/ic_arrow_16dp" />
                     </LinearLayout>
                 </LinearLayout>
 


### PR DESCRIPTION
**Description (required)**

Removed the arrow next to "Add location". It was shown incorrectly with Hebrew user interface, and I think that it's not necessary anyway. This deletes it from the layout and deletes the arrow vector image file.

This resolves #6489 using the "remove arrow" method.

If this is a good solution, discard my other pull request that resolves the same issue: #6490.

**Tests performed (required)**

Tested in the Android Studio emulator. Everything seems to work, and the arrow doesn't appear.