### PR TITLE
Fix #6727: Correct Parcelable serialization order in Place

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/Place.java
@@ -95,6 +95,15 @@ public class Place implements Parcelable {
         this.entityID = entityID;
     }
 
+    /**
+     * Reconstructs a Place object from a Parcel.
+     *
+     * IMPORTANT: The fields must be read in the exact same order in which they
+     * are written in writeToParcel(). Changing the order will lead to incorrect
+     * or failed deserialization of the object.
+     *
+     * @param in Parcel containing the serialized Place data
+     */
     public Place(Parcel in) {
         this.language = in.readString();
         this.name = in.readString();
@@ -105,10 +114,10 @@ public class Place implements Parcelable {
         this.siteLinks = in.readParcelable(Sitelinks.class.getClassLoader());
         String picString = in.readString();
         this.pic = (picString == null) ? "" : picString;
+        this.entityID = in.readString();
         String existString = in.readString();
         this.exists = Boolean.parseBoolean(existString);
         this.isMonument = in.readInt() == 1;
-        this.entityID = in.readString();
     }
 
     public static Place from(NearbyResultItem item) {


### PR DESCRIPTION
Fixes #6727


Corrected the order of fields in writeToParcel() and the Parcel constructor in the Place class and added a  Javadoc comment to clarify that the read/write order must match. Previously, mismatched order caused deserialization errors and Parcelable size mismatch.

Tested ProdDebug on a Pixel 5 emulator with API level 33. Verified that unparcelling Place objects no longer throws errors.


