### PR TITLE
Use allpages instead of allcategories to avoid getting deleted categories

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryInterface.kt
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryInterface.kt
@@ -34,12 +34,12 @@ interface CategoryInterface {
      * @return
      */
     @GET(
-        "w/api.php?action=query&format=json&formatversion=2&generator=allcategories&prop=categoryinfo|description|pageimages&piprop=thumbnail&pithumbsize=70",
+        "w/api.php?action=query&format=json&formatversion=2&generator=allpages&gapnamespace=14&prop=categoryinfo|description|pageimages&piprop=thumbnail&pithumbsize=70",
     )
     fun searchCategoriesForPrefix(
-        @Query("gacprefix") prefix: String?,
-        @Query("gaclimit") itemLimit: Int,
-        @Query("gacoffset") offset: Int,
+        @Query("gapprefix") prefix: String?,
+        @Query("gaplimit") itemLimit: Int,
+        @Query("gapoffset") offset: Int,
     ): Single<MwQueryResponse>
 
     /**
@@ -52,13 +52,13 @@ interface CategoryInterface {
      * @return MwQueryResponse
      */
     @GET(
-        "w/api.php?action=query&format=json&formatversion=2&generator=allcategories&prop=categoryinfo|description|pageimages&piprop=thumbnail&pithumbsize=70",
+        "w/api.php?action=query&format=json&formatversion=2&generator=allpages&gapnamespace=14&prop=categoryinfo|description|pageimages&piprop=thumbnail&pithumbsize=70",
     )
     fun getCategoriesByName(
-        @Query("gacfrom") startingCategory: String?,
-        @Query("gacto") endingCategory: String?,
-        @Query("gaclimit") itemLimit: Int,
-        @Query("gacoffset") offset: Int,
+        @Query("gapfrom") startingCategory: String?,
+        @Query("gapto") endingCategory: String?,
+        @Query("gaplimit") itemLimit: Int,
+        @Query("gapoffset") offset: Int,
     ): Single<MwQueryResponse>
 
     /**


### PR DESCRIPTION
**Description (required)**

Fixes #6924

Use the "allpages" API endpoint instead of "allcategories" to search for categories. It looks like the former doesn't include deleted ones in results, while the latter does.

(Current UploadWizard uses [another endpoint](https://www.mediawiki.org/wiki/API:Prefixsearch), but I would like to save it for possible future improvement because it would also introduce changes unrelated to deleted categories.)

**Tests performed (required)**

Manual test steps:
1. Take a photo in the app
2. Enter something to caption (it shouldn't matter in this test)
3. Add "Bean" (the seed) a a depict value
4. In the next screen, see "Beans" in the candidate category list
5. Enter "Bean" and see "Bean 14", "Bean 12", "Bean, Kent", etc, but no "Bean" suggested.

Step 4 and Step 5 use the two API methods that are changed by this PR.

Tested ProdDebug on emulator with API level 35.

**Screenshots (for UI changes only)**
<img width="200" alt="Screenshot_20260725_154706" src="https://github.com/user-attachments/assets/bdcaf002-c2c5-4c6d-be76-68ca91c69f5a" />
