### PR TITLE
Nearby: prevent multiple offline snackbars from showing during map scroll

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
@@ -225,6 +225,7 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
     private var broadcastReceiver: BroadcastReceiver? = null
     private var isNetworkErrorOccurred = false
     private var snackbar: Snackbar? = null
+    private var hasShownOfflinePinsMessage = false
     private var view: View? = null
     private var scope: LifecycleCoroutineScope? = null
     private var presenter: NearbyParentFragmentPresenter? = null
@@ -1291,12 +1292,14 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
                             snackbar!!.dismiss()
                             snackbar = null
                         }
+                        hasShownOfflinePinsMessage = false
                     } else {
                         if (snackbar == null) {
                             snackbar = Snackbar.make(
                                 view!!, fr.free.nrw.commons.R.string.no_internet,
                                 Snackbar.LENGTH_INDEFINITE
                             )
+                            hasShownOfflinePinsMessage = false
                             searchable = false
                             setProgressBarVisibility(false)
                         }
@@ -1318,10 +1321,10 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
         if (!isNetworkErrorOccurred || snackbar == null) {
             return
         }
-        if (offlinePinsShown) {
+        // Avoid flickering between offline messages while panning; switch once per offline session.
+        if (offlinePinsShown && !hasShownOfflinePinsMessage) {
             snackbar!!.setText(fr.free.nrw.commons.R.string.nearby_showing_pins_offline)
-        } else {
-            snackbar!!.setText(fr.free.nrw.commons.R.string.no_internet)
+            hasShownOfflinePinsMessage = true
         }
     }
 


### PR DESCRIPTION
Fixes #6806

**The Problem**
When the user is offline on the Nearby screen, panning the map triggers repeated viewport updates. This caused updateSnackbar() in NearbyParentFragment to fire repeatedly, thrashing the snackbar text between the generic "No Internet" message and the "Showing cached pins" message, resulting in multiple snackbars appearing.

**The Solution & Justification**

- I implemented a minimal state deduplication fix in NearbyParentFragment.kt:
- Added a hasShownOfflinePinsMessage flag.
- Updated updateSnackbar() so it only upgrades from the generic offline message to the cached pins message once per offline session, rather than flipping back and forth on every map scroll event.
- The flag cleanly resets when connectivity is restored or when a new offline snackbar instance is created.
- This approach stabilizes the UI without requiring a broader presenter/contract refactor, keeping the blast radius of the bugfix as small as possible.

**Testing Performed**

- Passed targeted unit tests: :app:testProdDebugUnitTest --tests "fr.free.nrw.commons.nearby.NearbyParentFragmentPresenterTest"
- Manually verified that turning off Wi-Fi/Data and panning the map no longer spawns multiple snackbars.
- Manually verified the snackbar properly dismisses when internet is restored.

**Videos**

Before:

https://github.com/user-attachments/assets/8517691b-5495-4eac-ab6e-f18c2faecb16

After:

https://github.com/user-attachments/assets/eb164510-4a3c-4150-9fea-f419b135b114
