### PR TITLE
fix : NearbyParentFragment Leaks

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
@@ -820,7 +820,6 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
         searchRunnable?.let {
             searchHandler.removeCallbacks(it)
         } ?: run {
@@ -831,6 +830,8 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
         if (applicationKvStore == null) Timber.w("NearbyParentFragment: applicationKvStore is null")
 
         presenter?.removeNearbyPreferences(applicationKvStore ?: return)
+        binding = null
+        super.onDestroyView()
     }
 
     private fun initViews() {


### PR DESCRIPTION
Follow up for #6705 

What changes did you make and why?

NearbyParentFragment.kt
* Nullifies binding in onDestroyView().

**Screenshots (for UI changes only)**

![Screenshot_2026-03-09-21-21-03-49_d5db3f3edc380047609fe9c266f7c566](https://github.com/user-attachments/assets/b0cd6060-068f-477b-8919-8005420d54be)


