### PR TITLE
fix :  recycler view item's text alignment

### DIFF
--- a/app/src/main/res/layout/nearby_search_list_item.xml
+++ b/app/src/main/res/layout/nearby_search_list_item.xml
@@ -16,5 +16,9 @@
     <TextView
         android:id="@+id/place_text"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/tiny_margin"
+        android:layout_marginEnd="@dimen/tiny_margin"
+        android:layout_marginTop="@dimen/tiny_height"
+        android:paddingTop="@dimen/miniscule_margin"/>
 </LinearLayout>

--- a/app/src/main/res/layout/nearby_search_list_item_dark.xml
+++ b/app/src/main/res/layout/nearby_search_list_item_dark.xml
@@ -16,5 +16,9 @@
         android:id="@+id/place_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/tiny_margin"
+        android:layout_marginEnd="@dimen/tiny_margin"
+        android:layout_marginTop="@dimen/tiny_height"
+        android:paddingTop="@dimen/miniscule_margin"
         android:textColor="@color/white"/>
 </LinearLayout>


### PR DESCRIPTION

Fixes #6688


What changes did you make and why?
added necessary padding and margin to align the text of the recycler view item for better readability 

**Screenshots (for UI changes only)**

Dark mode : 

![Screenshot_2026-02-27-19-58-33-91_062c6066f629c24413cc8efde3bd9f38](https://github.com/user-attachments/assets/2b697f25-c9d9-4ac1-961b-4ab0439e4976)

Light mode :

![Screenshot_2026-02-27-19-58-47-60_062c6066f629c24413cc8efde3bd9f38](https://github.com/user-attachments/assets/1cdb6fca-9592-4b7e-89ed-5b2c35dc8c74)
