### PR TITLE
explore: use class-specific tab labels in item details only (Fixes #6395)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/depictions/WikidataItemDetailsActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/depictions/WikidataItemDetailsActivity.kt
@@ -112,8 +112,8 @@ class WikidataItemDetailsActivity : BaseActivity(), MediaDetailProvider, Categor
 
         viewPagerAdapter!!.setTabs(
             R.string.title_for_media to depictionImagesListFragment!!,
-            R.string.title_for_subcategories to childDepictionsFragment,
-            R.string.title_for_parent_categories to parentDepictionsFragment
+            R.string.title_for_child_classes to childDepictionsFragment,
+            R.string.title_for_parent_classes to parentDepictionsFragment
         )
         binding!!.viewPager.offscreenPageLimit = 2
         viewPagerAdapter!!.notifyDataSetChanged()


### PR DESCRIPTION
**Description (required)**

Fixes #6395

**What changes did you make and why?**

Problem  
The Item (Wikidata) details screen showed category-oriented labels (“Subcategories / Parent categories”) where class hierarchy labels are expected (“Child classes / Parent classes”). A prior attempt mistakenly changed global strings, which caused category flows (e.g., searching "rabbit" → open a **category**) to display the wrong labels.

Approach  
- **Scope labels to the correct context**  
  - In `WikidataItemDetailsActivity`, set tabs to use class-specific resources:  
    `title_for_child_classes` → child tab,  
    `title_for_parent_classes` → parent tab.
- **Keep categories unchanged**  
  - Do **not** rename or repoint category strings; category screens continue to use `title_for_subcategories` / `title_for_parent_categories`.
- **Clean up strings**  
  - Remove duplicate keys introduced earlier and ensure **unique resource names** for classes vs categories.
- **Repository hygiene**  
  - Rebased on latest upstream `main`.  
  - Deleted incorrect string edits from the previous attempt to avoid regressions.


**Tests performed (required)**

- Build variant: `6.0.2-debug-main~4ed9ad508`
- Device: Android 15 (API 35) Emulator (Medium Phone)

Manual checks  
1) **Category context**: expolre → search sth. (e.g.,"rabbit") → tab CATEGORIES→ choose one→ read ““Subcategories / Parent categories””.  
2) **Item context**: expolre → search sth. (e.g.,"rabbit") → tab ITEMS→choose one → read “Child classes / Parent classes”.  


**Before:**
1) category
<img width="1223" height="205" alt="image" src="https://github.com/user-attachments/assets/7505195a-57b7-45e4-addb-2c4678a87789" />

2) item
<img width="1080" height="1571" alt="image" src="https://github.com/user-attachments/assets/c83bc6c4-2fa3-435c-96d6-7c731df13353" />


**After:**
1) category:
<img width="519" height="1158" alt="85d3bb5fad6698042bb2954f36cd0202" src="https://github.com/user-attachments/assets/43ea3af4-ace5-4707-ad52-235617e9404a" />

2) item:
<img width="523" height="1166" alt="cd9204bebe1dba9efdb03f2bfadbb7f7" src="https://github.com/user-attachments/assets/43772293-680c-43a3-9407-ec8bd59a3e59" />



