### PR TITLE
fix(i18n): Correct capitalization for 'Sending thanks' status messages (#6515)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
   <!--accessibility UI description strings-->
   <string name="commons_facebook">Commons Facebook Page</string>
-  <string name="commons_github">Commons Github Source Code</string>
+  <string name="commons_github">Commons GitHub Source Code</string>
   <string name="commons_logo">Commons Logo</string>
   <string name="commons_website">Commons Website</string>
   <string name="exit_location_picker">Exit location picker</string>
@@ -493,12 +493,12 @@ Upload your first media by tapping on the add button.</string>
   <string name="check_category_failure_message">Could not request category check for %1$s</string>
   <string name="check_category_toast">Requesting category check for %1$s</string>
   <string name="nominate_for_deletion_done">Done</string>
-  <string name="send_thank_success_title">Sending Thanks: Success</string>
+  <string name="send_thank_success_title">Sending thanks: Success</string>
   <string name="send_thank_success_message">Sent thanks to %1$s</string>
   <string name="send_thank_failure_message">Failed to send thanks to %1$s</string>
-  <string name="send_thank_failure_title">Sending Thanks: Failure</string>
+  <string name="send_thank_failure_title">Sending thanks: Failure</string>
 
-  <string name="send_thank_toast">Sending Thanks for %1$s</string>
+  <string name="send_thank_toast">Sending thanks for %1$s</string>
   <string name="review_copyright">Does this follow the rules of copyright?</string>
   <string name="review_category">Is this correctly categorized?</string>
   <string name="review_spam">Is this in-scope?</string>


### PR DESCRIPTION
**Fixes  (#6515)**

This Pull Request resolves a minor capitalization inconsistency in the "Send Thanks" status messages. The capitalization was corrected to align with the application's standard **Sentence Case** convention for UI text.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update *(You can also check this if you consider string files as documentation)*

### Description and Changes Made
The issue was in the file strings.xml ,where it was visible in the lines 496,499 and 501 and action taken are:

| String Name | Original Value | Corrected Value |
| :--- | :--- | :--- |
| `send_thank_success_title` | `"Sending **T**hanks: Success"` | `"Sending **t**hanks: Success"` |
| `send_thank_failure_title` | `"Sending **T**hanks: Failure"` | `"Sending **t**hanks: Failure"` |
| `send_thank_toast` | `"Sending **T**hanks for %1$s"` | `"Sending **t**hanks for %1$s"` |


### Checklist
*(Ensure you check all these boxes before submitting)*
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works *(Not needed for this type of textual fix)*
- [ ] New and existing unit tests pass locally with my changes *(Not needed for this type of textual fix)*
- [x] I have added documentation wherever appropriate







