### PR TITLE
fix: prevent TransactionTooLargeException by removing large list save…

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/description/DescriptionEditActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/description/DescriptionEditActivity.kt
@@ -100,6 +100,7 @@ class DescriptionEditActivity :
 
         if (savedInstanceState != null) {
             descriptionAndCaptions = savedInstanceState.getParcelableArrayList(LIST_OF_DESCRIPTION_AND_CAPTION)
+                ?: bundle?.getParcelableArrayList(LIST_OF_DESCRIPTION_AND_CAPTION)
             wikiText = savedInstanceState.getString(WIKITEXT)
             savedLanguageValue = savedInstanceState.getString(Prefs.DESCRIPTION_LANGUAGE)!!
             media = savedInstanceState.getParcelable("media")
@@ -312,7 +313,6 @@ class DescriptionEditActivity :
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
 
-        outState.putParcelableArrayList(LIST_OF_DESCRIPTION_AND_CAPTION, uploadMediaDetailAdapter.items as ArrayList<out Parcelable?>)
         outState.putString(WIKITEXT, wikiText)
         outState.putString(Prefs.DESCRIPTION_LANGUAGE, savedLanguageValue)
         // save Media

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.kt
@@ -898,10 +898,6 @@ class UploadMediaDetailFragment : UploadBaseFragment(), UploadMediaDetailsContra
         if (uploadableFile != null) {
             outState.putParcelable(UPLOADABLE_FILE, uploadableFile)
         }
-        outState.putParcelableArrayList(
-            UPLOAD_MEDIA_DETAILS,
-            ArrayList(uploadMediaDetailAdapter.items)
-        )
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
Fixes #6639

### What changes did you make and why?

This PR fixes the `TransactionTooLargeException` crash that occurred when the app was backgrounded and resumed.

**Root Cause:**  
Fragment state (`android:support:fragments`) was ~530KB, exceeding Android's safe transaction limit. This was caused by saving large lists (`uploadMediaDetailAdapter.items`) directly into the Bundle in `onSaveInstanceState`.

**Changes:**
- Removed `putParcelableArrayList` for `UPLOAD_MEDIA_DETAILS` in `UploadMediaDetailFragment.onSaveInstanceState`
- Removed `putParcelableArrayList` for `LIST_OF_DESCRIPTION_AND_CAPTION` in `DescriptionEditActivity.onSaveInstanceState`
- Updated `DescriptionEditActivity` to fall back to intent bundle if savedInstanceState doesn't have the list

**Trade-off:**  
On process death (rare), users may need to re-enter description/caption data. This is acceptable compared to a crash.

### Tests performed

- Verified no compile errors
- Manual testing recommended: background app, kill process, restore from recents