### PR TITLE
Replace Exifinterface's saveattributes with manual Exif writer

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/filepicker/PickedFiles.kt
+++ b/app/src/main/java/fr/free/nrw/commons/filepicker/PickedFiles.kt
@@ -11,6 +11,7 @@ import android.webkit.MimeTypeMap
 import androidx.annotation.RequiresApi
 import androidx.core.content.FileProvider
 import androidx.exifinterface.media.ExifInterface
+import fr.free.nrw.commons.utils.RandomAccessFileExifWriter
 import fr.free.nrw.commons.filepicker.Constants.Companion.DEFAULT_FOLDER_NAME
 import timber.log.Timber
 import java.io.File
@@ -172,21 +173,7 @@ object PickedFiles : Constants {
     }
 
     private fun copyExif(src: ExifInterface, dstFile: File) {
-        val dst = ExifInterface(dstFile.absolutePath)
-        arrayOf(
-            ExifInterface.TAG_DATETIME_ORIGINAL, ExifInterface.TAG_DATETIME,
-            ExifInterface.TAG_GPS_LATITUDE, ExifInterface.TAG_GPS_LATITUDE_REF,
-            ExifInterface.TAG_GPS_LONGITUDE, ExifInterface.TAG_GPS_LONGITUDE_REF,
-            ExifInterface.TAG_GPS_ALTITUDE, ExifInterface.TAG_GPS_ALTITUDE_REF,
-            ExifInterface.TAG_GPS_DATESTAMP, ExifInterface.TAG_GPS_TIMESTAMP,
-            ExifInterface.TAG_MAKE, ExifInterface.TAG_MODEL,
-            ExifInterface.TAG_F_NUMBER, ExifInterface.TAG_EXPOSURE_TIME,
-            ExifInterface.TAG_FLASH, ExifInterface.TAG_FOCAL_LENGTH,
-            ExifInterface.TAG_PHOTOGRAPHIC_SENSITIVITY, ExifInterface.TAG_WHITE_BALANCE,
-            ExifInterface.TAG_IMAGE_WIDTH, ExifInterface.TAG_IMAGE_LENGTH,
-        ).forEach { tag -> src.getAttribute(tag)?.let { dst.setAttribute(tag, it) } }
-        dst.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL.toString())
-        dst.saveAttributes()
+        RandomAccessFileExifWriter.copyExif(src, dstFile)
     }
 
     @RequiresApi(Build.VERSION_CODES.P)

--- a/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/FileProcessor.kt
@@ -11,6 +11,7 @@ import fr.free.nrw.commons.mwapi.CategoryApi
 import fr.free.nrw.commons.mwapi.OkHttpJsonApiClient
 import fr.free.nrw.commons.settings.Prefs
 import fr.free.nrw.commons.upload.structure.depictions.DepictModel
+import fr.free.nrw.commons.utils.RandomAccessFileExifWriter
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
@@ -64,7 +65,7 @@ class FileProcessor
                     null
                 }
             // Redact EXIF data as indicated in preferences.
