### PR TITLE
Fix/issue 6845 reencode imperfect jpeg rotation

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/edit/TransformImageImpl.kt
+++ b/app/src/main/java/fr/free/nrw/commons/edit/TransformImageImpl.kt
@@ -1,5 +1,8 @@
 package fr.free.nrw.commons.edit
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
 import android.graphics.Rect
 import android.mediautil.image.jpeg.LLJTran
 import android.mediautil.image.jpeg.LLJTranException
@@ -16,6 +19,10 @@ import java.io.FileOutputStream
  * for rotating and cropping images using the LLJTran library for lossless JPEG transforms.
  */
 class TransformImageImpl : TransformImage {
+    companion object {
+        private const val REENCODE_JPEG_QUALITY = 95
+    }
+
     /**
      * Rotates the specified image file by the given degree.
      *
@@ -30,38 +37,42 @@ class TransformImageImpl : TransformImage {
     ): File? {
         Timber.tag("Trying to rotate image").d("Starting")
 
+        val normalizedDegree = ((degree % 360) + 360) % 360
+        val rotationOp =
+            when (normalizedDegree) {
+                0 -> null
+                90 -> LLJTran.ROT_90
+                180 -> LLJTran.ROT_180
+                270 -> LLJTran.ROT_270
+                else -> {
+                    Timber.w("Unsupported rotation degree: $degree")
+                    return null
+                }
+            }
+
         val imagePath = System.currentTimeMillis()
         val output = File(savePath, "rotated_$imagePath.jpg")
 
         val rotated =
             try {
-                val lljTran = LLJTran(imageFile)
-                lljTran.read(
-                    LLJTran.READ_ALL,
-                    false,
-                ) // This could throw an LLJTranException. I am not catching it for now... Let's see.
-                lljTran.transform(
-                    when (degree) {
-                        90 -> LLJTran.ROT_90
-                        180 -> LLJTran.ROT_180
-                        270 -> LLJTran.ROT_270
-                        else -> LLJTran.OPT_DEFAULTS
-                    },
-                    LLJTran.OPT_DEFAULTS or LLJTran.OPT_XFORM_ORIENTATION,
-                )
-                BufferedOutputStream(FileOutputStream(output)).use { writer ->
-                    lljTran.save(writer, LLJTran.OPT_WRITE_ALL)
+                if (rotationOp == null) {
+                    imageFile.copyTo(output, overwrite = true)
+                } else {
+                    rotateImageWithReencodeFallback(imageFile, output, normalizedDegree, rotationOp)
                 }
-                lljTran.freeMemory()
+
                 try {
                     val exif = ExifInterface(output.absolutePath)
                     exif.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL.toString())
                     exif.saveAttributes()
                 } catch (ex: Exception) {
-                    Timber.w(ex, "Failed to force EXIF orientation to tha Normal")
+                    Timber.w(ex, "Failed to force EXIF orientation to Normal")
                 }
                 true
             } catch (e: LLJTranException) {
+                Timber.tag("Error").d(e)
+                return null
+            } catch (e: Exception) {
                 Timber.tag("Error").d(e)
                 return null
             }
@@ -71,6 +82,80 @@ class TransformImageImpl : TransformImage {
             Timber.tag("Add").d(output.absolutePath)
         }
         return output
+    }
+
+    /**
+     * Uses lossless rotation for perfect JPEG transforms.
+     * Falls back to decode/rotate/re-encode for imperfect JPEGs to avoid
+     * visible edge artifacts while keeping the full rotated dimensions.
+     */
+    private fun rotateImageWithReencodeFallback(
+        imageFile: File,
+        output: File,
+        normalizedDegree: Int,
+        rotationOp: Int,
+    ) {
+        val lljTran = LLJTran(imageFile)
+        lljTran.read(
+            LLJTran.READ_ALL,
+            false,
+        ) // This could throw an LLJTranException. I am not catching it for now... Let's see.
+
+        val canRotateLosslessly = lljTran.checkPerfect(rotationOp, null) == 0
+
+        if (canRotateLosslessly) {
+            lljTran.transform(
+                rotationOp,
+                LLJTran.OPT_DEFAULTS or LLJTran.OPT_XFORM_ORIENTATION,
+            )
+            BufferedOutputStream(FileOutputStream(output)).use { writer ->
+                lljTran.save(writer, LLJTran.OPT_WRITE_ALL)
+            }
+            lljTran.freeMemory()
+            return
+        }
+
+        lljTran.freeMemory()
+        Timber.d("Using bitmap rotation fallback for imperfect JPEG")
+        reencodeRotatedBitmap(imageFile, output, normalizedDegree)
+    }
+
+    /**
+     * Re-encodes only the imperfect JPEG cases so the visible image keeps its full dimensions.
+     */
+    private fun reencodeRotatedBitmap(
+        imageFile: File,
+        output: File,
+        normalizedDegree: Int,
+    ) {
+        val sourceBitmap = BitmapFactory.decodeFile(imageFile.absolutePath)
+            ?: throw IllegalStateException("Failed to decode ${imageFile.absolutePath}")
+        val rotationMatrix = Matrix().apply {
+            postRotate(normalizedDegree.toFloat())
+        }
+        val rotatedBitmap =
+            Bitmap.createBitmap(
+                sourceBitmap,
+                0,
+                0,
+                sourceBitmap.width,
+                sourceBitmap.height,
+                rotationMatrix,
+                false,
+            )
+
+        try {
+            FileOutputStream(output).use { writer ->
+                check(rotatedBitmap.compress(Bitmap.CompressFormat.JPEG, REENCODE_JPEG_QUALITY, writer)) {
+                    "Failed to compress rotated bitmap"
+                }
+            }
+        } finally {
+            if (rotatedBitmap !== sourceBitmap) {
+                rotatedBitmap.recycle()
+            }
+            sourceBitmap.recycle()
+        }
     }
 
     /**

--- a/app/src/test/kotlin/fr/free/nrw/commons/edit/TransformImageTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/edit/TransformImageTest.kt
@@ -2,19 +2,25 @@ package fr.free.nrw.commons.edit
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Color
+import android.mediautil.image.jpeg.LLJTran
+import fr.free.nrw.commons.TestCommonsApplication
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import java.io.File
 import java.io.FileOutputStream
-import org.junit.Ignore
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [21], application = TestCommonsApplication::class)
 class TransformImageTest {
 
     @get:Rule
@@ -88,6 +94,49 @@ class TransformImageTest {
             finalBytes
         )
     }
+
+    private fun assertColorAlmostEquals(
+        message: String,
+        expectedColor: Int,
+        actualColor: Int,
+        tolerance: Int
+    ) {
+        assertChannelWithinTolerance(
+            message = message,
+            channelName = "red",
+            expected = Color.red(expectedColor),
+            actual = Color.red(actualColor),
+            tolerance = tolerance
+        )
+        assertChannelWithinTolerance(
+            message = message,
+            channelName = "green",
+            expected = Color.green(expectedColor),
+            actual = Color.green(actualColor),
+            tolerance = tolerance
+        )
+        assertChannelWithinTolerance(
+            message = message,
+            channelName = "blue",
+            expected = Color.blue(expectedColor),
+            actual = Color.blue(actualColor),
+            tolerance = tolerance
+        )
+    }
+
+    private fun assertChannelWithinTolerance(
+        message: String,
+        channelName: String,
+        expected: Int,
+        actual: Int,
+        tolerance: Int
+    ) {
+        val difference = kotlin.math.abs(expected - actual)
+        if (difference > tolerance) {
+            throw AssertionError("$message ($channelName channel) expected <$expected> but was <$actual>")
+        }
+    }
+
     @Ignore("Disabled due to ICC Color Profile brightness shift during rotation. see issue https://github.com/commons-app/apps-android-commons/issues/6659 ")
     @Test
     fun `test 360 degree rotation cycles for all EXIF images`() {
@@ -131,5 +180,37 @@ class TransformImageTest {
 
             println("$fileName passed all rotation cycle tests")
         }
+    }
+
+    @Test
+    fun `rotateImage keeps imperfect JPEG dimensions by re-encoding`() {
+        val originalFile = getResourceAsTempFile("TEST_1.jpg") ?: error("Missing test resource")
+        val lljTran = LLJTran(originalFile)
+        lljTran.read(LLJTran.READ_ALL, false)
+
+        assertNotEquals(
+            "TEST_1.jpg should exercise the imperfect JPEG fallback path",
+            0,
+            lljTran.checkPerfect(LLJTran.ROT_90, null)
+        )
+
+        lljTran.freeMemory()
+
+        val rotatedFile = transformImage.rotateImage(originalFile, 90, savePath)!!
+        val originalBitmap = decodeBitmap(originalFile)
+        val rotatedBitmap = decodeBitmap(rotatedFile)
+
+        assertEquals("Imperfect JPEG rotation should keep the full rotated width", originalBitmap.height, rotatedBitmap.width)
+        assertEquals("Imperfect JPEG rotation should keep the full rotated height", originalBitmap.width, rotatedBitmap.height)
+
+        val centerX = originalBitmap.width / 3
+        val centerY = originalBitmap.height / 3
+        assertColorAlmostEquals(
+            message = "Interior pixels should remain close after fallback re-encoding",
+            expectedColor = originalBitmap.getPixel(centerX, centerY),
+            actualColor = rotatedBitmap.getPixel(originalBitmap.height - centerY - 1, centerX),
+            tolerance = 20
+        )
+
     }
 }


### PR DESCRIPTION
**Description (required)**

Fixes #6845

**What changes did you make and why?**

While working on this issue, I considered three possible approaches for handling the rotation artifact on imperfect JPEGs.

1. Trim the image during lossless rotation
- This removes the problematic edge blocks and avoids the visible artifact.
- However, it changes the output resolution.
- For example, a 4000x3000 image rotated by 90 degrees may become 2992x4000 instead of keeping the full 3000x4000 size.
- Because this changes the saved image dimensions, I did not consider it the best user-facing behavior.

2. Rotate by changing EXIF orientation only
- This avoids re-encoding and also avoids the edge artifact.
- However, it does not rotate the actual image pixels. It only tells viewers how to display the image.
- After reviewing recent issue and PR discussions in this repository, this approach did not seem appropriate for this project.
- In particular, the recent rotation-related work expects the saved file itself to be in the correct orientation, with EXIF orientation reset to `NORMAL`, rather than relying on EXIF-only rotation behavior.

3. Keep lossless rotation for perfect JPEGs, and use re-encode fallback only for imperfect JPEGs
- This keeps the existing lossless behavior where it is safe.
- It avoids the visible edge artifact on imperfect JPEGs.
- It also keeps the full rotated image dimensions instead of trimming.
- This is not strictly lossless for imperfect JPEGs, because it re-encodes those files, but among the considered options it provided the best balance between image correctness, preserved dimensions, and user-visible output quality.

Based on those tradeoffs, this PR keeps the existing LLJTran lossless path for perfect JPEG transforms and only falls back to bitmap decode/rotate/re-encode when `LLJTran.checkPerfect(...)` shows that the JPEG transform is imperfect.

### Implementation summary:
- Keep lossless rotation for perfect JPEGs.
- Use re-encode fallback only when the JPEG transform is imperfect.
- Reset EXIF orientation to `NORMAL` after saving the rotated file.
- Add a unit test that verifies the imperfect JPEG fallback path, dimension preservation, and expected rotated pixel mapping.

### Demo Videos

**Before :**

https://github.com/user-attachments/assets/116fafb8-3935-451e-9532-395c22c7f0f7

**After :**

https://github.com/user-attachments/assets/b9cf0c33-bfb5-43c4-8aad-780f4f6ad734

**Tested on:** [Samsung S24 Ultra] | Android [16]