### PR TITLE
Remove the string SingleWebViewActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,8 +57,7 @@
     tools:replace="android:appComponentFactory">
     <activity
       android:name=".activity.SingleWebViewActivity"
-      android:exported="false"
-      android:label="@string/title_activity_single_web_view" />
+      android:exported="false" />
     <activity
       android:name=".nearby.WikidataFeedback"
       android:exported="false" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -873,7 +873,6 @@ Upload your first media by tapping on the add button.</string>
   <string name="usages_on_other_wikis_heading">Other wikis</string>
   <string name="bullet_point">•</string>
   <string name="file_usages_container_heading">File usages</string>
-  <string name="title_activity_single_web_view">SingleWebViewActivity</string>
   <string name="account">Account</string>
   <string name="vanish_account">Vanish Account</string>
   <string name="account_vanish_request_confirm_title">Vanish account warning</string>


### PR DESCRIPTION
**Description (required)**

Resolves issue #6492.

Remove the title of a web activity and the accompanying string resource.

This was not a real translatable message, but something that looks more like an identifier that shouldn't be translated. As far as I can tell, it's not seen anywhere in the interface because the actual title is set in the code that calls it.

**Tests performed (required)**

I ran it in the emulator, and the "Vanish account" function, which uses this activity, works as it worked before.