### PR TITLE
searchbar compose migration

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
@@ -6,6 +6,7 @@ import android.app.ProgressDialog
 import android.content.ActivityNotFoundException
 import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Context.INPUT_METHOD_SERVICE
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.res.Configuration
@@ -30,6 +31,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
+import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
@@ -52,8 +54,45 @@ import com.bumptech.glide.request.target.Target
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
 import com.google.android.material.snackbar.Snackbar
-import com.jakewharton.rxbinding2.view.RxView
-import com.jakewharton.rxbinding3.appcompat.queryTextChanges
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onInterceptKeyBeforeSoftKeyboard
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import fr.free.nrw.commons.CommonsApplication
 import fr.free.nrw.commons.MapController.NearbyPlacesInfo
 import fr.free.nrw.commons.Media
@@ -114,6 +153,7 @@ import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.delay
 import org.osmdroid.events.MapEventsReceiver
 import org.osmdroid.events.MapListener
 import org.osmdroid.events.ScrollEvent
@@ -169,6 +209,7 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
             } else if (isDetailsBottomSheetVisible) {
                 hideBottomDetailsSheet()
             }
+            hideListView()
             return true
         }
 
@@ -277,6 +318,7 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
 
     private var userLocationOverlay: Overlay? = null
     private var userLocationErrorOverlay: Overlay? = null
+    private var searchBarFocusManger: FocusManager? = null
 
     private val galleryPickLauncherForResult =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -589,7 +631,6 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
         binding?.tvAttribution?.movementMethod = LinkMovementMethod.getInstance()
         if (!isDepictsPickerMode) {
             binding?.nearbyFilterList?.btnAdvancedOptions?.setOnClickListener {
-                binding?.nearbyFilter?.searchViewLayout?.searchView?.clearFocus()
                 showHideAdvancedQueryFragment(true)
                 val fragment = AdvanceQueryFragment()
                 val bundle = Bundle()
@@ -993,24 +1034,6 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
     fun initNearbyFilter() {
         binding!!.nearbyFilterList.root.visibility = View.GONE
         hideBottomSheet()
-        binding!!.nearbyFilter.searchViewLayout.searchView.apply {
-            setIconifiedByDefault(false)
-            isIconified = false
-            setQuery("", false)
-            clearFocus()
-        }
-        binding!!.nearbyFilter.searchViewLayout.searchView.setOnQueryTextFocusChangeListener { v, hasFocus ->
-            setLayoutHeightAlignedToWidth(
-                1.25,
-                binding!!.nearbyFilterList.root
-            )
-            if (hasFocus) {
-                binding!!.nearbyFilterList.root.visibility = View.VISIBLE
-                presenter!!.searchViewGainedFocus()
-            } else {
-                binding!!.nearbyFilterList.root.visibility = View.GONE
-            }
-        }
         binding!!.nearbyFilterList.searchListView.setHasFixedSize(true)
         binding!!.nearbyFilterList.searchListView.addItemDecoration(
             DividerItemDecoration(
@@ -1050,15 +1073,38 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
         ).toInt()
         binding!!.nearbyFilterList.searchListView.adapter = nearbyFilterSearchRecyclerViewAdapter
         setLayoutHeightAlignedToWidth(1.25, binding!!.nearbyFilterList.root)
-        compositeDisposable.add(
-            binding!!.nearbyFilter.searchViewLayout.searchView.queryTextChanges()
-                .takeUntil(RxView.detaches(binding!!.nearbyFilter.searchViewLayout.searchView))
-                .debounce(500, TimeUnit.MILLISECONDS)
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { query: CharSequence ->
-                    (binding!!.nearbyFilterList.searchListView.adapter as NearbyFilterSearchRecyclerViewAdapter).filter
-                        .filter(query.toString())
-                })
+        binding!!.nearbyFilter.searchViewLayout.searchview.setContent {
+            nearbySearchBar(
+                isDarkTheme = _isDarkTheme,
+                filterListView = binding!!.nearbyFilterList.root,
+                placeholder = getString(R.string.search_nearby),
+                onQueryChanged = { query ->
+                    (binding?.nearbyFilterList?.searchListView?.adapter as?
+                            NearbyFilterSearchRecyclerViewAdapter)?.filter?.filter(query)
+                },
+                onFocusGained = { filterListView ->
+                    setLayoutHeightAlignedToWidth(1.25, filterListView)
+                    filterListView.visibility = View.VISIBLE
+                    presenter!!.searchViewGainedFocus()
+                },
+                onBackPressed = { filterListView ->
+                    filterListView.visibility = View.GONE
+                },
+                onFocusManagerReady = { fm -> searchBarFocusManger = fm }
+            )
+        }
+    }
+
+    /**
+     * hides list view , when list view hides the searchbar focus must be gone ,
+     * keyboard must be hidden
+     * */
+    private fun hideListView() {
+        searchBarFocusManger?.clearFocus()
+        val inputMethodManager =
+            context?.getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager?
+        inputMethodManager?.hideSoftInputFromWindow(view?.windowToken, 0)
+        binding!!.nearbyFilterList.root.visibility = View.GONE
     }
 
     private fun restoreStoredFilterSelection() {
@@ -3162,5 +3208,99 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
         fun containsParentheses(input: String): Boolean {
             return input.contains("(") || input.contains(")")
         }
+    }
+
+    /**
+     * Custom search bar as it gives more flexibility for adjustments.
+     */
+    @OptIn(ExperimentalComposeUiApi::class)
+    @Composable
+    fun nearbySearchBar(
+        isDarkTheme: Boolean,
+        filterListView: View,
+        placeholder: String,
+        onQueryChanged: (String) -> Unit,
+        onFocusGained: (View) -> Unit,
+        onBackPressed: (View) -> Unit,
+        onFocusManagerReady: (FocusManager) -> Unit,
+    ) {
+        var query by rememberSaveable { mutableStateOf("") }
+        val focusManager = LocalFocusManager.current
+        onFocusManagerReady(focusManager)
+        val textColor = colorResource(
+            if (isDarkTheme) R.color.white else R.color.contributionListDarkBackground
+        )
+        val shape = RoundedCornerShape(4.dp)
+        LaunchedEffect(query) {
+            delay(500)// debounce
+            onQueryChanged(query)
+        }
+        BasicTextField(
+            value = query,
+            onValueChange = { query = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 6.dp, bottom = 6.dp, start = 12.dp)
+                .height(36.dp)
+                .clip(shape)
+                //intercept the keys manually as backHandler requires two back taps
+                // to clear focus and hide keyboard
+                .onInterceptKeyBeforeSoftKeyboard { event ->
+                    if (event.type == KeyEventType.KeyDown && event.key == Key.Back) {
+                        focusManager.clearFocus()
+                        onBackPressed(filterListView)
+                    }
+                    false
+                }
+                .background(
+                    colorResource(
+                        if (isDarkTheme) R.color.contributionListDarkBackground
+                        else R.color.searchBarBackground
+                    ),
+                    shape
+                )
+                .onFocusChanged { focusState ->
+                    if (focusState.hasFocus) {
+                        onFocusGained(filterListView)
+                    }
+                }
+                .padding(horizontal = 12.dp),
+            singleLine = true,
+            textStyle = TextStyle(fontSize = 14.sp, color = textColor),
+            cursorBrush = SolidColor(textColor),
+            decorationBox = { innerTextField ->
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        Icons.Default.Search, contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                        tint = textColor.copy(alpha = 0.6f)
+                    )
+                    Box(
+                        Modifier.weight(1f).padding(start = 8.dp),
+                        contentAlignment = Alignment.CenterStart
+                    ) {
+                        if (query.isEmpty()) {
+                            Text(
+                                placeholder,
+                                style = TextStyle(
+                                    fontSize = 14.sp,
+                                    color = textColor.copy(0.5f)
+                                )
+                            )
+                        }
+                        innerTextField()
+                    }
+                    if (query.isNotEmpty()) {
+                        IconButton(onClick = { query = "" }, Modifier.size(20.dp)) {
+                            Icon(
+                                Icons.Default.Close, contentDescription = "Clear",
+                                modifier = Modifier.size(16.dp),
+                                tint = textColor.copy(alpha = 0.6f)
+                            )
+                        }
+                    }
+                }
+            }
+        )
     }
 }

