### PR TITLE
Fix media attribution display in contributions and explore screens

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionViewHolder.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionViewHolder.kt
@@ -122,7 +122,6 @@ an upload might take a dozen seconds. */
     private fun setAuthorText(media: Media) {
         binding.authorView.text = MediaAttributionUtil.getTagLine(media, itemView.context)
     }
-
     /**
      * Checks if a media exists on the corresponding Wikipedia article Currently the check is made
      * for the device's current language Wikipedia

--- a/app/src/main/java/fr/free/nrw/commons/explore/media/PagedMediaAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/explore/media/PagedMediaAdapter.kt
@@ -60,7 +60,7 @@ class PagedMediaAdapter(
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                     {  idAndLabels ->
-                        media.creatorName = MediaAttributionUtil.getCreatorName(idAndLabels);
+                        media.creatorName = MediaAttributionUtil.getCreatorName(idAndLabels)
                         holder.setAuthorText(media)
                     },
                     { t: Throwable? -> Timber.e(t) })
@@ -83,6 +83,6 @@ class SearchImagesViewHolder(
     }
 
     fun setAuthorText(media: Media) {
-        binding.categoryImageAuthor.text = MediaAttributionUtil.getTagLine(media, containerView.context)
+        binding.categoryImageAuthor.text = MediaAttributionUtil.getTagLine(media, itemView.context)
     }
 }


### PR DESCRIPTION
## Description
This fixes the media attribution text shown in contributions and explore screens.

Previously, the UI always displayed only the uploader name, even when creator
information was available and already fetched.

This change uses `MediaAttributionUtil.getTagLine(...)` so the app correctly shows:
- Uploaded by ...
- Created and uploaded by ...
- Created by ..., uploaded by ...

## Files changed
- ContributionViewHolder.kt
- PagedMediaAdapter.kt
