### PR TITLE
Fix: Remove unnecessary indentation and spacing inconsistencies in feedback screen

### DIFF
--- a/app/src/main/res/layout/dialog_feedback.xml
+++ b/app/src/main/res/layout/dialog_feedback.xml
@@ -31,10 +31,9 @@
       <fr.free.nrw.commons.ui.PasteSensitiveTextInputEditText
         android:id="@+id/feedback_item_edit_text"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:hint="@string/your_feedback"
         android:imeOptions="actionNext|flagNoExtractUi"
-        android:lines="4"
         android:inputType="text|textMultiLine"
         app:allowFormatting="false" />
 


### PR DESCRIPTION
**Description (required)**
Removed unnecessary indentation and extra spacing in feedback page layout to improve alignment consistency.
Fixes #6784 

**Tests performed (required)**

Tested 6.4.0-debug on Pixel 9(Android 16)

**Screenshots (for UI changes only)**
![a](https://github.com/user-attachments/assets/f849c8b6-e528-4cdc-9b0f-65f311c64255)
