### PR TITLE
Fix three Java lint errors

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/CheckBoxTriStates.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/CheckBoxTriStates.java
@@ -44,7 +44,7 @@ public class CheckBoxTriStates extends AppCompatCheckBox {
         public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
             switch (state) {
                 case UNKNOWN:
-                    setState(UNCHECKED);;
+                    setState(UNCHECKED);
                     break;
                 case UNCHECKED:
                     setState(CHECKED);

--- a/app/src/main/java/fr/free/nrw/commons/nearby/Sitelinks.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/Sitelinks.java
@@ -105,9 +105,6 @@ public class Sitelinks implements Parcelable {
         private String commonsLink;
         private String wikipediaLink;
 
-        public Builder() {
-        }
-
         public Sitelinks.Builder setWikipediaLink(String link) {
             this.wikipediaLink = link;
             return this;

--- a/app/src/test/java/android/text/TextUtils.java
+++ b/app/src/test/java/android/text/TextUtils.java
@@ -21,14 +21,18 @@ public class TextUtils {
      * mocks TextUtils.equals
      */
     public static boolean equals(CharSequence a, CharSequence b) {
-        if (a == b) return true;
+        if (a == b) {
+            return true;
+        }
         int length;
         if (a != null && b != null && (length = a.length()) == b.length()) {
             if (a instanceof String && b instanceof String) {
                 return a.equals(b);
             } else {
                 for (int i = 0; i < length; i++) {
-                    if (a.charAt(i) != b.charAt(i)) return false;
+                    if (a.charAt(i) != b.charAt(i)) {
+                        return false;
+                    }
                 }
                 return true;
             }


### PR DESCRIPTION
**Description (required)**

* Add braces to conditions.
* Remove an unnecessary semicolon.
* Remove an unnecessary constructor.

This fixes all the Java lint errors of these types.