### PR TITLE
Cleanup whitespace in the custom_selector_info_text2 string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -736,7 +736,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="back">Back</string>
   <string name="welcome_custom_picture_selector_text">Welcome to Custom Picture Selector</string>
   <string name="custom_selector_info_text1">This picker shows you which pictures you have already uploaded to Commons.</string>
-  <string name="custom_selector_info_text2">Unlike the picture on the left, the picture on the right has the Commons logo indicating it is already uploaded. \n Touch and hold for image preview.</string>
+  <string name="custom_selector_info_text2">Unlike the picture on the left, the picture on the right has the Commons logo indicating it is already uploaded.\n\nTouch and hold for image preview.</string>
   <string name="welcome_custom_selector_ok">Awesome</string>
   <string name="custom_selector_already_uploaded_image_text">This image has already been uploaded to Commons.</string>
   <string name="custom_selector_over_limit_warning">For technical reasons, the app can\'t reliably upload more than %1$d pictures at once. The upload limit of %1$d has been exceeded by %2$d.</string>


### PR DESCRIPTION
**Description (required)**

Cleanup whitespace in the custom_selector_info_text2 string

In the current state, it appears confusingly on translatewiki, with a space in the beginning of a line.

This patch changes it to just two linebreaks.