### PR TITLE
Fix: Enable welcome workflow by correcting contributor condition

### DIFF
--- a/.github/workflows/welcome_new_contributors.yml
+++ b/.github/workflows/welcome_new_contributors.yml
@@ -6,12 +6,15 @@ on:
 
 permissions:
   pull-requests: write
+  contents: read
   models: read
 
 jobs:
   welcome:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: |
+      github.event.pull_request.author_association == 'FIRST_TIMER' ||
+      github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
     steps:
       - name: Generate welcome message
         uses: actions/ai-inference@v1


### PR DESCRIPTION
**Description (required)**

Fixes #6759

The welcome workflow was being skipped due to an incorrect condition checking for 'FIRST_TIME_CONTRIBUTOR'.

GitHub uses 'FIRST_TIMER' as the valid value for first-time contributors, so the condition was never met.

This PR updates the condition to ensure that the workflow triggers correctly for new contributors.


**Tests performed (required)**

Verified that the workflow condition now correctly matches GitHub's `author_association` value for first-time contributors.


---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._