### PR TITLE
download: add User-Agent header and DownloadReceiver for failures

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -256,6 +256,14 @@
         android:resource="@xml/pic_of_day_app_widget_info" />
     </receiver>
 
+    <receiver
+      android:name=".utils.DownloadReceiver"
+      android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.DOWNLOAD_COMPLETE" />
+      </intent-filter>
+    </receiver>
+
     <uses-library
       android:name="org.apache.http.legacy"
       android:required="false" />

--- a/app/src/main/java/fr/free/nrw/commons/utils/DownloadReceiver.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/DownloadReceiver.kt
@@ -4,6 +4,7 @@ import android.app.DownloadManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.widget.Toast
 import timber.log.Timber
 
 //Added Javadocs for DownloadReceiver
@@ -37,19 +38,28 @@ class DownloadReceiver : BroadcastReceiver() {
 
                     Timber.e("DOWNLOAD FAILED! Title: $title | Reason Code: $reason")
 
-                    when (reason) {
-                        DownloadManager.ERROR_UNHANDLED_HTTP_CODE ->
-                            Timber.e("CAUSE: Server rejected request (Likely 403 Forbidden / Missing User-Agent)")
-                        DownloadManager.ERROR_HTTP_DATA_ERROR ->
-                            Timber.e("CAUSE: Network connection dropped mid-download (Beta cluster flakiness or VPN)")
-                        DownloadManager.ERROR_FILE_ERROR ->
-                            Timber.e("CAUSE: File system rejected the file (Storage issue or invalid filename characters)")
-                        DownloadManager.ERROR_INSUFFICIENT_SPACE ->
-                            Timber.e("CAUSE: Device is out of storage space")
-                        DownloadManager.ERROR_CANNOT_RESUME ->
-                            Timber.e("CAUSE: Download cannot be resumed")
-                        else ->
-                            Timber.e("CAUSE: Unknown system error (Code: $reason)")
+                    if (reason == 429) {
+                        Timber.e("CAUSE: Rate limited (HTTP 429 Too Many Requests)")
+                        Toast.makeText(
+                            context,
+                            "Too many downloads. Please wait a moment.",
+                            Toast.LENGTH_LONG
+                        ).show()
+                    } else {
+                        when (reason) {
+                            DownloadManager.ERROR_UNHANDLED_HTTP_CODE ->
+                                Timber.e("CAUSE: Server rejected request (Likely 403 Forbidden / Missing User-Agent)")
+                            DownloadManager.ERROR_HTTP_DATA_ERROR ->
+                                Timber.e("CAUSE: Network connection dropped mid-download (Beta cluster flakiness or VPN)")
+                            DownloadManager.ERROR_FILE_ERROR ->
+                                Timber.e("CAUSE: File system rejected the file (Storage issue or invalid filename characters)")
+                            DownloadManager.ERROR_INSUFFICIENT_SPACE ->
+                                Timber.e("CAUSE: Device is out of storage space")
+                            DownloadManager.ERROR_CANNOT_RESUME ->
+                                Timber.e("CAUSE: Download cannot be resumed")
+                            else ->
+                                Timber.e("CAUSE: Unknown system error (Code: $reason)")
+                        }
                     }
                 }
                 cursor.close()

--- a/app/src/main/java/fr/free/nrw/commons/utils/DownloadReceiver.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/DownloadReceiver.kt
@@ -42,7 +42,7 @@ class DownloadReceiver : BroadcastReceiver() {
                         Timber.e("CAUSE: Rate limited (HTTP 429 Too Many Requests)")
                         Toast.makeText(
                             context,
-                            "Too many downloads. Please wait a moment.",
+                            "Too many downloads in a short time. Please try again in a few seconds.",
                             Toast.LENGTH_LONG
                         ).show()
                     } else {

--- a/app/src/main/java/fr/free/nrw/commons/utils/DownloadReceiver.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/DownloadReceiver.kt
@@ -1,0 +1,59 @@
+package fr.free.nrw.commons.utils
+
+import android.app.DownloadManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import timber.log.Timber
+
+//Added Javadocs for DownloadReceiver
+/**
+ * A BroadcastReceiver that listens for [DownloadManager.ACTION_DOWNLOAD_COMPLETE].
+ * If a download fails, it queries the DownloadManager for the specific failure
+ * reason (COLUMN_REASON) and logs it via Timber to aid in future debugging
+ * of "Download Unsuccessful" errors.
+ */
+class DownloadReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == DownloadManager.ACTION_DOWNLOAD_COMPLETE) {
+
+            val downloadId = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1)
+            if (downloadId == -1L) return
+
+            val query = DownloadManager.Query().setFilterById(downloadId)
+            val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+
+            val cursor = downloadManager.query(query)
+            if (cursor != null && cursor.moveToFirst()) {
+                val statusIndex = cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)
+                val reasonIndex = cursor.getColumnIndex(DownloadManager.COLUMN_REASON)
+                val titleIndex = cursor.getColumnIndex(DownloadManager.COLUMN_TITLE)
+
+                val status = cursor.getInt(statusIndex)
+
+                if (status == DownloadManager.STATUS_FAILED) {
+                    val reason = cursor.getInt(reasonIndex)
+                    val title = if (titleIndex != -1) cursor.getString(titleIndex) else "Unknown"
+
+                    Timber.e("DOWNLOAD FAILED! Title: $title | Reason Code: $reason")
+
+                    when (reason) {
+                        DownloadManager.ERROR_UNHANDLED_HTTP_CODE ->
+                            Timber.e("CAUSE: Server rejected request (Likely 403 Forbidden / Missing User-Agent)")
+                        DownloadManager.ERROR_HTTP_DATA_ERROR ->
+                            Timber.e("CAUSE: Network connection dropped mid-download (Beta cluster flakiness or VPN)")
+                        DownloadManager.ERROR_FILE_ERROR ->
+                            Timber.e("CAUSE: File system rejected the file (Storage issue or invalid filename characters)")
+                        DownloadManager.ERROR_INSUFFICIENT_SPACE ->
+                            Timber.e("CAUSE: Device is out of storage space")
+                        DownloadManager.ERROR_CANNOT_RESUME ->
+                            Timber.e("CAUSE: Download cannot be resumed")
+                        else ->
+                            Timber.e("CAUSE: Unknown system error (Code: $reason)")
+                    }
+                }
+                cursor.close()
+            }
+        }
+    }
+}

