### PR TITLE
fix: UninitializedPropertyAccessException in ImageFragment onDestroy

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/ImageFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/customselector/ui/selector/ImageFragment.kt
@@ -83,7 +83,7 @@ class ImageFragment :
     private var selectorRV: RecyclerView? = null
     private var loader: ProgressBar? = null
     private var switch: SwitchMaterial? = null
-    lateinit var filteredImages: ArrayList<Image>
+    private var filteredImages: ArrayList<Image> = arrayListOf()
 
     /**
      * Stores all images
@@ -402,7 +402,7 @@ class ImageFragment :
                 ?.findFirstVisibleItemPosition() ?: -1
 
         // check for valid position and non-empty image list
-        if (position != -1 && ::filteredImages.isInitialized && filteredImages.isNotEmpty() && ::imageAdapter.isInitialized) {
+        if (position != -1 && filteredImages.isNotEmpty() && ::imageAdapter.isInitialized) {
             context?.let { context ->
                 context
                     .getSharedPreferences(
@@ -416,8 +416,8 @@ class ImageFragment :
                     }
             }
         } else {
-            Timber.d("Skipped saving item ID: position=%d, filteredImages initialized=%b",
-                position, ::filteredImages.isInitialized)
+            Timber.d("Skipped saving item ID: position=%d, filteredImages.size=%d, imageAdapter initialized=%b",
+                position, filteredImages.size, ::imageAdapter.isInitialized)
         }
         super.onDestroy()
     }


### PR DESCRIPTION
**Description (required)**

Fixes #6660 

The app was crashing with a `kotlin.UninitializedPropertyAccessException` when a user pressed the "Back" button while images were still loading in the Custom Selector. 

**Changes made:**
* Added a `::filteredImages.isInitialized` check in the `onDestroy` method of `ImageFragment`.
* so, this ensures that the fragment only attempts to access the `filteredImages` and save the last visible item ID if the background loading process has successfully completed and initialized the property.

**Tests performed (required)**

Tested **ProDebug** on **Redmi Note 13 Pro** with **API level 35 (Android 15)**.

Followed the steps mentioned in the issue #6660, and verified that the app no more crashes and safely returns  to the custom selector after pressing back from the folder which i entereed.

**Screenshots (for UI changes only)**
N/A 