### PR TITLE
Upload: drop duplicate images and display warning in normal selector

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.kt
@@ -375,7 +375,7 @@ class ContributionController @Inject constructor(@param:Named("default_preferenc
                 }
                 val intent = handleImagesPicked(activity, selectedFiles)
                 if (isNormalSelectorSource && selectedFiles.size != imagesFiles.size) {
-                    intent.putExtra(EXTRA_DUPLICATES_REMOVED, true)
+                    intent.putExtra(UploadActivity.EXTRA_DUPLICATES_REMOVED, true)
                 }
                 activity.startActivity(intent)
             }
@@ -383,13 +383,14 @@ class ContributionController @Inject constructor(@param:Named("default_preferenc
     }
 
     private fun deduplicateNormalSelectorImages(imagesFiles: List<UploadableFile>): List<UploadableFile> {
-        val seenKeys = LinkedHashSet<String>()
-        return imagesFiles.filter { seenKeys.add(getNormalSelectorDeduplicationKey(it)) }
+        return imagesFiles.distinctBy(::getNormalSelectorDeduplicationKey)
     }
 
     private fun getNormalSelectorDeduplicationKey(uploadableFile: UploadableFile): String {
         return try {
-            val sha1 = FileUtils.getSHA1(FileInputStream(uploadableFile.file))
+            val sha1 = FileInputStream(uploadableFile.file).use { inputStream ->
+                FileUtils.getSHA1(inputStream)
+            }
             if (sha1.isNotEmpty()) sha1 else uploadableFile.getFilePath()
         } catch (e: Exception) {
             uploadableFile.getFilePath()
@@ -497,6 +498,5 @@ class ContributionController @Inject constructor(@param:Named("default_preferenc
 
     companion object {
         const val ACTION_INTERNAL_UPLOADS: String = "internalImageUploads"
-        const val EXTRA_DUPLICATES_REMOVED: String = "duplicates_removed_before_upload"
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.kt
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/ContributionController.kt
@@ -28,12 +28,14 @@ import fr.free.nrw.commons.location.LocationPermissionsHelper.LocationPermission
 import fr.free.nrw.commons.location.LocationServiceManager
 import fr.free.nrw.commons.nearby.Place
 import fr.free.nrw.commons.upload.UploadActivity
+import fr.free.nrw.commons.upload.FileUtils
 import fr.free.nrw.commons.utils.DialogUtil.showAlertDialog
 import fr.free.nrw.commons.utils.PermissionUtils.PERMISSIONS_STORAGE
 import fr.free.nrw.commons.utils.PermissionUtils.checkPermissionsAndPerformAction
 import fr.free.nrw.commons.utils.ViewUtil.showLongToast
 import fr.free.nrw.commons.utils.ViewUtil.showShortToast
 import fr.free.nrw.commons.wikidata.WikidataConstants.PLACE_OBJECT
+import java.io.FileInputStream
 import java.util.Arrays
 import javax.inject.Inject
 import javax.inject.Named
@@ -364,10 +366,34 @@ class ContributionController @Inject constructor(@param:Named("default_preferenc
                 imagesFiles: List<UploadableFile>,
                 source: FilePicker.ImageSource, type: Int
             ) {
-                val intent = handleImagesPicked(activity, imagesFiles)
+                val isNormalSelectorSource = source == FilePicker.ImageSource.GALLERY ||
+                    source == FilePicker.ImageSource.DOCUMENTS
+                val selectedFiles = if (isNormalSelectorSource) {
+                    deduplicateNormalSelectorImages(imagesFiles)
+                } else {
+                    imagesFiles
+                }
+                val intent = handleImagesPicked(activity, selectedFiles)
+                if (isNormalSelectorSource && selectedFiles.size != imagesFiles.size) {
+                    intent.putExtra(EXTRA_DUPLICATES_REMOVED, true)
+                }
                 activity.startActivity(intent)
             }
         })
+    }
+
+    private fun deduplicateNormalSelectorImages(imagesFiles: List<UploadableFile>): List<UploadableFile> {
+        val seenKeys = LinkedHashSet<String>()
+        return imagesFiles.filter { seenKeys.add(getNormalSelectorDeduplicationKey(it)) }
+    }
+
+    private fun getNormalSelectorDeduplicationKey(uploadableFile: UploadableFile): String {
+        return try {
+            val sha1 = FileUtils.getSHA1(FileInputStream(uploadableFile.file))
+            if (sha1.isNotEmpty()) sha1 else uploadableFile.getFilePath()
+        } catch (e: Exception) {
+            uploadableFile.getFilePath()
+        }
     }
 
     fun handleExternalImagesPicked(
@@ -471,5 +497,6 @@ class ContributionController @Inject constructor(@param:Named("default_preferenc
 
     companion object {
         const val ACTION_INTERNAL_UPLOADS: String = "internalImageUploads"
+        const val EXTRA_DUPLICATES_REMOVED: String = "duplicates_removed_before_upload"
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.kt
@@ -105,6 +105,7 @@ class UploadActivity : BaseActivity(), UploadContract.View, UploadBaseFragment.C
     private var prevLocation: LatLng? = null
     private var currLocation: LatLng? = null
     private var isInAppCameraUpload = false
+    private var shouldShowDuplicatesRemovedWarning = false
     private var uploadableFiles: MutableList<UploadableFile> = mutableListOf()
     private var currentSelectedPosition = 0
 
@@ -673,6 +674,16 @@ class UploadActivity : BaseActivity(), UploadContract.View, UploadBaseFragment.C
 
             uploadImagesAdapter!!.fragments = fragments!!
             binding.vpUpload.offscreenPageLimit = fragments!!.size
+
+            if (shouldShowDuplicatesRemovedWarning) {
+                showAlertDialog(
+                    this,
+                    getString(R.string.warning),
+                    getString(R.string.duplicates_removed_before_upload),
+                    getString(R.string.ok)
+                ) { }
+                shouldShowDuplicatesRemovedWarning = false
+            }
         }
         // Saving size of uploadableFiles
         store!!.putInt(KEY_FOR_CURRENT_UPLOAD_IMAGE_SIZE, uploadableFiles.size)
@@ -787,6 +798,8 @@ class UploadActivity : BaseActivity(), UploadContract.View, UploadBaseFragment.C
         }
 
         isInAppCameraUpload = intent.getBooleanExtra(IN_APP_CAMERA_UPLOAD, false)
+        shouldShowDuplicatesRemovedWarning =
+            intent.getBooleanExtra(EXTRA_DUPLICATES_REMOVED, false)
         resetDirectPrefs()
     }
 
@@ -1015,6 +1028,7 @@ class UploadActivity : BaseActivity(), UploadContract.View, UploadBaseFragment.C
     companion object {
         private var uploadIsOfAPlace = false
         const val EXTRA_FILES: String = "commons_image_extra"
+        const val EXTRA_DUPLICATES_REMOVED: String = "duplicates_removed_before_upload"
         const val LOCATION_BEFORE_IMAGE_CAPTURE: String = "user_location_before_image_capture"
         const val IN_APP_CAMERA_UPLOAD: String = "in_app_camera_upload"
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.kt
@@ -679,7 +679,7 @@ class UploadActivity : BaseActivity(), UploadContract.View, UploadBaseFragment.C
                 showAlertDialog(
                     this,
                     getString(R.string.warning),
-                    getString(R.string.duplicates_removed_before_upload),
+                    getString(R.string.normal_selector_duplicates_warning),
                     getString(R.string.ok)
                 ) { }
                 shouldShowDuplicatesRemovedWarning = false

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -205,6 +205,7 @@
   <string name="in_app_camera_location_switch_pref_summary">Enable this to record location with in-app shots in case the device camera does not record it</string>
   <string name="ok">OK</string>
   <string name="warning">Warning</string>
+  <string name="duplicates_removed_before_upload">Some selected images were duplicates and have been removed before upload.</string>
   <string name="duplicate_file_name">Duplicate File Name found</string>
   <string name="upload">Upload</string>
   <string name="yes">Yes</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -205,7 +205,7 @@
   <string name="in_app_camera_location_switch_pref_summary">Enable this to record location with in-app shots in case the device camera does not record it</string>
   <string name="ok">OK</string>
   <string name="warning">Warning</string>
-  <string name="duplicates_removed_before_upload">Some selected images were duplicates and have been removed before upload.</string>
+  <string name="normal_selector_duplicates_warning">Some selected images were duplicates and have been removed before upload.</string>
   <string name="duplicate_file_name">Duplicate File Name found</string>
   <string name="upload">Upload</string>
   <string name="yes">Yes</string>


### PR DESCRIPTION
Fixes #6771 

**The Problem**

In the normal selector flow, duplicate content images (files sharing the same content hash) were silently passed through to the upload screen with no deduplication or user notification. This could result in redundant uploads to the Commons server and created an inconsistency with the custom selector, which already performs duplicate detection (see issue #6764  / PR #6765 ).

**The Solution & Justification**

I updated the normal selector's completion flow in `ContributionController.kt` to:

- Detect duplicate content images before passing the selection to the upload screen.
- Automatically drop the duplicates, keeping only unique images.
- Show a warning to the user notifying them that duplicate images were removed, so the count reduction is never silent or confusing.

This brings the normal selector's duplicate handling to full parity with the custom selector fix in #6765 , and ensures a consistent, transparent experience across both upload flows.

**Alternative Solutions Considered**

I considered passing duplicates through and only showing a warning (preserving the count), similar to what was initially proposed in #6765 . However, per the direction established in #6765 , dropping duplicates and warning the user is the correct approach, as duplicate uploads are genuinely unhelpful and should be prevented at the source rather than silently permitted.

**Testing Performed**

- Compiled and ran the `betaDebug` variant successfully.
- Passed targeted unit tests: `:app:testBetaDebugUnitTest --tests "fr.free.nrw.commons.contributions.ContributionControllerTest"`
- Manually verified that the duplicate warning is shown when identical images are selected via the normal selector.
- Manually verified that the upload screen receives only the deduplicated set of images.
- Manually verified that non-duplicate selections pass through normally with no warning shown.

**Videos**

Before:

https://github.com/user-attachments/assets/dbcc3be9-2071-4eea-9fcb-ce2ee5984243

After:

https://github.com/user-attachments/assets/a9bb35b4-eae1-4781-afd7-6b69eb05c5c8