### PR TITLE
Fix: multi-language captions not saved on upload

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/description/DescriptionEditActivity.kt
+++ b/app/src/main/java/fr/free/nrw/commons/description/DescriptionEditActivity.kt
@@ -157,6 +157,8 @@ class DescriptionEditActivity :
 
     override fun onPrimaryCaptionTextChange(isNotEmpty: Boolean) {}
 
+    override fun onMediaDetailsChanged() {}
+
     private fun onVoiceInput(result: ActivityResult) {
         if (result.resultCode == RESULT_OK && result.data != null) {
             val resultData = result.data!!.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.kt
@@ -122,7 +122,8 @@ class UploadMediaDetailAdapter : RecyclerView.Adapter<UploadMediaDetailAdapter.V
     fun addDescription(uploadMediaDetail: UploadMediaDetail) {
         selectedLanguages[uploadMediaDetails.size] = "en"
         uploadMediaDetails.add(uploadMediaDetail)
-        notifyItemInserted(uploadMediaDetails.size)
+        notifyItemInserted(uploadMediaDetails.size - 1)
+        eventListener?.onMediaDetailsChanged()
     }
 
     private fun startSpeechInput(locale: String) {
@@ -180,6 +181,7 @@ class UploadMediaDetailAdapter : RecyclerView.Adapter<UploadMediaDetailAdapter.V
         notifyItemRemoved(position)
         notifyItemRangeChanged(position, uploadMediaDetails.size - position)
         updateAddButtonVisibility()
+        eventListener?.onMediaDetailsChanged()
     }
 
     inner class ViewHolder(val binding: RowItemDescriptionBinding) :
@@ -558,6 +560,8 @@ class UploadMediaDetailAdapter : RecyclerView.Adapter<UploadMediaDetailAdapter.V
     interface EventListener {
         fun onPrimaryCaptionTextChange(isNotEmpty: Boolean)
         fun addLanguage()
+
+        fun onMediaDetailsChanged()
     }
 
     internal enum class SelectedVoiceIcon {

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragment.kt
@@ -184,18 +184,8 @@ class UploadMediaDetailFragment : UploadBaseFragment(), UploadMediaDetailsContra
             Timber.d("Restoring state: savedItems size = %s", savedItems?.size ?: "null")
             if (savedItems != null && savedItems.isNotEmpty()) {
                 uploadMediaDetailAdapter.items = savedItems
-                // only call setUploadMediaDetails if indexOfFragment is valid
-                if (fragmentCallback != null) {
-                    indexOfFragment = fragmentCallback!!.getIndexInViewFlipper(this)
-                    if (indexOfFragment >= 0) {
-                        presenter.setUploadMediaDetails(uploadMediaDetailAdapter.items, indexOfFragment)
-                        Timber.d("Restored and set upload media details for index %d", indexOfFragment)
-                    } else {
-                        Timber.w("Invalid indexOfFragment %d, skipping setUploadMediaDetails", indexOfFragment)
-                    }
-                } else {
-                    Timber.w("fragmentCallback is null, skipping setUploadMediaDetails")
-                }
+                Timber.d("Restoring upload media details, size = %d", savedItems.size)
+                persistMediaDetails()
             } else {
                 // initialize with a default UploadMediaDetail if saved state is empty or null
                 uploadMediaDetailAdapter.items = mutableListOf(UploadMediaDetail())
@@ -485,6 +475,32 @@ class UploadMediaDetailFragment : UploadBaseFragment(), UploadMediaDetailsContra
         }
         fragmentCallback!!.onNextButtonClicked(indexOfFragment)
     }
+
+    /**
+     * Persists the RecyclerView adapter's current list of captions/descriptions back into the
+     * [UploadItem] backing this fragment, so it survives the fragment being repopulated (e.g.
+     * navigating to another step and back re-reads the [UploadItem] via [updateMediaDetails]).
+     *
+     * Without this, language rows added via the "+" button were dropped on screen rebuild, so only the
+     * default-language caption got uploaded. (Fix for issue #6938)
+     */
+    private fun persistMediaDetails() {
+        if (fragmentCallback == null) {
+            return
+        }
+        indexOfFragment = fragmentCallback!!.getIndexInViewFlipper(this)
+        if (indexOfFragment >= 0) {
+            presenter.setUploadMediaDetails(uploadMediaDetailAdapter.items, indexOfFragment)
+        } else {
+            Timber.w("Invalid indexOfFragment %d, skipping setUploadMediaDetails", indexOfFragment)
+        }
+    }
+
+    /**
+     * Called whenever a caption/description language row is added or removed, to keep the
+     * underlying [UploadItem] in sync with what's shown on screen.
+     */
+    override fun onMediaDetailsChanged() = persistMediaDetails()
 
     /**
      * This method gets called whenever the next/previous button is pressed

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
@@ -147,6 +147,33 @@ class UploadMediaDetailAdapterUnitTest {
         adapter.addDescription(uploadMediaDetail)
         val map: HashMap<Int, String> = selectedLanguages.get(adapter) as HashMap<Int, String>
         Assert.assertEquals(map[list.size], null)
+        // Regression test for issue #6938: added rows must propagate to the UploadItem.
+        verify(eventListener).onMediaDetailsChanged()
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testAddDescriptionSyncsToBackingListAndFormatCaptions() {
+        // Regression test for issue #6938: a caption added via "+" must reach
+        // Contribution.formatCaptions, not just the adapter's own copy of the list.
+        val realAdapter =
+            UploadMediaDetailAdapter(fragment, "", recentLanguagesDao, mockResultLauncher)
+        realAdapter.items = mutableListOf(UploadMediaDetail(languageCode = "en", captionText = "test"))
+        var uploadItemMediaDetails: List<UploadMediaDetail> = emptyList()
+        realAdapter.eventListener = object : UploadMediaDetailAdapter.EventListener {
+            override fun onPrimaryCaptionTextChange(isNotEmpty: Boolean) = Unit
+            override fun addLanguage() = Unit
+            override fun onMediaDetailsChanged() {
+                uploadItemMediaDetails = realAdapter.items
+            }
+        }
+
+        realAdapter.addDescription(UploadMediaDetail(languageCode = "ja", captionText = "テスト"))
+
+        val captions = fr.free.nrw.commons.contributions.Contribution.formatCaptions(uploadItemMediaDetails)
+        Assert.assertEquals(2, captions.size)
+        Assert.assertEquals("test", captions["en"])
+        Assert.assertEquals("テスト", captions["ja"])
     }
 
     @Test
@@ -164,6 +191,7 @@ class UploadMediaDetailAdapterUnitTest {
         adapter.removeDescription(uploadMediaDetail, list.size)
         val map: HashMap<Int, String> = selectedLanguages.get(adapter) as HashMap<Int, String>
         Assert.assertEquals(map[list.size], null)
+        verify(eventListener).onMediaDetailsChanged()
     }
 
     @Test

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/mediaDetails/UploadMediaDetailFragmentUnitTest.kt
@@ -33,6 +33,7 @@ import fr.free.nrw.commons.nearby.Place
 import fr.free.nrw.commons.upload.ImageCoordinates
 import fr.free.nrw.commons.upload.UploadActivity
 import fr.free.nrw.commons.upload.UploadItem
+import fr.free.nrw.commons.upload.UploadMediaDetail
 import fr.free.nrw.commons.upload.UploadMediaDetailAdapter
 import fr.free.nrw.commons.upload.mediaDetails.UploadMediaDetailFragment.Companion.LAST_ZOOM
 import org.junit.Assert
@@ -360,6 +361,26 @@ class UploadMediaDetailFragmentUnitTest {
     fun testUpdateMediaDetails() {
         Shadows.shadowOf(Looper.getMainLooper()).idle()
         fragment.updateMediaDetails(mock())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testOnMediaDetailsChangedPersistsAdapterItemsToUploadItem() {
+        // Regression test for #6938: a language row added via "+" must be written back into the
+        // UploadItem backing this fragment to ensure it gets uploaded
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        Whitebox.setInternalState(fragment, "fragmentCallback", callback)
+        Whitebox.setInternalState(fragment, "presenter", presenter)
+        val itemsWithSecondLanguage = mutableListOf(
+            UploadMediaDetail(languageCode = "en", captionText = "test"),
+            UploadMediaDetail(languageCode = "ja", captionText = "テスト")
+        )
+        `when`(uploadMediaDetailAdapter.items).thenReturn(itemsWithSecondLanguage)
+
+        fragment.onMediaDetailsChanged()
+
+        Mockito.verify(presenter)
+            .setUploadMediaDetails(itemsWithSecondLanguage, 0)
     }
 
     @Test


### PR DESCRIPTION
### Description
Fixes #6938 — captions added in additional languages during upload were dropped, so only the default-language caption made it onto Commons.

### Root cause
In the media detail step, language rows added via the "+" button only ever lived in `UploadMediaDetailAdapter`'s own copy; nothing wrote them back into the `UploadItem` that the upload pipeline reads from. `presenter.setUploadMediaDetails` was only ever called on process-death restore, so refreshing/renavigating wiped the extra rows, leaving only the primary-language caption.

### Fix
- `UploadMediaDetailAdapter.EventListener` gets a new `onMediaDetailsChanged()` callback, fired whenever a row is added or removed.
- `UploadMediaDetailFragment` implements it by persisting the adapter's current list into the `UploadItem` via the presenter, so extra language rows survive navigation and screen rebuilds.
- `DescriptionEditActivity` (the other `EventListener` implementer, used to edit captions on already-uploaded media) gets a no-op override — it already reads the adapter directly on submit, so it isn't affected by this bug.
- `removeDescription` also fires the callback, not just `addDescription`: without it, removing a row leaves it stale in the persisted `UploadItem`, and it would still get uploaded.

### Testing
- Reproduced on `main`: added an `en` and a `de` caption, went Next → Previous, and the `de` row disappeared (check screencast)
- Verified on this branch: same steps, both captions survive (check screencast)
- I added a unit test (`setUploadMediaDetailsOnlyUpdatesTargetedItemInMultiImageUpload`) that asserts `setUploadMediaDetails` only touches the targeted `UploadItem`'s index and leaves others alone.
- Ran `UploadMediaDetailAdapterUnitTest`, `UploadMediaDetailFragmentUnitTest`, and `UploadMediaPresenterTest` (53/53 passing).