### PR TITLE
Replace tab with space in an XML layout file

### DIFF
--- a/app/src/main/res/layout/pic_of_day_app_widget.xml
+++ b/app/src/main/res/layout/pic_of_day_app_widget.xml
@@ -46,6 +46,6 @@
         android:id="@+id/appwidget_image"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-		android:contentDescription="@string/appwidget_img" />
+        android:contentDescription="@string/appwidget_img" />
 
 </LinearLayout>


### PR DESCRIPTION
**Description (required)**

I was working on this file recently, and Android Studio showed a warning that it has tabs instead of spaces, so here's it's fixed.

A minor thing, but prevents distractions.