### PR TITLE
fix : Upload MediaDetail Leaks

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadPresenter.kt
@@ -204,6 +204,7 @@ class UploadPresenter @Inject internal constructor(
         view = DUMMY
         compositeDisposable.clear()
         repository.cleanup()
+        basicKvStoreFactory = null
     }
 
     companion object {

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.kt
@@ -900,6 +900,9 @@ class UploadMediaDetailFragment : UploadBaseFragment(), UploadMediaDetailsContra
     }
 
     override fun onDestroyView() {
+        presenterCallback = null
+        fragmentCallback = null
+        _binding = null
         super.onDestroyView()
         presenter.onDetachView()
     }

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.kt
@@ -60,6 +60,7 @@ class UploadMediaPresenter @Inject constructor(
     override fun onDetachView() {
         view = DUMMY
         compositeDisposable.clear()
+        basicKvStoreFactory = null
     }
 
     /**


### PR DESCRIPTION

Follow up for #6705

What changes did you make and why?

UploadMediaDetailFragment.kt
* Nullifies presenterCallback, fragmentCallback, and _binding in onDestroyView().

UploadPresenter.kt
* Nullifies basicKvStoreFactory in onDetachView().

UploadMediaPresenter.kt
* Nullifies basicKvStoreFactory in onDetachView().

**Screenshots (for UI changes only)**
![Screenshot_2026-03-09-20-26-05-57_062c6066f629c24413cc8efde3bd9f38](https://github.com/user-attachments/assets/1578a90b-3c9c-4535-b6b1-6e5ae6a449f2)


