### PR TITLE
Add unit test for StringUtil.fromHtml

### DIFF
--- a/app/src/test/kotlin/fr/free/nrw/commons/utils/StringUtilTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/utils/StringUtilTest.kt
@@ -1,0 +1,38 @@
+package fr.free.nrw.commons.utils
+
+import android.graphics.Typeface
+import android.text.style.StyleSpan
+import androidx.core.text.getSpans
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StringUtilTest {
+    @Test
+    fun `plain text remains plain text`() {
+        val actual = StringUtil.fromHtml("foo bar")
+        assertEquals("foo bar", actual.toString())
+        assertArrayEquals(arrayOf<Object>(), actual.getSpans<Object>())
+    }
+
+    @Test
+    fun `italicized text has StyleSpan`() {
+        val actual = StringUtil.fromHtml("foo <i>bar</i>")
+        val spans = actual.getSpans<StyleSpan>()
+        assertEquals("foo bar", actual.toString())
+        assertEquals(1, spans.size)
+        assertEquals(Typeface.ITALIC, spans[0].style)
+        assertEquals(4, actual.getSpanStart(spans[0]))
+        assertEquals(7, actual.getSpanEnd(spans[0]))
+    }
+
+    @Test
+    fun `unescape ampersand`() {
+        val actual = StringUtil.fromHtml("foo &amp; bar")
+        assertEquals("foo & bar", actual.toString())
+        assertArrayEquals(arrayOf<Object>(), actual.getSpans<Object>())
+    }
+
+}


### PR DESCRIPTION
I added a new test for [StringUtil.fromHtml](https://github.com/commons-app/apps-android-commons/blob/46d6030162d4435eccd59ee63b3b5dfcee7f36b7/app/src/main/java/fr/free/nrw/commons/utils/StringUtil.kt#L14C9-L14C17) to increase test coverage. I think I should have done when I touched it last time #6295.

No modification to the main code, so I think we can skip manual testing.