### PR TITLE
Change "actioned" to "handled" in translatable strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -788,8 +788,8 @@ Upload your first media by tapping on the add button.</string>
   <string name="unmark_as_not_for_upload">Unmark as not for upload</string>
   <string name="marking_as_not_for_upload">Marking as not for upload</string>
   <string name="unmarking_as_not_for_upload">Unmarking as not for upload</string>
-  <string name="show_already_actioned_pictures">Show already actioned pictures</string>
-  <string name="hiding_already_actioned_pictures">Hiding already actioned pictures</string>
+  <string name="show_already_actioned_pictures">Show already handled pictures</string>
+  <string name="hiding_already_actioned_pictures">Hiding already handled pictures</string>
   <string name="no_more_images_found">No more images found</string>
   <string name="this_image_is_already_uploaded">This image is already uploaded</string>
   <string name="can_not_select_this_image_for_upload">Can not select this image for upload</string>


### PR DESCRIPTION
**Description (required)**

Change "actioned" to "handled" in translatable strings

"actioned" is not so standard in English as a verb.

"handled" sounds more appropriate.