### PR TITLE
fix : paging and explore map leaks

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/ExploreListRootFragment.kt
@@ -175,8 +175,7 @@ class ExploreListRootFragment : CommonsDaggerSupportFragment, MediaDetailProvide
     }
 
     override fun onDestroy() {
-        super.onDestroy()
-
         binding = null
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/map/ExploreMapFragment.kt
@@ -273,6 +273,12 @@ class ExploreMapFragment : CommonsDaggerSupportFragment(), ExploreMapContract.Vi
         // removed tha permission check here to prevent it from running on fragment creation
     }
 
+    override fun onDestroyView() {
+        presenter?.detachView()
+        binding = null
+        super.onDestroyView()
+    }
+
     override fun onResume() {
         super.onResume()
         binding!!.mapView.onResume()

--- a/app/src/main/java/fr/free/nrw/commons/explore/paging/BasePagingFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/paging/BasePagingFragment.kt
@@ -25,19 +25,20 @@ abstract class BasePagingFragment<T> :
     abstract val pagedListAdapter: PagedListAdapter<T, *>
     abstract val injectedPresenter: PagingContract.Presenter<T>
     abstract val errorTextId: Int
-    private val loadingAdapter by lazy { FooterAdapter { injectedPresenter.retryFailedRequest() } }
-    private val mergeAdapter by lazy { MergeAdapter(pagedListAdapter, loadingAdapter) }
+    private var loadingAdapter: FooterAdapter? = null
+    private var mergeAdapter: MergeAdapter? = null
     private var searchResults: LiveData<PagedList<T>>? = null
+    private var _binding: FragmentSearchPaginatedBinding? = null
 
-    protected lateinit var binding: FragmentSearchPaginatedBinding
+    val binding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View? {
-        binding = FragmentSearchPaginatedBinding.inflate(inflater, container, false)
-        return binding.root
+        _binding = FragmentSearchPaginatedBinding.inflate(inflater, container, false)
+        return _binding?.root
     }
 
     override fun onViewCreated(
@@ -45,15 +46,14 @@ abstract class BasePagingFragment<T> :
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        loadingAdapter = FooterAdapter { injectedPresenter.retryFailedRequest() }
+        mergeAdapter = MergeAdapter(pagedListAdapter, loadingAdapter!!)
 
-        binding.paginatedSearchResultsList.apply {
-            layoutManager = GridLayoutManager(context, if (isPortrait) 1 else 2)
-            adapter = mergeAdapter
+        binding.paginatedSearchResultsList.adapter = mergeAdapter
+
+        injectedPresenter.listFooterData.observe(viewLifecycleOwner) { data ->
+            loadingAdapter?.submitList(data)
         }
-        injectedPresenter.listFooterData.observe(
-            viewLifecycleOwner,
-            Observer(loadingAdapter::submitList),
-        )
     }
 
     /**
@@ -85,6 +85,14 @@ abstract class BasePagingFragment<T> :
     override fun onDetach() {
         super.onDetach()
         injectedPresenter.onDetachView()
+    }
+
+    override fun onDestroyView() {
+        binding.paginatedSearchResultsList.adapter = null
+        loadingAdapter = null
+        mergeAdapter = null
+        _binding = null
+        super.onDestroyView()
     }
 
     override fun hideInitialLoadProgress() {


### PR DESCRIPTION

follow up for #6705

What changes did you make and why?

ExploreMapFragment.kt
* Added onDestroyView() for cleanup 

ExploreListRootFragment.kt
* Nullifies binding in onDestroy() 

 BasePagingFragment.kt
* made sure loadingAdapter and mergeAdapter are nullable
* Nullifies adapters and _binding in onDestroyView() to prevent leaking of Recycler View and adapters

**Screenshots (for UI changes only)**

![Screenshot_2026-03-09-20-10-05-03_062c6066f629c24413cc8efde3bd9f38](https://github.com/user-attachments/assets/9d18b9af-8538-4973-ae7d-2b259412c974)
![Screenshot_2026-03-09-20-10-29-99_062c6066f629c24413cc8efde3bd9f38](https://github.com/user-attachments/assets/5b99ef13-0798-4bfb-8480-0df0966941ee)
