### PR TITLE
Fix i18n message

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -896,7 +896,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="image_tag_line_created_by_and_uploaded_by">Created by %1$s and uploaded by %2$s</string>
   <string name="nominated_for_deletion_btn">Nominated for Deletion</string>
   <string name="custom_selector_max_image_limit_reached">You can only select a maximum of %d images.</string>
-  <string name="edit_unsupported_format_explanation"><string name="edit_unsupported_format_explanation">In-app editing is only available for JPEG files. To edit other formats, please use a third-party tool.</string></string>
+  <string name="edit_unsupported_format_explanation">In-app editing is only available for JPEG files. To edit other formats, please use a third-party tool.</string>
   <string name="license_cc0_description">No copyright. You release all rights so anyone can use this work in any way.</string>
   <string name="license_cc_by_description">Attribution. Others are free to share and adapt as long as they give you credit.</string>
   <string name="license_cc_by_sa_description">Attribution-ShareAlike. Others can share and adapt, but must use the same license and give you credit.</string>


### PR DESCRIPTION
Fixed the bug where message is displayed as an empty string on translatewiki.net

<img width="1086" height="372" alt="image" src="https://github.com/user-attachments/assets/56313cf0-2fcd-4072-b622-7e99c0ffe260" />