-            redactExifTags(exifInterface, getExifTagsToRedact())
+            redactExifTags(exifInterface, getExifTagsToRedact(), filePath)
             Timber.d("Calling GPSExtractor")
             val originalImageCoordinates = ImageCoordinates(exifInterface, inAppPictureLocation)
             if (originalImageCoordinates.decimalCoords == null) {
@@ -97,44 +98,35 @@ class FileProcessor
          *
          * @param exifInterface ExifInterface object
          * @param redactTags    tags to be redacted
+         * @param filePath      path to the file for direct metadata redaction
          */
         fun redactExifTags(
             exifInterface: ExifInterface?,
             redactTags: Set<String>,
+            filePath: String? = null,
         ) {
-            compositeDisposable.add(
-                Observable
-                    .fromIterable(redactTags)
-                    .flatMap { Observable.fromArray(*FileMetadataUtils.getTagsFromPref(it)) }
-                    .subscribe(
-                        { redactTag(exifInterface, it) },
-                        { Timber.d(it) },
-                        { save(exifInterface) },
-                    ),
-            )
-        }
-
-        private fun save(exifInterface: ExifInterface?) {
-            try {
-                exifInterface?.saveAttributes()
-            } catch (e: IOException) {
-                Timber.w("EXIF redaction failed: %s", e.toString())
+            // Expand preference-level tags into actual EXIF tag names.
+            val expandedTags = mutableSetOf<String>()
+            for (pref in redactTags) {
+                expandedTags.addAll(FileMetadataUtils.getTagsFromPref(pref))
             }
-        }
 
-        private fun redactTag(
-            exifInterface: ExifInterface?,
-            tag: String,
-        ) {
-            Timber.d("Checking for tag: %s", tag)
-            exifInterface
-                ?.getAttribute(tag)
-                ?.takeIf { it.isNotEmpty() }
-                ?.let { attributeName ->
-                    exifInterface.setAttribute(tag, null).also {
-                        Timber.d("Exif tag $tag with value $attributeName redacted.")
-                    }
+            // Redact from in-memory ExifInterface so callers see updated state.
+            for (tag in expandedTags) {
+                exifInterface?.getAttribute(tag)?.takeIf { it.isNotEmpty() }?.let {
+                    exifInterface.setAttribute(tag, null)
+                    Timber.d("Exif tag $tag with value $it redacted.")
                 }
+            }
+
+            // Write redaction to file using RandomAccessFile.
+            if (filePath != null) {
+                try {
+                    RandomAccessFileExifWriter.redactTags(File(filePath), expandedTags)
+                } catch (e: IOException) {
+                    Timber.w("EXIF redaction failed: %s", e.toString())
+                }
+            }
         }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.kt
@@ -19,7 +19,6 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
-import androidx.exifinterface.media.ExifInterface
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.github.chrisbanes.photoview.PhotoView
 import fr.free.nrw.commons.CameraPosition
@@ -37,6 +36,7 @@ import fr.free.nrw.commons.nearby.Place
 import fr.free.nrw.commons.recentlanguages.RecentLanguagesDao
 import fr.free.nrw.commons.settings.Prefs
 import fr.free.nrw.commons.upload.ImageCoordinates
+import fr.free.nrw.commons.utils.RandomAccessFileExifWriter
 import fr.free.nrw.commons.upload.SimilarImageDialogFragment
 import fr.free.nrw.commons.upload.UploadActivity
 import fr.free.nrw.commons.upload.UploadBaseFragment
@@ -761,20 +761,8 @@ class UploadMediaDetailFragment : UploadBaseFragment(), UploadMediaDetailsContra
     private fun removeLocation() {
         editableUploadItem!!.gpsCoords!!.decimalCoords = null
         try {
-            val sourceExif = ExifInterface(
-                uploadableFile!!.getFilePath()
-            )
-            val exifTags = arrayOf(
-                ExifInterface.TAG_GPS_LATITUDE,
-                ExifInterface.TAG_GPS_LATITUDE_REF,
-                ExifInterface.TAG_GPS_LONGITUDE,
-                ExifInterface.TAG_GPS_LONGITUDE_REF,
-            )
-
-            for (tag in exifTags) {
-                sourceExif.setAttribute(tag, null)
-            }
-            sourceExif.saveAttributes()
+            val filePath = uploadableFile!!.getFilePath()
+            RandomAccessFileExifWriter.removeLocation(File(filePath))
 
             val mapQuestion =
                 ContextCompat.getDrawable(requireContext(), R.drawable.ic_map_not_available_20dp)

--- a/app/src/main/java/fr/free/nrw/commons/utils/CustomSelectorUtils.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/CustomSelectorUtils.kt
@@ -60,7 +60,7 @@ class CustomSelectorUtils {
                         Timber.e(e)
                         null
                     }
-                fileProcessor.redactExifTags(exifInterface, fileProcessor.getExifTagsToRedact())
+                fileProcessor.redactExifTags(exifInterface, fileProcessor.getExifTagsToRedact(), uploadableFile.getFilePath())
                 val sha1 =
                     fileUtilsWrapper.getSHA1(
                         fileUtilsWrapper.getFileInputStream(uploadableFile.getFilePath()),

--- a/app/src/main/java/fr/free/nrw/commons/utils/RandomAccessFileExifWriter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/RandomAccessFileExifWriter.kt
@@ -254,7 +254,7 @@ object RandomAccessFileExifWriter {
             } else {
                 val encoded = encodeValue(type, updates[tagId]!!, order) ?: continue
                 val unitSize = typeUnitSize(type)
-                val existingBytes = unitSize * cnt.toInt()
+                val existingBytes = unitSize * cnt
 
                 if (existingBytes <= 4) {
                     if (encoded.size <= 4) {
@@ -275,6 +275,16 @@ object RandomAccessFileExifWriter {
                     }
                 }
                 raf.seek(afterEntry)
+            }
+        }
+
+        // update next IFD if present (e.g. IFD0 -> IFD1 thumbnail IFD).
+        if (raf.filePointer <= raf.length() - 4) {
+            val nextIfdOff = readU32(raf, order)
+            if (nextIfdOff > 0) {
+                scanAndUpdateIfd(
+                    raf, tiffBase, tiffBase + nextIfdOff, order, updates,
+                )
             }
         }
     }

--- a/app/src/main/java/fr/free/nrw/commons/utils/RandomAccessFileExifWriter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/RandomAccessFileExifWriter.kt
@@ -1,0 +1,356 @@
+package fr.free.nrw.commons.utils
+
+import androidx.exifinterface.media.ExifInterface
+import timber.log.Timber
+import java.io.File
+import java.io.IOException
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.collections.iterator
+
+/**
+ * General-purpose EXIF metadata writer that operates on JPEG files via [RandomAccessFile],
+ * avoiding [ExifInterface.saveAttributes].
+ *
+ * ## Core API
+ * - [writeTag]  – update or remove a single tag in-place.
+ * - [writeTags] – update or remove multiple tags in-place.
+ *
+ * ## Convenience helpers
+ * - [removeLocation] – strips all GPS tags.
+ * - [redactTags]     – strips tags by ExifInterface tag name.
+ * - [copyExif]       – copies EXIF from an [androidx.exifinterface.media.ExifInterface] and writes into a file.
+ */
+object RandomAccessFileExifWriter {
+
+    private const val TYPE_BYTE = 1
+    private const val TYPE_ASCII = 2
+    private const val TYPE_SHORT = 3
+    private const val TYPE_LONG = 4
+    private const val TYPE_RATIONAL = 5
+    private const val TYPE_UNDEFINED = 7
+    private const val TYPE_SLONG = 9
+    private const val TYPE_SRATIONAL = 10
+
+    private enum class IfdGroup { IFD0, EXIF, GPS }
+
+    /** Specification for one tag: numeric ID, EXIF type, owning IFD. */
+    private data class TagSpec(val id: Int, val type: Int, val ifd: IfdGroup)
+
+    // Map ExifInterface tag-name constants (ID, data-type, IFD group).
+    private val TAG_REGISTRY: Map<String, TagSpec> = mapOf(
+
+        // IFD0 tags 3.
+        ExifInterface.TAG_IMAGE_DESCRIPTION to TagSpec(0x010E, TYPE_ASCII, IfdGroup.IFD0),
+        ExifInterface.TAG_MAKE to TagSpec(0x010F, TYPE_ASCII, IfdGroup.IFD0),
+        ExifInterface.TAG_MODEL to TagSpec(0x0110, TYPE_ASCII, IfdGroup.IFD0),
+        ExifInterface.TAG_ORIENTATION to TagSpec(0x0112, TYPE_SHORT, IfdGroup.IFD0),
+        ExifInterface.TAG_SOFTWARE to TagSpec(0x0131, TYPE_ASCII, IfdGroup.IFD0),
+        ExifInterface.TAG_DATETIME to TagSpec(0x0132, TYPE_ASCII, IfdGroup.IFD0),
+        ExifInterface.TAG_ARTIST to TagSpec(0x013B, TYPE_ASCII, IfdGroup.IFD0),
+        ExifInterface.TAG_COPYRIGHT to TagSpec(0x8298, TYPE_ASCII, IfdGroup.IFD0),
+
+        // Exif sub-IFD tags.
+        ExifInterface.TAG_EXPOSURE_TIME to TagSpec(0x829A, TYPE_RATIONAL, IfdGroup.EXIF),
+        ExifInterface.TAG_F_NUMBER to TagSpec(0x829D, TYPE_RATIONAL, IfdGroup.EXIF),
+        ExifInterface.TAG_PHOTOGRAPHIC_SENSITIVITY to TagSpec(0x8827, TYPE_SHORT, IfdGroup.EXIF),
+        ExifInterface.TAG_DATETIME_ORIGINAL to TagSpec(0x9003, TYPE_ASCII, IfdGroup.EXIF),
+        ExifInterface.TAG_DATETIME_DIGITIZED to TagSpec(0x9004, TYPE_ASCII, IfdGroup.EXIF),
+        ExifInterface.TAG_FLASH to TagSpec(0x9209, TYPE_SHORT, IfdGroup.EXIF),
+        ExifInterface.TAG_FOCAL_LENGTH to TagSpec(0x920A, TYPE_RATIONAL, IfdGroup.EXIF),
+        ExifInterface.TAG_IMAGE_WIDTH to TagSpec(0xA002, TYPE_LONG, IfdGroup.EXIF),
+        ExifInterface.TAG_IMAGE_LENGTH to TagSpec(0xA003, TYPE_LONG, IfdGroup.EXIF),
+        ExifInterface.TAG_CAMERA_OWNER_NAME to TagSpec(0xA430, TYPE_ASCII, IfdGroup.EXIF),
+        ExifInterface.TAG_BODY_SERIAL_NUMBER to TagSpec(0xA431, TYPE_ASCII, IfdGroup.EXIF),
+        ExifInterface.TAG_LENS_SPECIFICATION to TagSpec(0xA432, TYPE_RATIONAL, IfdGroup.EXIF),
+        ExifInterface.TAG_LENS_MAKE to TagSpec(0xA433, TYPE_ASCII, IfdGroup.EXIF),
+        ExifInterface.TAG_LENS_MODEL to TagSpec(0xA434, TYPE_ASCII, IfdGroup.EXIF),
+        ExifInterface.TAG_LENS_SERIAL_NUMBER to TagSpec(0xA435, TYPE_ASCII, IfdGroup.EXIF),
+        ExifInterface.TAG_WHITE_BALANCE to TagSpec(0xA405, TYPE_SHORT, IfdGroup.EXIF),
+
+        // GPS sub-IFD tags.
+        ExifInterface.TAG_GPS_LATITUDE_REF to TagSpec(0x0001, TYPE_ASCII, IfdGroup.GPS),
+        ExifInterface.TAG_GPS_LATITUDE to TagSpec(0x0002, TYPE_RATIONAL, IfdGroup.GPS),
+        ExifInterface.TAG_GPS_LONGITUDE_REF to TagSpec(0x0003, TYPE_ASCII, IfdGroup.GPS),
+        ExifInterface.TAG_GPS_LONGITUDE to TagSpec(0x0004, TYPE_RATIONAL, IfdGroup.GPS),
+        ExifInterface.TAG_GPS_ALTITUDE_REF to TagSpec(0x0005, TYPE_BYTE, IfdGroup.GPS),
+        ExifInterface.TAG_GPS_ALTITUDE to TagSpec(0x0006, TYPE_RATIONAL, IfdGroup.GPS),
+        ExifInterface.TAG_GPS_TIMESTAMP to TagSpec(0x0007, TYPE_RATIONAL, IfdGroup.GPS),
+        ExifInterface.TAG_GPS_DATESTAMP to TagSpec(0x001D, TYPE_ASCII, IfdGroup.GPS),
+    )
+
+    /** GPS IFD pointer tag – lives in IFD0, points to the GPS sub-IFD. */
+    private const val TAG_ID_GPS_IFD_POINTER = 0x8825
+
+    /**
+     * Update a single EXIF tag in a JPEG file.
+     *
+     * @param file    target JPEG file.
+     * @param tagName an [ExifInterface] tag constant, e.g. [ExifInterface.TAG_ORIENTATION]
+     * @param value   new value as a string (same format [ExifInterface.getAttribute]
+     *                returns), or **null** to remove the tag
+     */
+    fun writeTag(file: File, tagName: String, value: String?) {
+        writeTags(file, mapOf(tagName to value))
+    }
+
+    /**
+     * Update (or remove) multiple EXIF tags in a JPEG file in a single pass.
+     *
+     * @param tags map of tag-name → value (null = remove)
+     */
+    fun writeTags(file: File, tags: Map<String, String?>) {
+        if (!file.exists() || file.length() < 4 || tags.isEmpty()) return
+
+        val updates = mutableMapOf<Int, String?>()
+        for ((name, value) in tags) {
+            val spec = TAG_REGISTRY[name] ?: continue
+            updates[spec.id] = value
+            if (value == null && spec.ifd == IfdGroup.GPS) {
+                updates[TAG_ID_GPS_IFD_POINTER] = null
+            }
+        }
+        if (updates.isEmpty()) return
+
+        writeTagsInternal(file, updates)
+    }
+
+    /**
+     * Strips all GPS location metadata from a JPEG file.
+     */
+    fun removeLocation(file: File) {
+        if (!file.exists() || file.length() < 4) return
+
+        val updates = TAG_REGISTRY
+            .filter { it.value.ifd == IfdGroup.GPS }
+            .map { it.value.id }
+            .plus(TAG_ID_GPS_IFD_POINTER)
+            .associateWith { null as String? }
+
+        writeTagsInternal(file, updates)
+    }
+
+    /**
+     * Redacts (nulls) tags identified by their [ExifInterface] tag-name
+     * constants (e.g. `ExifInterface.TAG_MAKE`).
+     */
+    fun redactTags(file: File, redactTags: Set<String>) {
+        if (!file.exists() || file.length() < 4 || redactTags.isEmpty()) return
+
+        val updates = mutableMapOf<Int, String?>()
+        for (name in redactTags) {
+            val spec = TAG_REGISTRY[name] ?: continue
+            updates[spec.id] = null
+            if (spec.ifd == IfdGroup.GPS) updates[TAG_ID_GPS_IFD_POINTER] = null
+        }
+        if (updates.isEmpty()) return
+
+        writeTagsInternal(file, updates)
+    }
+
+    /**
+     * Copies all supported EXIF metadata from [src] Exif into [dstFile]
+     * by reading each known tag and writing it via [writeTags].
+     */
+    fun copyExif(src: ExifInterface, dstFile: File) {
+        val tags = mutableMapOf<String, String?>()
+        for ((tagName, _) in TAG_REGISTRY) {
+            val value = src.getAttribute(tagName) ?: continue
+            tags[tagName] = value
+        }
+        if (tags.isNotEmpty()) {
+            writeTags(dstFile, tags)
+        }
+    }
+
+    /**
+     * Opens the file, locates the APP1 segment, and applies [updates] through [scanAndUpdateIfd]
+     * (tag-ID → new value / null) in-place.
+     */
+    private fun writeTagsInternal(
+        file: File,
+        updates: Map<Int, String?>,
+    ) {
+        try {
+            RandomAccessFile(file, "rw").use { raf ->
+                raf.seek(0)
+                if (raf.readUnsignedShort() != 0xFFD8) return
+
+                while (raf.filePointer < raf.length() - 4) {
+                    val marker = raf.readUnsignedShort()
+                    val len = raf.readUnsignedShort()
+                    val next = raf.filePointer + len - 2
+
+                    if (marker == 0xFFE1 && len >= 8) {
+                        val app1Start = raf.filePointer
+                        val hdr = ByteArray(6)
+                        raf.readFully(hdr)
+                        if (String(hdr, 0, 4) == "Exif") {
+                            val tiffBase = app1Start + 6
+                            val bo = ByteArray(2)
+                            raf.readFully(bo)
+                            val order = if (bo[0] == 'I'.code.toByte())
+                                ByteOrder.LITTLE_ENDIAN else ByteOrder.BIG_ENDIAN
+
+                            readU16(raf, order) // skip magic 42
+                            val ifd0Off = readU32(raf, order)
+                            scanAndUpdateIfd(
+                                raf, tiffBase, tiffBase + ifd0Off,
+                                order, updates,
+                            )
+                        }
+                        break
+                    } else if (marker == 0xFFDA) break
+                    else raf.seek(next)
+                }
+            }
+        } catch (e: IOException) {
+            Timber.e(e, "Failed to update EXIF tags via RandomAccessFile")
+        }
+    }
+
+    /**
+     * Walks every entry in one IFD, applying matching updates or zeroing
+     * entries. Only recurses into Exif sub-IFD (0x8769) / GPS sub-IFD
+     * (0x8825) when the pointer tag is encountered.
+     */
+    private fun scanAndUpdateIfd(
+        raf: RandomAccessFile,
+        tiffBase: Long,
+        ifdPos: Long,
+        order: ByteOrder,
+        updates: Map<Int, String?>,
+    ) {
+        if (ifdPos >= raf.length() - 2) return
+        raf.seek(ifdPos)
+        val count = readU16(raf, order)
+
+        for (i in 0 until count) {
+            val entryPos = raf.filePointer
+            val tagId = readU16(raf, order)
+            val type = readU16(raf, order)
+            val cnt = readU32(raf, order)
+            val valFieldPos = raf.filePointer
+            val valOrOff = readU32(raf, order)
+            val afterEntry = raf.filePointer
+
+            // Recurse sub-IFDs.
+            if ((tagId == 0x8769 || tagId == 0x8825) && valOrOff > 0) {
+                scanAndUpdateIfd(
+                    raf, tiffBase, tiffBase + valOrOff, order, updates,
+                )
+                raf.seek(afterEntry)
+            }
+
+            // Remove or overwrite matching tags.
+            if (!updates.containsKey(tagId)) continue
+
+            if (updates[tagId] == null) {
+                // Zero out the 12-byte entry to remove the tag
+                raf.seek(entryPos)
+                raf.write(ByteArray(12))
+                raf.seek(afterEntry)
+            } else {
+                val encoded = encodeValue(type, updates[tagId]!!, order) ?: continue
+                val unitSize = typeUnitSize(type)
+                val existingBytes = unitSize * cnt.toInt()
+
+                if (existingBytes <= 4) {
+                    if (encoded.size <= 4) {
+                        raf.seek(valFieldPos)
+                        raf.write(encoded)
+                        repeat(4 - encoded.size) { raf.writeByte(0) }
+                    }
+                } else {
+                    if (encoded.size <= existingBytes) {
+                        raf.seek(tiffBase + valOrOff)
+                        raf.write(encoded)
+                        repeat(existingBytes - encoded.size) { raf.writeByte(0) }
+                    } else {
+                        Timber.w(
+                            "Tag 0x%04X: new value (%d B) exceeds existing space (%d B), skipped",
+                            tagId, encoded.size, existingBytes,
+                        )
+                    }
+                }
+                raf.seek(afterEntry)
+            }
+        }
+    }
+
+    /**
+     * Encodes a string value into a byte array matching the given EXIF
+     * [type], using [order] for multi-byte integers.
+     */
+    private fun encodeValue(type: Int, value: String, order: ByteOrder): ByteArray? {
+        return try {
+            when (type) {
+                TYPE_BYTE ->
+                    byteArrayOf(value.toInt().toByte())
+
+                TYPE_ASCII ->
+                    "$value\u0000".toByteArray(Charsets.US_ASCII)
+
+                TYPE_SHORT ->
+                    ByteBuffer.allocate(2).order(order)
+                        .putShort(value.toInt().toShort()).array()
+
+                TYPE_LONG ->
+                    ByteBuffer.allocate(4).order(order)
+                        .putInt(value.toLong().toInt()).array()
+
+                TYPE_RATIONAL, TYPE_SRATIONAL -> {
+                    val parts = value.split(",")
+                    val buf = ByteBuffer.allocate(parts.size * 8).order(order)
+                    for (part in parts) {
+                        val nd = part.trim().split("/")
+                        if (nd.size != 2) return null
+                        buf.putInt(nd[0].trim().toInt())
+                        buf.putInt(nd[1].trim().toInt())
+                    }
+                    buf.array()
+                }
+
+                TYPE_SLONG ->
+                    ByteBuffer.allocate(4).order(order)
+                        .putInt(value.toInt()).array()
+
+                TYPE_UNDEFINED ->
+                    value.toByteArray(Charsets.US_ASCII)
+
+                else -> null
+            }
+        } catch (e: NumberFormatException) {
+            Timber.w("Cannot encode value '%s' for EXIF type %d", value, type)
+            null
+        }
+    }
+
+    /** Size in bytes of one unit of the given EXIF [type]. */
+    private fun typeUnitSize(type: Int): Int = when (type) {
+        TYPE_BYTE, TYPE_ASCII, TYPE_UNDEFINED -> 1
+        TYPE_SHORT -> 2
+        TYPE_LONG, TYPE_SLONG -> 4
+        TYPE_RATIONAL, TYPE_SRATIONAL -> 8
+        else -> 1
+    }
+
+    private fun readU16(raf: RandomAccessFile, order: ByteOrder): Int {
+        val b1 = raf.readUnsignedByte()
+        val b2 = raf.readUnsignedByte()
+        return if (order == ByteOrder.LITTLE_ENDIAN) (b2 shl 8) or b1
+        else (b1 shl 8) or b2
+    }
+
+    private fun readU32(raf: RandomAccessFile, order: ByteOrder): Int {
+        val b1 = raf.readUnsignedByte()
+        val b2 = raf.readUnsignedByte()
+        val b3 = raf.readUnsignedByte()
+        val b4 = raf.readUnsignedByte()
+        return if (order == ByteOrder.LITTLE_ENDIAN)
+            (b4 shl 24) or (b3 shl 16) or (b2 shl 8) or b1
+        else
+            (b1 shl 24) or (b2 shl 16) or (b3 shl 8) or b4
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/utils/RandomAccessFileExifWriter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/RandomAccessFileExifWriter.kt
@@ -199,8 +199,10 @@ object RandomAccessFileExifWriter {
                                 raf, tiffBase, tiffBase + ifd0Off,
                                 order, updates,
                             )
+                            break
+                        } else {
+                            raf.seek(next)
                         }
-                        break
                     } else if (marker == 0xFFDA) break
                     else raf.seek(next)
                 }
@@ -221,6 +223,7 @@ object RandomAccessFileExifWriter {
         ifdPos: Long,
         order: ByteOrder,
         updates: Map<Int, String?>,
+        isMainIfd: Boolean = true,
     ) {
         if (ifdPos >= raf.length() - 2) return
         raf.seek(ifdPos)
@@ -238,7 +241,7 @@ object RandomAccessFileExifWriter {
             // Recurse sub-IFDs.
             if ((tagId == 0x8769 || tagId == 0x8825) && valOrOff > 0) {
                 scanAndUpdateIfd(
-                    raf, tiffBase, tiffBase + valOrOff, order, updates,
+                    raf, tiffBase, tiffBase + valOrOff, order, updates, isMainIfd = false,
                 )
                 raf.seek(afterEntry)
             }
@@ -247,7 +250,7 @@ object RandomAccessFileExifWriter {
             if (!updates.containsKey(tagId)) continue
 
             if (updates[tagId] == null) {
-                // Zero out the 12-byte entry to remove the tag
+                // Zero out the entire 12-byte IFD entry to remove the tag
                 raf.seek(entryPos)
                 raf.write(ByteArray(12))
                 raf.seek(afterEntry)
@@ -278,12 +281,12 @@ object RandomAccessFileExifWriter {
             }
         }
 
-        // update next IFD if present (e.g. IFD0 -> IFD1 thumbnail IFD).
-        if (raf.filePointer <= raf.length() - 4) {
+        // Only main IFDs (e.g. IFD0 -> IFD1 thumbnail IFD) have a next-IFD offset pointer.
+        if (isMainIfd && raf.filePointer <= raf.length() - 4) {
             val nextIfdOff = readU32(raf, order)
             if (nextIfdOff > 0) {
                 scanAndUpdateIfd(
-                    raf, tiffBase, tiffBase + nextIfdOff, order, updates,
+                    raf, tiffBase, tiffBase + nextIfdOff, order, updates, isMainIfd = true,
                 )
             }
         }

--- a/app/src/main/java/fr/free/nrw/commons/utils/RandomAccessFileExifWriter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/RandomAccessFileExifWriter.kt
@@ -106,7 +106,8 @@ object RandomAccessFileExifWriter {
         val updates = mutableMapOf<Int, String?>()
         for ((name, value) in tags) {
             val spec = TAG_REGISTRY[name] ?: continue
-            updates[spec.id] = value
+            val targetValue = if (name == ExifInterface.TAG_ORIENTATION && value == null) "1" else value
+            updates[spec.id] = targetValue
             if (value == null && spec.ifd == IfdGroup.GPS) {
                 updates[TAG_ID_GPS_IFD_POINTER] = null
             }
@@ -141,7 +142,8 @@ object RandomAccessFileExifWriter {
         val updates = mutableMapOf<Int, String?>()
         for (name in redactTags) {
             val spec = TAG_REGISTRY[name] ?: continue
-            updates[spec.id] = null
+            val targetValue = if (name == ExifInterface.TAG_ORIENTATION) "1" else null
+            updates[spec.id] = targetValue
             if (spec.ifd == IfdGroup.GPS) updates[TAG_ID_GPS_IFD_POINTER] = null
         }
         if (updates.isEmpty()) return

--- a/app/src/test/kotlin/fr/free/nrw/commons/utils/RandomAccessFileExifWriterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/utils/RandomAccessFileExifWriterTest.kt
@@ -14,7 +14,7 @@ import java.io.File
  */
 class RandomAccessFileExifWriterTest {
 
-    private val sampleImagePath = "src/test/resources/ImageTest/ok1.jpg"
+    private val sampleImagePath = "src/test/resources/ImageTest/dark1.jpg"
     private lateinit var testFile: File
 
     @Before

--- a/app/src/test/kotlin/fr/free/nrw/commons/utils/RandomAccessFileExifWriterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/utils/RandomAccessFileExifWriterTest.kt
@@ -1,0 +1,150 @@
+package fr.free.nrw.commons.utils
+
+import androidx.exifinterface.media.ExifInterface
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+/**
+ * Unit tests for [RandomAccessFileExifWriter].
+ */
+class RandomAccessFileExifWriterTest {
+
+    private val sampleImagePath = "src/test/resources/ImageTest/ok1.jpg"
+    private lateinit var testFile: File
+
+    @Before
+    fun setUp() {
+        val sampleFile = File(sampleImagePath)
+        testFile = File.createTempFile("exif_test_", ".jpg")
+        sampleFile.copyTo(testFile, overwrite = true)
+    }
+
+    @After
+    fun tearDown() {
+        if (::testFile.isInitialized && testFile.exists()) {
+            testFile.delete()
+        }
+    }
+
+    @Test
+    fun `writeTag updates orientation`() {
+        RandomAccessFileExifWriter.writeTag(
+            testFile, ExifInterface.TAG_ORIENTATION, "6"
+        )
+        val after = ExifInterface(testFile.absolutePath)
+        assertEquals("6", after.getAttribute(ExifInterface.TAG_ORIENTATION))
+    }
+
+    @Test
+    fun `writeTag removes a tag when value is null`() {
+        // Write a tag first to ensure it's set
+        RandomAccessFileExifWriter.writeTag(
+            testFile, ExifInterface.TAG_ORIENTATION, "1"
+        )
+        val before = ExifInterface(testFile.absolutePath)
+        assertNotNull(before.getAttribute(ExifInterface.TAG_ORIENTATION))
+
+        // Remove tag by passing null
+        RandomAccessFileExifWriter.writeTag(
+            testFile, ExifInterface.TAG_ORIENTATION, null
+        )
+        val after = ExifInterface(testFile.absolutePath)
+        assertNull(after.getAttribute(ExifInterface.TAG_ORIENTATION))
+    }
+
+    @Test
+    fun `writeTag does nothing on non-existent file`() {
+        val fake = File("src/test/resources/non_existent_file.jpg")
+        RandomAccessFileExifWriter.writeTag(fake, ExifInterface.TAG_ORIENTATION, "1")
+    }
+
+    @Test
+    fun `writeTag does nothing for unknown tag name`() {
+        RandomAccessFileExifWriter.writeTag(testFile, "UnknownTagName", "123")
+    }
+
+    @Test
+    fun `writeTags updates multiple tags at once`() {
+        RandomAccessFileExifWriter.writeTags(
+            testFile, mapOf(
+                ExifInterface.TAG_ORIENTATION to "3",
+                ExifInterface.TAG_MAKE to "TestMake"
+            )
+        )
+
+        val after = ExifInterface(testFile.absolutePath)
+        assertEquals("3", after.getAttribute(ExifInterface.TAG_ORIENTATION))
+        assertEquals("TestMake", after.getAttribute(ExifInterface.TAG_MAKE))
+    }
+
+    @Test
+    fun `writeTags with empty map does nothing`() {
+        val sizeBefore = testFile.length()
+        RandomAccessFileExifWriter.writeTags(testFile, emptyMap())
+        assertEquals(sizeBefore, testFile.length())
+    }
+
+    @Test
+    fun `removeLocation strips GPS tags`() {
+        // Set a GPS tag first
+        RandomAccessFileExifWriter.writeTag(
+            testFile, ExifInterface.TAG_GPS_LATITUDE_REF, "N"
+        )
+        val before = ExifInterface(testFile.absolutePath)
+        assertNotNull(before.getAttribute(ExifInterface.TAG_GPS_LATITUDE_REF))
+
+        // Remove location
+        RandomAccessFileExifWriter.removeLocation(testFile)
+
+        val after = ExifInterface(testFile.absolutePath)
+        assertNull(after.getAttribute(ExifInterface.TAG_GPS_LATITUDE_REF))
+    }
+
+    @Test
+    fun `redactTags removes specified tags`() {
+        RandomAccessFileExifWriter.writeTags(
+            testFile, mapOf(
+                ExifInterface.TAG_ORIENTATION to "1",
+                ExifInterface.TAG_MAKE to "TestMake"
+            )
+        )
+
+        RandomAccessFileExifWriter.redactTags(
+            testFile, setOf(
+                ExifInterface.TAG_ORIENTATION,
+                ExifInterface.TAG_MAKE
+            )
+        )
+
+        val after = ExifInterface(testFile.absolutePath)
+        assertNull(after.getAttribute(ExifInterface.TAG_ORIENTATION))
+        assertNull(after.getAttribute(ExifInterface.TAG_MAKE))
+    }
+
+    @Test
+    fun `copyExif copies tags from ExifInterface to destination file`() {
+        val sampleFile = File(sampleImagePath)
+        val dstFile = File.createTempFile("exif_dst_", ".jpg")
+        try {
+            sampleFile.copyTo(dstFile, overwrite = true)
+
+            // Set tag on source file
+            RandomAccessFileExifWriter.writeTag(
+                testFile, ExifInterface.TAG_ORIENTATION, "6"
+            )
+
+            val srcExif = ExifInterface(testFile.absolutePath)
+            RandomAccessFileExifWriter.copyExif(srcExif, dstFile)
+
+            val dstExif = ExifInterface(dstFile.absolutePath)
+            assertEquals("6", dstExif.getAttribute(ExifInterface.TAG_ORIENTATION))
+        } finally {
+            dstFile.delete()
+        }
+    }
+}

--- a/app/src/test/kotlin/fr/free/nrw/commons/utils/RandomAccessFileExifWriterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/utils/RandomAccessFileExifWriterTest.kt
@@ -44,17 +44,25 @@ class RandomAccessFileExifWriterTest {
     fun `writeTag removes a tag when value is null`() {
         // Write a tag first to ensure it's set
         RandomAccessFileExifWriter.writeTag(
-            testFile, ExifInterface.TAG_ORIENTATION, "1"
+            testFile, ExifInterface.TAG_ORIENTATION, "6"
+        )
+        RandomAccessFileExifWriter.writeTag(
+            testFile, ExifInterface.TAG_SOFTWARE, "TestSoftware"
         )
         val before = ExifInterface(testFile.absolutePath)
-        assertNotNull(before.getAttribute(ExifInterface.TAG_ORIENTATION))
+        assertEquals("6", before.getAttribute(ExifInterface.TAG_ORIENTATION))
+        assertEquals("TestSoftware", before.getAttribute(ExifInterface.TAG_SOFTWARE))
 
-        // Remove tag by passing null
+        // Remove tag by passing null (resets orientation to 1 / normal, software becomes null)
         RandomAccessFileExifWriter.writeTag(
             testFile, ExifInterface.TAG_ORIENTATION, null
         )
+        RandomAccessFileExifWriter.writeTag(
+            testFile, ExifInterface.TAG_SOFTWARE, null
+        )
         val after = ExifInterface(testFile.absolutePath)
-        assertNull(after.getAttribute(ExifInterface.TAG_ORIENTATION))
+        assertEquals("1", after.getAttribute(ExifInterface.TAG_ORIENTATION))
+        assertNull(after.getAttribute(ExifInterface.TAG_SOFTWARE))
     }
 
     @Test
@@ -109,7 +117,7 @@ class RandomAccessFileExifWriterTest {
     fun `redactTags removes specified tags`() {
         RandomAccessFileExifWriter.writeTags(
             testFile, mapOf(
-                ExifInterface.TAG_ORIENTATION to "1",
+                ExifInterface.TAG_ORIENTATION to "6",
                 ExifInterface.TAG_SOFTWARE to "TestSoftware"
             )
         )
@@ -122,7 +130,7 @@ class RandomAccessFileExifWriterTest {
         )
 
         val after = ExifInterface(testFile.absolutePath)
-        assertNull(after.getAttribute(ExifInterface.TAG_ORIENTATION))
+        assertEquals("1", after.getAttribute(ExifInterface.TAG_ORIENTATION))
         assertNull(after.getAttribute(ExifInterface.TAG_SOFTWARE))
     }
 

--- a/app/src/test/kotlin/fr/free/nrw/commons/utils/RandomAccessFileExifWriterTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/utils/RandomAccessFileExifWriterTest.kt
@@ -73,13 +73,13 @@ class RandomAccessFileExifWriterTest {
         RandomAccessFileExifWriter.writeTags(
             testFile, mapOf(
                 ExifInterface.TAG_ORIENTATION to "3",
-                ExifInterface.TAG_MAKE to "TestMake"
+                ExifInterface.TAG_SOFTWARE to "TestSoftware"
             )
         )
 
         val after = ExifInterface(testFile.absolutePath)
         assertEquals("3", after.getAttribute(ExifInterface.TAG_ORIENTATION))
-        assertEquals("TestMake", after.getAttribute(ExifInterface.TAG_MAKE))
+        assertEquals("TestSoftware", after.getAttribute(ExifInterface.TAG_SOFTWARE))
     }
 
     @Test
@@ -110,20 +110,20 @@ class RandomAccessFileExifWriterTest {
         RandomAccessFileExifWriter.writeTags(
             testFile, mapOf(
                 ExifInterface.TAG_ORIENTATION to "1",
-                ExifInterface.TAG_MAKE to "TestMake"
+                ExifInterface.TAG_SOFTWARE to "TestSoftware"
             )
         )
 
         RandomAccessFileExifWriter.redactTags(
             testFile, setOf(
                 ExifInterface.TAG_ORIENTATION,
-                ExifInterface.TAG_MAKE
+                ExifInterface.TAG_SOFTWARE
             )
         )
 
         val after = ExifInterface(testFile.absolutePath)
         assertNull(after.getAttribute(ExifInterface.TAG_ORIENTATION))
-        assertNull(after.getAttribute(ExifInterface.TAG_MAKE))
+        assertNull(after.getAttribute(ExifInterface.TAG_SOFTWARE))
     }
 
     @Test


### PR DESCRIPTION
**Description (required)**
The Occurences of `ExifInterface.saveattributes`  would result in ICC profile being stripped off because it does not consider the App2 marker when it rebuilds the segment, Created a `RandomAccessFileExifWriter` which uses RandomAccessFile API to manually overwrite the Exif tag values in the jpeg file.
What changes did you make and why?
- Created `RandomAccessFileExifWriter` which is a class exposed methods to handle exif tags and update its values similar and more simple as `ExifInterface.saveattributes`.
- Added a tests `RandomAccessFileExifWriterTest`.
- Replaced occurences of Exifinterface's saveattributes with  `RandomAccessFileExifWriter`.

**Tests performed (required)**
-  `RandomAccessFileExifWriterTest`

**Screenshots**

# Remove location 

 - Before
<img width="1619" height="880" alt="Screenshot 2026-08-12 133222" src="https://github.com/user-attachments/assets/da1a81df-4568-4a52-82a7-47e0e18349eb" />

- After
<img width="1467" height="750" alt="Screenshot 2026-08-12 133203" src="https://github.com/user-attachments/assets/28876569-13c1-488c-9a25-f1891e198fe8" />

# Remove (uncheck) all Exif Tags in settings (camera model, lens model, software)
- Before

<img width="659" height="604" alt="Screenshot 2026-08-12 134853" src="https://github.com/user-attachments/assets/9498da53-313f-4c30-ad78-9bf2e2fcb534" />

- After
- 
<img width="836" height="548" alt="Screenshot 2026-08-12 134842" src="https://github.com/user-attachments/assets/17ffb86e-f10d-461c-9fe8-f82b8964b595" />
