### PR TITLE
Fix #6902: Gracefully handle missing cached file when retrying failed uploads

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/ImageProcessingService.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/ImageProcessingService.kt
@@ -129,9 +129,32 @@ class ImageProcessingService @Inject constructor(
      * @return IMAGE_DUPLICATE or IMAGE_OK
      */
     fun checkIfFileAlreadyExists(originalFilePath: Uri, modifiedFilePath: Uri): Single<Int> {
+        val originalStreamResult = Single.fromCallable {
+            appContext.contentResolver.openInputStream(originalFilePath)!!
+        }.flatMap { inputStream ->
+            checkDuplicateImage(inputStream)
+        }.onErrorReturn { throwable ->
+            Timber.e(throwable, "Error checking duplicate for original file")
+            IMAGE_OK
+        }
+
+        val modifiedStreamResult = Single.fromCallable {
+            val path = modifiedFilePath.path
+            if (path != null && java.io.File(path).exists()) {
+                fileUtilsWrapper.getFileInputStream(path)
+            } else {
+                throw java.io.FileNotFoundException("Modified file not found at $path")
+            }
+        }.flatMap { inputStream ->
+            checkDuplicateImage(inputStream)
+        }.onErrorReturn { throwable ->
+            Timber.e(throwable, "Error checking duplicate for modified file")
+            IMAGE_OK
+        }
+
         return Single.zip(
-            checkDuplicateImage(inputStream = appContext.contentResolver.openInputStream(originalFilePath)!!),
-            checkDuplicateImage(inputStream = fileUtilsWrapper.getFileInputStream(modifiedFilePath.path))
+            originalStreamResult,
+            modifiedStreamResult
         ) { resultForOriginal, resultForDuplicate ->
             return@zip if (resultForOriginal == IMAGE_DUPLICATE || resultForDuplicate == IMAGE_DUPLICATE)
                 IMAGE_DUPLICATE else IMAGE_OK


### PR DESCRIPTION
Fixes #6902

**Description (required)**

When a user taps the retry/refresh button on a failed upload, `ImageProcessingService.checkIfFileAlreadyExists()` was opening the cached modified file's input stream synchronously. If the cached file no longer existed on disk (due to OS cache cleanup or device restart), a `FileNotFoundException` was thrown and crashed the app.

Changes made in `ImageProcessingService.kt`:
- Wrapped stream opening inside `Single.fromCallable` so it runs on a background thread.
- Added a `File.exists()` check before opening the modified cached file.
- Added `onErrorReturn { IMAGE_OK }` to gracefully handle missing files.

After the fix, the app no longer crashes. If the file is gone, the upload fails gracefully and a "Failed to upload" notification is shown to the user.

**Tests performed (required)**

Tested on BetaDebug running on a Poco F6 with API level 36.

- Tapped retry on a failed upload whose cached file no longer existed.
- Confirmed no crash occurs.
- Confirmed the upload fails gracefully and shows a "Failed to upload" notification.

**Screenshots (for UI changes only)**

Before fix (crashes):
https://youtube.com/shorts/3-1Y29T6y6I

After fix (graceful failure):
https://github.com/user-attachments/assets/9264779b-6ef8-4166-90d5-93066765be7a