--- a/app/src/main/java/fr/free/nrw/commons/utils/DownloadUtils.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/DownloadUtils.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.net.Uri
 import android.os.Environment
 import android.widget.Toast
+import fr.free.nrw.commons.CommonsApplication
 import fr.free.nrw.commons.Media
 import fr.free.nrw.commons.R
 import timber.log.Timber
@@ -32,14 +33,6 @@ object DownloadUtils {
         fileName = fileName.substringAfter("File:")
         val imageUri = Uri.parse(imageUrl)
 
-        val versionName = try {
-            activity?.packageManager?.getPackageInfo(activity.packageName, 0)?.versionName ?: "unknown"
-        } catch (e: Exception) {
-            "unknown"
-        }
-
-        val userAgent = "CommonsAndroidApp/$versionName (https://github.com/commons-app/apps-android-commons)"
-
         val req =
             DownloadManager.Request(imageUri).apply {
                 setTitle(m.displayTitle)
@@ -47,7 +40,7 @@ object DownloadUtils {
                 setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
                 allowScanningByMediaScanner()
                 setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-                addRequestHeader("User-Agent", userAgent)
+                addRequestHeader("User-Agent", CommonsApplication.instance.userAgent)
             }
         PermissionUtils.checkPermissionsAndPerformAction(
             activity,

--- a/app/src/main/java/fr/free/nrw/commons/utils/DownloadUtils.kt
+++ b/app/src/main/java/fr/free/nrw/commons/utils/DownloadUtils.kt
@@ -31,6 +31,15 @@ object DownloadUtils {
         // Strip 'File:' from beginning of filename, we really shouldn't store it
         fileName = fileName.substringAfter("File:")
         val imageUri = Uri.parse(imageUrl)
+
+        val versionName = try {
+            activity?.packageManager?.getPackageInfo(activity.packageName, 0)?.versionName ?: "unknown"
+        } catch (e: Exception) {
+            "unknown"
+        }
+
+        val userAgent = "CommonsAndroidApp/$versionName (https://github.com/commons-app/apps-android-commons)"
+
         val req =
             DownloadManager.Request(imageUri).apply {
                 setTitle(m.displayTitle)
@@ -38,6 +47,7 @@ object DownloadUtils {
                 setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
                 allowScanningByMediaScanner()
                 setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+                addRequestHeader("User-Agent", userAgent)
             }
         PermissionUtils.checkPermissionsAndPerformAction(
             activity,


### PR DESCRIPTION
Description
Fixed "Download Unsuccessful" errors caused by HTTP 429 (Too Many Requests) rate limiting from Wikimedia/Cloudflare servers. 

Fixes #6947 

Changes made: 

    Added a dynamic User-Agent header to DownloadManager requests so the server recognizes the app as a legitimate client instead of a generic bot.
    Added a DownloadReceiver (BroadcastReceiver) to log the specific DownloadManager failure reason code (e.g., 429, 1001, 1004) via Timber if a download fails, making future debugging much easier.

Tests performed
Tested prodRelease & prodDebug on Android 16 & 17. Verified that downloads now complete successfully without the error notification.