### PR TITLE
Fix 5144 heic files

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.kt
@@ -407,7 +407,8 @@ object FilePicker : Constants {
         return if (extension == "heic" || extension == "heif") {
             AlertDialog.Builder(activity)
                 .setTitle("Unsupported format")
-                .setMessage("This image type isn't supported and will be converted to JPG.")
+                .setMessage("The image type previously selected " +
+                        "was not supported and has been converted to JPG.")
                 .setPositiveButton("OK") { dialog, _ ->
                     dialog.dismiss()
                 }

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.kt
@@ -15,6 +15,12 @@ import fr.free.nrw.commons.filepicker.PickedFiles.singleFileList
 import java.io.File
 import java.io.IOException
 import java.net.URISyntaxException
+import android.graphics.Bitmap
+import android.graphics.ImageDecoder
+import android.os.Build
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import java.io.FileOutputStream
 
 
 object FilePicker : Constants {
@@ -52,7 +58,7 @@ object FilePicker : Constants {
     ): Intent {
         // storing picked image type to shared preferences
         storeType(context, type)
-        // Supported types are SVG, PNG and JPEG, GIF, TIFF, WebP, XCF
+        // Supported types are SVG, PNG and JPEG, GIF, TIFF, WebP, XCF and HEIC (for future conversion)
         val mimeTypes = arrayOf(
             "image/jpg",
             "image/png",
@@ -62,7 +68,8 @@ object FilePicker : Constants {
             "image/webp",
             "image/xcf",
             "image/svg+xml",
-            "image/webp"
+            "image/heic",
+            "image/heif"
         )
         return plainGalleryPickerIntent(openDocumentIntentPreferred)
             .putExtra(
@@ -379,6 +386,39 @@ object FilePicker : Constants {
             callbacks.onCanceled(ImageSource.GALLERY, restoreType(activity))
         }
     }
+    @JvmStatic
+    fun convertHeicToJpg(file: File, context: Context): File {
+        val bitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val source = ImageDecoder.createSource(context.contentResolver, Uri.fromFile(file))
+            ImageDecoder.decodeBitmap(source)
+        } else {
+            throw IllegalStateException("HEIC conversion requires Android P+")
+        }
+
+        val jpgFile = File(file.parent, file.nameWithoutExtension + ".jpg")
+        FileOutputStream(jpgFile).use { out ->
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, out)
+        }
+        return jpgFile
+    }
+    @JvmStatic
+    private fun handleHeicFile(file: UploadableFile, activity: Activity): UploadableFile {
+        val extension = file.file.extension.lowercase()
+        return if (extension == "heic" || extension == "heif") {
+            AlertDialog.Builder(activity)
+                .setTitle("Unsupported format")
+                .setMessage("This image type isn't supported and will be converted to JPG.")
+                .setPositiveButton("OK") { dialog, _ ->
+                    dialog.dismiss()
+                }
+                .show()
+
+            val jpgFile = convertHeicToJpg(file.file, activity)
+            UploadableFile(jpgFile)
+        } else {
+            file
+        }
+    }
 
     @Throws(IOException::class, SecurityException::class)
     @JvmStatic
@@ -390,7 +430,8 @@ object FilePicker : Constants {
         val clipData = data?.clipData
         if (clipData == null) {
             val uri = data?.data
-            val file = PickedFiles.pickedExistingPicture(activity, uri!!)
+            var file = PickedFiles.pickedExistingPicture(activity, uri!!)
+            file = handleHeicFile(file, activity)
             files.add(file)
         } else {
             for (i in 0 until clipData.itemCount) {

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/FilePicker.kt
@@ -356,7 +356,8 @@ object FilePicker : Constants {
         val images = data?.getParcelableArrayListExtra<Image>("Images")
         images?.forEach { image ->
             val uri = image.uri
-            val file = PickedFiles.pickedExistingPicture(activity, uri)
+            var file = PickedFiles.pickedExistingPicture(activity, uri)
+            file = handleHeicFile(file, activity)
             files.add(file)
         }
 
@@ -405,17 +406,10 @@ object FilePicker : Constants {
     private fun handleHeicFile(file: UploadableFile, activity: Activity): UploadableFile {
         val extension = file.file.extension.lowercase()
         return if (extension == "heic" || extension == "heif") {
-            AlertDialog.Builder(activity)
-                .setTitle("Unsupported format")
-                .setMessage("The image type previously selected " +
-                        "was not supported and has been converted to JPG.")
-                .setPositiveButton("OK") { dialog, _ ->
-                    dialog.dismiss()
-                }
-                .show()
-
             val jpgFile = convertHeicToJpg(file.file, activity)
-            UploadableFile(jpgFile)
+            val uploadableFile = UploadableFile(jpgFile)
+            uploadableFile.hasUnsupportedFormat = true
+            uploadableFile
         } else {
             file
         }
@@ -437,7 +431,8 @@ object FilePicker : Constants {
         } else {
             for (i in 0 until clipData.itemCount) {
                 val uri = clipData.getItemAt(i).uri
-                val file = PickedFiles.pickedExistingPicture(activity, uri)
+                var file = PickedFiles.pickedExistingPicture(activity, uri)
+                file = handleHeicFile(file, activity)
                 files.add(file)
             }
         }

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/PickedFiles.kt
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/PickedFiles.kt
@@ -2,11 +2,15 @@ package fr.free.nrw.commons.filepicker
 
 import android.content.ContentResolver
 import android.content.Context
+import android.graphics.Bitmap
 import android.media.MediaScannerConnection
 import android.net.Uri
+import android.os.Build
 import android.os.Environment
 import android.webkit.MimeTypeMap
+import androidx.annotation.RequiresApi
 import androidx.core.content.FileProvider
+import androidx.exifinterface.media.ExifInterface
 import fr.free.nrw.commons.filepicker.Constants.Companion.DEFAULT_FOLDER_NAME
 import timber.log.Timber
 import java.io.File
@@ -143,8 +147,17 @@ object PickedFiles : Constants {
     @JvmStatic
     fun pickedExistingPicture(context: Context, photoUri: Uri): UploadableFile {
         val directory = tempImageDirectory(context)
-        val mimeType = getMimeType(context, photoUri)
-        val photoFile = File(directory, "${UUID.randomUUID()}.$mimeType")
+        val ext = getMimeType(context, photoUri)
+        val isHeic = ext.equals("heic", true) || ext.equals("heif", true)
+        val photoFile = File(directory, "${UUID.randomUUID()}.${if (isHeic) "jpg" else ext}")
+
+        if (isHeic) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) throw IOException("HEIC not supported on this Android version")
+            val srcExif = context.contentResolver.openInputStream(photoUri)?.use { ExifInterface(it) }
+            HeicApi28.transcodeToJpeg(context.contentResolver, photoUri, photoFile)
+            srcExif?.let { copyExif(it, photoFile) }
+            return UploadableFile(photoUri, photoFile)
+        }
 
         if (photoFile.createNewFile()) {
             context.contentResolver.openInputStream(photoUri)?.use { inputStream ->
@@ -154,6 +167,33 @@ object PickedFiles : Constants {
             throw IOException("Could not create photoFile to write upon")
         }
         return UploadableFile(photoUri, photoFile)
+    }
+
+    private fun copyExif(src: ExifInterface, dstFile: File) {
+        val dst = ExifInterface(dstFile.absolutePath)
+        arrayOf(
+            ExifInterface.TAG_DATETIME_ORIGINAL, ExifInterface.TAG_DATETIME,
+            ExifInterface.TAG_GPS_LATITUDE, ExifInterface.TAG_GPS_LATITUDE_REF,
+            ExifInterface.TAG_GPS_LONGITUDE, ExifInterface.TAG_GPS_LONGITUDE_REF,
+            ExifInterface.TAG_GPS_ALTITUDE, ExifInterface.TAG_GPS_ALTITUDE_REF,
+            ExifInterface.TAG_GPS_DATESTAMP, ExifInterface.TAG_GPS_TIMESTAMP,
+            ExifInterface.TAG_MAKE, ExifInterface.TAG_MODEL,
+            ExifInterface.TAG_F_NUMBER, ExifInterface.TAG_EXPOSURE_TIME,
+            ExifInterface.TAG_FLASH, ExifInterface.TAG_FOCAL_LENGTH,
+            ExifInterface.TAG_PHOTOGRAPHIC_SENSITIVITY, ExifInterface.TAG_WHITE_BALANCE,
+            ExifInterface.TAG_IMAGE_WIDTH, ExifInterface.TAG_IMAGE_LENGTH,
+        ).forEach { tag -> src.getAttribute(tag)?.let { dst.setAttribute(tag, it) } }
+        dst.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL.toString())
+        dst.saveAttributes()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    private object HeicApi28 {
+        fun transcodeToJpeg(cr: ContentResolver, uri: Uri, outFile: File) {
+            val src = android.graphics.ImageDecoder.createSource(cr, uri)
+            val bmp = android.graphics.ImageDecoder.decodeBitmap(src)
+            FileOutputStream(outFile).use { bmp.compress(Bitmap.CompressFormat.JPEG, 95, it) }
+        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.kt
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/UploadableFile.kt
@@ -20,6 +20,7 @@ class UploadableFile : Parcelable {
 
     val contentUri: Uri
     val file: File
+    var hasUnsupportedFormat: Boolean = false
 
     constructor(contentUri: Uri, file: File) {
         this.contentUri = contentUri
@@ -34,6 +35,7 @@ class UploadableFile : Parcelable {
     private constructor(parcel: Parcel) {
         contentUri = parcel.readParcelable(Uri::class.java.classLoader)!!
         file = parcel.readSerializable() as File
+        hasUnsupportedFormat = parcel.readInt() == 1
     }
 
     fun getFilePath(): String {
@@ -126,6 +128,7 @@ class UploadableFile : Parcelable {
     override fun writeToParcel(parcel: Parcel, flags: Int) {
         parcel.writeParcelable(contentUri, flags)
         parcel.writeSerializable(file)
+        parcel.writeInt(if (hasUnsupportedFormat) 1 else 0)
     }
 
     class DateTimeWithSource {

--- a/app/src/main/java/fr/free/nrw/commons/upload/ImageProcessingService.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ImageProcessingService.kt
@@ -59,11 +59,12 @@ class ImageProcessingService @Inject constructor(
             checkFBMD(filePath),
             checkEXIF(filePath)
         ) { duplicateImage: Int, wrongGeoLocation: Int, darkImage: Int, fbmd: Int, exif: Int ->
+            val unsupportedFormatResult = if (uploadItem.hasUnsupportedFormat) fr.free.nrw.commons.utils.ImageUtils.IMAGE_FORMAT_UNSUPPORTED else 0
             Timber.d(
-                "duplicate: %d, geo: %d, dark: %d, fbmd: %d, exif: %d",
-                duplicateImage, wrongGeoLocation, darkImage, fbmd, exif
+                "duplicate: %d, geo: %d, dark: %d, fbmd: %d, exif: %d, unsupported: %d",
+                duplicateImage, wrongGeoLocation, darkImage, fbmd, exif, unsupportedFormatResult
             )
-            return@zip duplicateImage or wrongGeoLocation or darkImage or fbmd or exif
+            return@zip duplicateImage or wrongGeoLocation or darkImage or fbmd or exif or unsupportedFormatResult
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadItem.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadItem.kt
@@ -19,7 +19,8 @@ class UploadItem(
      */
     var contentUri: Uri?,
     //according to EXIF data
-    val fileCreatedDateString: String?
+    val fileCreatedDateString: String?,
+    val hasUnsupportedFormat: Boolean = false
 ) {
     var imageQuality: Int = ImageUtils.IMAGE_WAIT
     var uploadMediaDetails: MutableList<UploadMediaDetail> = mutableListOf(UploadMediaDetail())

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.kt
@@ -145,7 +145,8 @@ class UploadModel @Inject internal constructor(
             uploadableFile?.getMimeType(context), imageCoordinates, place, fileCreatedDate,
             createdTimestampSource,
             uploadableFile?.contentUri,
-            fileCreatedDateString
+            fileCreatedDateString,
+            uploadableFile?.hasUnsupportedFormat ?: false
         )
 
         // If an uploadItem of the same uploadableFile has been created before, we return that.

--- a/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.kt
@@ -73,6 +73,7 @@ object ImageUtils {
     const val EMPTY_CAPTION = -3
     const val FILE_NAME_EXISTS = 1 shl 6 // 64
     const val NO_CATEGORY_SELECTED = -5
+    const val IMAGE_FORMAT_UNSUPPORTED = 1 shl 7 // 128
 
     private var progressDialogWallpaper: ProgressDialog? = null
 
@@ -90,7 +91,8 @@ object ImageUtils {
             EMPTY_CAPTION,
             FILE_NAME_EXISTS,
             NO_CATEGORY_SELECTED,
-            IMAGE_GEOLOCATION_DIFFERENT
+            IMAGE_GEOLOCATION_DIFFERENT,
+            IMAGE_FORMAT_UNSUPPORTED
         ]
     )
     @Retention
@@ -348,6 +350,10 @@ object ImageUtils {
             if (result and IMAGE_DUPLICATE != 0) {
                 errorMessage.append("\n - ").
                 append(context.getString(R.string.upload_problem_image_duplicate))
+            }
+            if (result and IMAGE_FORMAT_UNSUPPORTED != 0) {
+                errorMessage.append("\n - ")
+                    .append(context.getString(R.string.upload_problem_image_format_unsupported))
             }
             if (result and IMAGE_GEOLOCATION_DIFFERENT != 0) {
                 errorMessage.append("\n - ")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,7 @@
   <string name="upload_problem_image_dark">Image is too dark.</string>
   <string name="upload_problem_image_blurry">Image is blurry.</string>
   <string name="upload_problem_image_duplicate">Image is already on Commons.</string>
+  <string name="upload_problem_image_format_unsupported">The image type previously selected was not supported and has been converted to JPG.</string>
   <string name="upload_problem_different_geolocation">This picture was taken at a different location.</string>
   <string name="upload_problem_fbmd">Please only upload pictures that you have taken by yourself. Don\'t upload pictures that you have found on other people\'s Facebook accounts.</string>
   <string name="upload_problem_do_you_continue">Do you still want to upload this picture?</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,11 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Thu Mar 01 15:28:48 IST 2018
-org.gradle.jvmargs=-Xmx1536M
+# Bumped heap to prevent Kotlin/KAPT OOM during compilation tasks (e.g. kaptGenerateStubs*).
+org.gradle.jvmargs=-Xmx3072m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError
+
+# Kotlin compiler daemon heap (separate from Gradle daemon heap)
+kotlin.daemon.jvmargs=-Xmx2048m
 org.gradle.caching=true
 android.enableR8.fullMode=false
 


### PR DESCRIPTION
Fix 5144 heic files

1) What changes did you make and why?

Fix for the older android versions that needed a message error instead of a crash for trying to use heic/heif files.
Fix of the EXIF data not retained for the new created image after being converted.

2) Tests performed (required)

I tried to test ProdDebug build on Pixel 6 emulator with API level 33 like last time but had some troubles on my end but I got prior agreement on this pr even if this test couldn't be done this time.
All the gradle tests pass.
