### PR TITLE
Feat: Link to actual profile when using custom author name

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/PageContentsCreator.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/PageContentsCreator.kt
@@ -24,7 +24,6 @@ class PageContentsCreator @Inject constructor(private val context: Context) {
             append("}}")
         }
         append("|source=").append("{{own}}\n")
-        //fix:use themedia.user for the link, and media.autho for the label
         append("|author=[[User:").append(media?.user).append("|")
         append(media?.author).append("]]\n")
 


### PR DESCRIPTION
Fixes #5803
Fixes #6591

**What changes did you make and why?**

* **Updated the Wikitext Generation:** Modified the author tag logic in `PageContentsCreator` to use `media.user` ffor the link target, while keeping the `media.author` this is for the label.

This resolves the issue where setting a "Personalised author name" created broken links (the red links) by ensuring the app always links to the actual user profile (`[[User:RealAccount|CustomDisplay]]`).

**Tests performed (required)**

Tested **ProDebug** on **Redmi Note 13 Pro** with API **35**.

* **Verification:** Set a custom author name (`kotajr`)in settings, uploaded the file, and confirmed that the author link on the resulting file page now correctly redirects to my real user profile.

Picture links : (Before the fix)
https://commons.wikimedia.org/wiki/File%3ATesting_(62675).jpg

Pic link : (After the fixx)
https://commons.wikimedia.org/wiki/File%3ANature1_(51385).jpg

**Screenshots (for UI changes only)**

no because only logic fix.