### PR TITLE
Fix InputStream leak in UploadModel.buildContributions()

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadModel.kt
@@ -164,9 +164,12 @@ class UploadModel @Inject internal constructor(
 
     fun buildContributions(): Observable<Contribution> {
         return Observable.fromIterable(items).map { item: UploadItem ->
-            val imageSHA1 = getSHA1(
-                context.contentResolver.openInputStream(item.contentUri!!)!!
-            )
+            val inputStream = requireNotNull(context.contentResolver.openInputStream(item.contentUri!!)) {
+                "Unable to open InputStream for contentUri: ${item.contentUri}"
+            }
+            val imageSHA1 = inputStream.use {
+                getSHA1(it)
+            }
             val contribution = Contribution(
                 item,
                 sessionManager,


### PR DESCRIPTION
**Description (required)**
Wrapped the InputStream initialization in a Kotlin .use block to guarantee safe resource closure
Fixes #6853 

**Tests performed (required)**

Tested 6.5.0-debug on Pixel 9(Android 16)