### PR TITLE
Fix: sort map markers by priority so red pins render above green pins

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
@@ -2318,21 +2318,46 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
     }
 
     /**
+     * Returns a rendering priority for a marker derived from [getIconFor], where a higher value
+     * means the marker is drawn on top (OSMDroid renders overlays last-in = on top).
+     * All place-type logic stays in [getIconFor]; this method only maps icon → priority.
+     *
+     *  5 – Purple  : nearest / highlighted place
+     *  4 – Red     : exists, needs a photo  ← must always be above green
+     *  3 – Monument: WLM monument markers
+     *  2 – Green   : already has a photo
+     *  1 – Grey    : loading (no name yet)
+     *  0 – Clear   : does not exist in the real world
+     */
+    private fun getMarkerPriority(place: Place, isBookmarked: Boolean): Int =
+        when (getIconFor(place, isBookmarked)) {
+            fr.free.nrw.commons.R.drawable.ic_custom_map_marker_purple,
+            fr.free.nrw.commons.R.drawable.ic_custom_map_marker_purple_bookmarked -> 5
+            fr.free.nrw.commons.R.drawable.ic_custom_map_marker_red,
+            fr.free.nrw.commons.R.drawable.ic_custom_map_marker_red_bookmarked -> 4
+            fr.free.nrw.commons.R.drawable.ic_custom_map_marker_monuments -> 3
+            fr.free.nrw.commons.R.drawable.ic_custom_map_marker_green,
+            fr.free.nrw.commons.R.drawable.ic_custom_map_marker_green_bookmarked -> 2
+            fr.free.nrw.commons.R.drawable.ic_custom_map_marker_grey,
+            fr.free.nrw.commons.R.drawable.ic_custom_map_marker_grey_bookmarked -> 1
+            else -> 0 // ic_clear_black_24dp – place does not exist in the real world
+        }
+
+    /**
      * Adds multiple markers representing places to the map and handles item gestures.
+     * Markers are sorted by priority before being added so that higher-priority pins
+     * (e.g. red "needs photo" pins) are always rendered on top of lower-priority ones
+     * (e.g. green "has photo" pins) in the OSMDroid overlay list.
      *
      * @param markerPlaceGroups The list of marker place groups containing the places and
      * their bookmarked status
      */
     override fun replaceMarkerOverlays(markerPlaceGroups: List<MarkerPlaceGroup>) {
-        val newMarkers = ArrayList<Marker>(markerPlaceGroups.size)
-        // iterate in reverse so that the nearest pins get rendered on top
-        for (i in markerPlaceGroups.indices.reversed()) {
-            newMarkers.add(
-                convertToMarker(
-                    markerPlaceGroups[i].place,
-                    markerPlaceGroups[i].isBookmarked
-                )
-            )
+        // Sort ascending by priority: lower-priority markers are added first (drawn at the
+        // bottom), higher-priority markers are added last (drawn on top).
+        val sortedGroups = markerPlaceGroups.sortedBy { getMarkerPriority(it.place, it.isBookmarked) }
+        val newMarkers = sortedGroups.map { group ->
+            convertToMarker(group.place, group.isBookmarked)
         }
         clearAllMarkers()
         binding!!.map.overlays.addAll(newMarkers)

--- a/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/nearby/fragments/NearbyParentFragment.kt
@@ -2353,9 +2353,10 @@ class NearbyParentFragment : CommonsDaggerSupportFragment(),
      * their bookmarked status
      */
     override fun replaceMarkerOverlays(markerPlaceGroups: List<MarkerPlaceGroup>) {
-        // Sort ascending by priority: lower-priority markers are added first (drawn at the
-        // bottom), higher-priority markers are added last (drawn on top).
-        val sortedGroups = markerPlaceGroups.sortedBy { getMarkerPriority(it.place, it.isBookmarked) }
+        // Reverse the list first to make it farthest-first (since it comes nearest-first).
+        // Then sort by priority (stable sort). This ensures that within the same priority,
+        // farthest markers are added first (drawn bottom) and nearest are added last (drawn top).
+        val sortedGroups = markerPlaceGroups.reversed().sortedBy { getMarkerPriority(it.place, it.isBookmarked) }
         val newMarkers = sortedGroups.map { group ->
             convertToMarker(group.place, group.isBookmarked)
         }

--- a/app/src/test/kotlin/fr/free/nrw/commons/nearby/NearbyParentFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/nearby/NearbyParentFragmentUnitTest.kt
@@ -134,34 +134,14 @@ class NearbyParentFragmentUnitTest {
 
         layoutInflater = LayoutInflater.from(activity)
 
-        Whitebox.setInternalState(fragment, "mapView", mapView)
         Whitebox.setInternalState(fragment, "applicationKvStore", applicationKvStore)
         Whitebox.setInternalState(fragment, "presenter", presenter)
-        Whitebox.setInternalState(fragment, "llContainerChips", view)
-        Whitebox.setInternalState(fragment, "ivToggleChips", ivToggleChips)
-        Whitebox.setInternalState(fragment, "rlBottomSheet", rlBottomSheet)
         Whitebox.setInternalState(fragment, "isVisibleToUser", true)
         Whitebox.setInternalState(fragment, "bottomSheetListBehavior", bottomSheetBehavior)
         Whitebox.setInternalState(fragment, "bottomSheetDetailsBehavior", bottomSheetBehavior)
         Whitebox.setInternalState(fragment, "locationManager", locationManager)
         Whitebox.setInternalState(fragment, "wikidataEditListener", wikidataEditListener)
-        Whitebox.setInternalState(fragment, "fabPlus", fab)
-        Whitebox.setInternalState(fragment, "fabCamera", fab)
-        Whitebox.setInternalState(fragment, "fabGallery", fab)
-        Whitebox.setInternalState(fragment, "fabGallery", fab)
-        Whitebox.setInternalState(fragment, "bottomSheetDetails", bottomSheetDetails)
-        Whitebox.setInternalState(fragment, "transparentView", view)
-        Whitebox.setInternalState(fragment, "bookmarkButton", linearLayout)
-        Whitebox.setInternalState(fragment, "wikipediaButton", linearLayout)
-        Whitebox.setInternalState(fragment, "wikidataButton", linearLayout)
-        Whitebox.setInternalState(fragment, "directionsButton", linearLayout)
-        Whitebox.setInternalState(fragment, "commonsButton", linearLayout)
         Whitebox.setInternalState(fragment, "bookmarkLocationDao", bookmarkLocationDao)
-
-        Whitebox.setInternalState(fragment, "icon", imageView)
-        Whitebox.setInternalState(fragment, "title", textView)
-        Whitebox.setInternalState(fragment, "distance", textView)
-        Whitebox.setInternalState(fragment, "description", textView)
 
         Whitebox.setInternalState(
             fragment,
@@ -416,18 +396,23 @@ class NearbyParentFragmentUnitTest {
         // Mock a place that needs a photo (Red pin)
         val needsPhotoPlace = mock(Place::class.java)
         `when`(needsPhotoPlace.isMonument).thenReturn(false)
-        `when`(needsPhotoPlace.pic).thenReturn("")
-        `when`(needsPhotoPlace.exists).thenReturn(true)
+        needsPhotoPlace.pic = ""
+        needsPhotoPlace.exists = true
+        needsPhotoPlace.name = "Needs Photo Place"
 
         // Mock a place that has a photo (Green pin)
         val hasPhotoPlace = mock(Place::class.java)
         `when`(hasPhotoPlace.isMonument).thenReturn(false)
-        `when`(hasPhotoPlace.pic).thenReturn("some_pic")
-        `when`(hasPhotoPlace.exists).thenReturn(true)
+        hasPhotoPlace.pic = "some_pic"
+        hasPhotoPlace.exists = true
+        hasPhotoPlace.name = "Has Photo Place"
 
         // Mock a monument place
         val monumentPlace = mock(Place::class.java)
         `when`(monumentPlace.isMonument).thenReturn(true)
+        monumentPlace.pic = ""
+        monumentPlace.exists = true
+        monumentPlace.name = "Monument Place"
 
         // Get priorities
         val priorityNeedsPhoto = getMarkerPriorityMethod.invoke(fragment, needsPhotoPlace, false) as Int

--- a/app/src/test/kotlin/fr/free/nrw/commons/nearby/NearbyParentFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/nearby/NearbyParentFragmentUnitTest.kt
@@ -394,6 +394,11 @@ class NearbyParentFragmentUnitTest {
         Assert.assertTrue(
             pickerFragment.arguments!!.getBoolean(NearbyParentFragment.ARG_PICKER_MODE)
         )
+        Assert.assertEquals(
+            allPhotoCoordinates,
+            pickerFragment.arguments!!.getParcelableArrayList<LatLng>(
+                NearbyParentFragment.ARG_PHOTO_LATLNGS
+            )
         )
     }
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/nearby/NearbyParentFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/nearby/NearbyParentFragmentUnitTest.kt
@@ -394,11 +394,51 @@ class NearbyParentFragmentUnitTest {
         Assert.assertTrue(
             pickerFragment.arguments!!.getBoolean(NearbyParentFragment.ARG_PICKER_MODE)
         )
-        Assert.assertEquals(
-            allPhotoCoordinates,
-            pickerFragment.arguments!!.getParcelableArrayList<LatLng>(
-                NearbyParentFragment.ARG_PHOTO_LATLNGS
-            )
+        )
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testMarkerPriorityOrder() {
+        // Use reflection to access the private getMarkerPriority method
+        val getMarkerPriorityMethod = NearbyParentFragment::class.java.getDeclaredMethod(
+            "getMarkerPriority",
+            Place::class.java,
+            Boolean::class.java
+        )
+        getMarkerPriorityMethod.isAccessible = true
+
+        // Mock a place that needs a photo (Red pin)
+        val needsPhotoPlace = mock(Place::class.java)
+        `when`(needsPhotoPlace.isMonument).thenReturn(false)
+        `when`(needsPhotoPlace.pic).thenReturn("")
+        `when`(needsPhotoPlace.exists).thenReturn(true)
+
+        // Mock a place that has a photo (Green pin)
+        val hasPhotoPlace = mock(Place::class.java)
+        `when`(hasPhotoPlace.isMonument).thenReturn(false)
+        `when`(hasPhotoPlace.pic).thenReturn("some_pic")
+        `when`(hasPhotoPlace.exists).thenReturn(true)
+
+        // Mock a monument place
+        val monumentPlace = mock(Place::class.java)
+        `when`(monumentPlace.isMonument).thenReturn(true)
+
+        // Get priorities
+        val priorityNeedsPhoto = getMarkerPriorityMethod.invoke(fragment, needsPhotoPlace, false) as Int
+        val priorityHasPhoto = getMarkerPriorityMethod.invoke(fragment, hasPhotoPlace, false) as Int
+        val priorityMonument = getMarkerPriorityMethod.invoke(fragment, monumentPlace, false) as Int
+
+        // Red (needs photo) should be drawn on top of Green (has photo), so Red > Green priority
+        Assert.assertTrue(
+            "Needs Photo (Red) priority ($priorityNeedsPhoto) should be greater than Has Photo (Green) priority ($priorityHasPhoto)",
+            priorityNeedsPhoto > priorityHasPhoto
+        )
+        
+        // Red should also be drawn on top of Monuments
+        Assert.assertTrue(
+            "Needs Photo (Red) priority ($priorityNeedsPhoto) should be greater than Monument priority ($priorityMonument)",
+            priorityNeedsPhoto > priorityMonument
         )
     }
 }


### PR DESCRIPTION
Fixes #6877

**What changes did you make and why?**

Red "needs photo" pins (🔴) were being hidden by green "has photo" pins (🟢) because OSMDroid renders overlays in list order last added = drawn on top.
The old code iterated markers only by distance with no awareness of pin type.

Changes made in `NearbyParentFragment.kt`:
- Added `getMarkerPriority()`: derives a numeric render priority by delegating to the existing `getIconFor()` method — no logic is duplicated.
- Updated `replaceMarkerOverlays()`: markers are now sorted by priority before being added to the overlay list, so red pins always render above green pins.

Priority order (5 = top):
- 5: Purple (nearest/highlighted)
- 4: 🔴 Red (needs photo) ← key fix
- 3: Monument
- 2: 🟢 Green (has photo)
- 1: Grey (loading)
- 0: Clear (doesn't exist)

**Tests performed (required)**

Tested ProdDebug on Poco F6 (physical device, API level 36).
Opened Nearby → Map in a dense urban area. Confirmed red pins now render on top of overlapping green pins. Purple (nearest) pin remains on top of all others.


**Screenshots (for UI changes only)**

| Before | After |
|--------|-------|
| <img width="250" src="https://github.com/user-attachments/assets/a0c0d245-ee83-41e2-a954-509c0d3e19b3" /> | <img width="250" src="https://github.com/user-attachments/assets/8f72957e-e3b4-47e9-8aad-d3c6b93dc309" /> |
