### PR TITLE
Replace deprecated ProgressDialog with modern AlertDialog

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/auth/LoginActivity.kt
@@ -1,7 +1,6 @@
 package fr.free.nrw.commons.auth
 
 import android.accounts.AccountAuthenticatorActivity
-import android.app.ProgressDialog
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
@@ -34,6 +33,7 @@ import fr.free.nrw.commons.databinding.ActivityLoginBinding
 import fr.free.nrw.commons.di.ApplicationlessInjection
 import fr.free.nrw.commons.kvstore.JsonKvStore
 import fr.free.nrw.commons.utils.applyEdgeToEdgeAllInsets
+import fr.free.nrw.commons.utils.DialogUtil
 import fr.free.nrw.commons.utils.AbstractTextWatcher
 import fr.free.nrw.commons.utils.ActivityUtils.startActivityWithFlags
 import fr.free.nrw.commons.utils.ConfigUtils.isBetaFlavour
@@ -62,7 +62,7 @@ class LoginActivity : AccountAuthenticatorActivity() {
     lateinit var systemThemeUtils: SystemThemeUtils
 
     private var binding: ActivityLoginBinding? = null
-    private var progressDialog: ProgressDialog? = null
+    private var progressDialog: AlertDialog? = null
     private val textWatcher = AbstractTextWatcher(::onTextChanged)
     private val compositeDisposable = CompositeDisposable()
     private val delegate: AppCompatDelegate by lazy {
@@ -403,12 +403,11 @@ class LoginActivity : AccountAuthenticatorActivity() {
     }
 
     private fun showLoggingProgressBar() {
-        progressDialog = ProgressDialog(this).apply {
-            isIndeterminate = true
-            setTitle(getString(R.string.logging_in_title))
-            setMessage(getString(R.string.logging_in_message))
-            setCancelable(false)
-        }
+        progressDialog = DialogUtil.createProgressDialog(
+            context = this,
+            title = getString(R.string.logging_in_title),
+            message = getString(R.string.logging_in_message),
+        )
         progressDialog!!.show()
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/description/DescriptionEditActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/description/DescriptionEditActivity.kt
@@ -1,6 +1,6 @@
 package fr.free.nrw.commons.description
 
-import android.app.ProgressDialog
+import androidx.appcompat.app.AlertDialog
 import android.os.Bundle
 import android.os.Parcelable
 import android.speech.RecognizerIntent
@@ -24,6 +24,7 @@ import fr.free.nrw.commons.theme.BaseActivity
 import fr.free.nrw.commons.utils.applyEdgeToEdgeBottomInsets
 import fr.free.nrw.commons.upload.UploadMediaDetail
 import fr.free.nrw.commons.upload.UploadMediaDetailAdapter
+import fr.free.nrw.commons.utils.DialogUtil
 import fr.free.nrw.commons.utils.DialogUtil.showAlertDialog
 import fr.free.nrw.commons.utils.applyEdgeToEdgeTopPaddingInsets
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -67,7 +68,7 @@ class DescriptionEditActivity :
     /**
      * For showing progress dialog
      */
-    private var progressDialog: ProgressDialog? = null
+    private var progressDialog: AlertDialog? = null
 
     @Inject
     lateinit var recentLanguagesDao: RecentLanguagesDao
@@ -301,11 +302,11 @@ class DescriptionEditActivity :
     }
 
     private fun showLoggingProgressBar() {
-        progressDialog = ProgressDialog(this)
-        progressDialog!!.isIndeterminate = true
-        progressDialog!!.setTitle(getString(R.string.updating_caption_title))
-        progressDialog!!.setMessage(getString(R.string.updating_caption_message))
-        progressDialog!!.setCancelable(false)
+        progressDialog = DialogUtil.createProgressDialog(
+            context = this,
+            title = getString(R.string.updating_caption_title),
+            message = getString(R.string.updating_caption_message),
+        )
         progressDialog!!.show()
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
@@ -2,7 +2,6 @@ package fr.free.nrw.commons.nearby.fragments
 
 import android.Manifest.permission
 import android.annotation.SuppressLint
-import android.app.ProgressDialog
 import android.content.ActivityNotFoundException
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -92,6 +91,7 @@ import fr.free.nrw.commons.nearby.contract.NearbyParentFragmentContract
 import fr.free.nrw.commons.nearby.model.BottomSheetItem
 import fr.free.nrw.commons.nearby.presenter.NearbyParentFragmentPresenter
 import fr.free.nrw.commons.upload.FileUtils
+import fr.free.nrw.commons.utils.DialogUtil
 import fr.free.nrw.commons.utils.DialogUtil.showAlertDialog
 import fr.free.nrw.commons.utils.ExecutorUtils.get
 import fr.free.nrw.commons.utils.LayoutUtils.getScreenWidth
@@ -232,7 +232,7 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
     private var isFABsExpanded = false
     private var selectedPlace: Place? = null
     private var clickedMarker: Marker? = null
-    private var progressDialog: ProgressDialog? = null
+    private var progressDialog: AlertDialog? = null
     private val CAMERA_TARGET_SHIFT_FACTOR_PORTRAIT = 0.005
     private val CAMERA_TARGET_SHIFT_FACTOR_LANDSCAPE = 0.004
     private var isPermissionDenied = false
@@ -388,9 +388,6 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
             bookmarkLocationDao!!,
             placesRepository!!, nearbyController!!
         )
-        progressDialog = ProgressDialog(activity)
-        progressDialog!!.setCancelable(false)
-        progressDialog!!.setMessage("Saving in progress...")
         setHasOptionsMenu(true)
 
         // Inflate the layout for this fragment
@@ -434,7 +431,11 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
 
         saveAsGPXButton.setOnMenuItemClickListener {
             try {
-                progressDialog!!.setTitle(getString(fr.free.nrw.commons.R.string.saving_gpx_file))
+                progressDialog = DialogUtil.createProgressDialog(
+                    context = requireContext(),
+                    title = getString(fr.free.nrw.commons.R.string.saving_gpx_file),
+                    message = getString(fr.free.nrw.commons.R.string.saving_in_progress),
+                )
                 progressDialog!!.show()
                 savePlacesAsGPX()
             } catch (e: Exception) {
@@ -444,7 +445,11 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
         }
         saveAsKMLButton.setOnMenuItemClickListener {
             try {
-                progressDialog!!.setTitle(getString(fr.free.nrw.commons.R.string.saving_kml_file))
+                progressDialog = DialogUtil.createProgressDialog(
+                    context = requireContext(),
+                    title = getString(fr.free.nrw.commons.R.string.saving_kml_file),
+                    message = getString(fr.free.nrw.commons.R.string.saving_in_progress),
+                )
                 progressDialog!!.show()
                 savePlacesAsKML()
             } catch (e: Exception) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadActivity.kt
@@ -2,7 +2,6 @@ package fr.free.nrw.commons.upload
 
 import android.Manifest
 import android.annotation.SuppressLint
-import android.app.ProgressDialog
 import android.content.DialogInterface
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -48,6 +47,7 @@ import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment
 import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.UploadMediaDetailFragmentCallback
 import fr.free.nrw.commons.upload.mediaDetails.UploadMediaPresenter
 import fr.free.nrw.commons.upload.worker.WorkRequestHelper.Companion.makeOneTimeWorkRequest
+import fr.free.nrw.commons.utils.DialogUtil
 import fr.free.nrw.commons.utils.DialogUtil.showAlertDialog
 import fr.free.nrw.commons.utils.PermissionUtils.PERMISSIONS_STORAGE
 import fr.free.nrw.commons.utils.PermissionUtils.checkPermissionsAndPerformAction
@@ -93,7 +93,7 @@ class UploadActivity : BaseActivity(), UploadContract.View, UploadBaseFragment.C
 
     private var isTitleExpanded = true
 
-    private var progressDialog: ProgressDialog? = null
+    private var progressDialog: AlertDialog? = null
     private var uploadImagesAdapter: UploadImageAdapter? = null
     private var fragments: MutableList<UploadBaseFragment>? = null
     private var uploadCategoriesFragment: UploadCategoriesFragment? = null
@@ -241,9 +241,10 @@ class UploadActivity : BaseActivity(), UploadContract.View, UploadBaseFragment.C
     }
 
     private fun initProgressDialog() {
-        progressDialog = ProgressDialog(this)
-        progressDialog!!.setMessage(getString(R.string.please_wait))
-        progressDialog!!.setCancelable(false)
+        progressDialog = DialogUtil.createProgressDialog(
+            context = this,
+            message = getString(R.string.please_wait),
+        )
     }
 
     private fun initThumbnailsRecyclerView() {

--- a/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/categories/UploadCategoriesFragment.kt
@@ -2,7 +2,6 @@ package fr.free.nrw.commons.upload.categories
 
 import android.annotation.SuppressLint
 import android.app.Activity
-import android.app.ProgressDialog
 import android.content.Context
 import android.os.Bundle
 import android.view.KeyEvent
@@ -28,6 +27,7 @@ import fr.free.nrw.commons.media.MediaDetailFragment
 import fr.free.nrw.commons.upload.UploadActivity
 import fr.free.nrw.commons.upload.UploadBaseFragment
 import fr.free.nrw.commons.utils.DialogUtil.showAlertDialog
+import fr.free.nrw.commons.utils.DialogUtil
 import fr.free.nrw.commons.utils.handleKeyboardInsets
 import fr.free.nrw.commons.wikidata.WikidataConstants.SELECTED_NEARBY_PLACE_CATEGORY
 import io.reactivex.Notification
@@ -56,7 +56,7 @@ class UploadCategoriesFragment : UploadBaseFragment(), CategoriesContract.View {
     /**
      * Progress Dialog for showing background process
      */
-    private var progressDialog: ProgressDialog? = null
+    private var progressDialog: AlertDialog? = null
 
     /**
      * WikiText from the server
@@ -297,11 +297,11 @@ class UploadCategoriesFragment : UploadBaseFragment(), CategoriesContract.View {
      * Shows the progress dialog
      */
     override fun showProgressDialog() {
-        progressDialog = ProgressDialog(requireContext()).apply {
-            setMessage(getString(R.string.please_wait))
-        }.also {
-            it.show()
-        }
+        progressDialog = DialogUtil.createProgressDialog(
+            context = requireContext(),
+            message = getString(R.string.please_wait),
+        )
+        progressDialog!!.show()
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/depicts/DepictsFragment.kt
@@ -1,7 +1,7 @@
 package fr.free.nrw.commons.upload.depicts
 
 import android.app.Activity
-import android.app.ProgressDialog
+import androidx.appcompat.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -33,6 +33,7 @@ import fr.free.nrw.commons.upload.UploadActivity
 import fr.free.nrw.commons.upload.UploadBaseFragment
 import fr.free.nrw.commons.upload.structure.depictions.DepictedItem
 import fr.free.nrw.commons.utils.DialogUtil.showAlertDialog
+import fr.free.nrw.commons.utils.DialogUtil
 import fr.free.nrw.commons.utils.handleKeyboardInsets
 import fr.free.nrw.commons.wikidata.WikidataConstants.SELECTED_NEARBY_PLACE
 import io.reactivex.Notification
@@ -65,7 +66,7 @@ class DepictsFragment : UploadBaseFragment(), DepictsContract.View {
     private var adapter: UploadDepictsAdapter? = null
     private var subscribe: Disposable? = null
     private var media: Media? = null
-    private var progressDialog: ProgressDialog? = null
+    private var progressDialog: AlertDialog? = null
 
     /**
      * Determines each encounter of edit depicts
@@ -364,9 +365,10 @@ class DepictsFragment : UploadBaseFragment(), DepictsContract.View {
      * Shows the progress dialog
      */
     override fun showProgressDialog() {
-        progressDialog = ProgressDialog(requireContext())
-        progressDialog!!.setMessage(getString(R.string.please_wait))
-        progressDialog!!.setCancelable(false)
+        progressDialog = DialogUtil.createProgressDialog(
+            context = requireContext(),
+            message = getString(R.string.please_wait),
+        )
         progressDialog!!.show()
     }
 

--- a/app/src/main/java/fr/free/nrw/commons/utils/DialogUtil.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/DialogUtil.kt
@@ -2,7 +2,13 @@ package fr.free.nrw.commons.utils
 
 import android.app.Activity
 import android.app.AlertDialog
+import android.content.Context
+import android.view.Gravity
 import android.view.View
+import android.widget.LinearLayout
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog as AppCompatAlertDialog
 import fr.free.nrw.commons.R
 import timber.log.Timber
 
@@ -179,5 +185,44 @@ object DialogUtil {
                     }
                 }.create(),
         )
+    }
+    @JvmStatic
+    @JvmOverloads
+    fun createProgressDialog(
+        context: Context,
+        title: String? = null,
+        message: String,
+        cancelable: Boolean = false,
+    ): AppCompatAlertDialog {
+        val padding = context.resources
+            .getDimensionPixelSize(R.dimen.standard_gap)
+
+        val progressBar = ProgressBar(context).apply {
+            isIndeterminate = true
+        }
+
+        val messageView = TextView(context).apply {
+            text = message
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ).also { it.marginStart = padding }
+        }
+
+        val layout = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(padding, padding, padding, padding)
+            addView(progressBar)
+            addView(messageView)
+        }
+
+        return AppCompatAlertDialog.Builder(context)
+            .apply {
+                title?.let { setTitle(it) }
+                setView(layout)
+                setCancelable(cancelable)
+            }
+            .create()
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/ImageUtils.kt
@@ -2,8 +2,8 @@ package fr.free.nrw.commons.utils
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
-import android.app.ProgressDialog
 import android.content.Context
+import androidx.appcompat.app.AlertDialog
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
@@ -23,6 +23,7 @@ import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
+import fr.free.nrw.commons.utils.DialogUtil
 import timber.log.Timber
 import androidx.core.graphics.createBitmap
 
@@ -75,9 +76,7 @@ object ImageUtils {
     const val NO_CATEGORY_SELECTED = -5
     const val IMAGE_FORMAT_UNSUPPORTED = 1 shl 7 // 128
 
-    private var progressDialogWallpaper: ProgressDialog? = null
-
-    private var progressDialogAvatar: ProgressDialog? = null
+    private var progressDialogAvatar: AlertDialog? = null
 
     @IntDef(
         flag = true,
@@ -281,25 +280,13 @@ object ImageUtils {
     }
 
     @JvmStatic
-    private fun showSettingWallpaperProgressBar(context: Context) {
-        progressDialogWallpaper = ProgressDialog.show(
-            context,
-            context.getString(R.string.setting_wallpaper_dialog_title),
-            context.getString(R.string.setting_wallpaper_dialog_message),
-            true,
-            false
-        )
-    }
-
-    @JvmStatic
     private fun showSettingAvatarProgressBar(context: Context) {
-        progressDialogAvatar = ProgressDialog.show(
-            context,
-            context.getString(R.string.setting_avatar_dialog_title),
-            context.getString(R.string.setting_avatar_dialog_message),
-            true,
-            false
+        progressDialogAvatar = DialogUtil.createProgressDialog(
+            context = context,
+            title = context.getString(R.string.setting_avatar_dialog_title),
+            message = context.getString(R.string.setting_avatar_dialog_message),
         )
+        progressDialogAvatar!!.show()
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -839,6 +839,7 @@ Upload your first media by tapping on the add button.</string>
   <string name="failed_to_save_gpx_file">Failed to save the GPX file.</string>
   <string name="saving_kml_file">Saving as a KML file...</string>
   <string name="saving_gpx_file">Saving as a GPX file...</string>
+  <string name="saving_in_progress">Saving in progress…</string>
   <plurals name="custom_picker_images_selected_title_appendix">
     <item quantity="one">%1$d image selected</item>
     <item quantity="other">%1$d images selected</item>

--- a/app/src/test/kotlin/fr/free/nrw/commons/auth/LoginActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/auth/LoginActivityUnitTests.kt
@@ -1,7 +1,7 @@
 package fr.free.nrw.commons.auth
 
 import android.accounts.Account
-import android.app.ProgressDialog
+import androidx.appcompat.app.AlertDialog
 import android.content.Context
 import android.os.Bundle
 import android.view.KeyEvent
@@ -41,7 +41,7 @@ class LoginActivityUnitTests {
     private lateinit var activity: LoginActivity
 
     @Mock
-    private lateinit var progressDialog: ProgressDialog
+    private lateinit var progressDialog: AlertDialog
 
     @Mock
     private lateinit var view: View

--- a/app/src/test/kotlin/fr/free/nrw/commons/description/DescriptionEditActivityUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/description/DescriptionEditActivityUnitTest.kt
@@ -2,7 +2,6 @@ package fr.free.nrw.commons.description
 
 import android.app.Activity
 import android.app.AlertDialog
-import android.app.ProgressDialog
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -37,8 +36,8 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import org.robolectric.shadows.ShadowAlertDialog
-import org.robolectric.shadows.ShadowProgressDialog
+import org.robolectric.shadows.ShadowDialog
+
 import java.lang.reflect.Method
 import java.util.Date
 
@@ -121,7 +120,7 @@ class DescriptionEditActivityUnitTest {
             )
         method.isAccessible = true
         method.invoke(activity)
-        val dialog: ProgressDialog = ShadowProgressDialog.getLatestDialog() as ProgressDialog
+        val dialog: androidx.appcompat.app.AlertDialog = ShadowDialog.getLatestDialog() as androidx.appcompat.app.AlertDialog
         assertEquals(dialog.isShowing, true)
     }
 
@@ -196,7 +195,7 @@ class DescriptionEditActivityUnitTest {
             R.string.ok,
             R.string.ok,
         )
-        val dialog: AlertDialog = ShadowAlertDialog.getLatestDialog() as AlertDialog
+        val dialog: AlertDialog = ShadowDialog.getLatestDialog() as AlertDialog
         assertEquals(dialog.isShowing, true)
     }
 }

--- a/app/src/test/kotlin/fr/free/nrw/commons/login/LoginActivityUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/login/LoginActivityUnitTests.kt
@@ -1,6 +1,6 @@
 package fr.free.nrw.commons.login
 
-import android.app.ProgressDialog
+import androidx.appcompat.app.AlertDialog
 import android.content.Context
 import android.view.MenuItem
 import android.view.View
@@ -32,7 +32,7 @@ class LoginActivityUnitTests {
     private lateinit var context: Context
 
     @Mock
-    private lateinit var progressDialog: ProgressDialog
+    private lateinit var progressDialog: AlertDialog
 
     @Mock
     private lateinit var view: View

--- a/app/src/test/kotlin/fr/free/nrw/commons/navtab/MoreBottomSheetFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/navtab/MoreBottomSheetFragmentUnitTests.kt
@@ -101,7 +101,7 @@ class MoreBottomSheetFragmentUnitTests {
     fun testOnLogoutClicked() {
         Shadows.shadowOf(Looper.getMainLooper()).idle()
         fragment.onLogoutClicked()
-        val dialog: AlertDialog = ShadowAlertDialog.getLatestDialog() as AlertDialog
+        val dialog: AlertDialog = ShadowDialog.getLatestDialog() as AlertDialog
         Assert.assertEquals(dialog.isShowing, true)
     }
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/depicts/DepictsFragmentUnitTests.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/depicts/DepictsFragmentUnitTests.kt
@@ -1,6 +1,6 @@
 package fr.free.nrw.commons.upload.depicts
 
-import android.app.ProgressDialog
+import androidx.appcompat.app.AlertDialog
 import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -61,7 +61,7 @@ class DepictsFragmentUnitTests {
     private lateinit var media: Media
 
     @Mock
-    private lateinit var progressDialog: ProgressDialog
+    private lateinit var progressDialog: AlertDialog
 
     @Before
     fun setUp() {

--- a/app/src/test/kotlin/fr/free/nrw/commons/utils/ImageUtilsTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/utils/ImageUtilsTest.kt
@@ -1,6 +1,6 @@
 package fr.free.nrw.commons.utils
 
-import android.app.ProgressDialog
+import androidx.appcompat.app.AlertDialog
 import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
@@ -31,7 +31,7 @@ class ImageUtilsTest {
     private lateinit var context: Context
 
     @Mock
-    private lateinit var progressDialogWallpaper: ProgressDialog
+    private lateinit var progressDialogWallpaper: AlertDialog
 
     @Mock
     private lateinit var okHttpJsonApiClient: OkHttpJsonApiClient


### PR DESCRIPTION
**Description (required)**
Replacing all deprecated instances of android.app.ProgressDialog across the app with a modern AlertDialog
Fixes #3487

**Tests performed (required)**

Tested on Pixel 9 6.5.0-debug (Android16) 
