### PR TITLE
Fix #6881: Add intent to Failed Upload notification to open Failed tab

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadProgressActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadProgressActivity.kt
@@ -66,6 +66,11 @@ class UploadProgressActivity : BaseActivity() {
             },
         )
         setTabs()
+
+        val targetTab = intent.getIntExtra("upload_target_tab", 0)
+        if (targetTab != 0) {
+            binding.uploadProgressViewPager.currentItem = targetTab
+        }
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadProgressActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadProgressActivity.kt
@@ -67,7 +67,7 @@ class UploadProgressActivity : BaseActivity() {
         )
         setTabs()
 
-        val targetTab = intent.getIntExtra("upload_target_tab", 0)
+        val targetTab = intent.getIntExtra(EXTRA_TARGET_TAB, 0)
         if (targetTab != 0) {
             binding.uploadProgressViewPager.currentItem = targetTab
         }
@@ -92,7 +92,7 @@ class UploadProgressActivity : BaseActivity() {
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         menuInflater.inflate(R.menu.menu_uploads, menu)
         this.menu = menu
-        updateMenuItems(0)
+        updateMenuItems(binding.uploadProgressViewPager.currentItem)
         return super.onCreateOptionsMenu(menu)
     }
 
@@ -212,5 +212,10 @@ class UploadProgressActivity : BaseActivity() {
     fun setErrorIconsVisibility(visible: Boolean) {
         isErrorIconsVisisble = visible
         updateMenuItems(binding.uploadProgressViewPager.currentItem)
+    }
+
+    companion object {
+        const val EXTRA_TARGET_TAB = "upload_target_tab"
+        const val TAB_FAILED = 1
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
@@ -629,7 +629,7 @@ class UploadWorker(
     @SuppressLint("StringFormatInvalid", "MissingPermission")
     private fun showFailedNotification(contribution: Contribution) {
         val displayTitle = contribution.media.displayTitle
-        currentNotification.setContentIntent(getPendingIntent(UploadProgressActivity::class.java, 1))
+        currentNotification.setContentIntent(getPendingIntent(UploadProgressActivity::class.java, UploadProgressActivity.TAB_FAILED))
         currentNotification
             .setContentTitle(
                 appContext.getString(
@@ -671,7 +671,7 @@ class UploadWorker(
     @SuppressLint("StringFormatInvalid", "MissingPermission")
     private fun showErrorNotification(contribution: Contribution) {
         val displayTitle = contribution.media.displayTitle
-        currentNotification.setContentIntent(getPendingIntent(UploadProgressActivity::class.java, 1))
+        currentNotification.setContentIntent(getPendingIntent(UploadProgressActivity::class.java, UploadProgressActivity.TAB_FAILED))
         currentNotification
             .setContentTitle(
                 appContext.getString(
@@ -741,7 +741,7 @@ class UploadWorker(
      */
     private fun getPendingIntent(toClass: Class<out BaseActivity>, targetTab: Int = 0): PendingIntent {
         val intent = Intent(appContext, toClass)
-        intent.putExtra("upload_target_tab", targetTab)
+        intent.putExtra(UploadProgressActivity.EXTRA_TARGET_TAB, targetTab)
         return TaskStackBuilder.create(appContext).run {
             addNextIntentWithParentStack(intent)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {

--- a/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/worker/UploadWorker.kt
@@ -629,7 +629,7 @@ class UploadWorker(
     @SuppressLint("StringFormatInvalid", "MissingPermission")
     private fun showFailedNotification(contribution: Contribution) {
         val displayTitle = contribution.media.displayTitle
-        currentNotification.setContentIntent(getPendingIntent(UploadProgressActivity::class.java))
+        currentNotification.setContentIntent(getPendingIntent(UploadProgressActivity::class.java, 1))
         currentNotification
             .setContentTitle(
                 appContext.getString(
@@ -671,6 +671,7 @@ class UploadWorker(
     @SuppressLint("StringFormatInvalid", "MissingPermission")
     private fun showErrorNotification(contribution: Contribution) {
         val displayTitle = contribution.media.displayTitle
+        currentNotification.setContentIntent(getPendingIntent(UploadProgressActivity::class.java, 1))
         currentNotification
             .setContentTitle(
                 appContext.getString(
@@ -736,18 +737,20 @@ class UploadWorker(
     /**
      * Method used to get Pending intent for opening different screen after clicking on notification
      * @param toClass
+     * @param targetTab
      */
-    private fun getPendingIntent(toClass: Class<out BaseActivity>): PendingIntent {
+    private fun getPendingIntent(toClass: Class<out BaseActivity>, targetTab: Int = 0): PendingIntent {
         val intent = Intent(appContext, toClass)
+        intent.putExtra("upload_target_tab", targetTab)
         return TaskStackBuilder.create(appContext).run {
             addNextIntentWithParentStack(intent)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 getPendingIntent(
-                    0,
+                    targetTab,
                     PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
                 )
             } else {
-                getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT)
+                getPendingIntent(targetTab, PendingIntent.FLAG_UPDATE_CURRENT)
             }
         }
     }


### PR DESCRIPTION
**Description (required)**

Fixes #6881

**What changes did you make and why?**
- **Added missing PendingIntent:** The `showErrorNotification` method in `UploadWorker.kt` was missing a `PendingIntent`, which caused tapping on the "Failed to upload" error notification to do nothing. I added the intent to correctly launch `UploadProgressActivity`.
- **Direct routing to FAILED tab:** When an upload fails, clicking the notification should ideally open the "FAILED" tab directly instead of defaulting to the "PENDING" tab. 
  - I updated `UploadWorker.getPendingIntent()` to accept a `targetTab` argument, and added it to the intent extras. 
  - Crucially, I set `targetTab` as the `requestCode` to ensure the Android OS treats it as a unique `PendingIntent`, preventing `FLAG_IMMUTABLE` from reusing a previous intent and ignoring our extras.
  - Finally, I updated `UploadProgressActivity` to check for this `upload_target_tab` extra and switch the `ViewPager` to the correct tab on launch.

**Tests performed (required)**

Tested ProdDebug on POCO F6 with API level 36.

- Forced a network failure by starting an upload and immediately toggling off the internet connection.
- Verified that tapping the "Failed to upload" notification successfully launches the app and opens the correct "FAILED" tab inside the Uploads activity.

**Screenshots (for UI changes only)**


https://github.com/user-attachments/assets/b625112a-b45c-4fa2-bf7d-6b525a0d7855

---
