### PR TITLE
Fix depicts and categories pickers for RTL languages

### DIFF
--- a/app/src/main/res/layout/layout_upload_categories_item.xml
+++ b/app/src/main/res/layout/layout_upload_categories_item.xml
@@ -3,6 +3,7 @@
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/category_layout"
+  android:layoutDirection="locale"
   android:layout_width="match_parent"
   android:layout_height="wrap_content">
 
@@ -10,26 +11,31 @@
     android:id="@+id/upload_category_checkbox"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:minWidth="48dp"
+    android:minHeight="48dp"
     android:checkMark="?android:attr/textCheckMark"
     android:checked="false"
     android:gravity="center_vertical"
     android:padding="@dimen/tiny_gap"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toStartOf="@+id/category_image"
-    app:layout_constraintLeft_toLeftOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
 
   <com.facebook.drawee.view.SimpleDraweeView
     android:id="@+id/category_image"
     android:layout_width="50dp"
     android:layout_height="50dp"
-    android:paddingEnd="@dimen/tiny_gap"
+    android:layout_marginStart="@dimen/tiny_gap"
+    android:layout_marginEnd="@dimen/tiny_gap"
     app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintLeft_toRightOf="@+id/upload_category_checkbox"
+    app:layout_constraintStart_toEndOf="@+id/upload_category_checkbox"
     app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintEnd_toStartOf="@+id/text_container"
     app:placeholderImage="@drawable/commons" />
 
   <LinearLayout
+    android:id="@+id/text_container"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:orientation="vertical"

--- a/app/src/main/res/layout/layout_upload_depicts_item.xml
+++ b/app/src/main/res/layout/layout_upload_depicts_item.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:id="@+id/depicts_layout"
+  android:layoutDirection="locale"
   android:layout_width="match_parent"
   android:layout_height="wrap_content">
 
@@ -9,26 +10,31 @@
     android:id="@+id/depict_checkbox"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:minWidth="48dp"
+    android:minHeight="48dp"
     android:checkMark="?android:attr/textCheckMark"
     android:checked="false"
     android:gravity="center_vertical"
     android:padding="@dimen/tiny_gap"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toStartOf="@+id/depicted_image"
-    app:layout_constraintLeft_toLeftOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
 
   <com.facebook.drawee.view.SimpleDraweeView
     android:id="@+id/depicted_image"
     android:layout_width="50dp"
     android:layout_height="50dp"
-    android:paddingRight="@dimen/tiny_gap"
+    android:layout_marginStart="@dimen/tiny_gap"
+    android:layout_marginEnd="@dimen/tiny_gap"
     app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintLeft_toRightOf="@+id/depict_checkbox"
+    app:layout_constraintStart_toEndOf="@+id/depict_checkbox"
     app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintEnd_toStartOf="@+id/text_container"
     app:placeholderImage="@drawable/ic_wikidata_logo_24dp" />
 
   <LinearLayout
+    android:id="@+id/text_container"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:orientation="vertical"
@@ -41,14 +47,14 @@
       android:id="@+id/depicts_label"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:text="Label"
+      android:text="@string/depicts_label"
       android:textStyle="bold" />
 
     <TextView
       android:id="@+id/description"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:text="Description" />
+      android:text="@string/depicts_description" />
   </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/upload_categories_fragment.xml
+++ b/app/src/main/res/layout/upload_categories_fragment.xml
@@ -17,7 +17,6 @@
       android:layout_width="wrap_content"
       android:layout_height="@dimen/half_standard_height"
       android:layout_marginEnd="@dimen/standard_gap"
-      android:layout_marginRight="@dimen/standard_gap"
       android:orientation="horizontal">
 
       <TextView
@@ -25,7 +24,6 @@
         android:layout_width="wrap_content"
         android:layout_height="@dimen/half_standard_height"
         android:layout_marginEnd="@dimen/standard_gap"
-        android:layout_marginRight="@dimen/standard_gap"
         android:gravity="center_vertical"
         android:textSize="@dimen/normal_text"
         android:textStyle="bold"
@@ -77,7 +75,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/tiny_gap"
-        android:layout_marginRight="@dimen/tiny_gap"
         android:layout_gravity="center_vertical|end"
         android:indeterminate="true"
         android:indeterminateOnly="true"

--- a/app/src/main/res/layout/upload_depicts_fragment.xml
+++ b/app/src/main/res/layout/upload_depicts_fragment.xml
@@ -22,7 +22,6 @@
           android:layout_marginEnd="@dimen/standard_gap"
           android:layout_marginRight="@dimen/standard_gap"
           android:layout_alignParentStart="true"
-          android:layout_alignParentLeft="true"
           android:layout_alignParentTop="true"
           android:orientation="horizontal">
             <TextView
@@ -30,7 +29,6 @@
               android:layout_width="wrap_content"
               android:layout_height="@dimen/half_standard_height"
               android:layout_marginEnd="@dimen/standard_gap"
-              android:layout_marginRight="@dimen/standard_gap"
               android:gravity="center_vertical"
               android:textSize="@dimen/normal_text"
               android:textStyle="bold"
@@ -99,7 +97,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/tiny_gap"
-            android:layout_marginRight="@dimen/tiny_gap"
             android:layout_gravity="center_vertical|end"
             android:indeterminate="true"
             android:indeterminateOnly="true"

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -468,6 +468,8 @@
   <string name="map_attribution">{{Optional}}\n&lt;code&gt;&amp;amp;#169;&lt;/code&gt; is the copyright symbol (©).</string>
   <string name="categories_tooltip">{{Doc-commons-app-depicts}}</string>
   <string name="depicts_step_title">{{Doc-commons-app-depicts}}</string>
+  <string name="depicts_label">Label</string>
+  <string name="depicts_description">Description</string>
   <string name="pan_and_zoom_to_adjust">Panning means moving the map left/right/up/down, typically by touching the screen with one finger and moving it.\n\nZooming means making the map\'s scale bigger or smaller, typically by pinching with two fingers.\n\nExample in other app:\nhttps://igss.schneider-electric.com/features/pan-and-zoom-in-definition/</string>
   <string name="location_picker_image_view_shadow">A description of a visual element, location picker image shadow. Used for accesibility usually.</string>
   <string name="label">{{Identical|Label}}</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -710,6 +710,8 @@ Upload your first media by tapping on the add button.</string>
   <string name="categories_tooltip">Please select the appropriate categories. Unlike depictions, categories are only in English.</string>
   <string name="license_tooltip">Commons makes your pictures reusable and adapted by everyone. Do you want to waive all rights? Do you want to be attributed? Do you want adaptations to use the same license?</string>
   <string name="depicts_step_title">Depicts</string>
+  <string name="depicts_label">Label</string>
+  <string name="depicts_description">Description</string>
   <string name="license_step_title">Media License</string>
   <string name="media_detail_step_title">Media Details</string>
   <string name="menu_view_category_page">View category page</string>


### PR DESCRIPTION
**Description (required)**

This fixes the layouts for search for Depicts items and Categories in the uploading process to work in both left to right (LTR) and right to left (RTL) languages.

This also replaces two hard-coded strings in the depicts picker with proper string resources.

Fixes #6502.

**Tests performed (required)**

Tested in both English and Hebrew in the Android Studio emulator.

Please note that this is my first big patch with Real Code in this repo, or in any Android repo for that matter, so it's possible that I didn't test as thoroughly as I should have. Comments are very welcome.