### PR TITLE
Simplify android:gravity in two layouts

### DIFF
--- a/app/src/main/res/layout/fragment_review_image.xml
+++ b/app/src/main/res/layout/fragment_review_image.xml
@@ -22,9 +22,8 @@
         android:id="@+id/tv_review_question"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center_vertical"
+        android:gravity="center"
         tools:text="testing1"
-        android:textAlignment="center"
         android:textColor="?attr/reviewHeading"
         android:textSize="32sp"/>
 
@@ -33,9 +32,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/filter_padding"
-        android:gravity="center_vertical"
+        android:gravity="center"
         tools:text="testing2"
-        android:textAlignment="center"
         android:textSize="22sp"/>
 
     </LinearLayout>

--- a/app/src/main/res/layout/pic_of_day_app_widget.xml
+++ b/app/src/main/res/layout/pic_of_day_app_widget.xml
@@ -35,7 +35,6 @@
         android:layout_height="wrap_content"
         android:id="@+id/appwidget_title"
         android:textAlignment="center"
-        android:layout_gravity="bottom"
         android:textColor="@color/white"
         android:layout_marginTop="@dimen/filter_padding"
         android:layout_marginStart="@dimen/tiny_padding"


### PR DESCRIPTION
**Description (required)**

The "Inspect Code" linter complained that these two files had Right-to-left text compatibility issues. I couldn't really see any problems neither in English nor in Hebrew, but the linter's suggestion still made sense, so I cleaned it up.

This fixes all the errors of the type
"Android Lint: Internationalization / Right-to-left text compatibility issues".

**Tests performed (required)**

Tested the widget and the review screen in the emulator in Android Studio in English and Hebrew, and saw no changes in display.