### PR TITLE
fix: correct Parcelable read order in Place constructor

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
@@ -95,21 +95,32 @@ public class Place implements Parcelable {
         this.entityID = entityID;
     }
 
-    public Place(Parcel in) {
-        this.language = in.readString();
-        this.name = in.readString();
-        this.label = (Label) in.readSerializable();
-        this.longDescription = in.readString();
-        this.location = in.readParcelable(LatLng.class.getClassLoader());
-        this.category = in.readString();
-        this.siteLinks = in.readParcelable(Sitelinks.class.getClassLoader());
-        String picString = in.readString();
-        this.pic = (picString == null) ? "" : picString;
-        String existString = in.readString();
-        this.exists = Boolean.parseBoolean(existString);
-        this.isMonument = in.readInt() == 1;
-        this.entityID = in.readString();
-    }
+    /**
+ * Constructor used when recreating the object from a Parcel.
+ *
+ * IMPORTANT: The order of reading fields here MUST match exactly the
+ * order used in writeToParcel(). Changing the order will corrupt the
+ * deserialized object and may cause runtime errors.
+ */
+public Place(Parcel in) {
+    this.language = in.readString();
+    this.name = in.readString();
+    this.label = (Label) in.readSerializable();
+    this.longDescription = in.readString();
+    this.location = in.readParcelable(LatLng.class.getClassLoader());
+    this.category = in.readString();
+    this.siteLinks = in.readParcelable(Sitelinks.class.getClassLoader());
+
+    String picString = in.readString();
+    this.pic = (picString == null) ? "" : picString;
+
+    this.entityID = in.readString();
+
+    String existString = in.readString();
+    this.exists = Boolean.parseBoolean(existString);
+
+    this.isMonument = in.readInt() == 1;
+}
 
     public static Place from(NearbyResultItem item) {
         String itemClass = item.getClassName().getValue();


### PR DESCRIPTION
Fixes #6727

This change reorders the fields in the `Place(Parcel in)` constructor to match
the order used in `writeToParcel()`. Additionally, a comment has been added
above the constructor to explicitly document that the read and write order
must remain identical to prevent parcel corruption.

The read order in `Place(Parcel in)` did not match the write order used in
`writeToParcel()`. Since Parcelable requires fields to be read in the exact
same order as they are written, this mismatch could lead to incorrect
deserialization of `Place` objects.

Tested ProdDebug build on Android Emulator (Pixel 5) with API level 33.
