### PR TITLE
fix : keyboard flash

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
@@ -39,6 +39,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
+import androidx.core.view.doOnLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.lifecycle.lifecycleScope
@@ -883,11 +884,9 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
     fun initNearbyFilter() {
         binding!!.nearbyFilterList.root.visibility = View.GONE
         hideBottomSheet()
-        binding!!.nearbyFilter.searchViewLayout.searchView.apply {
-            setIconifiedByDefault(false)
-            isIconified = false
-            setQuery("", false)
-            clearFocus()
+        binding!!.nearbyFilter.searchViewLayout.searchView.doOnLayout {
+            binding!!.nearbyFilter.searchViewLayout.searchView.setIconifiedByDefault(false)
+            it.clearFocus()
         }
         binding!!.nearbyFilter.searchViewLayout.searchView.setOnQueryTextFocusChangeListener { v, hasFocus ->
             setLayoutHeightAlignedToWidth(

--- a/app/src/main/res/drawable/search_view_static_underline.xml
+++ b/app/src/main/res/drawable/search_view_static_underline.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">->
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+    <item android:gravity="bottom">
+        <shape android:shape="rectangle">
+            <solid android:color="#80C1C1C1" />
+            <size android:height="0.2dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/filter_search_view_layout.xml
+++ b/app/src/main/res/layout/filter_search_view_layout.xml
@@ -17,9 +17,11 @@
         android:id="@+id/search_view"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:tint="@color/white"
+      android:focusable="false"
+      android:focusableInTouchMode="false"
         android:queryHint="@string/nearby_search_hint"
         android:searchIcon="@drawable/ic_search_white_24dp"
-        app:theme="@style/WhiteSearchBarTheme"/>
+      android:tint="@color/white"
+      app:queryBackground="@drawable/search_view_static_underline" />
 
 </LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -146,9 +146,6 @@
         <item name="android:textColor">@color/primaryDarkColor</item>
     </style>
 
-    <style name="WhiteSearchBarTheme" parent="DarkAppTheme">
-        <item name="colorControlActivated">@android:color/white</item>
-    </style>
 
     <style name="DarkSpinnerTheme" parent="DarkAppTheme">
         <item name="colorControlNormal">#ffffff</item>


### PR DESCRIPTION
solves keyboard flashing on nearby launch which was happening as the search view input field was focused on initial layout of nearby

Fixes #6703

What changes did you make and why?
made the search view not get focused during initial launch of nearby fragment 

note : this is just a temporary workaround which forces it to use a custom static underline as the default one flashes due to initial layout focus issues in XML and will be perfectly solves when moved to jetpack compose 

@neeldoshii  is it too early / wrong just to move small element to compose ?? just asking )



before :

https://github.com/user-attachments/assets/b7a99313-615a-490e-a64d-859dae45cf6f


After :


https://github.com/user-attachments/assets/5cea0087-dfc4-4c28-ab3b-67caad254e1f



