### PR TITLE
fix :leaks  contribution fragment

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.kt
@@ -140,6 +140,14 @@ class ContributionController @Inject constructor(@param:Named("default_preferenc
             arrayOf(permission.ACCESS_FINE_LOCATION)
         )
     }
+    
+    /**
+    cleanup callback and helpers to avoid leaks
+     */
+    fun cleanup() {
+        locationPermissionCallback = null
+        locationPermissionsHelper = null
+    }
 
     /**
      * Shows a dialog alerting the user about location services being off and asking them to turn it

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsFragment.kt
@@ -753,6 +753,7 @@ class ContributionsFragment : CommonsDaggerSupportFragment(), FragmentManager.On
     }
 
     override fun onDestroyView() {
+        contributionController?.cleanup()
         super.onDestroyView()
         presenter!!.onDetachView()
     }
@@ -859,9 +860,10 @@ class ContributionsFragment : CommonsDaggerSupportFragment(), FragmentManager.On
                 binding!!.cardViewNearby.visibility = View.GONE
             }
             removeFragment(mediaDetailPagerFragment!!)
+            mediaDetailPagerFragment = null
             showFragment(
                 contributionsListFragment!!, CONTRIBUTION_LIST_FRAGMENT_TAG,
-                mediaDetailPagerFragment
+                null
             )
             if (isUserProfile) {
                 // Fragment is associated with ProfileActivity
@@ -965,8 +967,8 @@ class ContributionsFragment : CommonsDaggerSupportFragment(), FragmentManager.On
         if (mediaDetailPagerFragment != null && !contributionsListFragment!!.isVisible) {
             removeFragment(mediaDetailPagerFragment!!)
             mediaDetailPagerFragment = MediaDetailPagerFragment.newInstance(false, true)
-            mediaDetailPagerFragment?.showImage(index)
             showMediaDetailPagerFragment()
+            mediaDetailPagerFragment?.showImage(index)
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionsListFragment.kt
@@ -218,6 +218,8 @@ class ContributionsListFragment : CommonsDaggerSupportFragment(), ContributionsL
     }
 
     override fun onDestroyView() {
+        controller?.cleanup()
+        controller = null
         binding = null
         super.onDestroyView()
     }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.kt
@@ -19,7 +19,6 @@ import fr.free.nrw.commons.databinding.MainBinding
 import fr.free.nrw.commons.explore.ExploreFragment
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import fr.free.nrw.commons.location.LocationServiceManager
-import fr.free.nrw.commons.media.MediaDetailPagerFragment
 import fr.free.nrw.commons.navtab.MoreBottomSheetFragment
 import fr.free.nrw.commons.navtab.MoreBottomSheetLoggedOutFragment
 import fr.free.nrw.commons.navtab.NavTab
@@ -65,7 +64,6 @@ class MainActivity : BaseActivity(), FragmentManager.OnBackStackChangedListener 
     private var bookmarkFragment: BookmarkFragment? = null
     @JvmField
     var activeFragment: ActiveFragment? = null
-    private val mediaDetailPagerFragment: MediaDetailPagerFragment? = null
     var navListener: BottomNavigationView.OnNavigationItemSelectedListener? = null
         private set
 
@@ -195,15 +193,15 @@ after opening the app.
     private fun loadFragment(fragment: Fragment?, showBottom: Boolean): Boolean {
         //showBottom so that we do not show the bottom tray again when constructing
         //from the saved instance state.
+        if (fragment is ContributionsFragment && activeFragment == ActiveFragment.CONTRIBUTIONS) {
+            // scroll to top if already on the Contributions tab
+            contributionsFragment?.scrollToTop()
+            return true
+        }
 
         freeUpFragments();
 
         if (fragment is ContributionsFragment) {
-            if (activeFragment == ActiveFragment.CONTRIBUTIONS) {
-                // scroll to top if already on the Contributions tab
-                contributionsFragment!!.scrollToTop()
-                return true
-            }
             contributionsFragment = fragment
             activeFragment = ActiveFragment.CONTRIBUTIONS
         } else if (fragment is NearbyParentFragment) {
@@ -271,8 +269,7 @@ after opening the app.
      * Called in loadFragment() before doing the actual loading.
      */
     fun freeUpFragments() {
-        // free all fragments except contributionsFragment because several tests depend on it.
-        // hence, contributionsFragment is probably still a leak
+        contributionsFragment = null
         nearbyParentFragment = null
         exploreFragment = null
         bookmarkFragment = null


### PR DESCRIPTION
follow up for #6705

Fixes #6692 

What changes did you make and why?
 ContributionController.kt 
*  Added a cleanup() method to nullify locationPermissionCallback and locationPermissionsHelper

ContributionsFragment.kt   
* Calls the cleanup method contributionController?.cleanup() in onDestroyView()
* Added cleanup logic to nullify mediaDetailPagerFragment to prevent leaking it when removed

 ContributionsListFragment.k


* Nullifies controller as the leak persisted when tab switching

MainActivity.kt
* In freeUpFragments(), nullifies contributionsFragment which was previously left out causing a leak
* Updated loadFragment to reuse contributionsFragment  without leaking it

**Screenshots (for UI changes only)**
![Screenshot_2026-03-09-19-28-42-31_062c6066f629c24413cc8efde3bd9f38](https://github.com/user-attachments/assets/36817d57-3c20-41c5-9969-98287a6a378b)
![Screenshot_2026-03-09-19-28-55-15_062c6066f629c24413cc8efde3bd9f38](https://github.com/user-attachments/assets/59294c0a-5ad8-443a-9747-f5a2f072521e)



