### PR TITLE
upload:fix for multilingual captions not appearing in image metadata after upload.

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.kt
@@ -56,7 +56,7 @@ class UploadMediaDetailAdapter : RecyclerView.Adapter<UploadMediaDetailAdapter.V
     var items: List<UploadMediaDetail>
         get() = uploadMediaDetails
         set(value) {
-            uploadMediaDetails = value.toMutableList()
+            uploadMediaDetails = value as? MutableList<UploadMediaDetail> ?: value.toMutableList()
             selectedLanguages = mutableMapOf()
             notifyDataSetChanged()
         }

--- a/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.kt
+++ b/app/src/main/java/fr/free/nrw/commons/upload/mediaDetails/UploadMediaPresenter.kt
@@ -72,7 +72,7 @@ class UploadMediaPresenter @Inject constructor(
         val uploadItems = repository.getUploads()
         if (uploadItemIndex >= 0 && uploadItemIndex < uploadItems.size) {
             if (uploadMediaDetails.isNotEmpty()) {
-                uploadItems[uploadItemIndex].uploadMediaDetails = uploadMediaDetails.toMutableList()
+                uploadItems[uploadItemIndex].uploadMediaDetails = uploadMediaDetails as? MutableList<UploadMediaDetail> ?: uploadMediaDetails.toMutableList()
                 Timber.d("Set uploadMediaDetails for index %d, size %d", uploadItemIndex, uploadMediaDetails.size)
             } else {
                 uploadItems[uploadItemIndex].uploadMediaDetails = mutableListOf(UploadMediaDetail())


### PR DESCRIPTION

**Description (required)**

Fixes #6956

Made changes to UploadMediaDetailAdapter and UploadMediaPresenter

The bug comes from the UploadMediaDetailAdapter setting the shared uploadMedia mutable list as a brand new list, causing a divergence between Fragment and Adapter: 

uploadMediaDetails = value.toMutableList() -> Causes a new copy of uploadMediaDetails that only contains the first caption, which is the copy that the Contribution is built from. When user adds more captions, the UploadMediaDetail is being added by the Adapter to its own list,  but not the one instantiated in the adapter setter 

uploadMediaDetails = value as? MutableList<UploadMediaDetail> ?: value.toMutableList() -> shared reference is passed, so the UploadMediaDetailAdapter will share the list with the fragment that is passed to the contribution object.

Similar change for uploadMediaPresenter, causes its own divergence resulting in captions alone not being saved (but descriptions are)

**Tests performed**

Tested Beta on Pixel 10a with API level 37.1

**Screenshots **

<img width="768" height="1720" alt="image" src="https://github.com/user-attachments/assets/28e0e0d7-706f-4e45-8593-1d488be8733d" />

