### PR TITLE
fix: log undeliverable RxJava exceptions instead of silently discarding them

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/CommonsApplication.kt
+++ b/app/src/main/java/fr/free/nrw/commons/CommonsApplication.kt
@@ -36,7 +36,6 @@ import fr.free.nrw.commons.utils.ConfigUtils.isBetaFlavour
 import fr.free.nrw.commons.wikidata.cookies.CommonsCookieJar
 import io.reactivex.Completable
 import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.internal.functions.Functions
 import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.schedulers.Schedulers
 import org.acra.ACRA.init
@@ -134,7 +133,9 @@ class CommonsApplication : MultiDexApplication() {
 
         // This handler will catch exceptions thrown from Observables after they are disposed,
         // or from Observables that are (deliberately or not) missing an onError handler.
-        RxJavaPlugins.setErrorHandler(Functions.emptyConsumer())
+        // Log rather than silently discard - these are real bugs (crashes that would
+        // otherwise have surfaced) and silently swallowing them hides that fact entirely.
+        RxJavaPlugins.setErrorHandler { Timber.e(it, "Undeliverable RxJava exception") }
 
         // Fire progress callbacks for every 3% of uploaded content
         System.setProperty("in.yuvi.http.fluent.PROGRESS_TRIGGER_THRESHOLD", "3.0")


### PR DESCRIPTION
Fixes #6830.

`RxJavaPlugins.setErrorHandler(Functions.emptyConsumer())` in `CommonsApplication.onCreate()` silently swallows every exception that reaches RxJava's global undeliverable-exception handler, app-wide. Per the comment directly above it, this deliberately covers two cases: exceptions from already-disposed Observables, and exceptions from Observables that are "(deliberately or not) missing an onError handler" — that second category is a real bug class, not a benign one.

It's worth noting this doesn't duplicate #6852/PR #6860 (which adds explicit `onError` handlers to ~15 previously-bare `.subscribe {}` calls) — that PR fixes the call sites it touches, but this global handler still silently swallows anything that reaches it regardless, from any call site, present or future.

**Fix**: replace the no-op consumer with `Timber.e(it, "Undeliverable RxJava exception")`. Behaviour is otherwise identical — it still prevents the crash — but the exception is now actually visible (logcat / crash reporting) instead of disappearing without a trace.

**Tested**: `./gradlew :app:compileProdDebugKotlin` — clean build. No dedicated test coverage exists for this line (it's `Application.onCreate()` global wiring); didn't add one given the difficulty of meaningfully unit-testing a static `RxJavaPlugins` handler installed at process start.

(Roniscend asked to be assigned #6830 back in April but no PR ever followed — this is a minimal, low-risk one-liner so I went ahead rather than let the diagnosis sit; happy for this to be superseded if there's a PR already in flight I've missed.)