### PR TITLE
Fix/issue 6845 imperfect exif perfect lossless

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/edit/EditActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/edit/EditActivity.kt
@@ -275,10 +275,11 @@ class EditActivity : AppCompatActivity() {
     private fun saveEditedImage() {
         val filePath = imageUri.toUri().path
         var file = filePath?.let { File(it) }
+        val relativeRotation = ((imageRotation - startOrientation) % 360 + 360) % 360
 
         // Apply rotation first if needed
-        if (imageRotation != 0 && file != null) {
-            val rotatedImage = vm.rotateImage(imageRotation, file, applicationContext.cacheDir)
+        if (relativeRotation != 0 && file != null) {
+            val rotatedImage = vm.rotateImage(relativeRotation, file, applicationContext.cacheDir)
             if (rotatedImage == null) {
                 Toast.makeText(this, "Failed to rotate image", Toast.LENGTH_LONG).show()
                 return

--- a/app/src/main/java/fr/free/nrw/commons/edit/TransformImageImpl.kt
+++ b/app/src/main/java/fr/free/nrw/commons/edit/TransformImageImpl.kt
@@ -30,38 +30,40 @@ class TransformImageImpl : TransformImage {
     ): File? {
         Timber.tag("Trying to rotate image").d("Starting")
 
+        val normalizedDegree = ((degree % 360) + 360) % 360
+        val rotationOp =
+            when (normalizedDegree) {
+                0 -> null
+                90 -> LLJTran.ROT_90
+                180 -> LLJTran.ROT_180
+                270 -> LLJTran.ROT_270
+                else -> {
+                    Timber.w("Unsupported rotation degree: $degree")
+                    return null
+                }
+            }
+
         val imagePath = System.currentTimeMillis()
         val output = File(savePath, "rotated_$imagePath.jpg")
 
         val rotated =
             try {
-                val lljTran = LLJTran(imageFile)
-                lljTran.read(
-                    LLJTran.READ_ALL,
-                    false,
-                ) // This could throw an LLJTranException. I am not catching it for now... Let's see.
-                lljTran.transform(
-                    when (degree) {
-                        90 -> LLJTran.ROT_90
-                        180 -> LLJTran.ROT_180
-                        270 -> LLJTran.ROT_270
-                        else -> LLJTran.OPT_DEFAULTS
-                    },
-                    LLJTran.OPT_DEFAULTS or LLJTran.OPT_XFORM_ORIENTATION,
-                )
-                BufferedOutputStream(FileOutputStream(output)).use { writer ->
-                    lljTran.save(writer, LLJTran.OPT_WRITE_ALL)
-                }
-                lljTran.freeMemory()
-                try {
-                    val exif = ExifInterface(output.absolutePath)
-                    exif.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL.toString())
-                    exif.saveAttributes()
-                } catch (ex: Exception) {
-                    Timber.w(ex, "Failed to force EXIF orientation to tha Normal")
+                if (rotationOp == null) {
+                    imageFile.copyTo(output, overwrite = true)
+                    // Keep save behavior consistent with absolute rotation=0 target.
+                    // If source had non-normal EXIF orientation, normalize it here.
+                    forceExifOrientationNormal(output)
+                } else if (shouldRotateLosslessly(imageFile, rotationOp)) {
+                    rotateLosslessly(imageFile, output, rotationOp)
+                    forceExifOrientationNormal(output)
+                } else {
+                    rotateWithExifOrientationOnly(imageFile, output, normalizedDegree)
                 }
                 true
             } catch (e: LLJTranException) {
+                Timber.tag("Error").d(e)
+                return null
+            } catch (e: Exception) {
                 Timber.tag("Error").d(e)
                 return null
             }
@@ -71,6 +73,70 @@ class TransformImageImpl : TransformImage {
             Timber.tag("Add").d(output.absolutePath)
         }
         return output
+    }
+
+    private fun shouldRotateLosslessly(imageFile: File, rotationOp: Int): Boolean {
+        val lljTran = LLJTran(imageFile)
+        try {
+            lljTran.read(
+                LLJTran.READ_ALL,
+                false,
+            ) // This could throw an LLJTranException. I am not catching it for now... Let's see.
+            return lljTran.checkPerfect(rotationOp, null) == 0
+        } finally {
+            lljTran.freeMemory()
+        }
+    }
+
+    private fun rotateLosslessly(imageFile: File, output: File, rotationOp: Int) {
+        val lljTran = LLJTran(imageFile)
+        try {
+            lljTran.read(
+                LLJTran.READ_ALL,
+                false,
+            ) // This could throw an LLJTranException. I am not catching it for now... Let's see.
+            lljTran.transform(
+                rotationOp,
+                LLJTran.OPT_DEFAULTS or LLJTran.OPT_XFORM_ORIENTATION,
+            )
+            BufferedOutputStream(FileOutputStream(output)).use { writer ->
+                lljTran.save(writer, LLJTran.OPT_WRITE_ALL)
+            }
+        } finally {
+            lljTran.freeMemory()
+        }
+    }
+
+    private fun rotateWithExifOrientationOnly(
+        imageFile: File,
+        output: File,
+        normalizedDegree: Int,
+    ) {
+        imageFile.copyTo(output, overwrite = true)
+        val exif = ExifInterface(output.absolutePath)
+        val targetOrientation = exifOrientationForAbsoluteRotation(normalizedDegree)
+        exif.setAttribute(ExifInterface.TAG_ORIENTATION, targetOrientation.toString())
+        exif.saveAttributes()
+    }
+
+    private fun forceExifOrientationNormal(output: File) {
+        try {
+            val exif = ExifInterface(output.absolutePath)
+            exif.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL.toString())
+            exif.saveAttributes()
+        } catch (ex: Exception) {
+            Timber.w(ex, "Failed to force EXIF orientation to tha Normal")
+        }
+    }
+
+    private fun exifOrientationForAbsoluteRotation(rotationDegrees: Int): Int {
+        return when (rotationDegrees) {
+            0 -> ExifInterface.ORIENTATION_NORMAL
+            90 -> ExifInterface.ORIENTATION_ROTATE_90
+            180 -> ExifInterface.ORIENTATION_ROTATE_180
+            270 -> ExifInterface.ORIENTATION_ROTATE_270
+            else -> ExifInterface.ORIENTATION_UNDEFINED
+        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/edit/TransformImageImpl.kt
+++ b/app/src/main/java/fr/free/nrw/commons/edit/TransformImageImpl.kt
@@ -31,6 +31,7 @@ class TransformImageImpl : TransformImage {
         Timber.tag("Trying to rotate image").d("Starting")
 
         val normalizedDegree = ((degree % 360) + 360) % 360
+        val currentExifOrientation = readExifOrientation(imageFile)
         val rotationOp =
             when (normalizedDegree) {
                 0 -> null
@@ -50,12 +51,9 @@ class TransformImageImpl : TransformImage {
             try {
                 if (rotationOp == null) {
                     imageFile.copyTo(output, overwrite = true)
-                    // Keep save behavior consistent with absolute rotation=0 target.
-                    // If source had non-normal EXIF orientation, normalize it here.
-                    forceExifOrientationNormal(output)
                 } else if (shouldRotateLosslessly(imageFile, rotationOp)) {
                     rotateLosslessly(imageFile, output, rotationOp)
-                    forceExifOrientationNormal(output)
+                    forceExifOrientation(output, currentExifOrientation)
                 } else {
                     rotateWithExifOrientationOnly(imageFile, output, normalizedDegree)
                 }
@@ -113,29 +111,49 @@ class TransformImageImpl : TransformImage {
         normalizedDegree: Int,
     ) {
         imageFile.copyTo(output, overwrite = true)
-        val exif = ExifInterface(output.absolutePath)
-        val targetOrientation = exifOrientationForAbsoluteRotation(normalizedDegree)
-        exif.setAttribute(ExifInterface.TAG_ORIENTATION, targetOrientation.toString())
-        exif.saveAttributes()
+        val currentOrientation = readExifOrientation(output)
+        val currentDegrees = exifOrientationToDegrees(currentOrientation)
+        val targetDegrees = ((currentDegrees + normalizedDegree) % 360 + 360) % 360
+        val targetOrientation = degreesToExifOrientation(targetDegrees)
+        forceExifOrientation(output, targetOrientation)
     }
 
-    private fun forceExifOrientationNormal(output: File) {
+    private fun forceExifOrientation(output: File, orientation: Int) {
         try {
             val exif = ExifInterface(output.absolutePath)
-            exif.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL.toString())
+            exif.setAttribute(ExifInterface.TAG_ORIENTATION, orientation.toString())
             exif.saveAttributes()
         } catch (ex: Exception) {
-            Timber.w(ex, "Failed to force EXIF orientation to tha Normal")
+            Timber.w(ex, "Failed to set EXIF orientation")
         }
     }
 
-    private fun exifOrientationForAbsoluteRotation(rotationDegrees: Int): Int {
-        return when (rotationDegrees) {
-            0 -> ExifInterface.ORIENTATION_NORMAL
+    private fun readExifOrientation(imageFile: File): Int {
+        return try {
+            ExifInterface(imageFile.absolutePath).getAttributeInt(
+                ExifInterface.TAG_ORIENTATION,
+                ExifInterface.ORIENTATION_NORMAL
+            )
+        } catch (_: Exception) {
+            ExifInterface.ORIENTATION_NORMAL
+        }
+    }
+
+    private fun exifOrientationToDegrees(orientation: Int): Int {
+        return when (orientation) {
+            ExifInterface.ORIENTATION_ROTATE_90 -> 90
+            ExifInterface.ORIENTATION_ROTATE_180 -> 180
+            ExifInterface.ORIENTATION_ROTATE_270 -> 270
+            else -> 0
+        }
+    }
+
+    private fun degreesToExifOrientation(degrees: Int): Int {
+        return when (((degrees % 360) + 360) % 360) {
             90 -> ExifInterface.ORIENTATION_ROTATE_90
             180 -> ExifInterface.ORIENTATION_ROTATE_180
             270 -> ExifInterface.ORIENTATION_ROTATE_270
-            else -> ExifInterface.ORIENTATION_UNDEFINED
+            else -> ExifInterface.ORIENTATION_NORMAL
         }
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/edit/TransformImageImpl.kt
+++ b/app/src/main/java/fr/free/nrw/commons/edit/TransformImageImpl.kt
@@ -73,6 +73,14 @@ class TransformImageImpl : TransformImage {
         return output
     }
 
+    /**
+     * Checks whether the requested JPEG transform can be applied as a perfect
+     * lossless operation for the given image.
+     *
+     * @param imageFile The source JPEG file.
+     * @param rotationOp The LLJTran rotation operation (for example, ROT_90).
+     * @return True if the transform is perfect-lossless for this file, false otherwise.
+     */
     private fun shouldRotateLosslessly(imageFile: File, rotationOp: Int): Boolean {
         val lljTran = LLJTran(imageFile)
         try {
@@ -86,6 +94,15 @@ class TransformImageImpl : TransformImage {
         }
     }
 
+    /**
+     * Applies LLJTran lossless rotation and writes the full JPEG structure to [output].
+     *
+     * This path is used only when [shouldRotateLosslessly] returns true.
+     *
+     * @param imageFile The source JPEG file.
+     * @param output The destination file where the rotated JPEG is written.
+     * @param rotationOp The LLJTran rotation operation to apply.
+     */
     private fun rotateLosslessly(imageFile: File, output: File, rotationOp: Int) {
         val lljTran = LLJTran(imageFile)
         try {
@@ -105,6 +122,16 @@ class TransformImageImpl : TransformImage {
         }
     }
 
+    /**
+     * Performs a relative rotation by updating only EXIF orientation after copying
+     * the original JPEG bytes to [output].
+     *
+     * This path is used for imperfect JPEG transforms to avoid edge artifacts.
+     *
+     * @param imageFile The source JPEG file.
+     * @param output The destination file to write.
+     * @param normalizedDegree The clockwise relative rotation in degrees (0/90/180/270).
+     */
     private fun rotateWithExifOrientationOnly(
         imageFile: File,
         output: File,
@@ -118,6 +145,12 @@ class TransformImageImpl : TransformImage {
         forceExifOrientation(output, targetOrientation)
     }
 
+    /**
+     * Sets EXIF orientation on the given file.
+     *
+     * @param output The JPEG file whose EXIF orientation will be updated.
+     * @param orientation The EXIF orientation constant to set.
+     */
     private fun forceExifOrientation(output: File, orientation: Int) {
         try {
             val exif = ExifInterface(output.absolutePath)
@@ -128,6 +161,12 @@ class TransformImageImpl : TransformImage {
         }
     }
 
+    /**
+     * Reads EXIF orientation from [imageFile], defaulting to NORMAL on read failure.
+     *
+     * @param imageFile The JPEG file to inspect.
+     * @return The EXIF orientation constant. Returns ORIENTATION_NORMAL on failure.
+     */
     private fun readExifOrientation(imageFile: File): Int {
         return try {
             ExifInterface(imageFile.absolutePath).getAttributeInt(
@@ -139,6 +178,14 @@ class TransformImageImpl : TransformImage {
         }
     }
 
+    /**
+     * Converts EXIF orientation constants to clockwise degrees.
+     *
+     * Non-rotating and unsupported values are treated as 0 degrees.
+     *
+     * @param orientation The EXIF orientation constant.
+     * @return The equivalent clockwise rotation in degrees.
+     */
     private fun exifOrientationToDegrees(orientation: Int): Int {
         return when (orientation) {
             ExifInterface.ORIENTATION_ROTATE_90 -> 90
@@ -148,6 +195,12 @@ class TransformImageImpl : TransformImage {
         }
     }
 
+    /**
+     * Converts clockwise degrees to EXIF orientation constants.
+     *
+     * @param degrees The clockwise rotation in degrees.
+     * @return The corresponding EXIF orientation constant.
+     */
     private fun degreesToExifOrientation(degrees: Int): Int {
         return when (((degrees % 360) + 360) % 360) {
             90 -> ExifInterface.ORIENTATION_ROTATE_90

--- a/app/src/test/kotlin/fr/free/nrw/commons/edit/TransformImageTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/edit/TransformImageTest.kt
@@ -2,8 +2,11 @@ package fr.free.nrw.commons.edit
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.mediautil.image.jpeg.LLJTran
+import androidx.exifinterface.media.ExifInterface
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -88,6 +91,37 @@ class TransformImageTest {
             finalBytes
         )
     }
+
+    private fun getTempFileForRotationType(expectPerfect: Boolean): File {
+        val candidates =
+            listOf(
+                "TEST_1.jpg",
+                "TEST_IMAGE.jpg",
+                "Landscape_1.jpg",
+                "Landscape_2.jpg",
+                "Landscape_3.jpg",
+                "Portrait_1.jpg",
+                "Portrait_2.jpg",
+                "Portrait_3.jpg",
+            )
+
+        for (fileName in candidates) {
+            val file = getResourceAsTempFile(fileName) ?: continue
+            val lljTran = LLJTran(file)
+            try {
+                lljTran.read(LLJTran.READ_ALL, false)
+                val isPerfect = lljTran.checkPerfect(LLJTran.ROT_90, null) == 0
+                if (isPerfect == expectPerfect) {
+                    return file
+                }
+            } finally {
+                lljTran.freeMemory()
+            }
+        }
+
+        throw AssertionError("No ${if (expectPerfect) "perfect" else "imperfect"} JPEG test resource found")
+    }
+
     @Ignore("Disabled due to ICC Color Profile brightness shift during rotation. see issue https://github.com/commons-app/apps-android-commons/issues/6659 ")
     @Test
     fun `test 360 degree rotation cycles for all EXIF images`() {
@@ -131,5 +165,90 @@ class TransformImageTest {
 
             println("$fileName passed all rotation cycle tests")
         }
+    }
+
+    @Test
+    fun `rotateImage keeps lossless pixel rotation for perfect JPEG`() {
+        val originalFile = getTempFileForRotationType(expectPerfect = true)
+        val rotatedFile = transformImage.rotateImage(originalFile, 90, savePath)
+        assertNotNull(rotatedFile)
+        assertRotationWorked(originalFile, rotatedFile!!, 90)
+
+        val rotatedExif = ExifInterface(rotatedFile.absolutePath)
+        assertEquals(
+            "Perfect JPEG path should write pixels rotated and reset orientation to normal",
+            ExifInterface.ORIENTATION_NORMAL,
+            rotatedExif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
+        )
+    }
+
+    @Test
+    fun `rotateImage applies EXIF-only rotation for imperfect JPEG`() {
+        val originalFile = getTempFileForRotationType(expectPerfect = false)
+
+        val sourceExif = ExifInterface(originalFile.absolutePath)
+        sourceExif.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL.toString())
+        sourceExif.saveAttributes()
+
+        val rotatedFile = transformImage.rotateImage(originalFile, 90, savePath)
+        assertNotNull(rotatedFile)
+
+        val rotatedExif = ExifInterface(rotatedFile!!.absolutePath)
+        assertEquals(
+            "Imperfect JPEG path should rotate via EXIF orientation only",
+            ExifInterface.ORIENTATION_ROTATE_90,
+            rotatedExif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
+        )
+
+        val originalBitmap = decodeBitmap(originalFile)
+        val rotatedBitmap = decodeBitmap(rotatedFile)
+        assertEquals("EXIF-only rotation should keep pixel width unchanged", originalBitmap.width, rotatedBitmap.width)
+        assertEquals("EXIF-only rotation should keep pixel height unchanged", originalBitmap.height, rotatedBitmap.height)
+
+        val testX = originalBitmap.width / 3
+        val testY = originalBitmap.height / 3
+        assertEquals(
+            "EXIF-only rotation should not change pixel matrix",
+            originalBitmap.getPixel(testX, testY),
+            rotatedBitmap.getPixel(testX, testY)
+        )
+    }
+
+    @Test
+    fun `rotateImage EXIF-only path uses absolute target orientation`() {
+        val originalFile = getTempFileForRotationType(expectPerfect = false)
+
+        val sourceExif = ExifInterface(originalFile.absolutePath)
+        sourceExif.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_ROTATE_90.toString())
+        sourceExif.saveAttributes()
+
+        val rotatedFile = transformImage.rotateImage(originalFile, 180, savePath)
+        assertNotNull(rotatedFile)
+
+        val rotatedExif = ExifInterface(rotatedFile!!.absolutePath)
+        assertEquals(
+            "EXIF-only path must set final orientation to the absolute requested rotation",
+            ExifInterface.ORIENTATION_ROTATE_180,
+            rotatedExif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
+        )
+    }
+
+    @Test
+    fun `rotateImage zero degree normalizes EXIF orientation`() {
+        val originalFile = getTempFileForRotationType(expectPerfect = false)
+
+        val sourceExif = ExifInterface(originalFile.absolutePath)
+        sourceExif.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_ROTATE_90.toString())
+        sourceExif.saveAttributes()
+
+        val rotatedFile = transformImage.rotateImage(originalFile, 0, savePath)
+        assertNotNull(rotatedFile)
+
+        val rotatedExif = ExifInterface(rotatedFile!!.absolutePath)
+        assertEquals(
+            "Zero-degree target should save with NORMAL orientation",
+            ExifInterface.ORIENTATION_NORMAL,
+            rotatedExif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
+        )
     }
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/edit/TransformImageTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/edit/TransformImageTest.kt
@@ -170,6 +170,10 @@ class TransformImageTest {
     @Test
     fun `rotateImage keeps lossless pixel rotation for perfect JPEG`() {
         val originalFile = getTempFileForRotationType(expectPerfect = true)
+        val sourceExif = ExifInterface(originalFile.absolutePath)
+        sourceExif.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL.toString())
+        sourceExif.saveAttributes()
+
         val rotatedFile = transformImage.rotateImage(originalFile, 90, savePath)
         assertNotNull(rotatedFile)
         assertRotationWorked(originalFile, rotatedFile!!, 90)
@@ -215,7 +219,7 @@ class TransformImageTest {
     }
 
     @Test
-    fun `rotateImage EXIF-only path uses absolute target orientation`() {
+    fun `rotateImage EXIF-only path applies relative rotation on current orientation`() {
         val originalFile = getTempFileForRotationType(expectPerfect = false)
 
         val sourceExif = ExifInterface(originalFile.absolutePath)
@@ -227,18 +231,18 @@ class TransformImageTest {
 
         val rotatedExif = ExifInterface(rotatedFile!!.absolutePath)
         assertEquals(
-            "EXIF-only path must set final orientation to the absolute requested rotation",
-            ExifInterface.ORIENTATION_ROTATE_180,
+            "EXIF-only path should add relative rotation to current orientation",
+            ExifInterface.ORIENTATION_ROTATE_270,
             rotatedExif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
         )
     }
 
     @Test
-    fun `rotateImage zero degree normalizes EXIF orientation`() {
+    fun `rotateImage zero degree keeps EXIF orientation when already normal`() {
         val originalFile = getTempFileForRotationType(expectPerfect = false)
 
         val sourceExif = ExifInterface(originalFile.absolutePath)
-        sourceExif.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_ROTATE_90.toString())
+        sourceExif.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL.toString())
         sourceExif.saveAttributes()
 
         val rotatedFile = transformImage.rotateImage(originalFile, 0, savePath)
@@ -246,9 +250,62 @@ class TransformImageTest {
 
         val rotatedExif = ExifInterface(rotatedFile!!.absolutePath)
         assertEquals(
-            "Zero-degree target should save with NORMAL orientation",
+            "Zero-degree save should keep NORMAL orientation",
             ExifInterface.ORIENTATION_NORMAL,
             rotatedExif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
+        )
+    }
+
+    @Test
+    fun `rotateImage repeated saves returns to original orientation after full cycle`() {
+        val originalFile = getTempFileForRotationType(expectPerfect = false)
+
+        val sourceExif = ExifInterface(originalFile.absolutePath)
+        sourceExif.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL.toString())
+        sourceExif.saveAttributes()
+
+        val fileAfterFirstSave = transformImage.rotateImage(originalFile, 90, savePath)
+        assertNotNull(fileAfterFirstSave)
+
+        val fileAfterSecondSave = transformImage.rotateImage(fileAfterFirstSave!!, 90, savePath)
+        assertNotNull(fileAfterSecondSave)
+
+        val fileAfterThirdSave = transformImage.rotateImage(fileAfterSecondSave!!, 180, savePath)
+        assertNotNull(fileAfterThirdSave)
+
+        val finalExif = ExifInterface(fileAfterThirdSave!!.absolutePath)
+        assertEquals(
+            "After 90 -> 90 -> 180 relative saves, EXIF orientation should return to NORMAL",
+            ExifInterface.ORIENTATION_NORMAL,
+            finalExif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
+        )
+    }
+
+    @Test
+    fun `rotateImage 180 then another 180 returns to normal for imperfect JPEG`() {
+        val originalFile = getTempFileForRotationType(expectPerfect = false)
+        val sourceExif = ExifInterface(originalFile.absolutePath)
+        sourceExif.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL.toString())
+        sourceExif.saveAttributes()
+
+        val afterFirst180 = transformImage.rotateImage(originalFile, 180, savePath)
+        assertNotNull(afterFirst180)
+
+        val exifAfterFirst = ExifInterface(afterFirst180!!.absolutePath)
+        assertEquals(
+            "After first 180 save, EXIF should represent 180 orientation",
+            ExifInterface.ORIENTATION_ROTATE_180,
+            exifAfterFirst.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
+        )
+
+        val afterSecond180 = transformImage.rotateImage(afterFirst180, 180, savePath)
+        assertNotNull(afterSecond180)
+
+        val finalExif = ExifInterface(afterSecond180!!.absolutePath)
+        assertEquals(
+            "After 180 + 180, EXIF should return to NORMAL",
+            ExifInterface.ORIENTATION_NORMAL,
+            finalExif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
         )
     }
 }


### PR DESCRIPTION
## Description
Fixes #6845: Rotated 4000x3000 picture gets border artefact.

This PR keeps the existing lossless LLJTran path for perfect JPEG transforms, and uses EXIF-only rotation for imperfect JPEG transforms to avoid border artefacts.

What changed:
1. Rotation input handling is consistent via relative rotation.
- `startOrientation`: EXIF orientation when EditActivity opens (initial baseline).
- `imageRotation`: current preview rotation after user taps rotate.
- On save, actual rotation is computed as:
  - `relativeRotation = (imageRotation - startOrientation) mod 360`

2. Transform behavior:
- **Perfect JPEG path** (lossless LLJTran):
  - No behavioral change from existing lossless path.
- **Imperfect JPEG path** (EXIF-only):
  - Pixel data is not re-encoded.
  - EXIF orientation is updated by applying `relativeRotation` to current orientation.

## Tests performed

Updated/added tests in `TransformImageTest`:
- `rotateImage keeps lossless pixel rotation for perfect JPEG`
- `rotateImage applies EXIF-only rotation for imperfect JPEG`
- `rotateImage EXIF-only path applies relative rotation on current orientation`
- `rotateImage zero degree keeps EXIF orientation when already normal`
- `rotateImage repeated saves returns to original orientation after full cycle`
- `rotateImage 180 then another 180 returns to normal for imperfect JPEG`

Demo Videos
**Before :**

https://github.com/user-attachments/assets/116fafb8-3935-451e-9532-395c22c7f0f7

**After :**

https://github.com/user-attachments/assets/fb153bff-8267-443e-b673-9376d4d830d7

**Tested on:** [Samsung S24 Ultra] | Android [16]

