### PR TITLE
auto_assign: guide new contributors to suitable issues

### DIFF
--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -73,6 +73,32 @@ jobs:
               return;
             }
 
+            // New contributors should start with bugs or good first issues
+            const isNewcomerFriendly = issue.data.type?.name === 'Bug'
+              || issue.data.labels.some(label => (label.name || label) === 'good first issue');
+
+            if (!isNewcomerFriendly) {
+              const mergedPullRequests = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:merged author:${commenter}`,
+                per_page: 1
+              });
+
+              if (mergedPullRequests.data.total_count < 6) {
+                let body = `Hi @${commenter}! Thank you for your enthusiasm!`;
+                body += `\n\nWhile we appreciate your interest in fixing this issue, we found out that contributors who are not veterans learn better from fixing bugs (issues with Type=Bug) or working on good first issues (issues with Label=good first issue). [Our documentation](https://github.com/commons-app/commons-app-documentation/blob/master/android/Volunteers-welcome!.md) contains the details and a link to an issue search that gives you the best issues to work on.`;
+                body += `\n\nWould you mind trying that? Once you have found a suitable issue you want to solve, you can ask to be assigned there.`;
+                body += `\n\nThanks a lot!`;
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: body
+                });
+                return;
+              }
+            }
+
             // Check commenter's existing assignments and PR's
             const assignedIssues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,


### PR DESCRIPTION
**Description**

Fixes #6958

`auto_assign.yml` assigned any issue on request, without checking the issue's
type or the contributor's experience. That conflicts with our documented
guideline:

> If you are a new contributor, please only ask to be assigned to issues with
> a "Bug" type or "good first issue" label. Issues of type "Feature" will
> usually only be assigned to contributors with more than 5 merged pull
> requests to this repo.

The workflow now enforces that guideline before assigning.

**Changes**

- `.github/workflows/auto_assign.yml`: after the existing "already assigned"
  check, determine whether the issue is `Type=Bug` or labelled
  `good first issue`. This reuses the issue object already fetched for the
  assignee check, so it costs no extra API call.
- If the issue is neither, look up the commenter's merged PR count in this
  repo via the search API. Fewer than 6 merged PRs means the workflow posts
  the friendly redirect from the issue (linking to the volunteers
  documentation) and returns without assigning.
- The merged-PR lookup only runs when the issue is not newcomer-friendly, so
  bugs and good first issues are assigned with no additional API request.
- All existing behaviour is untouched: the already-assigned message, the
  "already busy with another task" message, and the normal assignment path
  are unchanged.

**Tests performed**

No app code changed, so the Android build and unit tests are unaffected —
this touches only a GitHub Actions workflow.

Validated the workflow itself:
- YAML parses correctly and the job/step structure is intact.
- The embedded `github-script` body passes `node --check`.
- Simulated the script against mocked `github`/`context` objects for 12
  scenarios: Feature with 0/5/6/20 merged PRs (confirming the `<6` boundary),
  `Type=Bug` with 0 merged PRs, `good first issue` label with 0 merged PRs,
  labels supplied as plain strings, an issue with no type set, an
  already-assigned issue, and the "already busy" paths both with and without
  an open PR. All behaved as intended, and every pre-existing path produced
  the same output as before the change.

Because automated runs are still commented out (see #6576), this can be
exercised on a fork via `workflow_dispatch` or once the `issue_comment`
trigger is re-enabled.
