### PR TITLE
Refine assignment logic with issue context

### DIFF
--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -21,16 +21,22 @@ jobs:
         id: check-request
         with:
           prompt: |
-            Analyze the following comment and determine if the user is EXPLICITLY asking to be assigned to work on this GitHub issue.
-            
-            Strict Rules:
-            1. If the user is just answering a question (e.g., "Yes, it is a bug"), respond with "no".
-            2. If the user is providing feedback or info, respond with "no".
-            3. ONLY respond with "yes" if the user clearly says they WANT to work on it (e.g., "I'll take this," "Can I work on this?", "I'm interested").
-            
+            You are a project management assistant. Determine if the user is explicitly asking to be assigned to THIS specific GitHub issue.
+
+            ISSUE CONTEXT:
+            Title: ${{ github.event.issue.title }}
+            Description: ${{ github.event.issue.body }}
+
+            USER COMMENT:
+            "${{ github.event.comment.body }}"
+
+            STRICT RULES:
+            1. Respond "yes" ONLY if the user wants to work on the task described in the ISSUE CONTEXT.
+            2. Respond "no" if the user is offering general help, suggesting new features, or discussing unrelated topics.
+            3. Respond "no" if the user is just answering a question or providing feedback.
+            4. If they say "I can help" but are talking about a different topic than the issue description, respond "no".
+
             Respond with only "yes" or "no".
-            
-            Comment: ${{ github.event.comment.body }}
           model: openai/gpt-4o-mini
 
       - name: Handle assignment


### PR DESCRIPTION
**Description (required)**

Fixes #6631

What changes did you make and why?
I have upgraded the `auto_assign.yml` workflow to be context-aware.

Key updates:
* **Contextual AI Logic:** The bot now reads the **Issue Title and Description** before assigning. It distinguishes between someone answering a question and someone volunteering for the specific task, preventing accidental assignments like in #6628.