### PR TITLE
Fix: empty bookmarked items list by initializing LayoutManager and renaming RecyclerView

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/bookmarks/items/BookmarkItemsFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/bookmarks/items/BookmarkItemsFragment.kt
@@ -45,7 +45,8 @@ class BookmarkItemsFragment : DaggerFragment() {
      */
     private fun initList(context: Context) {
         val depictItems = controller!!.loadFavoritesItems()
-        binding!!.listView.adapter = BookmarkItemsAdapter(depictItems, context)
+        binding!!.recyclerView.apply { layoutManager = androidx.recyclerview.widget.LinearLayoutManager(context)
+            adapter = BookmarkItemsAdapter(depictItems, context) }
         binding!!.loadingImagesProgressBar.visibility = View.GONE
         if (depictItems.isEmpty()) {
             binding!!.statusMessage.setText(R.string.bookmark_empty)

--- a/app/src/main/res/layout/fragment_bookmarks_items.xml
+++ b/app/src/main/res/layout/fragment_bookmarks_items.xml
@@ -25,7 +25,7 @@
     android:visibility="gone" />
 
   <androidx.recyclerview.widget.RecyclerView
-    android:id="@+id/list_view"
+    android:id="@+id/recyclerView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:scrollbars="vertical"

--- a/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/items/BookmarkItemsFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/bookmarks/items/BookmarkItemsFragmentUnitTest.kt
@@ -102,7 +102,7 @@ class BookmarkItemsFragmentUnitTest {
 
         statusTextView = view.findViewById(R.id.status_message)
         progressBar = view.findViewById(R.id.loading_images_progress_bar)
-        recyclerView = view.findViewById(R.id.list_view)
+        recyclerView = view.findViewById(R.id.recyclerView)
 
         fragment.controller = controller
 


### PR DESCRIPTION
**Description (required)**

Fixes #6210

What changes did you make and why?

The bookmarks "items" tab was the failing to render the list of the bookmarked Wikidata items even though the data being present in the db.

-  added a LinearLayoutManager to the RecyclerView in boookmarkitemsfragment. because the RecyclerView requires a LayoutManager to position its items, the list remained blank even when the adapterr was populated.
- renamed the view id in fragment_bookmarks_items.xml from list_view to `recyclerView`. that legacy id was misleading, as ListView handles its own layout while RecyclerView does not.

**Tests performed (required)**

Tested **ProdDebug** on **Redmi Note 13 pro** with API level **35**.

- Bookmarked a new item from the explore tab.
- navigated to bookmarks -> items.
- and verified that the item is now visible (previously the screen was blank).
- deleted the bookmark and verified the "you don't have any bookmarks" message reappeared.

**Screenshots (for UI changes only)**


https://github.com/user-attachments/assets/ff335764-9bb3-4095-a112-6887180c321d



Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
