### PR TITLE
Fix keyboard covering screen after rotation on Nearby screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -125,7 +125,7 @@
       android:name=".contributions.MainActivity"
       android:configChanges="screenSize|keyboard|orientation"
       android:icon="@mipmap/ic_launcher"
-      />
+      android:windowSoftInputMode="adjustResize" />
     <activity
       android:name=".settings.SettingsActivity"
       android:label="@string/title_activity_settings" />

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
@@ -29,6 +29,7 @@ import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.animation.Animation
+import android.view.inputmethod.EditorInfo
 import android.view.animation.AnimationUtils
 import android.widget.Toast
 import androidx.activity.result.ActivityResult
@@ -888,6 +889,8 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
             isIconified = false
             setQuery("", false)
             clearFocus()
+
+            imeOptions = imeOptions or EditorInfo.IME_FLAG_NO_EXTRACT_UI
         }
         binding!!.nearbyFilter.searchViewLayout.searchView.setOnQueryTextFocusChangeListener { v, hasFocus ->
             setLayoutHeightAlignedToWidth(


### PR DESCRIPTION
**Description (required)**

Fixes #6701 
Resolves an issue where the keyboard covered most of the screen in landscape mode on the Nearby screen

Tested 6.3.0-debug on Pixel 9 (Android 16)

**Screenshots (for UI changes only)**
Before
![b](https://github.com/user-attachments/assets/d40aa961-e7c1-4eff-82c0-df2152d96ee7)
After
![a](https://github.com/user-attachments/assets/b6b4ab75-dcca-4ba5-b6a0-3b6096a28a79)
The text entered by the user is now visible 