### PR TITLE
Fix lint warning about Timber

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.kt
@@ -324,7 +324,7 @@ after opening the app.
         )
             .subscribeOn(Schedulers.io())
             .blockingGet()
-        Timber.d("Resuming " + stuckUploads.size + " uploads...")
+        Timber.d("Resuming %d uploads...", stuckUploads.size)
         if (!stuckUploads.isEmpty()) {
             for (contribution in stuckUploads) {
                 contribution.state = Contribution.STATE_QUEUED

--- a/app/src/main/java/fr/free/nrw/commons/profile/ProfileActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/profile/ProfileActivity.kt
@@ -27,6 +27,7 @@ import java.io.File
 import java.io.FileOutputStream
 import java.util.Locale
 import javax.inject.Inject
+import timber.log.Timber
 
 /**
  * This activity will set two tabs, achievements and
@@ -122,7 +123,7 @@ class ProfileActivity : BaseActivity() {
                 val rootView = window.decorView.findViewById<View>(android.R.id.content)
                 val screenShot = getScreenShot(rootView)
                 if (screenShot == null) {
-                    Log.e("ERROR", "ScreenShot is null")
+                    Timber.e("ScreenShot is null")
                     return false
                 }
                 showAlert(screenShot)

--- a/app/src/main/java/fr/free/nrw/commons/utils/LocationUtils.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/LocationUtils.kt
@@ -37,7 +37,7 @@ object LocationUtils {
             latLng = LatLng(latLngArray[1].trim().toDouble(),
                 latLngArray[0].trim().toDouble(), 1f)
         } catch (e: Exception) {
-            Timber.e("Error while parsing user entered lat long: %s", e)
+            Timber.e(e, "Error while parsing user entered lat long")
         }
 
         return latLng


### PR DESCRIPTION
**Description (required)**

Change trivial string formatting and function calls for Timber logging.

This resolves all the lint warnings in the
Android/Lint/Correctness/Messages group.