### PR TITLE
Fix ViewBinding memory leak in MediaDetailFragment

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/media/MediaDetailFragment.kt
@@ -792,6 +792,7 @@ class MediaDetailFragment : CommonsDaggerSupportFragment(), CategoryEditHelper.C
         }
 
         compositeDisposable.clear()
+        _binding = null
 
         super.onDestroyView()
     }


### PR DESCRIPTION
**Description (required)**

Fixes #6827 
Set _binding = null in onDestroyView() to release the view hierarchy reference when the fragment view is destroyed

**Tests performed (required)**

Tested 6.4.0-debug on Pixel 9 (Android 16)
