### PR TITLE
Fix about landscape

### DIFF
--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -24,9 +24,6 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent">
 
-        <ScrollView
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content">
 
         <ScrollView
             android:layout_width="match_parent"
@@ -181,7 +178,6 @@
 
                 </LinearLayout>
             </RelativeLayout>
-        </ScrollView>
         </ScrollView>
     </LinearLayout>
     </LinearLayout>


### PR DESCRIPTION
I am a GSoC 2026 aspirant, and this is my first contribution to the project. I'm looking forward to learning more about the codebase!

**Description (required)**

This PR fixes a UI bug in the About screen where the ScrollView content was overlapping the Toolbar when the device was rotated to landscape. This invisible overlap was intercepting touch events, preventing the user from clicking the back navigation arrow.

Fixes #6751

What changes did you make and why?

- Wrapped the DrawerLayout children inside a vertical LinearLayout to strictly separate the Toolbar from the content area, preventing coordinate collisions.
- Adjusted Toolbar width to match_parent to preserve action icons (like the share button) alignment.
- Removed redundant margin and layout_below attributes from the content container.

**Tests performed (required)**

Tested ProdDebug on Xiaomi 2311DRK48G with API level 34.

**Screenshots (for UI changes only)**
<img width="797" height="361" alt="image" src="https://github.com/user-attachments/assets/ff1dc224-3e7f-4181-b3e1-689b7f817dd4" />