--- a/app/src/main/res/layout/filter_search_view_layout.xml
+++ b/app/src/main/res/layout/filter_search_view_layout.xml
@@ -1,25 +1,30 @@
-<LinearLayout android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:id="@+id/search_view_layout"
-    android:paddingVertical="@dimen/filter_padding"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="@dimen/large_gap"
+  android:clipChildren="false"
+  android:clipToPadding="false"
+  android:focusable="true"
+  android:focusableInTouchMode="true"
+  android:paddingStart="@dimen/medium_height">
 
     <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:paddingStart="@dimen/filter_padding"
-        android:text="@string/place_type"
-        android:textColor="@color/white"/>
+      android:id="@+id/label"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/place_type"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
 
-    <androidx.appcompat.widget.SearchView
-        android:id="@+id/search_view"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:tint="@color/white"
-        android:queryHint="@string/nearby_search_hint"
-        android:searchIcon="@drawable/ic_search_white_24dp"
-        app:theme="@style/WhiteSearchBarTheme"/>
+    <androidx.compose.ui.platform.ComposeView
+      android:id="@+id/searchview"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toEndOf="@id/label"
+      app:layout_constraintTop_toTopOf="parent" />
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -80,6 +80,7 @@
 
     <color name="nav_tab_icon_unselected_color">#61000000</color>
     <color name="card_light_grey">#EDEDED</color>
+    <color name="searchBarBackground">#EEEEEE</color>
 
     <color name="wikimedia_green">#339966</color>
     <color name="primary_color_night">#1e8cab</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -625,6 +625,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="place_state_needs_photo">Needs Photo</string>
   <string name="place_type">Place type:</string>
   <string name="nearby_search_hint">Bridge, museum, hotel, etc.</string>
+  <string name="search_nearby">Search nearby…</string>
   <string name="you_must_reset_your_passsword">Something went wrong with log-in. You must reset your password!</string>
   <string name="title_for_media">MEDIA</string>
   <string name="title_for_child_classes">CHILD CLASSES</string>


### PR DESCRIPTION
fixes the keyboard flash happening #6703


What changes did you make and why?

removed the legacy searchview and  implemented a custom searchbar 
the choice to not choose the default searchBar( ) in compose was to have complete control over the size and adjustments and the default one had default padding  which is redundant 

**Screenshots (for UI changes only)**

NOTE : The list view only closes when clicked on the map or back button by clicking done button in keyboard will only make the keyboard go away this is made to keep the listview visible in horizontal view mode for better accessibility of listview 

![Screenshot_2026-03-19-02-44-52-95_062c6066f629c24413cc8efde3bd9f38](https://github.com/user-attachments/assets/c0ac41ca-37b1-46d1-8334-a92ff602c2da)
![Screenshot_2026-03-19-02-44-36-60_062c6066f629c24413cc8efde3bd9f38](https://github.com/user-attachments/assets/0949050b-a621-4013-a63e-2b80153ba459)


https://github.com/user-attachments/assets/62ec7ff9-144f-4ee2-b6f3-fdb0743f353d

