### PR TITLE
fix(upload): Preserve UploadActivity state across screen resize/split-screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,7 +99,7 @@
     <activity android:name=".WelcomeActivity" />
     <activity
       android:name=".upload.UploadActivity"
-      android:configChanges="orientation|screenSize|keyboard"
+      android:configChanges="orientation|screenSize|keyboard|smallestScreenSize|screenLayout"
       android:exported="true"
       android:hardwareAccelerated="false"
       android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
## **Description**

Fixes #5784 

### What changes did you make and why?

The `UploadActivity` was previously being destroyed and recreated (restarted) when the user resized the application window, such as when entering or exiting split-screen mode. This caused the app to lose the current upload fragment state and return to the application's home screen.

* Added `smallestScreenSize` and `screenLayout` to the `android:configChanges` attribute for `UploadActivity` in `AndroidManifest.xml`. This instructs the Android system to notify the activity of these configuration changes instead of fully restarting it, thereby preserving the user's progress through the upload flow.
---
## **Tests performed**

Tested `ProdDebug` on `Redmi note 13 pro 5g` with API level `35`.