### PR TITLE
Fix 5144 HEIC files

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.kt
@@ -407,7 +407,8 @@ object FilePicker : Constants {
         return if (extension == "heic" || extension == "heif") {
             AlertDialog.Builder(activity)
                 .setTitle("Unsupported format")
-                .setMessage("This image type isn't supported and will be converted to JPG.")
+                .setMessage("The image type previously selected " +
+                        "was not supported and has been converted to JPG.")
                 .setPositiveButton("OK") { dialog, _ ->
                     dialog.dismiss()
                 }

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.kt
@@ -15,6 +15,12 @@ import fr.free.nrw.commons.filepicker.PickedFiles.singleFileList
 import java.io.File
 import java.io.IOException
 import java.net.URISyntaxException
+import android.graphics.Bitmap
+import android.graphics.ImageDecoder
+import android.os.Build
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import java.io.FileOutputStream
 
 
 object FilePicker : Constants {
@@ -52,7 +58,7 @@ object FilePicker : Constants {
     ): Intent {
         // storing picked image type to shared preferences
         storeType(context, type)
-        // Supported types are SVG, PNG and JPEG, GIF, TIFF, WebP, XCF
+        // Supported types are SVG, PNG and JPEG, GIF, TIFF, WebP, XCF and HEIC (for future conversion)
         val mimeTypes = arrayOf(
             "image/jpg",
             "image/png",
@@ -62,7 +68,8 @@ object FilePicker : Constants {
             "image/webp",
             "image/xcf",
             "image/svg+xml",
-            "image/webp"
+            "image/heic",
+            "image/heif"
         )
         return plainGalleryPickerIntent(openDocumentIntentPreferred)
             .putExtra(
@@ -379,6 +386,39 @@ object FilePicker : Constants {
             callbacks.onCanceled(ImageSource.GALLERY, restoreType(activity))
         }
     }
+    @JvmStatic
+    fun convertHeicToJpg(file: File, context: Context): File {
+        val bitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val source = ImageDecoder.createSource(context.contentResolver, Uri.fromFile(file))
+            ImageDecoder.decodeBitmap(source)
+        } else {
+            throw IllegalStateException("HEIC conversion requires Android P+")
+        }
+
+        val jpgFile = File(file.parent, file.nameWithoutExtension + ".jpg")
+        FileOutputStream(jpgFile).use { out ->
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, out)
+        }
+        return jpgFile
+    }
+    @JvmStatic
+    private fun handleHeicFile(file: UploadableFile, activity: Activity): UploadableFile {
+        val extension = file.file.extension.lowercase()
+        return if (extension == "heic" || extension == "heif") {
+            AlertDialog.Builder(activity)
+                .setTitle("Unsupported format")
+                .setMessage("This image type isn't supported and will be converted to JPG.")
+                .setPositiveButton("OK") { dialog, _ ->
+                    dialog.dismiss()
+                }
+                .show()
+
+            val jpgFile = convertHeicToJpg(file.file, activity)
+            UploadableFile(jpgFile)
+        } else {
+            file
+        }
+    }
 
     @Throws(IOException::class, SecurityException::class)
     @JvmStatic
@@ -390,7 +430,8 @@ object FilePicker : Constants {
         val clipData = data?.clipData
         if (clipData == null) {
             val uri = data?.data
-            val file = PickedFiles.pickedExistingPicture(activity, uri!!)
+            var file = PickedFiles.pickedExistingPicture(activity, uri!!)
+            file = handleHeicFile(file, activity)
             files.add(file)
         } else {
             for (i in 0 until clipData.itemCount) {

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.kt
@@ -356,7 +356,8 @@ object FilePicker : Constants {
         val images = data?.getParcelableArrayListExtra<Image>("Images")
         images?.forEach { image ->
             val uri = image.uri
-            val file = PickedFiles.pickedExistingPicture(activity, uri)
+            var file = PickedFiles.pickedExistingPicture(activity, uri)
+            file = handleHeicFile(file, activity)
             files.add(file)
         }
 
@@ -405,17 +406,10 @@ object FilePicker : Constants {
     private fun handleHeicFile(file: UploadableFile, activity: Activity): UploadableFile {
         val extension = file.file.extension.lowercase()
         return if (extension == "heic" || extension == "heif") {
-            AlertDialog.Builder(activity)
-                .setTitle("Unsupported format")
-                .setMessage("The image type previously selected " +
-                        "was not supported and has been converted to JPG.")
-                .setPositiveButton("OK") { dialog, _ ->
-                    dialog.dismiss()
-                }
-                .show()
-
             val jpgFile = convertHeicToJpg(file.file, activity)
-            UploadableFile(jpgFile)
+            val uploadableFile = UploadableFile(jpgFile)
+            uploadableFile.hasUnsupportedFormat = true
+            uploadableFile
         } else {
             file
         }
@@ -437,7 +431,8 @@ object FilePicker : Constants {
         } else {
             for (i in 0 until clipData.itemCount) {
                 val uri = clipData.getItemAt(i).uri
-                val file = PickedFiles.pickedExistingPicture(activity, uri)
+                var file = PickedFiles.pickedExistingPicture(activity, uri)
+                file = handleHeicFile(file, activity)
                 files.add(file)
             }
         }

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.kt
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.kt
@@ -20,6 +20,7 @@ class UploadableFile : Parcelable {
 
     val contentUri: Uri
     val file: File
+    var hasUnsupportedFormat: Boolean = false
 
     constructor(contentUri: Uri, file: File) {
         this.contentUri = contentUri
@@ -34,6 +35,7 @@ class UploadableFile : Parcelable {
     private constructor(parcel: Parcel) {
         contentUri = parcel.readParcelable(Uri::class.java.classLoader)!!
         file = parcel.readSerializable() as File
+        hasUnsupportedFormat = parcel.readInt() == 1
     }
 
     fun getFilePath(): String {
@@ -126,6 +128,7 @@ class UploadableFile : Parcelable {
     override fun writeToParcel(parcel: Parcel, flags: Int) {
         parcel.writeParcelable(contentUri, flags)
         parcel.writeSerializable(file)
+        parcel.writeInt(if (hasUnsupportedFormat) 1 else 0)
     }
 
     class DateTimeWithSource {

--- a/app/src/main/java/fr/free/nrw/commons/upload/ImageProcessingService.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ImageProcessingService.kt
@@ -59,11 +59,12 @@ class ImageProcessingService @Inject constructor(
             checkFBMD(filePath),
             checkEXIF(filePath)
         ) { duplicateImage: Int, wrongGeoLocation: Int, darkImage: Int, fbmd: Int, exif: Int ->
+            val unsupportedFormatResult = if (uploadItem.hasUnsupportedFormat) fr.free.nrw.commons.utils.ImageUtils.IMAGE_FORMAT_UNSUPPORTED else 0
             Timber.d(
-                "duplicate: %d, geo: %d, dark: %d, fbmd: %d, exif: %d",
-                duplicateImage, wrongGeoLocation, darkImage, fbmd, exif
+                "duplicate: %d, geo: %d, dark: %d, fbmd: %d, exif: %d, unsupported: %d",
+                duplicateImage, wrongGeoLocation, darkImage, fbmd, exif, unsupportedFormatResult
             )
-            return@zip duplicateImage or wrongGeoLocation or darkImage or fbmd or exif
+            return@zip duplicateImage or wrongGeoLocation or darkImage or fbmd or exif or unsupportedFormatResult
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadItem.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadItem.kt
@@ -19,7 +19,8 @@ class UploadItem(
      */
     var contentUri: Uri?,
     //according to EXIF data
-    val fileCreatedDateString: String?
+    val fileCreatedDateString: String?,
+    val hasUnsupportedFormat: Boolean = false
 ) {
     var imageQuality: Int = ImageUtils.IMAGE_WAIT
     var uploadMediaDetails: MutableList<UploadMediaDetail> = mutableListOf(UploadMediaDetail())

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.kt
@@ -145,7 +145,8 @@ class UploadModel @Inject internal constructor(
             uploadableFile?.getMimeType(context), imageCoordinates, place, fileCreatedDate,
             createdTimestampSource,
             uploadableFile?.contentUri,
-            fileCreatedDateString
+            fileCreatedDateString,
+            uploadableFile?.hasUnsupportedFormat ?: false
         )
 
         // If an uploadItem of the same uploadableFile has been created before, we return that.

--- a/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.kt
@@ -73,6 +73,7 @@ object ImageUtils {
     const val EMPTY_CAPTION = -3
     const val FILE_NAME_EXISTS = 1 shl 6 // 64
     const val NO_CATEGORY_SELECTED = -5
+    const val IMAGE_FORMAT_UNSUPPORTED = 1 shl 7 // 128
 
     private var progressDialogWallpaper: ProgressDialog? = null
 
@@ -90,7 +91,8 @@ object ImageUtils {
             EMPTY_CAPTION,
             FILE_NAME_EXISTS,
             NO_CATEGORY_SELECTED,
-            IMAGE_GEOLOCATION_DIFFERENT
+            IMAGE_GEOLOCATION_DIFFERENT,
+            IMAGE_FORMAT_UNSUPPORTED
         ]
     )
     @Retention
@@ -348,6 +350,10 @@ object ImageUtils {
             if (result and IMAGE_DUPLICATE != 0) {
                 errorMessage.append("\n - ").
                 append(context.getString(R.string.upload_problem_image_duplicate))
+            }
+            if (result and IMAGE_FORMAT_UNSUPPORTED != 0) {
+                errorMessage.append("\n - ")
+                    .append(context.getString(R.string.upload_problem_image_format_unsupported))
             }
             if (result and IMAGE_GEOLOCATION_DIFFERENT != 0) {
                 errorMessage.append("\n - ")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,7 @@
   <string name="upload_problem_image_dark">Image is too dark.</string>
   <string name="upload_problem_image_blurry">Image is blurry.</string>
   <string name="upload_problem_image_duplicate">Image is already on Commons.</string>
+  <string name="upload_problem_image_format_unsupported">The image type previously selected was not supported and has been converted to JPG.</string>
   <string name="upload_problem_different_geolocation">This picture was taken at a different location.</string>
   <string name="upload_problem_fbmd">Please only upload pictures that you have taken by yourself. Don\'t upload pictures that you have found on other people\'s Facebook accounts.</string>
   <string name="upload_problem_do_you_continue">Do you still want to upload this picture?</string>


### PR DESCRIPTION
**Description (required)**

Fixes #5144 

**1) What changes did you make and why?**

First I added support for HEIC/HEIF images by converting them to JPG before upload.
Then I added the HEIC/HEIF type to the list of accepted file types.
At first I implemented a pop up message to say that a conversion has been made.
But instead of showing a separate pop-up message, I decided to add the conversion note to the “Potential problems with this image” section during upload:

"
Problems found in this image
Potential problems with this image:
- The image type previously selected was not supported and has been converted to JPG.
- [Other potential problem messages that can usually appear…]

Do you still want to upload this picture ?

[cancel] | [upload]
"
(see image bellow)

For those changes I implemented two functions in FilePicker:

convertHeicToJpg(file: File, context: Context): File — converts a HEIC file to JPG using ImageDecoder for Android P+ devices.

handleHeicFile(file: UploadableFile, activity: Activity): UploadableFile — checks if a file is HEIC/HEIF and converts it, marking it as hasUnsupportedFormat for display in the potential problems list.

At first i was working on another issue so I hope the solutions brought were relevant to this issue.

**2) Tests performed (required)**

Tested ProdDebug build on Pixel 6 emulator with API level 33. 
(I had to make some research here because I wasn't sure how to test everything efficiently).

I verified if HEIC and HEIF images are correctly converted to JPG. If converted images are flagged in the “Potential problems” list. And if other accepted formats continue to work as expected.

**3) Screenshots (for UI changes only)**

We can now select HEIC : 
![75570](https://github.com/user-attachments/assets/f9e2a3a4-92a6-4989-9bd5-2caf6a6e1fcb)
(exemple of an image of a street in Paris I took for tests)

We can see the problem/warning message for conversion :
![75552](https://github.com/user-attachments/assets/1da95e83-6bd1-48ac-9d28-a42d53fd55be)

We can upload HEIC with successfull conversion to jpg : 
![75566](https://github.com/user-attachments/assets/1b8137df-bb4d-4a12-b4de-e54d671bd2fa)
![75557](https://github.com/user-attachments/assets/bf0f6ecd-6a78-494f-8027-8a1cfd48316d)

---