### PR TITLE
fix: migrate deprecated edge-to-edge APIs for Android 15

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.kt
@@ -22,6 +22,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.app.NavUtils
 import androidx.core.content.ContextCompat
+import androidx.activity.enableEdgeToEdge
 import androidx.core.view.WindowCompat
 import fr.free.nrw.commons.BuildConfig
 import fr.free.nrw.commons.CommonsApplication
@@ -77,6 +78,7 @@ class LoginActivity : AccountAuthenticatorActivity() {
             .commonsApplicationComponent
             .inject(this)
 
+        enableEdgeToEdge()
         val isDarkTheme = systemThemeUtils.isDeviceInNightMode()
         setTheme(if (isDarkTheme) R.style.DarkAppTheme else R.style.LightAppTheme)
         delegate.installViewFactory()
@@ -84,8 +86,6 @@ class LoginActivity : AccountAuthenticatorActivity() {
 
         WindowCompat.getInsetsController(window, window.decorView)
             .isAppearanceLightStatusBars = !isDarkTheme
-
-        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         binding = ActivityLoginBinding.inflate(layoutInflater)
         applyEdgeToEdgeAllInsets(binding!!.root)

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,7 +20,8 @@
         <item name="reviewHeading">@color/white</item>
         <item name="aboutIconsColor">@color/white</item>
         <item name="caption_description_text_color">@color/white</item>
-        <item name="android:statusBarColor">@color/main_background_dark</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
 
         <item name="semitransparentText">@color/commons_app_blue_dark</item>
         <item name="subBackground">@color/sub_background_dark</item>


### PR DESCRIPTION
**Description (required)**

This PR migrates the app away from deprecated Android 15 APIs related to edge-to-edge display. Google Play has flagged these deprecated APIs that need to be updated before targeting Android 15:

- Add enableEdgeToEdge() to LoginActivity for proper edge-to-edge setup
- Remove redundant WindowCompat.setDecorFitsSystemWindows() call
- Update DarkAppTheme with transparent status/navigation bar colors

Fixes #6275

**Tests performed (required)**

Tested ProdDebug and BetaDebug on Medium Phone emulator (Android Virtual Device) with API level 36 (Android 15).

**Screenshots (for UI changes only)**

None - This is a behind-the-scenes API migration with no visible UI changes. The edge-to-edge display behavior remains the same.