### PR TITLE
fix: add assignment confirmation comment and fix new contributor welc…

### DIFF
--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -60,7 +60,7 @@ jobs:
               let body = `Hi @${commenter}! Thanks for reaching out. It looks like someone is already working on this one at the moment. `;
               body += `\n\nNo worries, though-there are plenty of other ways to help! You can find more open issues here: https://github.com/commons-app/apps-android-commons/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug%20no%3Aassignee%20-label%3A%22low%20priority%22%20-label%3Adebated%20-label%3Aupstream`;
             
-              // Only  show the welcome message to new contributors
+              // Only show the welcome message to new contributors
               if (isFirstTime) body += welcomeMessage;
 
               await github.rest.issues.createComment({
@@ -87,9 +87,9 @@ jobs:
               state: 'open'
             });
 
-            // decision logic:
+            // Decision logic:
             // - If no assigned issues: safe to assign
-            // - If has assigned issues andd has open PR: safe to assign (they are waiting for review)
+            // - If has assigned issues and has open PR: safe to assign (they are waiting for review)
             // - If has assigned issues but no pr's: block (they need to finish current work first)
             
             if (assignedIssues.data.length === 0 || pullRequests.data.length > 0) {


### PR DESCRIPTION
**Description (required)**

Fixes #6631 

What changes did you make and why?

- I updated the logic in auto_assign.yml.

1) Now, when a new contributor asks to be assigned the issue, the bot not only assigns the issue but also sends a welcome message (only if the user is a new contributor).


2) From now on, whenever someone asks to be assigned the issue, the bot not only assigns the person but also sends a confirmation message saying, "You have been assigned."