### PR TITLE
fix: pass source wiki to echomarkread so cross-wiki notifications clear

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationClient.kt
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationClient.kt
@@ -35,13 +35,14 @@ class NotificationClient
                     it.toCommonsNotification()
                 }.toList()
 
-        fun markNotificationAsRead(notificationId: String?): Observable<Boolean> =
+        fun markNotificationAsRead(notificationId: String?, wiki: String): Observable<Boolean> =
             try {
                 service
                     .markRead(
                         token = csrfTokenClient.getTokenBlocking(),
                         readList = notificationId,
                         unreadList = "",
+                        wikis = wiki,
                     ).map(MwQueryResponse::success)
             } catch (throwable: Throwable) {
                 if (throwable is InvalidLoginTokenException) {
@@ -68,6 +69,7 @@ class NotificationClient
                     link = contents?.links?.getPrimary()?.url ?: "",
                     iconUrl = "",
                     notificationId = id().toString(),
+                    wiki = wiki(),
                 )
         }
     }

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationController.kt
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationController.kt
@@ -20,6 +20,6 @@ class NotificationController @Inject constructor(
     }
 
     fun markAsRead(notification: Notification): Observable<Boolean> {
-        return notificationClient.markNotificationAsRead(notification.notificationId)
+        return notificationClient.markNotificationAsRead(notification.notificationId, notification.wiki)
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationInterface.kt
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationInterface.kt
@@ -26,5 +26,6 @@ interface NotificationInterface {
         @Field("token") token: String,
         @Field("list") readList: String?,
         @Field("unreadlist") unreadList: String?,
+        @Field("wikis") wikis: String?,
     ): Observable<MwQueryResponse?>
 }

--- a/app/src/main/java/fr/free/nrw/commons/notification/models/Notification.kt
+++ b/app/src/main/java/fr/free/nrw/commons/notification/models/Notification.kt
@@ -10,4 +10,5 @@ data class Notification(
     var link: String,
     var iconUrl: String,
     var notificationId: String,
+    var wiki: String = "commonswiki",
 )


### PR DESCRIPTION
Fixes #6895.

## Problem

`echomarkread` was called on the Commons API endpoint (`MW_API_PREFIX`) with no `wikis` parameter. The app fetches notifications from `wikidatawiki|commonswiki|enwiki`, but mark-as-read only targeted Commons. Notifications originating from enwiki or wikidatawiki disappeared from the local list (the API returned success) but reappeared immediately on the next fetch because they were never marked read on the originating wiki.

Confirmed on device: Pixel 6 / Android 16. Tapping a notification removes it locally, but on returning to the Contributions screen the badge count is unchanged and the notifications reappear.

## Fix

- Add `wiki` field to the `Notification` model, populated from `WikimediaNotification.wiki()` during mapping
- Add `@Field("wikis")` parameter to `NotificationInterface.markRead()`
- Pass `notification.wiki` through `NotificationController.markAsRead()` → `NotificationClient.markNotificationAsRead()`

No behaviour change for notifications originating on commonswiki (default value).

## Testing

Built and confirmed `compileProdDebugKotlin` passes. Device testing of the fix itself requires a fresh login (credentials were unavailable at time of testing), but the root cause was confirmed by reproducing the reappearing-notification behaviour and tracing it to the missing `wikis` parameter.