### PR TITLE
utils: replace deprecated TelephonyManager with NetworkCapabilities in getNetworkType()

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/utils/NetworkUtils.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/NetworkUtils.kt
@@ -3,8 +3,8 @@ package fr.free.nrw.commons.utils
 import android.annotation.SuppressLint
 import android.content.Context
 import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.net.NetworkInfo
-import android.telephony.TelephonyManager
 
 import fr.free.nrw.commons.utils.model.NetworkConnectionType
 
@@ -33,42 +33,19 @@ object NetworkUtils {
      */
     @JvmStatic
     fun getNetworkType(context: Context): NetworkConnectionType {
-        val telephonyManager = context.applicationContext.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
+        val connectivityManager =
+            context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+                ?: return NetworkConnectionType.UNKNOWN
+
+        val activeNetwork = connectivityManager.activeNetwork ?: return NetworkConnectionType.UNKNOWN
+        val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork)
             ?: return NetworkConnectionType.UNKNOWN
 
-        val networkInfo = getNetworkInfo(context)
-            ?: return NetworkConnectionType.UNKNOWN
-
-        val network = networkInfo.type
-        if (network == ConnectivityManager.TYPE_WIFI) {
-            return NetworkConnectionType.WIFI
+        return if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+            NetworkConnectionType.WIFI
+        } else {
+            NetworkConnectionType.UNKNOWN
         }
-
-        // TODO for Android 12+ request permission from user is mandatory
-        /*
-        val mobileNetwork = telephonyManager.networkType
-        return when (mobileNetwork) {
-            TelephonyManager.NETWORK_TYPE_GPRS,
-            TelephonyManager.NETWORK_TYPE_EDGE,
-            TelephonyManager.NETWORK_TYPE_CDMA,
-            TelephonyManager.NETWORK_TYPE_1xRTT -> NetworkConnectionType.TWO_G
-
-            TelephonyManager.NETWORK_TYPE_HSDPA,
-            TelephonyManager.NETWORK_TYPE_UMTS,
-            TelephonyManager.NETWORK_TYPE_HSUPA,
-            TelephonyManager.NETWORK_TYPE_HSPA,
-            TelephonyManager.NETWORK_TYPE_EHRPD,
-            TelephonyManager.NETWORK_TYPE_EVDO_0,
-            TelephonyManager.NETWORK_TYPE_EVDO_A,
-            TelephonyManager.NETWORK_TYPE_EVDO_B -> NetworkConnectionType.THREE_G
-
-            TelephonyManager.NETWORK_TYPE_LTE,
-            TelephonyManager.NETWORK_TYPE_HSPAP -> NetworkConnectionType.FOUR_G
-
-            else -> NetworkConnectionType.UNKNOWN
-        }
-         */
-        return NetworkConnectionType.UNKNOWN
     }
 
     /**

--- a/app/src/test/kotlin/fr/free/nrw/commons/utils/NetworkUtilsTest.java
+++ b/app/src/test/kotlin/fr/free/nrw/commons/utils/NetworkUtilsTest.java
@@ -3,19 +3,16 @@ package fr.free.nrw.commons.utils;
 import android.app.Application;
 import android.content.Context;
 import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
-import android.telephony.TelephonyManager;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import fr.free.nrw.commons.utils.model.NetworkConnectionType;
 
-import static android.telephony.TelephonyManager.NETWORK_TYPE_EDGE;
-import static android.telephony.TelephonyManager.NETWORK_TYPE_HSPA;
-import static android.telephony.TelephonyManager.NETWORK_TYPE_LTE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -80,16 +77,14 @@ public class NetworkUtilsTest {
         Context mockContext = mock(Context.class);
         Application mockApplication = mock(Application.class);
         ConnectivityManager mockConnectivityManager = mock(ConnectivityManager.class);
-        NetworkInfo mockNetworkInfo = mock(NetworkInfo.class);
-        when(mockNetworkInfo.getType())
-                .thenReturn(ConnectivityManager.TYPE_WIFI);
-        when(mockConnectivityManager.getActiveNetworkInfo())
-                .thenReturn(mockNetworkInfo);
+        Network mockNetwork = mock(Network.class);
+        NetworkCapabilities mockCapabilities = mock(NetworkCapabilities.class);
+
+        when(mockConnectivityManager.getActiveNetwork()).thenReturn(mockNetwork);
+        when(mockConnectivityManager.getNetworkCapabilities(mockNetwork)).thenReturn(mockCapabilities);
+        when(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)).thenReturn(true);
         when(mockApplication.getSystemService(Context.CONNECTIVITY_SERVICE))
                 .thenReturn(mockConnectivityManager);
-
-        when(mockApplication.getSystemService(Context.TELEPHONY_SERVICE))
-                .thenReturn(mock(TelephonyManager.class));
         when(mockContext.getApplicationContext()).thenReturn(mockApplication);
 
         NetworkConnectionType networkType = NetworkUtils.getNetworkType(mockContext);
@@ -98,83 +93,65 @@ public class NetworkUtilsTest {
     }
 
     @Test
-    @Ignore("Fix these test with telemetry permission")
     public void testCellular2GNetwork() {
         Context mockContext = mock(Context.class);
         Application mockApplication = mock(Application.class);
         ConnectivityManager mockConnectivityManager = mock(ConnectivityManager.class);
-        NetworkInfo mockNetworkInfo = mock(NetworkInfo.class);
-        when(mockNetworkInfo.getType())
-                .thenReturn(ConnectivityManager.TYPE_MOBILE);
-        when(mockConnectivityManager.getActiveNetworkInfo())
-                .thenReturn(mockNetworkInfo);
+        Network mockNetwork = mock(Network.class);
+        NetworkCapabilities mockCapabilities = mock(NetworkCapabilities.class);
+
+        when(mockConnectivityManager.getActiveNetwork()).thenReturn(mockNetwork);
+        when(mockConnectivityManager.getNetworkCapabilities(mockNetwork)).thenReturn(mockCapabilities);
+        when(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)).thenReturn(false);
+        when(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)).thenReturn(true);
         when(mockApplication.getSystemService(Context.CONNECTIVITY_SERVICE))
                 .thenReturn(mockConnectivityManager);
-
-        TelephonyManager mockTelephonyManager = mock(TelephonyManager.class);
-        when(mockTelephonyManager.getNetworkType())
-                .thenReturn(NETWORK_TYPE_EDGE);
-
-        when(mockApplication.getSystemService(Context.TELEPHONY_SERVICE))
-                .thenReturn(mockTelephonyManager);
         when(mockContext.getApplicationContext()).thenReturn(mockApplication);
 
         NetworkConnectionType networkType = NetworkUtils.getNetworkType(mockContext);
 
-        assertEquals(networkType, NetworkConnectionType.TWO_G);
+        assertEquals(networkType, NetworkConnectionType.UNKNOWN);
     }
 
     @Test
-    @Ignore("Fix these test with telemetry permission")
     public void testCellular3GNetwork() {
         Context mockContext = mock(Context.class);
         Application mockApplication = mock(Application.class);
         ConnectivityManager mockConnectivityManager = mock(ConnectivityManager.class);
-        NetworkInfo mockNetworkInfo = mock(NetworkInfo.class);
-        when(mockNetworkInfo.getType())
-                .thenReturn(ConnectivityManager.TYPE_MOBILE);
-        when(mockConnectivityManager.getActiveNetworkInfo())
-                .thenReturn(mockNetworkInfo);
+        Network mockNetwork = mock(Network.class);
+        NetworkCapabilities mockCapabilities = mock(NetworkCapabilities.class);
+
+        when(mockConnectivityManager.getActiveNetwork()).thenReturn(mockNetwork);
+        when(mockConnectivityManager.getNetworkCapabilities(mockNetwork)).thenReturn(mockCapabilities);
+        when(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)).thenReturn(false);
+        when(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)).thenReturn(true);
         when(mockApplication.getSystemService(Context.CONNECTIVITY_SERVICE))
                 .thenReturn(mockConnectivityManager);
-
-        TelephonyManager mockTelephonyManager = mock(TelephonyManager.class);
-        when(mockTelephonyManager.getNetworkType())
-                .thenReturn(NETWORK_TYPE_HSPA);
-
-        when(mockApplication.getSystemService(Context.TELEPHONY_SERVICE))
-                .thenReturn(mockTelephonyManager);
         when(mockContext.getApplicationContext()).thenReturn(mockApplication);
 
         NetworkConnectionType networkType = NetworkUtils.getNetworkType(mockContext);
 
-        assertEquals(networkType, NetworkConnectionType.THREE_G);
+        assertEquals(networkType, NetworkConnectionType.UNKNOWN);
     }
 
     @Test
-    @Ignore("Fix these test with telemetry permission")
     public void testCellular4GNetwork() {
         Context mockContext = mock(Context.class);
         Application mockApplication = mock(Application.class);
         ConnectivityManager mockConnectivityManager = mock(ConnectivityManager.class);
-        NetworkInfo mockNetworkInfo = mock(NetworkInfo.class);
-        when(mockNetworkInfo.getType())
-                .thenReturn(ConnectivityManager.TYPE_MOBILE);
-        when(mockConnectivityManager.getActiveNetworkInfo())
-                .thenReturn(mockNetworkInfo);
+        Network mockNetwork = mock(Network.class);
+        NetworkCapabilities mockCapabilities = mock(NetworkCapabilities.class);
+
+        when(mockConnectivityManager.getActiveNetwork()).thenReturn(mockNetwork);
+        when(mockConnectivityManager.getNetworkCapabilities(mockNetwork)).thenReturn(mockCapabilities);
+        when(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)).thenReturn(false);
+        when(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)).thenReturn(true);
         when(mockApplication.getSystemService(Context.CONNECTIVITY_SERVICE))
                 .thenReturn(mockConnectivityManager);
-
-        TelephonyManager mockTelephonyManager = mock(TelephonyManager.class);
-        when(mockTelephonyManager.getNetworkType())
-                .thenReturn(NETWORK_TYPE_LTE);
-
-        when(mockApplication.getSystemService(Context.TELEPHONY_SERVICE))
-                .thenReturn(mockTelephonyManager);
         when(mockContext.getApplicationContext()).thenReturn(mockApplication);
 
         NetworkConnectionType networkType = NetworkUtils.getNetworkType(mockContext);
 
-        assertEquals(networkType, NetworkConnectionType.FOUR_G);
+        assertEquals(networkType, NetworkConnectionType.UNKNOWN);
     }
 }


### PR DESCRIPTION
Fixes #6891.

## Summary

- `getNetworkType()` was using `TelephonyManager.networkType` to detect cellular
  generation, which requires the `READ_PHONE_STATE` dangerous permission on
  Android 12+ (API 31+). The app does not declare this permission, so the
  detection block had been commented out and the method always returned `UNKNOWN`
  for cellular connections.
- Replace with `ConnectivityManager.getNetworkCapabilities()` (API 21+, no
  permission required). WiFi is correctly detected. Generation (2G/3G/4G) is not
  recoverable without `READ_PHONE_STATE`, but the only caller (`DeviceInfoUtil`)
  already maps `UNKNOWN → CELLULAR`, so there is no user-visible regression.
- Removes the large commented-out block and unused `TelephonyManager` import.
- Re-enables three previously `@Ignore`d unit tests, updated to assert `UNKNOWN`
  for cellular.

## Test plan

- [x] All 8 `NetworkUtilsTest` tests pass
- Tested by: unit tests only — `getNetworkType()` is used only in crash reports
  and the feedback dialog, so no device test is needed for this change