### PR TITLE
Remove an unused element from layout/fragment_media_detail.xml

### DIFF
--- a/app/src/main/res/layout/fragment_media_detail.xml
+++ b/app/src/main/res/layout/fragment_media_detail.xml
@@ -24,16 +24,6 @@
           layout="@layout/show_captions_descriptions" />
     </LinearLayout>
 
-    <ImageView
-      android:id="@+id/mediaDetailImageFailed"
-      android:layout_height="wrap_content"
-      android:layout_width="wrap_content"
-      android:layout_gravity="center"
-      android:src="@android:drawable/ic_menu_close_clear_cancel"
-      android:visibility="gone"
-      android:contentDescription="@string/mediaimage_failed"
-      />
-
     <com.facebook.drawee.view.SimpleDraweeView
       android:id="@+id/mediaDetailImageView"
       android:layout_width="wrap_content"

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -228,7 +228,6 @@
   <string name="_2fa_code">Login form label.</string>
   <string name="email_auth_code">Login screen command.</string>
   <string name="logout_verification">Confirmation string.</string>
-  <string name="mediaimage_failed">Alternative text.</string>
   <string name="no_subcategory_found">Notice when searching for subcategories.</string>
   <string name="no_parentcategory_found">Notice when searching for subcategories.</string>
   <string name="welcome_image_mount_zao">This is a mountain between Yamagata and Miyagi Prefectures in Japan, see [[d:Q167951]] for details.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,7 +226,6 @@
   <string name="_2fa_code">2FA Code</string>
   <string name="email_auth_code">Email verification code</string>
   <string name="logout_verification">Do you really want to logout?</string>
-  <string name="mediaimage_failed">Media Image Failed</string>
   <string name="no_subcategory_found">No subcategories found</string>
   <string name="no_parentcategory_found">No parent categories found</string>
   <string name="welcome_image_mount_zao">Mount Zao</string>


### PR DESCRIPTION
**Description (required)**

I noticed this issue years ago because it used a hard-to-understand string that needed better documentation (see https://github.com/commons-app/apps-android-commons/issues/688). I forgot it, but recently, I started to explore the app much more deeply and came back to it.

It looks like this string is only used in this layout element, but the element itself is not used anywhere. Its usage appears to have been removed in #634.

This fixes #688 by removing the message in question.

(Comment: I previously submitted it as #6511, but deleted the branch by mistake.)

**Tests performed (required)**

Tested the layout that uses it in Android Studio emulator, everything works as it did previously.