### PR TITLE
Fix Parcelable unparceling order in Place

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
@@ -95,6 +95,16 @@ public class Place implements Parcelable {
         this.entityID = entityID;
     }
 
+
+    /**
+     * Reconstructs a Place object from a Parcel.
+     *
+     * IMPORTANT: The fields must be read in the exact same order in which they
+     * are written in writeToParcel(). Changing the order will lead to incorrect
+     * or failed deserialization of the object.
+     *
+     * @param in Parcel containing the serialized Place data
+     */
     public Place(Parcel in) {
         this.language = in.readString();
         this.name = in.readString();
@@ -105,10 +115,11 @@ public class Place implements Parcelable {
         this.siteLinks = in.readParcelable(Sitelinks.class.getClassLoader());
         String picString = in.readString();
         this.pic = (picString == null) ? "" : picString;
+        this.entityID = in.readString();
         String existString = in.readString();
         this.exists = Boolean.parseBoolean(existString);
         this.isMonument = in.readInt() == 1;
-        this.entityID = in.readString();
+
     }
 
     public static Place from(NearbyResultItem item) {


### PR DESCRIPTION
Related to #5073.

Ensure fields in the Parcel constructor are read in the same order as they are written in `writeToParcel()`.

Previously, the read order did not match the write order, which caused runtime unparceling errors such as:

"consumed X bytes but Y expected"

This PR updates the Parcel constructor in `Place.java` so that fields are read in the exact order they are written, ensuring correct reconstruction of the `Place` object when passed between Android components.

This issue was discovered while investigating #5073.