### PR TITLE
Fix: Prevent premature finish() from canceling async location removal (#6872)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/locationpicker/LocationPickerActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/locationpicker/LocationPickerActivity.kt
@@ -405,16 +405,23 @@ class LocationPickerActivity : BaseActivity(), LocationPermissionCallback {
             )
                 ?.subscribeOn(Schedulers.io())
                 ?.observeOn(AndroidSchedulers.mainThread())
-                ?.subscribe { _ ->
-                    Timber.d("Coordinates removed from the image")
-                }?.let { it1 ->
-                    compositeDisposable.add(
-                        it1
-                    )
+                ?.subscribe(
+                    { _ ->
+                        Timber.d("Coordinates removed from the image")
+                        // Finish AFTER removal is complete
+                        setResult(RESULT_OK, Intent())
+                        finish()
+                    },
+                    { error ->
+                        Timber.e(error, "Failed to remove coordinates")
+                        // Handle error gracefully
+                        setResult(RESULT_CANCELED, Intent())
+                        finish()
+                    }
+                )?.let { it1 ->
+                    compositeDisposable.add(it1)
                 }
         }
-        setResult(RESULT_OK, Intent())
-        finish()
     }
 
     /**


### PR DESCRIPTION
## Description
Fixes the bug where LocationPickerActivity finishes prematurely, 
canceling the async location removal operation.

## Problem
When a user clicks the remove location button and then the back button 
(or activity finishes), the async operation gets canceled before completion.

## Solution
- Moved `setResult()` and `finish()` calls into the RxJava subscribe 
  success callback
- Added error handling to gracefully handle coordinate edit failures
- Ensures the activity only closes after the async operation 
  completes or fails

## Changes Made
- Modified `removeLocationFromImage()` method in LocationPickerActivity.kt
- Now waits for async coordinate removal before finishing activity
- Added error callback to handle failures gracefully

## Testing
- Code builds without errors
- Ready for manual testing on Android device/emulator

## Fixes
Closes #6872