### PR TITLE
Fix: Prevent "CONTRIBUTIONS" tab text wrapping by using scrollable tab mode

### DIFF
--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -33,7 +33,7 @@
                   android:layout_below="@id/toolbar"
                   android:background="?attr/tabBackground"
                   app:tabIndicatorColor="?attr/tabIndicatorColor"
-                  app:tabMode="fixed"
+                  app:tabMode="scrollable"
                   app:tabSelectedTextColor="?attr/tabSelectedTextColor"
                   app:tabTextColor="?attr/tabTextColor" />
             </com.google.android.material.appbar.AppBarLayout>


### PR DESCRIPTION
**Description (required)**

Fixes #6782 

What changes did you make and why?
Changed tab mode to scrollable to prevent "CONTRIBUTIONS" text wrapping and ensure proper tab rendering.

Tested 6.4.0-debug on Pixel 9 (Android 16)

**Screenshots (for UI changes only)**

https://github.com/user-attachments/assets/9ed3bfa2-e59b-4a01-855b-ae07473cbbc4