### PR TITLE
Fix: Crash when parsing MediaWiki error responses & Refactor Interceptor

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/OkHttpConnectionFactory.kt
+++ b/app/src/main/java/fr/free/nrw/commons/OkHttpConnectionFactory.kt
@@ -96,7 +96,6 @@ private class UnsuccessfulResponseInterceptor : Interceptor {
                                 bodyString,
                                 MwErrorResponse::class.java
                             )
-                            // Fix: Only throw if error is not null (prevents NPE)
                             if (errorResponse?.error != null) {
                                 throw MwIOException(
                                     "MediaWiki API returned error: $bodyString",


### PR DESCRIPTION
## Summary
This PR fixes a crash (NullPointerException) that occurred when the MediaWiki API returned malformed error JSON (e.g., when trying to edit Depicts).

## Changes
1. **Fix Crash:** Added `try-catch` blocks and null checks in the response interceptor to handle parsing errors safely without crashing the app.
2. **Refactor:** Extracted the private `UnsuccessfulResponseInterceptor` from `OkHttpConnectionFactory.kt` into its own public file named `CommonsResponseInterceptor.kt`.
   - This fixes visibility issues that prevented proper unit testing.
   - Renamed the class to `CommonsResponseInterceptor` for clarity.
3. **Tests:** Updated unit tests to verify that malformed JSON no longer causes a crash.

## Related Issue
Fixes #6593