### PR TITLE
Docs: Fix broken link 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This software is open source, licensed under the [Apache License 2.0][10].
 
 [1]: https://play.google.com/store/apps/details?id=fr.free.nrw.commons
 [2]: https://commons-app.github.io/
-[3]: https://github.com/commons-app/apps-android-commons/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee+-label%3Adebated+label%3Abug+-label%3A%22low+priority%22+-label%3Aupstream
+[3]: https://github.com/commons-app/apps-android-commons/issues?q=is%3Aopen%20is%3Aissue%20no%3Aassignee%20-label%3Adebated%20type%3Abug%20-label%3A%22low%20priority%22%20-label%3Aupstream
 
 [4]: https://github.com/commons-app/commons-app-documentation/blob/master/android/README.md#-android-documentation
 [5]: https://github.com/commons-app/commons-app-documentation/blob/master/android/README.md#-user-documentation


### PR DESCRIPTION
After migrating from `label: bug` to `type: bug` in #6363, the link for “open issues” in the README was not updated, as it still used the old `label: bug` and displayed 0 open issues when opened. so, updated the link to use `type: bug`, and now the link in the README works correctly 🙂 