### PR TITLE
fix: prevent ANR in ExploreMapFragment.moveCameraToPosition

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.kt
@@ -95,6 +95,7 @@ class ExploreMapFragment : CommonsDaggerSupportFragment(), ExploreMapContract.Vi
     private var clickedMarker: BaseMarker? = null
     private var mapCenter: GeoPoint? = null
     private var lastMapFocus: GeoPoint? = null
+    private var isAnimatingCamera = false
     private var intentFilter: IntentFilter = IntentFilter(MapUtils.NETWORK_INTENT_ACTION)
     private var baseMarkerOverlayMap: MutableMap<BaseMarker?, Overlay?>? = null
     private var locationPermissionsHelper: LocationPermissionsHelper? = null
@@ -247,25 +248,25 @@ class ExploreMapFragment : CommonsDaggerSupportFragment(), ExploreMapContract.Vi
 
         binding!!.mapView.addMapListener(object : MapListener {
             override fun onScroll(event: ScrollEvent): Boolean {
-                if (getLastMapFocus() != null) {
-                    val mylocation = Location("")
-                    val dest_location = Location("")
-                    dest_location.latitude = binding!!.mapView.mapCenter.latitude
-                    dest_location.longitude = binding!!.mapView.mapCenter.longitude
-                    mylocation.latitude = getLastMapFocus()!!.latitude
-                    mylocation.longitude = getLastMapFocus()!!.longitude
-                    val distance = mylocation.distanceTo(dest_location) //in meters
-                    if (getLastMapFocus() != null) {
-                        if (isNetworkConnectionEstablished() && (event.getX() > 0
-                                    || event.getY() > 0)
-                        ) {
-                            setSearchThisAreaButtonVisibility(distance > 2000.0)
-                        }
-                    } else {
-                        setSearchThisAreaButtonVisibility(false)
+                val lastFocus = getLastMapFocus()
+                if (lastFocus != null) {
+                    val dest_location = Location("").apply {
+                        latitude = binding!!.mapView.mapCenter.latitude
+                        longitude = binding!!.mapView.mapCenter.longitude
                     }
+                    val mylocation = Location("").apply {
+                        latitude = lastFocus.latitude
+                        longitude = lastFocus.longitude
+                    }
+                    val distance = mylocation.distanceTo(dest_location)
+                    if (isNetworkConnectionEstablished() && (event.getX() > 0
+                                || event.getY() > 0)
+                    ) {
+                        setSearchThisAreaButtonVisibility(distance > 2000.0)
+                    }
+                } else {
+                    setSearchThisAreaButtonVisibility(false)
                 }
-
                 return true
             }
 
@@ -1022,7 +1023,10 @@ class ExploreMapFragment : CommonsDaggerSupportFragment(), ExploreMapContract.Vi
      * @param geoPoint The GeoPoint representing the new camera position for the map.
      */
     private fun moveCameraToPosition(geoPoint: GeoPoint?) {
+        if (isAnimatingCamera) return
+        isAnimatingCamera = true
         binding!!.mapView.controller.animateTo(geoPoint)
+        isAnimatingCamera = false
     }
 
     /**
@@ -1034,7 +1038,10 @@ class ExploreMapFragment : CommonsDaggerSupportFragment(), ExploreMapContract.Vi
      * @param speed    Speed of animation
      */
     private fun moveCameraToPosition(geoPoint: GeoPoint?, zoom: Double, speed: Long) {
+        if (isAnimatingCamera) return
+        isAnimatingCamera = true
         binding!!.mapView.controller.animateTo(geoPoint, zoom, speed)
+        isAnimatingCamera = false
     }
 
     override fun getLastMapFocus(): LatLng? = if (lastMapFocus == null) {

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.kt
@@ -95,7 +95,6 @@ class ExploreMapFragment : CommonsDaggerSupportFragment(), ExploreMapContract.Vi
     private var clickedMarker: BaseMarker? = null
     private var mapCenter: GeoPoint? = null
     private var lastMapFocus: GeoPoint? = null
-    private var isAnimatingCamera = false
     private var intentFilter: IntentFilter = IntentFilter(MapUtils.NETWORK_INTENT_ACTION)
     private var baseMarkerOverlayMap: MutableMap<BaseMarker?, Overlay?>? = null
     private var locationPermissionsHelper: LocationPermissionsHelper? = null
@@ -1023,10 +1022,8 @@ class ExploreMapFragment : CommonsDaggerSupportFragment(), ExploreMapContract.Vi
      * @param geoPoint The GeoPoint representing the new camera position for the map.
      */
     private fun moveCameraToPosition(geoPoint: GeoPoint?) {
-        if (isAnimatingCamera) return
-        isAnimatingCamera = true
+        if (binding!!.mapView.isAnimating) return
         binding!!.mapView.controller.animateTo(geoPoint)
-        isAnimatingCamera = false
     }
 
     /**
@@ -1038,10 +1035,8 @@ class ExploreMapFragment : CommonsDaggerSupportFragment(), ExploreMapContract.Vi
      * @param speed    Speed of animation
      */
     private fun moveCameraToPosition(geoPoint: GeoPoint?, zoom: Double, speed: Long) {
-        if (isAnimatingCamera) return
-        isAnimatingCamera = true
+        if (binding!!.mapView.isAnimating) return
         binding!!.mapView.controller.animateTo(geoPoint, zoom, speed)
-        isAnimatingCamera = false
     }
 
     override fun getLastMapFocus(): LatLng? = if (lastMapFocus == null) {


### PR DESCRIPTION
## Summary
- Fixes #6276
- Adds a re-entrancy guard (`isAnimatingCamera`) to both `moveCameraToPosition` overloads to prevent infinite recursion (`moveCameraToPosition → animateTo → onScroll → getLastMapFocus → getMapCenter → moveCameraToPosition`)
- Caches the `getLastMapFocus()` result in `onScroll` so it is called once per scroll event instead of four times, avoiding redundant KvStore I/O on the main thread

## Test plan
- [ ] Open Explore → Map, scroll around, verify "Search this area" button appears/disappears correctly
- [ ] Verify no ANR occurs during rapid map scrolling/zooming
- [ ] Build succeeds with `./gradlew assembleDebug`