### PR TITLE
6269: Disable instrumentation tests

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -78,12 +78,12 @@ jobs:
         if: github.event_name == 'pull_request'
         run: ./gradlew -Pcoverage testBetaDebugUnitTestCoverage --stacktrace
 
-      - name: Upload Test Report to Codecov
-        if: github.event_name != 'pull_request'
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov -f "app/build/reports/jacoco/testBetaDebugUnitTestUnifiedCoverage/testBetaDebugUnitTestUnifiedCoverage.xml" -Z
+      # - name: Upload Test Report to Codecov
+      #   if: github.event_name != 'pull_request'
+      #   run: |
+      #     curl -Os https://uploader.codecov.io/latest/linux/codecov
+      #     chmod +x codecov
+      #     ./codecov -f "app/build/reports/jacoco/testBetaDebugUnitTestUnifiedCoverage/testBetaDebugUnitTestUnifiedCoverage.xml" -Z
 
       - name: Generate betaDebug APK
         run: bash ./gradlew assembleBetaDebug --stacktrace


### PR DESCRIPTION
**Description (required)**

Updates #6269 

What changes did you make and why?

Commented out the instrumented tests related flows in our GitHub workflow. Running these tests just got harder - it now asks for the OTP every time the test tries to login. Not sure if we can run these easily even if we fix them. 
 
---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
