### PR TITLE
Fix: Warning dialog reappears after configuration change despite user dismissal

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/WelcomeActivity.kt
@@ -15,7 +15,7 @@ import fr.free.nrw.commons.utils.ConfigUtils.isBetaFlavour
 class WelcomeActivity : BaseActivity() {
     private var binding: ActivityWelcomeBinding? = null
     private var isQuiz = false
-
+    private var isWarningDialogDismissed = false
     /**
      * Initialises exiting fields and dependencies
      *
@@ -23,6 +23,9 @@ class WelcomeActivity : BaseActivity() {
      */
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (savedInstanceState != null) {
+            isWarningDialogDismissed = savedInstanceState.getBoolean("warning_dismissed", false)
+        }
         binding = ActivityWelcomeBinding.inflate(layoutInflater)
         applyEdgeToEdgeAllInsets(binding!!.welcomePager.rootView)
         setContentView(binding!!.root)
@@ -32,6 +35,7 @@ class WelcomeActivity : BaseActivity() {
         // Enable skip button if beta flavor
         if (isBetaFlavour) {
             binding!!.finishTutorialButton.visibility = View.VISIBLE
+            if (!isWarningDialogDismissed) {
 
             val copyrightBinding = PopupForCopyrightBinding.inflate(layoutInflater)
 
@@ -41,13 +45,19 @@ class WelcomeActivity : BaseActivity() {
                 .create()
             dialog.show()
 
-            copyrightBinding.buttonOk.setOnClickListener { v: View? -> dialog.dismiss() }
+            copyrightBinding.buttonOk.setOnClickListener { v: View? -> dialog.dismiss()
+                isWarningDialogDismissed = true}
+        }
         }
 
         val adapter = WelcomePagerAdapter()
         binding!!.welcomePager.adapter = adapter
         binding!!.welcomePagerIndicator.setViewPager(binding!!.welcomePager)
         binding!!.finishTutorialButton.setOnClickListener { v: View? -> finishTutorial() }
+    }
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean("warning_dismissed", isWarningDialogDismissed)
     }
 
     public override fun onDestroy() {


### PR DESCRIPTION
**Description (required)**
Persisted dialog state after user dismissal to prevent warning dialog from reappearing on configuration changes.
Fixes #6783 

**Tests performed (required)**

Tested 6.4.0-debug on Pixel 9(Android 16)

