### PR TITLE
Replace android.R.string.* with R.string

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.kt
@@ -180,8 +180,8 @@ class ContributionController @Inject constructor(@param:Named("default_preferenc
         showAlertDialog(
             activity, activity.getString(R.string.location_permission_title),
             activity.getString(R.string.in_app_camera_location_permission_rationale),
-            activity.getString(android.R.string.ok),
-            activity.getString(android.R.string.cancel),
+            activity.getString(R.string.ok),
+            activity.getString(R.string.cancel),
             {
                 createDialogsAndHandleLocationPermissions(
                     activity,

--- a/app/src/main/java/fr/free/nrw/commons/description/DescriptionEditActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/description/DescriptionEditActivity.kt
@@ -150,7 +150,7 @@ class DescriptionEditActivity :
             this,
             getString(titleStringID),
             getString(messageStringId),
-            getString(android.R.string.ok),
+            getString(R.string.ok),
             null
         )
     }

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.kt
@@ -140,8 +140,8 @@ class ExploreMapFragment : CommonsDaggerSupportFragment(), ExploreMapContract.Vi
                     requireActivity(),
                     requireActivity().getString(R.string.location_permission_title),
                     requireActivity().getString(R.string.location_permission_rationale_explore),
-                    requireActivity().getString(android.R.string.ok),
-                    requireActivity().getString(android.R.string.cancel),
+                    requireActivity().getString(R.string.ok),
+                    requireActivity().getString(R.string.cancel),
                     { askForLocationPermission() },
                     null,
                     null

--- a/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/recentsearches/RecentSearchesFragment.kt
@@ -67,10 +67,10 @@ class RecentSearchesFragment : CommonsDaggerSupportFragment() {
     private fun showDeleteRecentAlertDialog(context: Context) {
         AlertDialog.Builder(context)
             .setMessage(getString(R.string.delete_recent_searches_dialog))
-            .setPositiveButton(android.R.string.yes) { dialog: DialogInterface, _: Int ->
+            .setPositiveButton(R.string.yes) { dialog: DialogInterface, _: Int ->
                 setDeleteRecentPositiveButton(context, dialog)
             }
-            .setNegativeButton(android.R.string.no, null)
+            .setNegativeButton(R.string.no, null)
             .setCancelable(false)
             .create()
             .show()
@@ -102,7 +102,7 @@ class RecentSearchesFragment : CommonsDaggerSupportFragment() {
                     setDeletePositiveButton(context, dialog, position)
                 }
             )
-            .setNegativeButton(android.R.string.cancel, null)
+            .setNegativeButton(R.string.cancel, null)
             .setCancelable(false)
             .create()
             .show()

--- a/app/src/main/java/fr/free/nrw/commons/location/LocationPermissionsHelper.kt
+++ b/app/src/main/java/fr/free/nrw/commons/location/LocationPermissionsHelper.kt
@@ -64,8 +64,8 @@ class LocationPermissionsHelper(
                     activity,
                     activity.getString(dialogTitleResource),
                     activity.getString(dialogTextResource),
-                    activity.getString(android.R.string.ok),
-                    activity.getString(android.R.string.cancel),
+                    activity.getString(R.string.ok),
+                    activity.getString(R.string.cancel),
                     {
                         ActivityCompat.requestPermissions(
                             activity,

--- a/app/src/main/java/fr/free/nrw/commons/quiz/QuizChecker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/quiz/QuizChecker.kt
@@ -151,7 +151,7 @@ class QuizChecker @Inject constructor(
             activity.getString(R.string.quiz),
             activity.getString(R.string.quiz_alert_message, revertPercentageForMessage),
             activity.getString(R.string.about_translate_proceed),
-            activity.getString(android.R.string.cancel),
+            activity.getString(R.string.cancel),
             { startQuizActivity(activity) },
             null
         )

--- a/app/src/main/java/fr/free/nrw/commons/quiz/QuizResultActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/quiz/QuizResultActivity.kt
@@ -193,7 +193,7 @@ class QuizResultActivity : AppCompatActivity() {
         alertadd.setPositiveButton(R.string.about_translate_proceed) { dialog, _ ->
             shareScreen(screenshot)
         }
-        alertadd.setNegativeButton(android.R.string.cancel) { dialog, _ ->
+        alertadd.setNegativeButton(R.string.cancel) { dialog, _ ->
             dialog.cancel()
         }
         alertadd.show()

--- a/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/review/ReviewActivity.kt
@@ -238,7 +238,7 @@ class ReviewActivity : BaseActivity() {
             this,
             getString(R.string.skip_image).uppercase(Locale.ROOT),
             getString(R.string.skip_image_explanation),
-            getString(android.R.string.ok),
+            getString(R.string.ok),
             null,
             null,
             null
@@ -250,7 +250,7 @@ class ReviewActivity : BaseActivity() {
             this,
             getString(R.string.title_activity_review),
             getString(R.string.review_image_explanation),
-            getString(android.R.string.ok),
+            getString(R.string.ok),
             null,
             null,
             null

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.kt
@@ -446,7 +446,7 @@ class UploadActivity : BaseActivity(), UploadContract.View, UploadBaseFragment.C
                                 this,
                                 getString(R.string.storage_permissions_denied),
                                 getString(R.string.unable_to_share_upload_item),
-                                getString(android.R.string.ok)
+                                getString(R.string.ok)
                             ) { finish() }
                         } else {
                             showAlertDialog(
@@ -455,7 +455,7 @@ class UploadActivity : BaseActivity(), UploadContract.View, UploadBaseFragment.C
                                 getString(
                                     R.string.write_storage_permission_rationale_for_image_share
                                 ),
-                                getString(android.R.string.ok)
+                                getString(R.string.ok)
                             ) { checkStoragePermissions() }
                         }
                     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.kt
@@ -117,7 +117,7 @@ class UploadCategoriesFragment : UploadBaseFragment(), CategoriesContract.View {
                 requireActivity(),
                 getString(R.string.categories_activity_title),
                 getString(R.string.categories_tooltip),
-                getString(android.R.string.ok),
+                getString(R.string.ok),
                 null
             )
         }

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.kt
@@ -116,7 +116,7 @@ class DepictsFragment : UploadBaseFragment(), DepictsContract.View {
                 requireActivity(),
                 getString(R.string.depicts_step_title),
                 getString(R.string.depicts_tooltip),
-                getString(android.R.string.ok),
+                getString(R.string.ok),
                 null
             )
         }

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.kt
@@ -303,7 +303,7 @@ class UploadMediaDetailFragment : UploadBaseFragment(), UploadMediaDetailsContra
             requireActivity(),
             getString(titleStringID),
             getString(messageStringId),
-            getString(android.R.string.ok),
+            getString(R.string.ok),
             null
         )
     }

--- a/app/src/main/java/fr/free/nrw/commons/utils/PermissionUtils.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/PermissionUtils.kt
@@ -209,8 +209,8 @@ object PermissionUtils {
                         activity,
                         activity.getString(rationaleTitle),
                         activity.getString(rationaleMessage),
-                        activity.getString(android.R.string.ok),
-                        activity.getString(android.R.string.cancel),
+                        activity.getString(R.string.ok),
+                        activity.getString(R.string.cancel),
                         {
                             if (activity is UploadActivity) {
                                 activity.isShowPermissionsDialog = true

--- a/app/src/test/kotlin/fr/free/nrw/commons/description/DescriptionEditActivityUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/description/DescriptionEditActivityUnitTest.kt
@@ -193,8 +193,8 @@ class DescriptionEditActivityUnitTest {
         method.isAccessible = true
         method.invoke(
             activity,
-            android.R.string.ok,
-            android.R.string.ok,
+            R.string.ok,
+            R.string.ok,
         )
         val dialog: AlertDialog = ShadowAlertDialog.getLatestDialog() as AlertDialog
         assertEquals(dialog.isShowing, true)


### PR DESCRIPTION
**Description (required)**

Replace android.R.string.* with R.string

All these messages are not really necessary because the app has its own localizations, and android.R.string sometimes doesn't display the localized string.

Resolves #6470.

**Tests performed (required)**

Works in emulator.