### PR TITLE
fix nearby filter recycler view not rendering proper items

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFilterSearchRecyclerViewAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/NearbyFilterSearchRecyclerViewAdapter.java
@@ -128,7 +128,7 @@ public class NearbyFilterSearchRecyclerViewAdapter
                     for (Label label : labels) {
                         String data = label.toString();
                         if (data.toLowerCase(Locale.ROOT).startsWith(constraint.toString())) {
-                            filteredArrayList.add(Label.fromText(label.getText()));
+                            filteredArrayList.add(label);
                         }
                     }
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
@@ -1057,7 +1057,7 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { query: CharSequence ->
                     (binding!!.nearbyFilterList.searchListView.adapter as NearbyFilterSearchRecyclerViewAdapter).filter
-                        .filter(query.toString())
+                        .filter(query)
                 })
     }
 


### PR DESCRIPTION
**Description (required)**

Fixes proper rendering of filter items

What changes did you make and why?
filtered array list gets label directly instead of getting it form .fromtext

@nicolas-raoul  this was left of form the subclass implementation )

**Screenshots (for UI changes only)**

Before :

https://github.com/user-attachments/assets/3a549a60-ad6b-4d19-b158-c3a7e93d076a

After :
![Screenshot_2026-03-18-02-24-48-74_062c6066f629c24413cc8efde3bd9f38](https://github.com/user-attachments/assets/b46a96d0-3ff9-48b6-8582-a5dd7502fde8)


