### PR TITLE
Fixing the initialisation issues of `categoryImagesCallback` due to `CategoryDetailsActivity`, `WikidataItemDetailsActivity` not using reformed fragments

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.kt
@@ -85,9 +85,23 @@ class CategoryDetailsActivity : BaseActivity(),
      * Set the fragments according to the tab selected in the viewPager.
      */
     private fun setTabs() {
-        categoriesMediaFragment = CategoriesMediaFragment()
-        val subCategoryListFragment = SubCategoriesFragment()
-        val parentCategoriesFragment = ParentCategoriesFragment()
+        // Either load the fragments (of viewPager) from the saved state, or create new ones
+        // Use depictedImagesListFragment as a field for later access.
+        // -> firstOrNull, as we expect 1 if there is state, or 0 otherwise
+        val fragments = supportFragmentManager.fragments
+        categoriesMediaFragment = fragments
+            .filterIsInstance<CategoriesMediaFragment>()
+            .firstOrNull()
+            ?: CategoriesMediaFragment()
+        val subCategoryListFragment = fragments
+            .filterIsInstance<SubCategoriesFragment>()
+            .firstOrNull()
+            ?: SubCategoriesFragment()
+        val parentCategoriesFragment = fragments
+            .filterIsInstance<ParentCategoriesFragment>()
+            .firstOrNull()
+            ?: ParentCategoriesFragment()
+
         categoryName = intent?.getStringExtra("categoryName")
         if (intent != null && categoryName != null) {
             val arguments = Bundle().apply {

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.kt
@@ -107,9 +107,17 @@ class CategoryDetailsActivity : BaseActivity(),
             val arguments = Bundle().apply {
                 putString("categoryName", categoryName)
             }
-            categoriesMediaFragment.arguments = arguments
-            subCategoryListFragment.arguments = arguments
-            parentCategoriesFragment.arguments = arguments
+
+            // Only set the arguments if the fragments are freshly made -- don't set if loaded from
+            // the fragment manager. The arguments will be null only if created from a new instance.
+            // This prevents the IllegalStateException "Fragment already added and state has been
+            // saved"  (per the LLM peer review bot).
+            if (categoriesMediaFragment.arguments == null)
+                categoriesMediaFragment.arguments = arguments
+            if (subCategoryListFragment.arguments == null)
+                subCategoryListFragment.arguments = arguments
+            if (parentCategoriesFragment.arguments == null)
+                parentCategoriesFragment.arguments = arguments
 
             viewModel.onCheckIfBookmarked(categoryName!!)
         }

--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.kt
@@ -85,9 +85,23 @@ class CategoryDetailsActivity : BaseActivity(),
      * Set the fragments according to the tab selected in the viewPager.
      */
     private fun setTabs() {
-        categoriesMediaFragment = CategoriesMediaFragment()
-        val subCategoryListFragment = SubCategoriesFragment()
-        val parentCategoriesFragment = ParentCategoriesFragment()
+        // Either load the fragments (of viewPager) from the saved state, or create new ones
+        // Use categoriesMediaFragment as a field for later access.
+        // -> firstOrNull, as we expect 1 if there is state, or 0 otherwise
+        val fragments = supportFragmentManager.fragments
+        categoriesMediaFragment = fragments
+            .filterIsInstance<CategoriesMediaFragment>()
+            .firstOrNull()
+            ?: CategoriesMediaFragment()
+        val subCategoryListFragment = fragments
+            .filterIsInstance<SubCategoriesFragment>()
+            .firstOrNull()
+            ?: SubCategoriesFragment()
+        val parentCategoriesFragment = fragments
+            .filterIsInstance<ParentCategoriesFragment>()
+            .firstOrNull()
+            ?: ParentCategoriesFragment()
+
         categoryName = intent?.getStringExtra("categoryName")
         if (intent != null && categoryName != null) {
             val arguments = Bundle().apply {

--- a/app/src/main/java/fr/free/nrw/commons/explore/depictions/WikidataItemDetailsActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/depictions/WikidataItemDetailsActivity.kt
@@ -119,9 +119,17 @@ class WikidataItemDetailsActivity : BaseActivity(), MediaDetailProvider, Categor
                 "wikidataItemName" to wikidataItemName,
                 "entityId" to entityId
             )
-            depictedImagesListFragment!!.arguments = arguments
-            parentDepictionsFragment.arguments = arguments
-            childDepictionsFragment.arguments = arguments
+
+            // Only set the arguments if the fragments are freshly made -- don't set if loaded from
+            // the fragment manager. The arguments will be null only if created from a new instance.
+            // This prevents the IllegalStateException "Fragment already added and state has been
+            // saved"  (per the LLM peer review bot).
+            if (depictedImagesListFragment!!.arguments == null)
+                depictedImagesListFragment!!.arguments = arguments
+            if (parentDepictionsFragment.arguments == null)
+                parentDepictionsFragment.arguments = arguments
+            if (childDepictionsFragment.arguments == null)
+                childDepictionsFragment.arguments = arguments
         }
 
         viewPagerAdapter!!.setTabs(

--- a/app/src/main/java/fr/free/nrw/commons/explore/depictions/WikidataItemDetailsActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/depictions/WikidataItemDetailsActivity.kt
@@ -45,7 +45,7 @@ class WikidataItemDetailsActivity : BaseActivity(), MediaDetailProvider, Categor
     var depictModel: DepictModel? = null
 
     private var supportFragmentManager: FragmentManager? = null
-    private var depictionImagesListFragment: DepictedImagesFragment? = null
+    private var depictedImagesListFragment: DepictedImagesFragment? = null
     private var mediaDetailPagerFragment: MediaDetailPagerFragment? = null
     private var binding: ActivityWikidataItemDetailsBinding? = null
 
@@ -95,9 +95,23 @@ class WikidataItemDetailsActivity : BaseActivity(), MediaDetailProvider, Categor
      * Set the fragments according to the tab selected in the viewPager.
      */
     private fun setTabs() {
-        depictionImagesListFragment = DepictedImagesFragment()
-        val childDepictionsFragment = ChildDepictionsFragment()
-        val parentDepictionsFragment = ParentDepictionsFragment()
+        // Either load the fragments (of viewPager) from the saved state, or create new ones
+        // Use depictedImagesListFragment as a field for later access.
+        // -> firstOrNull, as we expect 1 if there is state, or 0 otherwise
+        val fragments = supportFragmentManager!!.fragments
+        depictedImagesListFragment = fragments
+            .filterIsInstance<DepictedImagesFragment>()
+            .firstOrNull()
+            ?: DepictedImagesFragment()
+        val childDepictionsFragment = fragments
+            .filterIsInstance<ChildDepictionsFragment>()
+            .firstOrNull()
+            ?: ChildDepictionsFragment()
+        val parentDepictionsFragment = fragments
+            .filterIsInstance<ParentDepictionsFragment>()
+            .firstOrNull()
+            ?: ParentDepictionsFragment()
+
         val wikidataItemName = intent.getStringExtra("wikidataItemName")
         val entityId = intent.getStringExtra("entityId")
         if (intent != null && wikidataItemName != null) {
@@ -105,13 +119,13 @@ class WikidataItemDetailsActivity : BaseActivity(), MediaDetailProvider, Categor
                 "wikidataItemName" to wikidataItemName,
                 "entityId" to entityId
             )
-            depictionImagesListFragment!!.arguments = arguments
+            depictedImagesListFragment!!.arguments = arguments
             parentDepictionsFragment.arguments = arguments
             childDepictionsFragment.arguments = arguments
         }
 
         viewPagerAdapter!!.setTabs(
-            R.string.title_for_media to depictionImagesListFragment!!,
+            R.string.title_for_media to depictedImagesListFragment!!,
             R.string.title_for_child_classes to childDepictionsFragment,
             R.string.title_for_parent_classes to parentDepictionsFragment
         )
@@ -148,7 +162,7 @@ class WikidataItemDetailsActivity : BaseActivity(), MediaDetailProvider, Categor
      * @return Media Object
      */
     override fun getMediaAtPosition(i: Int): Media? {
-        return depictionImagesListFragment!!.getMediaAtPosition(i)
+        return depictedImagesListFragment!!.getMediaAtPosition(i)
     }
 
     /**
@@ -169,7 +183,7 @@ class WikidataItemDetailsActivity : BaseActivity(), MediaDetailProvider, Categor
      * The viewpager will contain same number of media items as that of media elements in adapter.
      * @return Total Media count in the adapter
      */
-    override fun getTotalMediaCount(): Int = depictionImagesListFragment!!.getTotalMediaCount()
+    override fun getTotalMediaCount(): Int = depictedImagesListFragment!!.getTotalMediaCount()
 
     override fun getContributionStateAt(position: Int): Int? = null
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/explore/depictions/WikidataItemDetailsActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/explore/depictions/WikidataItemDetailsActivityUnitTests.kt
@@ -35,7 +35,7 @@ class WikidataItemDetailsActivityUnitTests {
     private lateinit var mediaDetailPagerFragment: MediaDetailPagerFragment
 
     @Mock
-    private lateinit var depictionImagesListFragment: DepictedImagesFragment
+    private lateinit var depictedImagesListFragment: DepictedImagesFragment
 
     @Mock
     private lateinit var supportFragmentManager: FragmentManager
@@ -65,8 +65,8 @@ class WikidataItemDetailsActivityUnitTests {
         Whitebox.setInternalState(activity, "mediaDetailPagerFragment", mediaDetailPagerFragment)
         Whitebox.setInternalState(
             activity,
-            "depictionImagesListFragment",
-            depictionImagesListFragment,
+            "depictedImagesListFragment",
+            depictedImagesListFragment,
         )
         Whitebox.setInternalState(activity, "supportFragmentManager", supportFragmentManager)
 


### PR DESCRIPTION
**Description**

Fixes #6358 

_"What changes did you make and why?"_:
Inside the `setTabs` function (called through `onCreate`) of both `*DetailsActivity` classes, I switched from initialising the fragments directly
```kt
depictedImagesListFragment = DepictedImagesFragment()
// ...
```
to only initialising if the fragment is currently not in the `supportFragmentManager`, meaning that it was not yet created/loaded in the current lifecycle:
```kt
depictedImagesListFragment = fragments
    .filterIsInstance<DepictedImagesFragment>()
    .firstOrNull()
    ?: DepictedImagesFragment()
```

This is because during the reformation of the fragments and activities after a theme switch, the fragments apparently get loaded _first_, meaning that in the default behaviour, the loaded (and initialised) instances would be overwritten by one which does not load before being queried for the `categoryImagesCallback`. When this occurs, however, the fragments are already present as children inside the `supportFragmentManager`, meaning we can pull them out. I'll explain further in the discussion of issue #6358 to leave a breadcrumb trail for anyone encountering this issue again.

I deemed the `filterIsInstance` method as the most elegant method of pulling these children out of the manager. Other methods would be to index `fragments[i]` (children seem to always be in the same order they were added) or use the find by tag function, looking for "android:switcher:{viewPage id}:{i}", in accordance to [this undocumented behaviour](https://github.com/androidx/androidx/blob/androidx-main/fragment/fragment/src/main/java/androidx/fragment/app/FragmentPagerAdapter.java#L284).

Furthermore, I also renamed the variable `depictionImagesListFragment` to `depictedImagesListFragment`, in accordance to its class, `DepictedImagesFragment`.

PS: that weird little merge in the commit history is because a typo I wanted to amend, but my IDE turned into into a merge hiccup :(

**Tests performed**

As per the issue description, I tested this non-automatically on the Pixel 9 Pro emulator, running API 36.

I have tested the following scenarios:
- Click on an image that you have submitted, click on a category, then switch dark mode in the menu and click any of the items in the list. No longer crashes.
- Click on an image from the 'Explore' tab, click on a category, then switch dark mode in the menu and click any of the items in the list. No longer crashes.
- On an image from the 'Explore' tab, click on an item listed next to 'Depictions', then switch dark mode in the menu and click any of the items in the list. No longer crashes.